### PR TITLE
Harden toolkit after the npm/plugin upgrade (two-model review)

### DIFF
--- a/.github/agents/pbi-migration-validator.agent.md
+++ b/.github/agents/pbi-migration-validator.agent.md
@@ -28,17 +28,32 @@ Refuse to do a meaningful pass without these — flag it back rather than guessi
    types, encodings, reference lines, filters, parameters). This is what makes your review
    structurally grounded instead of just "vibes-based pixel comparison."
 2. **Tableau reference screenshots**, one whole-dashboard capture per dashboard at minimum, ideally
-   per-worksheet crops too. If none exist yet, capture them yourself with Playwright against the live
-   public workbook (see Gotchas below for the proven technique) before doing anything else — a
-   fidelity review without ground-truth imagery is just guessing.
-3. **The deployed semantic model + PBIP report location** — for your own PBI-side screenshots
-   (Desktop Bridge `screenshot` command if that skill version is available, otherwise ask the
-   orchestrator/user for a fresh one) and for `semantic-model-consumption` `EVALUATE` queries.
+   per-worksheet crops too. **Ground truth lives at `migrations/<slug>/reference/` (with a
+   `manifest.json`) — look there FIRST; all existing migrations already have one.** If it's empty, use
+   the repo's purpose-built, provenance-stamped capture subsystem rather than hand-rolling Playwright:
+   ```
+   python scripts/capture_tableau_reference.py migrations/<slug> [--public-url <url> --view <view>]
+   ```
+   It has a **`manual` provider** for workbooks that are *not* on Tableau Public (the enterprise case):
+   the user drops screenshots into `reference/` and they become the immutable ground truth. See
+   `docs/reference-capture.md`. Only fall back to raw Playwright (Gotchas below) if that script can't
+   serve the case. A fidelity review without ground-truth imagery is guessing — but **"not on Tableau
+   Public" is NOT a reason to refuse**; ask for a manual capture instead.
+3. **The semantic model + PBIP report location** — for your own PBI-side screenshots (Desktop Bridge
+   `screenshot`/`screenshot-all`, otherwise ask the orchestrator/user for a fresh one) and for the
+   numeric `EVALUATE` pass (see *Skills you use* for the offline path that works on a local PBIP).
 
 ## Skills you use
 
-- **`semantic-model-consumption`** — your primary tool for the numeric-fidelity pass. Every numeric
-  claim you make must be backed by an actual `EVALUATE` result, not an assumption.
+- **Numeric pass — DAX `EVALUATE`.** Every numeric claim must be backed by a real query result, not an
+  assumption. The default flow produces a **local PBIP that is never published**, so use the offline
+  path: `powerbi-modeling-mcp` → `connection_operations` **ConnectFolder** on the
+  `<Name>.SemanticModel` folder, then `dax_query_operations` **Execute**. For a model already open in
+  Desktop, `python scripts/probe_desktop_query.py --pid <pid>` runs a one-row probe. Use
+  `powerbi-remote` (`GetSemanticModelSchema` / `ExecuteQuery`) **only** if the model really was
+  published to a workspace. (`semantic-model-consumption` is an optional convenience that ships in the
+  `fabric-skills` plugin — it is *not* required by this repo's setup and is being deprecated upstream;
+  never make it your only path.)
 - **`powerbi-report-authoring`**'s Desktop Bridge screenshot/reload commands, if the newer skill copy
   is active (check with `check-updates` first — this repo has hit real skill-version drift before).
 - Playwright (via the shell), only if Tableau reference screenshots don't already exist.
@@ -47,10 +62,18 @@ Refuse to do a meaningful pass without these — flag it back rather than guessi
 
 Run these passes **in order** — cheap structural checks first, expensive judgment calls last:
 
-1. **Inventory/completeness pass** (cheap, mechanical, do first). For every `dashboards[]` entry in
-   `migration-spec.json`, confirm a corresponding PBI page exists and every non-hidden `worksheets[]`
-   entry has a corresponding visual somewhere on it. A silently-dropped worksheet is a total-fidelity
-   failure, not a nuance — catch it before spending time on aesthetic judgment.
+1. **Inventory/completeness pass** (cheap, mechanical, do first). Scope each dashboard to **its own**
+   worksheets: from that `dashboards[]` entry's zone tree, derive the worksheets *it actually
+   references*, and confirm a corresponding PBI page exists with a visual for each of them. **Do NOT
+   require every workbook worksheet on every dashboard** — a workbook whose Dashboard A uses sheets 1-3
+   and Dashboard B uses sheets 4-6 is correct, and a global check would false-fail both. Separately,
+   list workbook worksheets referenced by *no* dashboard as workbook-level inventory (not a per-dashboard
+   defect). If the report builder split one Tableau dashboard across several PBI pages, validate against
+   its dashboard→pages mapping and give both per-page verdicts and one composite dashboard verdict.
+   A silently-dropped worksheet is a total-fidelity failure, not a nuance — catch it before spending
+   time on aesthetic judgment.
+   `powerbi-report-author preview-pages <report>` and `preview-visuals <report>` emit this inventory as
+   structured JSON — use them instead of reading every `visual.json` by hand.
 2. **Whole-dashboard pass** (do this *before* drilling into individual visuals, not after). Compare
    the full-page PBI screenshot against the full Tableau dashboard screenshot as a gestalt: overall
    layout density/proportions, visual hierarchy (what draws the eye first), color usage, spacing,
@@ -123,7 +146,12 @@ Run these passes **in order** — cheap structural checks first, expensive judgm
 1. Every dashboard has an explicit whole-dashboard verdict, not just per-visual notes.
 2. Every visual has either an explicit "no discrepancy found" or a specific, actionable entry in the
    discrepancy table — no vague "looks mostly fine."
-3. Every numeric claim in the report is backed by a cited `EVALUATE` result, not an assumption.
+3. Every numeric claim in the report is backed by a **pair** of cited evidence: (a) the PBI-side DAX
+   query + its result, and (b) the Tableau-side number it is compared against (an exported row/cell, or
+   a clearly legible location in a reference screenshot). Proving only what Power BI returned proves
+   nothing about fidelity. If no Tableau-side number can be obtained, record the check as
+   `numeric_status: unverified` and say so explicitly — never issue an unqualified "faithful" verdict
+   on the strength of a PBI value alone.
 4. The inventory/completeness pass ran and is reported first — structural gaps found before aesthetic
    critique.
 5. Every discrepancy is routed to an owner (a subagent, or `accepted-limitation`) — nothing left

--- a/.github/agents/pbi-report-builder.agent.md
+++ b/.github/agents/pbi-report-builder.agent.md
@@ -17,6 +17,15 @@ Power BI report. You are invoked by the `tableau-migrator` orchestrator.
    workflow) — point it at the model `pbi-semantic-builder` deployed.
 3. **`powerbi-report-authoring`** — implements the actual PBIR files (pages, visuals, bookmarks, theme)
    from the design brief, and validates in Desktop.
+4. **Read-only DAX (you need this — several of your own rules require it).** DoD #5 and the
+   `formatString` gotcha require sampling a *real* value before choosing e.g. `0.00%` vs `0.00"%"`;
+   you cannot infer that from a field name. Use `powerbi-modeling-mcp` → `connection_operations`
+   **ConnectFolder** on the `<Name>.SemanticModel` folder, then `dax_query_operations` **Execute**.
+   This is **read-only inspection**, so it does not violate layer ownership — you still never edit
+   TMDL; anything needing a model change goes back to `pbi-semantic-builder`.
+5. **`powerbi-report-author` CLI previews** — `preview-visuals` / `preview-pages` / `preview-filters`
+   / `preview-themes` summarise the whole report as structured JSON. Use them to self-check your own
+   output (especially filter placement) instead of re-reading every `visual.json`.
 
 Do not skip straight to authoring — these three skills are explicitly designed as a chained handoff
 (planning → design → authoring), each with its own scope boundary; follow that boundary.
@@ -67,11 +76,24 @@ year ago may be superseded.
      property names, enum values, selector requirements.
    - `expr encode --kind <t> <v>` — generate a correct value encoding instead of hand-writing the
      `expr`/`Literal` wrapper.
+   - `preview-visuals --with-derived` / `preview-pages` / `preview-filters` / `preview-themes <path>` —
+     summarise your *own* output as structured JSON (use these to self-check filter placement and page
+     inventory instead of re-reading every `visual.json`); `doctor` self-checks the toolchain.
+   - **Hard limit — the CLI describes what you may *declare*, never what actually *renders*.**
+     `catalog describe actionButton` reports `"deprecated": false` with a `text` formatting object, yet
+     Desktop **ignores `visual.objects` and draws a blank rectangle** while `validate` returns 0 errors.
+     So a green CLI/`validate` result is *never* evidence that a visual draws — only a render-verified
+     cookbook entry or your own Desktop screenshot is.
 2. **Cookbook composition — but trust it by tier, because the cookbook is a *cache*, not the authority.**
    `.github/pbi.kb/visual-cookbook.md` + `visuals/<type>.visual.json`/`.md`. The CLI gives you the
    vocabulary; the cookbook gives you a *worked composition* (the nested JSON that actually holds
-   together for a real idiom — which the CLI cannot compose and `validate` cannot render-check). Trust
-   it **by tier**:
+   together for a real idiom — which the CLI cannot compose and `validate` cannot render-check).
+   **Don't open an entry reflexively.** Measured against CLI 0.1.4 (see the cookbook's "What's actually
+   in here"), **19 of 28 entries are pure transcribed `catalog describe` output with zero drift** — for
+   those, step 1 already gave you everything and the lookup is wasted. The entries worth opening are the
+   **6 idioms** (`error-bars`, `reference-lines`, `smallmultiples`, `zoom-slider`, `table-cond-format`,
+   `table-databars` — not visual types at all, so the CLI returns `VISUAL_TYPE_UNKNOWN`) and the
+   **3 render-truth entries** (`actionButton`, `shape`, `azureMap`). Trust it **by tier**:
    - **🟢 render-verified** (proven by an actual render / human Desktop capture) → *more* trustworthy
      than composing yourself, because it truly rendered. **Copy it and rebind fields**, then reconcile
      its property names against step 1's CLI output to catch version drift.
@@ -150,7 +172,10 @@ wrong encoding. Instead:
 3. For each planned page, hand `powerbi-report-design` the relevant `worksheets[]` entries (mark type,
    encodings, reference lines) and the zone layout — let it produce a `Design Brief:` per the chart
    mapping table above. Don't override its archetype/chart-selection judgment except where this file's
-   mapping table gives a hard signal (e.g. reference-lines → Gauge).
+   mapping table gives a hard signal — noting that **reference-lines → Gauge is a *soft* signal, not a
+   hard one**: it only holds for a single KPI vs a target. If the worksheet compares multiple
+   categories/regions, keep it a dot plot/scatter (see the mark-type table's `Circle` + `reference_lines`
+   row, which governs).
 4. **Build an empty layout skeleton before authoring any real visual.** Place a blank/placeholder
    shape (a rectangle, or the target visual type with no field wells bound yet) for *every* zone in
    the `layout_contract` at its correct region — position and size only. Screenshot or render this
@@ -323,7 +348,8 @@ only a live Desktop screenshot catches them, so treat structural validation as n
   **no-op on initial render** (matrix still shows collapsed); don't burn cycles chasing it, document a
   collapsed default or use a flat `tableEx` when the grain is one row per leaf.
 
-**Data colors / conditional formatting (see `conditional-formatting.md`):**
+**Data colors / conditional formatting (see the `powerbi-report-authoring` skill →
+`references/conditional-formatting.md`; for table-specific idioms see `.github/pbi.kb/visuals/table-cond-format.md`):**
 - **Discrete/banded data colors use `dataPoint.fill.solid.color.expr.Conditional.Cases[]`, NOT
   `fillRule.cases`** (`fillRule` is gradient/`linearGradient` only). Each case = a `Comparison`
   (`Left = SelectRef.ExpressionName` of a projection's `queryRef`, cascading first-match) plus a
@@ -407,8 +433,10 @@ Superstore build.
   visuals.
 
 **Desktop verification mechanics (when a live check is possible):**
-- **The `powerbi-desktop` bridge has NO refresh command** (only `application.state.get` /
-  `report.snapshot.capture` / `file.reload`), and PBIP stores no data cache, so a freshly-opened import
+- **The `powerbi-desktop` bridge has NO refresh verb** (verbs as of bridge CLI 0.1.2: `status`,
+  `manifest`, `open`, `reload`, `screenshot`, `screenshot-all` — the underlying bridge methods are
+  `application.state.get` / `report.snapshot.capture` / `file.reload`), and PBIP stores no data cache,
+  so a freshly-opened import
   report renders **empty** ("tables have incomplete or no data"). A clean screenshot with empty visuals
   is an unrefreshed-model artifact, not a binding defect. **Workaround (proven):** refresh via TOM/XMLA
   against the child `msmdsrv` port — load `Microsoft.AnalysisServices.AdomdClient` (copy the DLL out of

--- a/.github/agents/pbi-semantic-builder.agent.md
+++ b/.github/agents/pbi-semantic-builder.agent.md
@@ -1,6 +1,6 @@
 ---
 name: pbi-semantic-builder
-description: Builds a Fabric Power BI semantic model (TMDL) from a Tableau migration-spec.json - tables, relationships, and DAX measures translated from Tableau calculated fields. Uses the semantic-model-authoring and semantic-model-consumption skills.
+description: Builds a Fabric Power BI semantic model (TMDL) from a Tableau migration-spec.json - tables, relationships, and DAX measures translated from Tableau calculated fields. Uses the semantic-model-authoring skill plus the Power BI modeling MCP for read-only DAX validation.
 ---
 
 # PBI Semantic Builder — Subagent
@@ -17,8 +17,14 @@ examples, not hypothetical ones.
 
 - **`semantic-model-authoring`** — for everything TMDL: creating tables/columns, relationships,
   measures, and deploying to Fabric. This is your primary tool for all file/deployment mechanics.
-- **`semantic-model-consumption`** — read-only DAX (`EVALUATE`) and metadata queries, used to validate
-  translated measures against expected behavior once deployed.
+- **Read-only DAX (`EVALUATE`) + metadata — your validation surface.** Primary path, works on the local
+  PBIP with nothing published: `powerbi-modeling-mcp` → `connection_operations` **ConnectFolder** on the
+  `<Name>.SemanticModel` folder, then `dax_query_operations` **Execute**. For a model open in Desktop,
+  `python scripts/probe_desktop_query.py --pid <pid>` gives a one-row probe. `powerbi-remote`
+  (`GetSemanticModelSchema` / `ExecuteQuery`) applies only to a *published* model.
+  (`semantic-model-consumption` is an optional convenience that ships in the `fabric-skills` plugin —
+  which this repo's setup marks optional, and which is being deprecated upstream in favour of folding
+  metadata discovery into `semantic-model-authoring`. Never make it your only path.)
 
 ## Mental model — mapping migration-spec.json to a semantic model
 
@@ -55,25 +61,37 @@ field is used inside an aggregated shelf reference (`sum:`, `avg:` prefix in the
    `caption` as the TMDL display name (never ship raw internal names like `Calculation_5871029` to the
    model).
 4. **Translate calculated fields to DAX**, field by field, using `docs/tableau-dax-translation-guide.md`:
-   - Check `is_lod` / `is_table_calc` first — route to §3/§4 of the guide; these need grain
-     verification, budget extra validation time.
+   - Check `is_lod` / `is_table_calc` first — route to **§5 (LOD)** / **§6 (table calculations)** of the
+     guide; these need grain verification, budget extra validation time.
    - Check `reshape_hint == "pivot_derived"` — do the reshape in Power Query (`Table.UnpivotOtherColumns`
      + conditional columns), not as a DAX calculated column replicating `CONTAINS`/`LEFT`/`RIGHT`
      string parsing. This is cleaner and belongs at the load layer.
    - Otherwise, use the direct expression translation table (guide §1) and worked examples.
-   - Respect `referenced_fields` ordering — a calculation referencing another calculated field needs
-     its dependency created first (or inlined).
+   - **Respect dependency order, but do NOT infer operand order from `referenced_fields`** — it records
+     which fields a formula references (identity), not the order they appear in the expression. Build the
+     dependency graph from the raw formula text so a calculation referencing another calculated field is
+     created first (or inlined); never reconstruct a non-commutative expression (`a - b`, `a / b`) from
+     `referenced_fields` order. See the matching Gotcha later in this file.
    - **Recognize the parameter-equality idiom** (guide §2): if a field's formula matches
      `IF [Parameters].[X] = [Dim] THEN [Dim] END` and it's only ever used as an exclude-null filter
      (check `worksheets[].filters[].note` in the spec — the parser already flags this), **do not**
      create the calculated column. Note in your output that `pbi-report-builder` should use a native
      slicer on the underlying dimension instead.
 5. **Create relationships** from `data_sources[].joins[]`.
-6. **Deploy** the model via `semantic-model-authoring`'s Fabric deployment workflow.
-7. **Validate a sample.** For at least the non-trivial translated measures (anything that wasn't a
-   pure passthrough), use `semantic-model-consumption`'s `EVALUATE` to sanity-check output shape and
-   spot values. Flag anything that can't be verified against a known Tableau value.
-8. **Report back to the orchestrator**: semantic model location (workspace + item), a table→field
+6. **Materialize the model locally.** The default deliverable is a **local PBIP**
+   (`migrations/<slug>/fabric/<Name>.SemanticModel` + `<Name>.pbip`) — **publishing to Fabric is NOT part
+   of the default flow** (it's phase-2 `pbi-deployer`; see `tableau-migrator.agent.md`). Only run
+   `semantic-model-authoring`'s Fabric deployment workflow if the orchestrator explicitly gave you a
+   target workspace. Never treat "not deployed" as a reason to skip step 7.
+7. **Validate a sample — this is mandatory and works offline.** For at least the non-trivial translated
+   measures (anything that wasn't a pure passthrough), run a real `EVALUATE` and sanity-check output
+   shape and spot values. On a local PBIP use `powerbi-modeling-mcp` → `connection_operations`
+   **ConnectFolder** on the `<Name>.SemanticModel` folder, then `dax_query_operations` **Execute**
+   (`semantic-model-consumption` is an optional convenience from the `fabric-skills` plugin and requires
+   a published model — never depend on it). Flag anything that can't be verified against a known
+   Tableau value.
+8. **Report back to the orchestrator**: semantic model location (local PBIP path, plus workspace + item
+   only if actually deployed), a table→field
    count summary, which calculated fields became measures vs. columns, which idioms were simplified
    away (parameter-equality, pivot reshape) and why, and any new `limitations_encountered` entries
    (append them to `migration-spec.json` so the report builder and final summary see them).

--- a/.github/agents/tableau-migrator.agent.md
+++ b/.github/agents/tableau-migrator.agent.md
@@ -18,8 +18,8 @@ PBIR files yourself.
                        |                                              |
                        v                                              v
               pbi-semantic-builder                            pbi-report-builder
-        (semantic-model-authoring,                    (powerbi-report-planning ->
-         semantic-model-consumption)                   powerbi-report-design ->
+        (semantic-model-authoring +                    (powerbi-report-planning ->
+         powerbi-modeling-mcp EVALUATE)                 powerbi-report-design ->
                        |                                powerbi-report-authoring)
                        v                                              v
               Fabric TMDL semantic model  <-------- binds to -------- PBIR report
@@ -41,16 +41,21 @@ it must show up in `limitations_encountered`, not be silently dropped.
 
 ## Workflow
 
-0. **Preflight the environment (do this EVERY invocation, before anything else).** Run:
+0. **Preflight the environment (do this EVERY invocation, before anything else).** Run the **plain**
+   form — **never `-Update`**:
    ```
    powershell -ExecutionPolicy Bypass -File scripts/preflight.ps1
    ```
+   `-Update` belongs to *session start* only (see `AGENTS.md` → "Session start"). Upgrading the bridge
+   CLIs from inside a migration would swap the validator underneath a half-built report — worse than a
+   slightly old CLI. If preflight reports a CLI **below the correctness floor**, stop and tell the user
+   to re-run session start with `-Update` rather than upgrading mid-flow yourself.
    It is a PowerShell (not Python) bootstrap on purpose — it must work even on a machine where Python
    isn't installed yet, because checking FOR Python is one of its jobs. It verifies the whole
    toolchain: Python + the parser's deps, the `powerbi-authoring@fabric-collection` skill plugin, the
    MCP servers (`powerbi-modeling-mcp`, `powerbi-remote`), Power BI Desktop + its Bridge CLI
-   (`powerbi-desktop`), `npx`, and the TOM refresh DLL. If it exits non-zero, **stop and surface the
-   missing items to the user with the printed install hints** (e.g. `/plugin` to add
+   (`powerbi-desktop`), `npx`, the .NET SDK, and the CLI version matrix. If it exits non-zero, **stop
+   and surface the missing items to the user with the printed install hints** (e.g. `/plugin` to add
    `microsoft/skills-for-fabric` + enable `powerbi-authoring`, `/mcp` to register the servers, or
    installing Python / Power BI Desktop) — do not attempt a migration against a half-configured
    machine. See `AGENTS.md` for the full setup. Only proceed once preflight reports "Ready to migrate."
@@ -58,7 +63,12 @@ it must show up in `limitations_encountered`, not be silently dropped.
    `migrations/<name>/` (create `source/`, and the spec will live at
    `migrations/<name>/migration-spec.json`). If the user hasn't picked a `<name>`, derive a short slug
    from the workbook's title.
-2. **Parse.** Run:
+2. **Parse — but only if the spec doesn't already exist.** **PRECONDITION (hard):** if
+   `migrations/<name>/migration-spec.json` already exists, **do not re-run the parser** without asking.
+   Re-parsing **overwrites the file in place** and destroys every `semantic_build` / `report_build` /
+   `validate` limitation the subagents appended to it (routinely 20-50 entries) — i.e. exactly the raw
+   material step 10's summary depends on. On a re-run, fix round, or resumed session, skip to step 3.
+   Only when the spec is absent (or the user explicitly confirms a re-parse of a changed source) run:
    ```
    python scripts/parse_tableau.py migrations/<name>/source/<file>.twbx -o migrations/<name>/migration-spec.json
    ```
@@ -68,8 +78,9 @@ it must show up in `limitations_encountered`, not be silently dropped.
    Summarize it for the user in three buckets: high severity (LOD/table calc formulas needing manual
    DAX verification), medium (extract-based data sources needing a data-materialization decision), low
    (unresolved shelf references, narrow parser gaps like ad-hoc worksheet-scoped calculations or
-   Tableau Groups — see `docs/tableau-dax-translation-guide.md` §6). Don't proceed silently past
-   high-severity items without flagging them.
+   Tableau Groups — see `docs/tableau-dax-translation-guide.md` §6 for table calcs; **Tableau Groups are
+   not yet covered by the guide** — translate them as a mapped calculated column and log a limitation).
+   Don't proceed silently past high-severity items without flagging them.
 4. **Data-source credential preflight (MANDATORY before building — do not skip for live sources).** Run
    `python scripts/preflight_source_credentials.py --spec migrations/<name>/migration-spec.json`. If it
    reports **only** extract/flat sources, there is no credential gate (data comes from CSV + a
@@ -92,11 +103,16 @@ it must show up in `limitations_encountered`, not be silently dropped.
 5. **Delegate to `pbi-semantic-builder`** with: the path to `migration-spec.json`, the target Fabric
    workspace/workspace-to-be, and any user preference on extract data materialization. Wait for it to
    report back the semantic model location and any new limitations it appended.
-6. **Delegate to `pbi-report-builder`** with: the path to `migration-spec.json` and the semantic model
-   location from step 5. Wait for it to report back the report location and any new limitations.
-7. **Delegate to `pbi-migration-validator`** with: `migration-spec.json`, Tableau reference screenshots
-   (capture them first via Playwright if none exist yet — see that agent's Gotchas for the proven
-   technique), and the deployed model/report locations. Use **spot-check mode** for a single
+6. **Delegate to `pbi-report-builder`** with: the path to `migration-spec.json`, the semantic model
+   location from step 5, **and the Tableau reference bundle** (`migrations/<name>/reference/` — its
+   step 4 skeleton gate compares against the source dashboard image, so it cannot run without this;
+   capture it first with `python scripts/capture_tableau_reference.py migrations/<name> …` if the
+   folder is empty). Wait for it to report back the report location and any new limitations.
+7. **Delegate to `pbi-migration-validator`** with: `migration-spec.json`, the Tableau reference bundle
+   at `migrations/<name>/reference/` (capture it first with
+   `python scripts/capture_tableau_reference.py migrations/<name> [--public-url … --view …]`; it has a
+   **`manual` provider** for workbooks that are not on Tableau Public — see `docs/reference-capture.md`),
+   and the model/report locations. Use **spot-check mode** for a single
    page/visual you're actively iterating on, and **full-migration sign-off mode** (optionally
    multi-model) as the final gate before sign-off (step 9). This is not optional or "nice to have" — it's the
    step that actually closes the loop between "the subagents reported success" and "it's verifiably
@@ -105,14 +121,23 @@ it must show up in `limitations_encountered`, not be silently dropped.
    to `pbi-semantic-builder`, visual/layout issues to `pbi-report-builder`, genuine capability gaps to
    `limitations_encountered` (not a fix request to anyone). **Never fix a validator finding yourself**
    — same rule as the ad hoc-edit Gotcha below, now applying to the validator's output too. Re-run the
-   validator (spot-check mode is enough) after each fix round; cap at 2-3 rounds per its own Gotchas —
-   anything still open after that is logged as an accepted limitation, not endlessly re-litigated.
+   validator (spot-check mode is enough) after each fix round; cap **autonomous retries** at 2-3 rounds.
+   **A retry cap is not a correctness waiver:** running out of attempts does NOT convert a real defect
+   into an accepted limitation. An item may be logged as a capability gap only with *evidence* that
+   Power BI cannot express it (product docs, a verified CLI/validate result, a Learn citation).
+   Otherwise it stays **open/blocking** and you surface it to the user for an explicit decision.
+   **You (the orchestrator) are the only writer of `stage:"validate"` entries** in
+   `limitations_encountered` — the validator is read-only and must never edit the spec.
 9. **Validate before declaring done.** Structural/mechanical validation is part of the default flow,
    not a phase-2 nice-to-have — confirm both build subagents ran their own "Mandatory validation"
    steps (see each subagent's own agent file) *and* that `pbi-migration-validator` has run a full
-   sign-off pass with no open high-severity discrepancies, before you summarize anything to the user.
-   "The parser ran and the subagents reported success" is not the same thing as "it was validated" —
-   don't let it substitute for an actual validation pass.
+   sign-off pass. **Sign-off requires ALL of:** (a) every dashboard's whole-dashboard verdict is
+   *faithful* — a "no" verdict blocks sign-off **even when every individual discrepancy is only
+   low/medium**, since the validator explicitly allows an accumulation of small deviations to fail the
+   gestalt; (b) no open high-severity discrepancies; (c) any remaining item is an *evidenced* accepted
+   limitation (see step 8), not merely an unresolved one. "The parser ran and the subagents reported
+   success" is not the same thing as "it was validated" — don't let it substitute for an actual
+   validation pass.
 10. **Summarize the migration** for the user: what was built (tables/measures/pages/visuals counts),
     what was *simplified* rather than transliterated (parameter-equality filters → slicers, pivot
     string-parsing → Power Query unpivot — these are positive findings, present them as such), what the

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,44 @@
+# Copilot instructions, tableau-to-pbi-migration
+
+> This file exists so agent runtimes that auto-load **`.github/copilot-instructions.md`** (VS Code
+> Copilot) pick up the same conventions as runtimes that auto-load **`/AGENTS.md`** (Copilot CLI).
+> **`/AGENTS.md` at the repo root is the source of truth — read it.** Only the session-start step is
+> duplicated here, because it has to fire before anything else.
+
+## Session start, do this first (before any other work)
+
+```
+powershell -ExecutionPolicy Bypass -File scripts/preflight.ps1 -Update
+```
+
+Repairs the npm bridge CLIs **if they are below the correctness floor**, then prints the environment
+readiness matrix. Session start is the **only safe moment** to change them.
+
+- `powerbi-report-author` **>= 0.1.4 is a correctness floor**, not a nicety. Older builds returned
+  `errorCount: 0` for PBIR that Power BI Desktop cannot open (e.g. a `report.json` missing the
+  schema-required `reportVersionAtImport`). A stale CLI silently green-lights a broken report.
+- `-Update` is a **floor check, not a blind `@latest`**. At or above the floor it does nothing (so it
+  costs no time); it only upgrades an install that is genuinely too old.
+- Being **above** the recorded known-good matrix is not an error — it raises a WARN, because that is
+  exactly when the version-specific Gotchas in `.github/agents/` need re-verification. Don't "fix" it
+  by downgrading; re-verify the prose.
+- **Never upgrade mid-migration.** Swapping the validator underneath a half-built report is worse than
+  a slightly old CLI. Between migrations is fine.
+- It cannot update the **skill bundles** — `copilot plugin update` hits a file lock while any Copilot
+  session is running, so plugin updates stay a manual, between-sessions step.
+
+### When to run which
+
+| When | Run | Why |
+|---|---|---|
+| Session start (nothing in flight) | `preflight.ps1 -Update` | Safe; the CLI floor is a correctness floor |
+| Migration start (orchestrator step 0) | `preflight.ps1` (plain) | Confirm READY without changing tooling mid-flow |
+| Mid-migration | never | Swapping the validator under a half-built report is worse than a slightly old one |
+
+## Everything else
+
+See [`/AGENTS.md`](../AGENTS.md) for the required plugin/MCP servers, the `migration-spec.json`
+contract, and the conventions every agent inherits (cite your source, confidence markers, own your
+layer, structural validation is necessary but not sufficient, keep `limitations_encountered` alive).
+Per-agent instructions live in [`.github/agents/`](agents/), and PBIR knowledge in
+[`.github/pbi.kb/`](pbi.kb/).

--- a/.github/pbi.kb/visual-cookbook.md
+++ b/.github/pbi.kb/visual-cookbook.md
@@ -46,7 +46,7 @@ current instead of freezing. See `.github/agents/pbi-report-builder.agent.md` ("
 ## The CLI is the research tool (deterministic, no guessing)
 
 ```
-powerbi-report-author catalog list                      # all 58 built-in types + deprecations
+powerbi-report-author catalog list                      # all built-in types + deprecations (57 on CLI 0.1.4)
 powerbi-report-author catalog describe <type>           # field-well roles, required/optional, formatting objects
 powerbi-report-author formatting effective-properties <type>   # every formatting surface for the type
 powerbi-report-author formatting describe-object <type> <object>
@@ -55,11 +55,40 @@ powerbi-report-author validate <path-to-.Report-dir>    # structural validation 
 
 Deprecated (do not emit): `filledMap` -> `azureMap`, `map` -> `azureMap`, `qnaVisual` (unsupported in PBIR).
 
+## What's actually in here (measured against CLI 0.1.4, 2026-07-28)
+
+An empirical sweep of all 28 `visuals/*.md` entries against `catalog describe` gives the honest
+breakdown — **use it to decide whether opening an entry is even worth a lookup**:
+
+| Category | Count | Do you need the cookbook? |
+|---|---|---|
+| **Typed entries whose role tables exactly match the CLI** (zero drift found) | **19** | ❌ **No.** Their Roles / formatting-object sections are literally transcribed `catalog describe` output. Call the CLI instead — it's live and can't go stale. Their only residual value is the Tableau-idiom mapping + tier verdict. |
+| **Idiom entries** — `error-bars`, `reference-lines`, `smallmultiples`, `zoom-slider`, `table-cond-format`, `table-databars` | **6** | ✅ **Yes.** These are *not visual types*: `catalog describe error-bars` → `VISUAL_TYPE_UNKNOWN`. They document a technique applied to a host visual, which the CLI has no concept of. |
+| **Render-truth entries** — `actionButton`, `shape`, `azureMap` | **3** | ✅ **Yes, critically.** These carry behaviour the CLI cannot know and in one case gets actively wrong. |
+
+**The canonical proof that CLI vocabulary ≠ render truth:** `catalog describe actionButton` reports
+`"deprecated": false` and a `text` formatting object — i.e. perfectly usable. In reality Desktop
+**ignores `visual.objects` and draws a blank rectangle**, while `validate` still returns 0 errors. Only
+`visuals/actionButton.md` tells you to use `shape` instead. Rule of thumb: **the CLI is authoritative
+for what you may *declare*; only a render-verified entry is authoritative for what actually *draws*.**
+
+**When adding a new entry:** if all you would write is the roles/formatting tables, **don't** — that's a
+cache of a command that already exists. Add an entry only for an idiom, a render-verified composition,
+or a behavioural trap.
+
 ## Confidence map (Tableau-relevant types + idioms)
 
 Legend: 🟢 render-proven · 🟡 structural template (CLI) · 🔴 needs human Desktop capture · ⛔ no native visual (marketplace `.pbiviz` / capability gap)
 
 ### 🟢 Proven in our migrations (copy from the cited migration)
+
+> **These rows have NO local `visuals/<type>.visual.json` file** — unlike the 🟡/🔴 entries below, the
+> 🟢 core types are proven *in situ*. To copy one, resolve it from the cited migration's PBIR, e.g.:
+> `Select-String -Path migrations\*\fabric\*.Report\definition\pages\*\visuals\*\visual.json -Pattern '"visualType": "columnChart"'`
+> then open that `visual.json` and rebind fields. If a row's location is vague ("all migrations"), any
+> hit from that glob is a valid, render-proven starting point. Do **not** treat a missing
+> `visuals/<type>.md` as "unproven" for these types.
+
 | Type | Example location |
 |---|---|
 | `columnChart` / `clusteredColumnChart` | airline `9f2607ea` pages |

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,10 @@ copilot-feedback-*.tgz
 # OS cruft
 .DS_Store
 Thumbs.db
+
+# uv lockfile - NOT committed on purpose. Running "uv lock" on a Microsoft-corp machine resolves against
+# internal feeds (packagefeedproxy.microsoft.io / ms-feed-*.pkgs.visualstudio.com), which would leak
+# internal infrastructure URLs and break "uv sync --frozen" for any external clone. The ">=" floors in
+# pyproject.toml are the contract instead. To commit a lock, regenerate it against public PyPI first
+# (UV_INDEX_URL=https://pypi.org/simple uv lock).
+uv.lock

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,14 +5,49 @@ repository. It has two jobs: (1) tell you (or a fresh contributor) exactly which
 MCP servers** this toolkit needs so the repo is self-configuring, and (2) hold the **conventions every
 agent inherits**, so the individual `.github/agents/*.agent.md` files stay lean and don't restate them.
 
+> **VS Code users:** VS Code Copilot auto-loads `.github/copilot-instructions.md`, *not* this file.
+> That pointer file duplicates only the session-start step below and defers everything else here, so
+> the two cannot drift.
+
+---
+
+## Session start, do this first (before any other work)
+
+```
+powershell -ExecutionPolicy Bypass -File scripts/preflight.ps1 -Update
+```
+
+`-Update` repairs the npm bridge CLIs **only when they are below the correctness floor** — it is a
+floor check, not a blind `@latest`, so at or above the floor it costs nothing.
+
+**Why a floor:** `powerbi-report-author` **>= 0.1.4** is a *correctness* floor. Older builds returned
+`errorCount: 0` for PBIR that Power BI Desktop cannot open (e.g. a `report.json` missing the
+schema-required `reportVersionAtImport`) — a stale CLI silently green-lights a broken report.
+
+**Above the known-good matrix is a WARN, not an error.** It means the version-specific Gotchas in
+`.github/agents/` were verified against an older build and may be stale — re-verify the prose; never
+"fix" it by downgrading.
+
+**The timing rule is what makes this safe:**
+
+| When | Run | Why |
+|---|---|---|
+| Session start (nothing in flight) | `preflight.ps1 -Update` | Safe; the CLI floor is a correctness floor |
+| Migration start (orchestrator step 0) | `preflight.ps1` (plain) | Confirm READY without swapping tooling mid-flow |
+| Mid-migration | **never** | Swapping the validator under a half-built report is worse than a slightly old one |
+
+It cannot update the **skill bundles**: `copilot plugin update` hits a file lock while any Copilot
+session is running, so plugin updates remain a manual, between-sessions step.
+
 ---
 
 ## Required Copilot setup (self-configuring dependencies)
 
 This toolkit is not self-contained: its agents build on Microsoft's official **Fabric / Power BI
 skills** (published as a Copilot *plugin*) and talk to Power BI through **MCP servers**. A clone needs
-all three layers below. The agent files under `.github/agents/` and the repo-local skills under
-`.github/skills/` are already committed and load automatically.
+all three layers below. The agent files under `.github/agents/` are already committed and load
+automatically; `.github/skills/` is an enabled skill location (see `.vscode/settings.json`) that is
+currently empty — repo-local skills dropped there load automatically too.
 
 ### 1. Skill plugin — `powerbi-authoring@fabric-collection`
 
@@ -63,16 +98,50 @@ Copilot CLI users register the same servers with `/mcp`, or copy them into
   `.vscode/settings.json`).
 - **Visual cookbook: [`.github/pbi.kb/visual-cookbook.md`](.github/pbi.kb/visual-cookbook.md) +
   [`.github/pbi.kb/visuals/`](.github/pbi.kb/visuals/)** — a committed library of worked,
-  `validate`-passing PBIR `visual.json` encodings (one per visual type/idiom), each with roles, the
-  Tableau idiom it maps to, and a confidence tier. `pbi-report-builder` copies these instead of
-  guessing visual JSON; new ground-truth encodings are added back here so every migration compounds.
+  `validate`-passing PBIR `visual.json` encodings, each with roles, the Tableau idiom it maps to, and a
+  confidence tier. **Coverage note:** the `visuals/` folder holds the *harder/rarer* encodings (combo,
+  waterfall, ribbon, treemap, small multiples, azureMap, shape…); the common core types
+  (`columnChart`/`barChart`/`lineChart`/`cardVisual`/`tableEx`/`slicer`/`textbox`) are proven **in situ**
+  and are copied from the migration paths cited in the cookbook's 🟢 table, not from a local file.
+  `pbi-report-builder` copies these instead of guessing visual JSON; new ground-truth encodings are
+  added back here so every migration compounds.
 
-### 4. Python tooling
+### 4. Node.js + the Power BI CLIs
 
-`uv venv && uv sync` — the deterministic parser (`scripts/parse_tableau.py`), harvester, showcase, and
-validation scripts. Lint/format with `ruff`; the parser has a `pytest` regression suite in `tests/`.
+Two npm CLIs do real work in the loop and are **not** bundled with the plugin — install them globally
+(needs **Node >= 20**):
 
-### 5. Preflight — verify everything above in one command
+```
+npm install -g @microsoft/powerbi-report-authoring-cli @microsoft/powerbi-desktop-bridge-cli
+```
+
+- `powerbi-report-author` — `validate`, `catalog`, `formatting`, `expr`, `theme`, plus
+  `preview-visuals` / `preview-pages` / `preview-filters` / `preview-themes` and `doctor`.
+- `powerbi-desktop` — the Desktop Bridge: `status`, `manifest`, `open`, `reload`, `screenshot`,
+  `screenshot-all`.
+
+**Known-good version matrix** (verified 2026-07-27). These are *unpinned global* installs, so they can
+change under you with no repo diff — and several agent Gotchas encode version-specific tool behaviour.
+`scripts/preflight.ps1` prints the installed versions and WARNs on drift:
+
+| Component | Known-good |
+|---|---|
+| `@microsoft/powerbi-report-authoring-cli` | 0.1.4 |
+| `@microsoft/powerbi-desktop-bridge-cli` | 0.1.2 |
+| `powerbi-authoring@fabric-collection` | 0.3.9 |
+| Node.js | >= 20 (26.2.0 tested) |
+| Python | >= 3.11 (3.11.9 tested) |
+
+If a version differs, re-verify the version-specific Gotchas in `.github/agents/` before trusting them.
+
+### 5. Python tooling
+
+`uv venv && uv sync --all-extras` — the deterministic parser (`scripts/parse_tableau.py`), harvester,
+showcase, and validation scripts (`--all-extras` pulls `tableauhyperapi`/`playwright`/`pillow`, which
+several documented scripts import). Lint/format with `ruff`; the parser has a `pytest` regression suite
+in `tests/`. **`uv.lock` is deliberately gitignored** — see the note in `.gitignore`.
+
+### 6. Preflight — verify everything above in one command
 
 ```
 powershell -ExecutionPolicy Bypass -File scripts/preflight.ps1
@@ -81,7 +150,8 @@ powershell -ExecutionPolicy Bypass -File scripts/preflight.ps1
 The `tableau-migrator` agent runs this first on every invocation. It is a PowerShell bootstrap (not
 Python) so it works even before Python is installed — checking FOR Python is one of its jobs. It checks
 the parser deps, the `powerbi-authoring` plugin, the MCP servers, Power BI Desktop + Bridge CLI, `npx`,
-and the TOM DLL, printing an install hint for anything missing (exit 0 = ready). Run it yourself after
+the .NET SDK, and the CLI version matrix (plus `powerbi-report-author doctor`), printing an install hint
+for anything missing (exit 0 = ready). Run it yourself after
 cloning to confirm the machine is configured.
 
 ---

--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ original dashboards belongs to their respective Tableau Public authors.
   natural-language Q&A. It is a required final phase in `pbi-semantic-builder`.
 - **Preflight** (`scripts/preflight.ps1`): a dependency-free PowerShell bootstrap the orchestrator
   runs first. It checks Python and parser deps, the `powerbi-authoring` plugin, the MCP servers,
-  Power BI Desktop and its Bridge CLI, `npx`, and the TOM DLL, printing an install hint for anything
-  missing.
+  Power BI Desktop and its Bridge CLI, `npx`, the .NET SDK, and the known-good CLI version matrix
+  (plus `powerbi-report-author doctor`), printing an install hint for anything missing.
 
 ## 🧩 Why a separate parser, not an all-LLM pipeline
 
@@ -145,8 +145,9 @@ BI through **MCP servers**. Those dependencies are declared in the repo so a clo
   conventions every agent inherits. **Read this first.**
 - [`.vscode/mcp.json`](.vscode/mcp.json): MCP server definitions (auto-read by VS Code Copilot; CLI
   users add the same with `/mcp`).
-- Repo-local agents (`.github/agents/`) and skills (`.github/skills/`) are committed and load
-  automatically.
+- Repo-local agents (`.github/agents/`) are committed and load automatically. `.github/skills/` is
+  enabled as a skill location (see `.vscode/settings.json`) but is currently empty — drop repo-local
+  skills there and they load automatically too.
 
 In Copilot CLI, install the plugin once with `/plugin` (add marketplace `microsoft/skills-for-fabric`,
 enable `powerbi-authoring`) and register the MCP servers with `/mcp`. Then run
@@ -173,7 +174,7 @@ For the full repo (all examples + showcase), use a normal `git clone …`. Then 
 ```powershell
 uv venv
 .venv\Scripts\Activate.ps1
-uv sync
+uv sync --all-extras   # --all-extras pulls tableauhyperapi/playwright/pillow used by the scripts below
 
 # Parse a workbook into the intermediate spec
 python scripts\parse_tableau.py migrations\<name>\source\<workbook>.twbx `

--- a/docs/data-source-credentials.md
+++ b/docs/data-source-credentials.md
@@ -33,9 +33,10 @@ agent-writable API**:
   Desktop / Mashup credential store on that machine. The connector shows a **modal** auth dialog the
   first time. Microsoft's own doc: *"Once you enter your credentials for a particular Databricks SQL
   Warehouse, Power BI Desktop caches and reuses those same credentials in subsequent connection
-  attempts."* The **Desktop Bridge exposes only `application.state.get`, `report.snapshot.capture`, and
-  `file.reload`** — there is **no method to fill the credential modal**. So the agent's build/render/
-  screenshot loop is blocked on live data until the user authenticates once.
+  attempts."* The **Desktop Bridge has no method to fill the credential modal** (its surface is
+  `application.state.get` / `report.snapshot.capture` / `file.reload`; CLI 0.1.2 verbs are `status`,
+  `manifest`, `open`, `reload`, `screenshot`, `screenshot-all` — none of them authenticate). So the
+  agent's build/render/screenshot loop is blocked on live data until the user authenticates once.
 - **Power BI service (cloud):** credentials live server-side in a **gateway datasource / Fabric
   connection**, set via the UI (*Semantic model > Settings > Data source credentials*) or the
   Connections API. Publishing via `fab import` binds **no** credential, so a refresh fails immediately.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,9 @@ exclude = [
     ".pyenv", ".pytest_cache", ".pytype", ".ruff_cache", ".svn",
     ".tox", ".venv", ".vscode", "__pypackages__", "_build",
     "buck-out", "build", "dist", "node_modules", "site-packages", "venv",
+    # Per-migration generated validation scripts are committed ARTIFACTS, not source. Linting them made
+    # the documented `ruff check .` rewrite ~77 lines across committed examples.
+    "migrations",
 ]
 line-length = 120
 indent-width = 4
@@ -67,7 +70,11 @@ max-module-lines = 1200
 
 [tool.pylint."messages control"]
 # TODO comments are a deliberate scope-tracking practice in this repo, not a defect.
-disable = ["fixme"]
+# duplicate-code (R0801): scripts/ holds INDEPENDENT one-shot CLI tools that intentionally keep small
+# local helpers self-contained (e.g. the sibling carousel/showcase image generators) rather than
+# coupling through a shared module. Without this, the documented `pylint scripts` command fails the
+# fail-under = 10 gate.
+disable = ["fixme", "duplicate-code"]
 
 [tool.pylint.basic]
 argument-naming-style = "snake_case"

--- a/scripts/preflight.ps1
+++ b/scripts/preflight.ps1
@@ -12,14 +12,27 @@
   is the correct, dependency-free bootstrap.
 
   Verifies: Python + the parser's Python deps, the powerbi-authoring@fabric-collection skill plugin,
-  the MCP servers, Power BI Desktop + its Bridge CLI, npx, and the TOM refresh DLL. Prints a per-item
-  status (OK / WARN / MISS) with an install hint for anything absent.
+  the MCP servers, Power BI Desktop + its Bridge CLI, npx, the .NET SDK, and the npm CLI version
+  matrix. Prints a per-item status (OK / WARN / MISS) with an install hint for anything absent.
+
+.PARAMETER Update
+  Session-start only. Upgrades the npm bridge CLIs, but ONLY when they are below the correctness
+  FLOOR (see $cliFloor) -- a floor check, not a blind `@latest`. Being above the floor is fine and is
+  left alone; being above the recorded known-good matrix raises a WARN instead, because that is when
+  the version-specific Gotchas in .github/agents/ need re-verification.
+
+  TIMING RULE (the `when` is what makes this safe):
+    - Session start, nothing in flight -> `-Update` is safe. The floor is a correctness floor.
+    - Migration start (orchestrator step 0) -> plain preflight, NEVER `-Update`.
+    - Mid-migration -> never. Swapping the validator under a half-built report is worse than a
+      slightly old CLI.
 
 .NOTES
-  Run:  powershell -ExecutionPolicy Bypass -File scripts\preflight.ps1
+  Run:  powershell -ExecutionPolicy Bypass -File scripts\preflight.ps1 [-Update]
   Exit: 0 if every CRITICAL + RECOMMENDED item is present; 1 if any is missing.
 #>
 #Requires -Version 5.1
+param([switch]$Update)
 
 $ErrorActionPreference = 'SilentlyContinue'
 $copilot = Join-Path $HOME '.copilot'
@@ -50,9 +63,17 @@ function Add-Cli([string]$Cmd, [string]$Tier, [string]$Hint) {
 $py = Get-Command python -ErrorAction SilentlyContinue
 if ($py) {
     $ver = (& python --version 2>&1) -replace 'Python\s*', ''
-    Add-Check 'Python >= 3.11' 'critical' $true $ver
+    # Actually compare - a bare $true here let Python 3.9 (or the Store alias stub, which prints nothing)
+    # report OK while pyproject.toml requires >=3.11.
+    $pyOk = $false
+    try { $pyOk = [version](($ver -split '\s')[0]) -ge [version]'3.11' } catch { $pyOk = $false }
+    Add-Check 'Python >= 3.11' 'critical' $pyOk `
+        $(if ($ver) { $ver } else { 'no version reported (Microsoft Store alias stub?)' }) `
+        'Install Python 3.11+ (pyproject requires >=3.11); ensure it precedes the Store alias on PATH.'
     foreach ($m in @(
+            @('lxml', 'critical', 'uv sync - the deterministic parser imports lxml.etree.'),
             @('jsonschema', 'critical', 'uv add jsonschema (validates migration-spec.json against the schema).'),
+            @('tableauhyperapi', 'optional', 'uv sync --extra extract (materializes .hyper extracts to CSV).'),
             @('playwright', 'optional', 'uv add playwright (harvester + validator screenshots).'),
             @('PIL', 'optional', 'uv add pillow (showcase gallery composition).'))) {
         & python -c "import $($m[0])" 2>$null
@@ -63,7 +84,63 @@ else {
     Add-Check 'Python >= 3.11' 'critical' $false 'not on PATH' 'Install Python 3.11+ (the deterministic parser and all scripts/ need it).'
 }
 
-Add-Cli 'powerbi-report-author' 'critical' 'Ships with the powerbi-authoring plugin; provides validate + catalog/formatting describe.'
+Add-Cli 'powerbi-report-author' 'critical' 'npm install -g @microsoft/powerbi-report-authoring-cli (needs Node >= 20); provides validate + catalog/formatting/preview-*.'
+
+# --- npm CLI versions: correctness FLOOR + known-good matrix (see AGENTS.md) ---
+# These CLIs are unpinned GLOBAL installs (the official skill installs them with @latest), so they can
+# change under you without any repo diff. Two distinct thresholds:
+#   * FLOOR      - below this is a CORRECTNESS bug, not a nicety. powerbi-report-author < 0.1.4 returns
+#                  errorCount:0 for PBIR that Desktop cannot open (e.g. report.json missing the
+#                  schema-required `reportVersionAtImport`) -- a stale CLI silently green-lights a
+#                  broken report. `-Update` repairs this, and only this.
+#   * KNOWN-GOOD - the version the agent Gotchas were verified against. ABOVE it is not an error, but
+#                  it does mean version-specific prose may be stale -> WARN, don't "fix" it.
+$cliFloor     = @{ 'powerbi-report-author' = '0.1.4'; 'powerbi-desktop' = '0.1.2' }
+$cliKnownGood = @{ 'powerbi-report-author' = '0.1.4'; 'powerbi-desktop' = '0.1.2' }
+$cliPackage   = @{ 'powerbi-report-author' = '@microsoft/powerbi-report-authoring-cli'
+                   'powerbi-desktop'       = '@microsoft/powerbi-desktop-bridge-cli' }
+
+function Get-CliVersion([string]$Cmd) {
+    if (-not (Get-Command $Cmd -ErrorAction SilentlyContinue)) { return $null }
+    $raw = (& $Cmd --version 2>&1 | Select-Object -First 1) -replace '[^0-9.]', ''
+    if ($raw -match '^\d+(\.\d+)+$') { return $raw } else { return $null }
+}
+
+foreach ($cliName in $cliFloor.Keys) {
+    $actual = Get-CliVersion $cliName
+    if (-not $actual) { continue }
+
+    # -Update: repair ONLY a below-floor install. Never a blind upgrade to @latest.
+    if ($Update -and ([version]$actual -lt [version]$cliFloor[$cliName])) {
+        Write-Host ("  [..  ] $cliName $actual is below the {0} correctness floor - upgrading ..." -f $cliFloor[$cliName])
+        & npm install -g "$($cliPackage[$cliName])@latest" 2>&1 | Out-Null
+        $actual = (Get-CliVersion $cliName), $actual | Where-Object { $_ } | Select-Object -First 1
+    }
+
+    $floorOk = [version]$actual -ge [version]$cliFloor[$cliName]
+    $drifted = $floorOk -and ([version]$actual -ne [version]$cliKnownGood[$cliName])
+    $detail = if (-not $floorOk) { "$actual is BELOW the $($cliFloor[$cliName]) correctness floor" }
+              elseif ($drifted)  { "$actual (above known-good $($cliKnownGood[$cliName]))" }
+              else               { "$actual (known-good)" }
+    $hint = if (-not $floorOk) {
+        "Run this script with -Update at SESSION START, or: npm install -g $($cliPackage[$cliName])@latest"
+    } else {
+        "Version moved past the matrix in AGENTS.md - re-verify the version-specific Gotchas in .github/agents/ before trusting them."
+    }
+    # Below the floor is a real (recommended-tier) failure; above known-good is only an advisory.
+    Add-Check "version: $cliName" $(if ($floorOk) { 'optional' } else { 'recommended' }) $(-not $drifted -and $floorOk) $detail $hint
+}
+
+# --- PBIR JSON-schema reachability (does `validate` actually run its schema layer this session?) ---
+# `validate` reports 0 errors even when it could NOT fetch the visualContainer schema (PBIR_SCHEMA_UNREACHABLE),
+# so this answers mechanically whether a green validate means "schema-checked" or only "structure-checked".
+if (Get-Command 'powerbi-report-author' -ErrorAction SilentlyContinue) {
+    $doc = & powerbi-report-author doctor 2>&1 | Out-String
+    $docOk = $doc -match '"ok"\s*:\s*true'
+    Add-Check 'powerbi-report-author doctor' 'optional' $docOk `
+        $(if ($docOk) { 'self-checks OK (node, ajv, metadata provider)' } else { 'doctor reported a problem' }) `
+        'Run `powerbi-report-author doctor` for detail. If schema fetch fails, treat a 0-error `validate` as STRUCTURE-ONLY (see AGENTS.md).'
+}
 
 # --- Fabric/Power BI skill plugin ---
 $cfg = Read-CopilotJson 'config.json'
@@ -86,7 +163,7 @@ foreach ($srv in @(@('powerbi-modeling-mcp', 'recommended'), @('powerbi-remote',
 }
 
 Add-Cli 'npx' 'recommended' 'Install Node.js; npx runs the powerbi-modeling MCP and the Desktop Bridge CLI.'
-Add-Cli 'powerbi-desktop' 'recommended' 'Desktop Bridge CLI (@microsoft/powerbi-desktop-bridge-cli) for open/reload/screenshot verification.'
+Add-Cli 'powerbi-desktop' 'recommended' 'npm install -g @microsoft/powerbi-desktop-bridge-cli - Desktop Bridge for open/reload/screenshot verification.'
 
 # --- Power BI Desktop (Windows-only; this is why the bootstrap is PowerShell) ---
 $desktop = $null
@@ -103,11 +180,12 @@ Add-Check 'Power BI Desktop' 'recommended' ([bool]$desktop) `
     $(if ($desktop) { $desktop } else { 'not found' }) `
     'Install Power BI Desktop (Store/MSIX preferred) - needed for the refresh + screenshot verification loop.'
 
-# --- TOM refresh DLL ---
-$tom = Get-ChildItem (Join-Path $copilot 'installed-plugins') -Recurse -Filter 'Microsoft.AnalysisServices.Tabular.dll' -ErrorAction SilentlyContinue | Select-Object -First 1
-Add-Check 'TOM DLL (Tabular)' 'recommended' ($null -ne $tom) `
-    $(if ($tom) { $tom.FullName } else { 'not found under ~/.copilot/installed-plugins' }) `
-    'Ships with the semantic-model-authoring skill (TabularEditor bundle); used for the local Desktop refresh workaround.'
+# --- .NET SDK (builds scripts/tmdl_validate for offline TMDL deserialization) ---
+# NOTE: this replaced an older check for Microsoft.AnalysisServices.Tabular.dll under
+# ~/.copilot/installed-plugins. The powerbi-authoring plugin no longer bundles Tabular Editor, so that
+# check could never pass. TOM now comes from the NuGet package Microsoft.AnalysisServices.NetCore.retail.amd64,
+# restored by the tmdl_validate project - so the real machine dependency is the .NET SDK.
+Add-Cli 'dotnet' 'recommended' 'Install the .NET SDK - needed to build/run the offline TMDL structural validator (tmdl_validate).'
 
 Add-Cli 'uv' 'optional' 'Install uv for env/dependency management (uv venv && uv sync).'
 Add-Cli 'az' 'optional' 'Azure CLI - only for Fabric REST / token-based operations.'

--- a/scripts/probe_desktop_query.py
+++ b/scripts/probe_desktop_query.py
@@ -50,6 +50,7 @@ def _load_adomd():
             # treated as a name and fails), so add the dir first, then reference by simple name.
             if str(dll.parent) not in sys.path:
                 sys.path.append(str(dll.parent))
+            # pylint: disable-next=no-member  # clr's members are generated at runtime by pythonnet
             clr.AddReference(dll.stem)
             from Microsoft.AnalysisServices.AdomdClient import AdomdConnection
 


### PR DESCRIPTION
Triggered by upgrading the Power BI npm CLIs (`powerbi-report-authoring-cli` 0.1.1 → **0.1.4**, `powerbi-desktop-bridge-cli` 0.1.1 → **0.1.2**). Reviewed with **two independent models** (Claude Opus 5 + GPT-5.6 Sol, deep-dive pass scoped to the agents). Every change below is backed by a `file:line` citation or an empirical probe.

## Fresh-clone blockers
- **`preflight.ps1` exited 1 on a correctly configured machine** — it searched for a TOM DLL the updated plugin no longer bundles, and the orchestrator is told to *stop* on non-zero, so the toolkit was self-blocking. The real dependency is the **.NET SDK** (`tmdl_validate` restores TOM from NuGet). Now exits 0.
- **The npm CLIs are not bundled with the plugin** and nothing told users to install them → circular dead-end. Added the `npm install -g` step + a known-good version matrix.
- **README `uv sync`** skipped the extras that documented scripts import → `ModuleNotFoundError`.

## Session-start update policy (correctness floor, not blind `@latest`)
`preflight.ps1 -Update` repairs the bridge CLIs **only when below the floor** (`report-author >= 0.1.4`), so it no-ops and costs nothing when current. Above the known-good matrix is a **WARN**, not an error — that's exactly when version-specific agent Gotchas need re-verification.

| When | Run | Why |
|---|---|---|
| Session start | `-Update` | Safe; the floor is a correctness floor |
| Migration start | plain | Confirm READY without swapping tooling mid-flow |
| Mid-migration | never | Swapping the validator under a half-built report is worse than a slightly old one |

Added **`.github/copilot-instructions.md`** — VS Code Copilot loads that path, not `AGENTS.md`, so without it the whole convention layer silently vanished in VS Code.

## Agent correctness (deep-dive findings)
- **LOD / table calcs routed to the wrong guide sections** (`§3/§4` = Field Parameters/CP-PP; correct is **`§5/§6`**) — the highest-risk translations were sent to the wrong page.
- **Validator's numeric pass required a *published* model**, but the default flow never publishes → silently degraded to reading numbers off screenshots. Named the offline path (modeling MCP `ConnectFolder` + `dax_query_operations`, `probe_desktop_query.py`). Same fix for the semantic builder, whose "Deploy" step was a phantom precondition nullifying its own strongest DoD item.
- **`pbi-report-builder` had no DAX tool** despite its own DoD requiring value sampling via DAX.
- **`referenced_fields`** described as ordered in the workflow, unordered in the Gotchas → non-commutative formulas could be rebuilt wrong.
- **Validator inventory required every worksheet on every dashboard** → false-fails any multi-dashboard workbook. Now scoped per dashboard zone tree.
- **Sign-off ignored a negative whole-dashboard verdict** when all findings were low/medium; the 2–3 round retry cap no longer launders unfixed bugs into "accepted limitations" without product evidence.
- **Step 2 re-parsed unconditionally**, wiping 20–50 agent-appended limitations on any re-run.
- **Agents never knew `scripts/capture_tableau_reference.py` existed** (incl. its `manual` provider), so the validator would refuse private/non-public workbooks.

## Cookbook vs the upgraded CLI (measured)
Swept all 28 entries against `catalog describe`: **19** match the CLI exactly (cached output, zero drift), **6** are idioms the CLI can't know (`VISUAL_TYPE_UNKNOWN`), **3** carry render truth. Documented which are worth a lookup.

Canonical proof that **CLI vocabulary ≠ render truth**: `catalog describe actionButton` reports `"deprecated": false` with a `text` object, while Desktop draws a **blank rectangle** and `validate` returns 0 errors.

## Repo hygiene
- **`uv.lock` gitignored** — `uv` resolves against internal Microsoft feeds here; committing it would leak infra URLs and break every external clone.
- `ruff` excludes generated `migrations/` artifacts; `pylint` `duplicate-code` disabled for independent CLI scripts. Both documented dev commands now pass.
- Corrected stale claims: bridge verb lists, `.github/skills/`, catalog type count, Gauge contradiction, unqualified `conditional-formatting.md`.

## Verification
**20/20 parser tests · ruff clean · pylint 10.00/10 · preflight exit 0 (plain and `-Update`).**

Cloud/publishing work (`bind_cloud_credential.py`, the service-gate false-green fix) is intentionally **not** in this PR — parked per prior decision.
