### PR TITLE
Support Tableau published data sources (sqlproxy) and standalone .tds/.tdsx

### DIFF
--- a/.github/agents/pbi-semantic-builder.agent.md
+++ b/.github/agents/pbi-semantic-builder.agent.md
@@ -48,6 +48,22 @@ field is used inside an aggregated shelf reference (`sum:`, `avg:` prefix in the
 
 ## Workflow
 
+0. **Published data source? Check for an existing shared model BEFORE building anything.** If the spec
+   has `data_sources[].published_datasource` (Tableau connection class `sqlproxy`), this workbook only
+   *points at* a server-side datasource that is typically shared by several workbooks. The correct
+   Power BI shape is **one semantic model, many reports bound to it** — not a near-duplicate model per
+   workbook. Run:
+   ```
+   python scripts/published_datasource_registry.py --spec migrations/<slug>/migration-spec.json
+   ```
+   - **exit 0 (already migrated):** do **NOT** rebuild. Reuse the semantic model it names; add only
+     measures this workbook genuinely needs that the shared model lacks, and report back that you
+     reused it. A duplicate model will drift from the shared one — that is the whole failure mode.
+   - **exit 1 (not yet built):** build it **once**, here, so later workbooks reuse it.
+   Also note the workbook does **not** contain that datasource's own calculated-field formulas (they
+   live server-side). If the orchestrator supplied a parsed `.tds`/`.tdsx` spec, treat **it** as the
+   authoritative field/calculation source; if it didn't, say so rather than silently modelling only the
+   partial set visible in the workbook.
 1. **Load and validate** `migration-spec.json` against `docs/migration-spec.schema.json` (the parser
    already did this, but re-validate if you're consuming a hand-edited spec).
 2. **Decide data materialization for extract-based sources.** Every `data_sources[].connection.mode ==

--- a/.github/agents/tableau-migrator.agent.md
+++ b/.github/agents/tableau-migrator.agent.md
@@ -67,7 +67,7 @@ it must show up in `limitations_encountered`, not be silently dropped.
    `migrations/<name>/migration-spec.json` already exists, **do not re-run the parser** without asking.
    Re-parsing **overwrites the file in place** and destroys every `semantic_build` / `report_build` /
    `validate` limitation the subagents appended to it (routinely 20-50 entries) — i.e. exactly the raw
-   material step 10's summary depends on. On a re-run, fix round, or resumed session, skip to step 3.
+   material step 11's summary depends on. On a re-run, fix round, or resumed session, skip to step 3.
    Only when the spec is absent (or the user explicitly confirms a re-parse of a changed source) run:
    ```
    python scripts/parse_tableau.py migrations/<name>/source/<file>.twbx -o migrations/<name>/migration-spec.json
@@ -81,7 +81,30 @@ it must show up in `limitations_encountered`, not be silently dropped.
    Tableau Groups — see `docs/tableau-dax-translation-guide.md` §6 for table calcs; **Tableau Groups are
    not yet covered by the guide** — translate them as a mapped calculated column and log a limitation).
    Don't proceed silently past high-severity items without flagging them.
-4. **Data-source credential preflight (MANDATORY before building — do not skip for live sources).** Run
+4. **Published data source check (MANDATORY when the parser flags one).** If any high-severity
+   limitation says **PUBLISHED Tableau data source** (connection class `sqlproxy`), the workbook only
+   *points at* a server-side datasource. Two consequences, both must be handled before building:
+   - **(a) The workbook is missing metadata.** That datasource's connection details, custom SQL and
+     calculated-field formulas live on the server, **not** in this `.twb` — so the spec you just parsed
+     under-reports them. (Calcs the author added *on top of* the published source DO appear, which
+     makes the gap partial and easy to miss.) **Ask the user to export the published data source
+     (`.tds`/`.tdsx`) from Tableau Server/Cloud** — *Server > Open Data Source*, or download it from
+     the datasource's page — then parse it too:
+     `python scripts/parse_tableau.py <exported>.tds -o migrations/<name>/datasource-spec.json`.
+     Treat that spec's fields/calculations as the authoritative model definition.
+   - **(b) One datasource is usually shared by MANY workbooks.** That maps onto **one Power BI semantic
+     model with many reports bound to it** — never one near-identical model per workbook. Before
+     delegating the build, run:
+     ```
+     python scripts/published_datasource_registry.py --spec migrations/<name>/migration-spec.json
+     ```
+     It matches the parser's stable dedup key (`published_datasource.key`, e.g. `finance/salesmaster`)
+     across every migration in the repo. Exit **0** = already built elsewhere → tell
+     `pbi-report-builder` to **bind to that existing semantic model** and tell `pbi-semantic-builder`
+     to add only genuinely-new measures; exit **1** = not yet built → build it **once** here, so later
+     workbooks reuse it. Rebuilding a duplicate model that then drifts from the shared one is the
+     failure this check exists to prevent.
+5. **Data-source credential preflight (MANDATORY before building — do not skip for live sources).** Run
    `python scripts/preflight_source_credentials.py --spec migrations/<name>/migration-spec.json`. If it
    reports **only** extract/flat sources, there is no credential gate (data comes from CSV + a
    `DataFolder`); proceed. If it flags any **live database** source (`needs-credential`), STOP and tell
@@ -100,24 +123,24 @@ it must show up in `limitations_encountered`, not be silently dropped.
    false `CREDENTIAL_PRESENT` for a *serverless* source that cold-starts and shows the sign-in modal only
    after the probe's timeout (confirmed 2026-07). It proves credentials + source reachability + valid M
    in one shot, entirely locally (no publish needed).
-5. **Delegate to `pbi-semantic-builder`** with: the path to `migration-spec.json`, the target Fabric
+6. **Delegate to `pbi-semantic-builder`** with: the path to `migration-spec.json`, the target Fabric
    workspace/workspace-to-be, and any user preference on extract data materialization. Wait for it to
    report back the semantic model location and any new limitations it appended.
-6. **Delegate to `pbi-report-builder`** with: the path to `migration-spec.json`, the semantic model
-   location from step 5, **and the Tableau reference bundle** (`migrations/<name>/reference/` — its
+7. **Delegate to `pbi-report-builder`** with: the path to `migration-spec.json`, the semantic model
+   location from step 6, **and the Tableau reference bundle** (`migrations/<name>/reference/` — its
    step 4 skeleton gate compares against the source dashboard image, so it cannot run without this;
    capture it first with `python scripts/capture_tableau_reference.py migrations/<name> …` if the
    folder is empty). Wait for it to report back the report location and any new limitations.
-7. **Delegate to `pbi-migration-validator`** with: `migration-spec.json`, the Tableau reference bundle
+8. **Delegate to `pbi-migration-validator`** with: `migration-spec.json`, the Tableau reference bundle
    at `migrations/<name>/reference/` (capture it first with
    `python scripts/capture_tableau_reference.py migrations/<name> [--public-url … --view …]`; it has a
    **`manual` provider** for workbooks that are not on Tableau Public — see `docs/reference-capture.md`),
    and the model/report locations. Use **spot-check mode** for a single
    page/visual you're actively iterating on, and **full-migration sign-off mode** (optionally
-   multi-model) as the final gate before sign-off (step 9). This is not optional or "nice to have" — it's the
+   multi-model) as the final gate before sign-off (step 10). This is not optional or "nice to have" — it's the
    step that actually closes the loop between "the subagents reported success" and "it's verifiably
    faithful to the source."
-8. **Route every discrepancy the validator reports back to its owning subagent** — numeric/DAX issues
+9. **Route every discrepancy the validator reports back to its owning subagent** — numeric/DAX issues
    to `pbi-semantic-builder`, visual/layout issues to `pbi-report-builder`, genuine capability gaps to
    `limitations_encountered` (not a fix request to anyone). **Never fix a validator finding yourself**
    — same rule as the ad hoc-edit Gotcha below, now applying to the validator's output too. Re-run the
@@ -128,23 +151,23 @@ it must show up in `limitations_encountered`, not be silently dropped.
    Otherwise it stays **open/blocking** and you surface it to the user for an explicit decision.
    **You (the orchestrator) are the only writer of `stage:"validate"` entries** in
    `limitations_encountered` — the validator is read-only and must never edit the spec.
-9. **Validate before declaring done.** Structural/mechanical validation is part of the default flow,
+10. **Validate before declaring done.** Structural/mechanical validation is part of the default flow,
    not a phase-2 nice-to-have — confirm both build subagents ran their own "Mandatory validation"
    steps (see each subagent's own agent file) *and* that `pbi-migration-validator` has run a full
    sign-off pass. **Sign-off requires ALL of:** (a) every dashboard's whole-dashboard verdict is
    *faithful* — a "no" verdict blocks sign-off **even when every individual discrepancy is only
    low/medium**, since the validator explicitly allows an accumulation of small deviations to fail the
    gestalt; (b) no open high-severity discrepancies; (c) any remaining item is an *evidenced* accepted
-   limitation (see step 8), not merely an unresolved one. "The parser ran and the subagents reported
+   limitation (see step 9), not merely an unresolved one. "The parser ran and the subagents reported
    success" is not the same thing as "it was validated" — don't let it substitute for an actual
    validation pass.
-10. **Summarize the migration** for the user: what was built (tables/measures/pages/visuals counts),
+11. **Summarize the migration** for the user: what was built (tables/measures/pages/visuals counts),
     what was *simplified* rather than transliterated (parameter-equality filters → slicers, pivot
     string-parsing → Power Query unpivot — these are positive findings, present them as such), what the
     validator's sign-off pass found and how it was resolved, and the final consolidated
     `limitations_encountered` as a "what needs your review" list. This is the answer to "what are the
     limitations of AI-assisted migration" — be concrete and honest, not hand-wavy.
-11. **(Phase 2 / on request)** Delegate to `pbi-deployer` to publish to a Fabric workspace and run
+12. **(Phase 2 / on request)** Delegate to `pbi-deployer` to publish to a Fabric workspace and run
     validation. Not part of the default flow until that agent exists.
 
 ## Delegating to subagents

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 &nbsp;![Microsoft Fabric](https://img.shields.io/badge/Microsoft_Fabric-117865)
 &nbsp;![GitHub Copilot](https://img.shields.io/badge/GitHub_Copilot-000000?logo=githubcopilot&logoColor=white)
 &nbsp;![Migrations](https://img.shields.io/badge/migrations-16-2ea44f)
-&nbsp;![Parser tests](https://img.shields.io/badge/parser_tests-20%2F20-2ea44f)
+&nbsp;![Parser tests](https://img.shields.io/badge/parser_tests-26%2F26-2ea44f)
 
 **[Showcase](docs/showcase/README.md)** &nbsp;·&nbsp; **[How it works](#how-it-works)** &nbsp;·&nbsp; **[Quickstart](#quickstart)** &nbsp;·&nbsp; **[Capabilities &amp; limits](docs/capabilities-and-limitations.md)**
 
@@ -73,7 +73,10 @@ original dashboards belongs to their respective Tableau Public authors.
 - **Deterministic Tableau parser + spec schema** (`scripts/parse_tableau.py`): extracts every data
   source, field, calculated-field formula, worksheet encoding, dashboard layout, reference line, and
   theme from the raw `.twb` XML into a normalized, schema-defined `migration-spec.json`
-  (see [`docs/migration-spec.md`](docs/migration-spec.md)). Covered by a 20-test `pytest` suite.
+  (see [`docs/migration-spec.md`](docs/migration-spec.md)). Also accepts a standalone `.tds`/`.tdsx`
+  data source, and flags Tableau **published** data sources (`sqlproxy`) with a stable dedup key so one
+  shared datasource becomes **one** semantic model instead of a duplicate per workbook
+  (`scripts/published_datasource_registry.py`). Covered by a 26-test `pytest` suite.
 - **Four Copilot CLI agents** (`.github/agents/`):
   - `tableau-migrator`: the orchestrator. Runs preflight, then coordinates the three subagents.
   - `pbi-semantic-builder`: translates the spec's calculated fields to DAX and builds the Fabric TMDL

--- a/docs/capabilities-and-limitations.md
+++ b/docs/capabilities-and-limitations.md
@@ -14,7 +14,7 @@ observed on a specific workbook, that workbook's slug is cited so the claim is c
 1. **Structural extraction (deterministic, reliable).** `scripts/parse_tableau.py` captures every data
    source, field, calculated-field formula, worksheet encoding, dashboard layout element, and reference
    line from the raw `.twb` XML into a normalized `migration-spec.json`. This runs with zero manual
-   effort on all 16 workbooks and is covered by a 20-test `pytest` suite, so it is the reproducible
+   effort on all 16 workbooks and is covered by a 26-test `pytest` suite, so it is the reproducible
    foundation the fuzzy AI steps build on.
 2. **Real data extraction from `.hyper` extracts.** `scripts/extract_hyper_data.py` pulls actual row
    data out of packaged extracts via `tableauhyperapi`, so a migrated model shows real numbers rather

--- a/docs/migration-spec.md
+++ b/docs/migration-spec.md
@@ -64,6 +64,23 @@ far more reliable than asking an LLM to re-derive this structure from raw XML on
   Y-axis field per measure on a clustered column chart) instead of trying to recreate a literal pivot
   column. `pivoted_field_ids` is empty when no resolvable filter was found (e.g. the idiom is used
   purely for text-table labeling) — that case needs a manual look at the worksheet's shelves/tooltip.
+- **`published_datasource` (Tableau PUBLISHED data sources).** Present only when a workbook merely
+  *points at* a server-side datasource (connection `class: sqlproxy` + a datasource-scoped
+  `<repository-location>`). Two things follow, and both are easy to get wrong:
+  - **The workbook is an incomplete source of truth.** That datasource's connection details, custom SQL
+    and calculated-field formulas live on Tableau Server/Cloud, *not* in the `.twb`. Calcs the author
+    added on top of it *do* appear, so the gap is partial and silent. Export the `.tds`/`.tdsx` and
+    parse it too — `parse_tableau.py` accepts both (a `.tds` has `<datasource>` as its root and simply
+    yields no worksheets/dashboards).
+  - **`key` is a stable dedup identity** (`<site>/<name>`, lowercased, excluding revision + host).
+    One published datasource usually feeds MANY workbooks, which should become **one Power BI semantic
+    model with many reports bound to it**, not a near-duplicate model each time.
+    `scripts/published_datasource_registry.py` indexes this key across all migrations so the
+    orchestrator can reuse an existing model. The name is resolved from `derived-from` → connection
+    `dbname` → `repository-location@id`, in that order, because `@id` can go stale: a real Tableau
+    Cloud workbook was found carrying `id='new'` after its datasource was renamed to `dandan003`, and
+    keying on `@id` would have split one shared datasource into two keys. `name_source` records which
+    attribute won and `id_attribute` preserves the raw (possibly stale) `@id` for audit.
 - **`connection.mode`.** The EEA workbook's 7 datasources are all `.hyper` extracts (`mode: extract`,
   no live DB) — real rows must be pulled from the embedded `.hyper` file via `tableauhyperapi` (see
   `scripts/extract_hyper_data.py`). Real-world workbooks may have `mode: live` connections instead;

--- a/docs/migration-spec.schema.json
+++ b/docs/migration-spec.schema.json
@@ -55,6 +55,20 @@
               "note": { "type": ["string", "null"] }
             }
           },
+          "published_datasource": {
+            "type": "object",
+            "description": "Present only when this datasource is a Tableau PUBLISHED (server-side) data source that the workbook merely points at (connection class 'sqlproxy'). Its calculated fields / custom SQL live server-side, so the exported .tds/.tdsx is required for complete coverage. Several workbooks commonly share one published datasource - migrate it once to a single semantic model and rebind downstream reports.",
+            "properties": {
+              "id": { "type": ["string", "null"], "description": "Published data source name on the server" },
+              "site": { "type": ["string", "null"], "description": "Tableau site the datasource lives on" },
+              "path": { "type": ["string", "null"] },
+              "derived_from": { "type": ["string", "null"], "description": "Full server URL it was derived from" },
+              "revision": { "type": ["string", "null"] },
+              "name_source": { "type": ["string", "null"], "description": "Which attribute the name was resolved from: derived-from | connection.dbname | repository-location.id (in precedence order)" },
+              "id_attribute": { "type": ["string", "null"], "description": "Raw repository-location@id. When it differs from `id`, the server-side datasource was renamed after this workbook was published and this value is stale." },
+              "key": { "type": ["string", "null"], "description": "Stable dedup identity '<site>/<name>' (lowercased, excludes revision + host) - the key to match the SAME published datasource across multiple workbooks so it is migrated to ONE shared semantic model" }
+            }
+          },
           "tables": {
             "type": "array",
             "items": {

--- a/scripts/parse_tableau.py
+++ b/scripts/parse_tableau.py
@@ -1,8 +1,9 @@
 """
-purpose: Parse a Tableau workbook (.twb / .twbx) into migration-spec.json, the normalized
+purpose: Parse a Tableau workbook (.twb / .twbx) or standalone data source (.tds / .tdsx) into
+         migration-spec.json, the normalized
          intermediate representation consumed by the pbi-semantic-builder and pbi-report-builder
          subagents. See docs/migration-spec.md for the schema and design rationale.
-usage:   python scripts/parse_tableau.py <workbook.twb|workbook.twbx> -o <migration-spec.json>
+usage:   python scripts/parse_tableau.py <workbook.twb|.twbx|datasource.tds|.tdsx> -o <migration-spec.json>
 """
 
 from __future__ import annotations
@@ -51,20 +52,38 @@ class IdRegistry:
         return base if count == 0 else f"{base}_{count}"
 
 
+def _wrap_datasource_as_workbook(ds_el: etree._Element) -> etree._Element:
+    """Wrap a standalone `<datasource>` root (a .tds/.tdsx) in a synthetic `<workbook><datasources>`
+    shell so every downstream `datasources/datasource` lookup works unchanged. A .tds legitimately has
+    no worksheets or dashboards, so those parse to empty lists."""
+    workbook = etree.Element("workbook")
+    datasources = etree.SubElement(workbook, "datasources")
+    datasources.append(ds_el)
+    return workbook
+
+
 def load_twb_root(path: Path) -> tuple[etree._Element, dict[str, str]]:
-    """Return the parsed .twb XML root, plus a map of hyper-file relative paths found in the archive
-    (empty if the input is a plain .twb with no packaged extracts)."""
+    """Return the parsed Tableau XML root, plus a map of hyper-file relative paths found in the archive
+    (empty for a plain .twb/.tds with no packaged extracts).
+
+    Accepts a workbook (.twb/.twbx) or a standalone data source (.tds/.tdsx). The latter matters for
+    PUBLISHED data sources: a workbook that points at one (connection class 'sqlproxy') does NOT carry
+    that datasource's calculated fields, so the exported .tds must be parsed to see them."""
+    suffix = path.suffix.lower()
     hyper_files: dict[str, str] = {}
-    if path.suffix.lower() == ".twbx":
+    if suffix in (".twbx", ".tdsx"):
+        inner_ext = ".twb" if suffix == ".twbx" else ".tds"
         with zipfile.ZipFile(path) as zf:
-            twb_names = [n for n in zf.namelist() if n.lower().endswith(".twb")]
-            if not twb_names:
-                raise ValueError(f"No .twb found inside {path}")
-            xml_bytes = zf.read(twb_names[0])
+            inner_names = [n for n in zf.namelist() if n.lower().endswith(inner_ext)]
+            if not inner_names:
+                raise ValueError(f"No {inner_ext} found inside {path}")
+            xml_bytes = zf.read(inner_names[0])
             hyper_files = {Path(n).name: n for n in zf.namelist() if n.lower().endswith(".hyper")}
     else:
         xml_bytes = path.read_bytes()
     root = etree.fromstring(xml_bytes)
+    if root.tag == "datasource":
+        root = _wrap_datasource_as_workbook(root)
     return root, hyper_files
 
 
@@ -127,6 +146,82 @@ def _parse_connection(ds_el: etree._Element, hyper_files: dict[str, str]) -> dic
 
 
 _CONTAINER_RELATION_TYPES = {"collection", "join", "union"}
+
+
+def _published_ds_name(repo: etree._Element, connection: dict[str, Any]) -> tuple[str | None, str]:
+    """Resolve the published datasource's real name, and say which attribute it came from.
+
+    Precedence is deliberate, and was derived from real published workbooks:
+      1. the last path segment of `derived-from` (the authoritative publish URL);
+      2. the sqlproxy connection's `dbname`;
+      3. the `repository-location@id` attribute -- LAST, because it can go stale.
+    Real-world evidence: a Tableau Cloud workbook published against datasource `dandan003` carried
+    `id='new'` (a leftover from a rename) while `derived-from`, `dbname` and `caption` all agreed on
+    `dandan003`. Keying on `id` would have given two workbooks that share ONE datasource two different
+    keys -- defeating the de-duplication this key exists for.
+    """
+    derived = repo.get("derived-from")
+    if derived:
+        segment = derived.split("?")[0].rstrip("/").rsplit("/", 1)[-1]
+        if segment:
+            return segment, "derived-from"
+    dbname = connection.get("database")
+    if dbname:
+        return dbname, "connection.dbname"
+    return repo.get("id"), "repository-location.id"
+
+
+def _parse_published_datasource(ds_el: etree._Element, connection: dict[str, Any]) -> dict[str, Any] | None:
+    """Identify a Tableau *published* (server-side) datasource the workbook merely points at.
+
+    A workbook that connects to a Published Data Source carries `connection class='sqlproxy'` plus a
+    `<repository-location>` naming the server-side datasource. The datasource's own metadata -- its
+    connection details, custom SQL and (critically) its calculated-field formulas -- live centrally in
+    that published datasource, NOT in this .twb, so parsing the workbook alone silently under-reports
+    them. The exported `.tds`/`.tdsx` is required for complete coverage.
+
+    Returns None for ordinary embedded datasources.
+
+    The `key` is a STABLE identity (site + datasource name, lowercased) deliberately excluding
+    `revision` and the server host: it is what lets the orchestrator recognise that several workbooks
+    share ONE published datasource and bind them all to a single Power BI semantic model instead of
+    rebuilding an identical model per workbook.
+    """
+    conn_classes = {c.get("class") for c in ds_el.iter("connection")}
+    repo = ds_el.find("repository-location")
+    # A standalone .tds carries an EMPTY `<repository-location />` placeholder even when the datasource
+    # is not published at all (verified against tableau/document-api-python's datasource_test.tds), so
+    # an element alone proves nothing -- require real server identity, or a sqlproxy connection.
+    has_repo_identity = repo is not None and bool(repo.get("id") or repo.get("derived-from"))
+    if "sqlproxy" not in conn_classes and not has_repo_identity:
+        return None
+    if repo is None or not has_repo_identity:
+        return {
+            "id": None,
+            "site": None,
+            "path": None,
+            "derived_from": None,
+            "revision": None,
+            "key": None,
+            "name_source": None,
+            "id_attribute": None,
+        }
+
+    ds_name, name_source = _published_ds_name(repo, connection)
+    site = repo.get("site")
+    key_parts = [p for p in (site, ds_name) if p]
+    return {
+        "id": ds_name,
+        "site": site,
+        "path": repo.get("path"),
+        "derived_from": repo.get("derived-from"),
+        "revision": repo.get("revision"),
+        "key": "/".join(key_parts).lower() if key_parts else None,
+        "name_source": name_source,
+        # Kept for auditability: when this differs from `id`, the server-side datasource was renamed
+        # after this workbook was published, and `id` is the stale value.
+        "id_attribute": repo.get("id"),
+    }
 
 
 def _collect_leaf_relations(rel: etree._Element) -> list[etree._Element]:
@@ -333,15 +428,19 @@ def _parse_single_data_source(
         if ci.get("column", "") in name_to_id
     }
 
+    connection = _parse_connection(ds_el, hyper_files)
     data_source = {
         "id": ds_id,
         "caption": caption,
         "internal_name": internal_name,
-        "connection": _parse_connection(ds_el, hyper_files),
+        "connection": connection,
         "tables": tables,
         "joins": _parse_joins(ds_el),
         "fields": fields,
     }
+    published = _parse_published_datasource(ds_el, connection)
+    if published is not None:
+        data_source["published_datasource"] = published
     return data_source, internal_name, instance_map, name_to_id
 
 
@@ -883,6 +982,31 @@ def collect_limitations(spec: dict[str, Any]) -> list[dict[str, Any]]:
     shelf references) and emit limitations_encountered entries for the honest capabilities writeup."""
     limitations = []
     for ds in spec["data_sources"]:
+        published = ds.get("published_datasource")
+        if published:
+            name = published.get("id") or ds.get("caption") or ds["id"]
+            site = published.get("site") or "?"
+            key = published.get("key") or "unknown"
+            limitations.append(
+                {
+                    "item": ds["id"],
+                    "issue": (
+                        f"PUBLISHED Tableau data source ('{name}' on site '{site}', dedup key "
+                        f"'{key}'): this workbook only POINTS at a server-side datasource "
+                        "(connection class 'sqlproxy'). Its connection details, custom SQL and "
+                        "calculated-field formulas live in the published datasource, NOT in this "
+                        "workbook, so parsing the .twb alone under-reports them (workbook-local "
+                        "calcs built on top of it DO appear here, which makes the gap partial and "
+                        "easy to miss). ACTION: export the published data source (.tds/.tdsx) from "
+                        "Tableau Server/Cloud and parse it too. NOTE: several workbooks typically "
+                        "share ONE published datasource - migrate it ONCE to a single Power BI "
+                        "semantic model and bind every downstream report to that model; do not "
+                        "rebuild an identical model per workbook. Match on the dedup key above."
+                    ),
+                    "severity": "high",
+                    "stage": "parse",
+                }
+            )
         if ds["connection"]["mode"] == "extract":
             limitations.append(
                 {
@@ -982,7 +1106,7 @@ def validate_spec(spec: dict[str, Any], schema_path: Path) -> None:
 def main() -> None:
     """CLI entry point: parse the workbook given on the command line and write migration-spec.json."""
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("workbook", type=Path, help="Path to a .twb or .twbx file")
+    parser.add_argument("workbook", type=Path, help="Path to a .twb/.twbx workbook or .tds/.tdsx data source")
     parser.add_argument("-o", "--output", type=Path, required=True, help="Output migration-spec.json path")
     parser.add_argument(
         "--schema",

--- a/scripts/published_datasource_registry.py
+++ b/scripts/published_datasource_registry.py
@@ -1,0 +1,171 @@
+"""
+purpose: answer "has this Tableau PUBLISHED data source already been migrated?" before a semantic
+         model is rebuilt for it.
+
+         A Tableau Published Data Source (connection class 'sqlproxy') is typically shared by SEVERAL
+         downstream workbooks. The correct Power BI shape mirrors that: migrate the datasource ONCE
+         into a single semantic model, then bind every downstream report to that same model -- not one
+         near-identical model per workbook. The parser stamps a stable dedup key
+         (`data_sources[].published_datasource.key`, e.g. "finance/salesmaster") on every affected
+         spec; this script indexes those keys across all migrations so the orchestrator can reuse an
+         existing model instead of rebuilding it.
+
+         It derives everything from the committed migration-spec.json files, so there is no separate
+         registry file to keep in sync (and nothing to go stale).
+
+usage:   python scripts/published_datasource_registry.py --scan
+         python scripts/published_datasource_registry.py --key finance/salesmaster
+         python scripts/published_datasource_registry.py --spec migrations/<slug>/migration-spec.json
+
+Exit codes for --key / --spec: 0 = already migrated somewhere (reuse it), 1 = not yet migrated
+(build it once, in this migration), 2 = the spec has no published data source at all.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+log = logging.getLogger("published_datasource_registry")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MIGRATIONS_DIR = REPO_ROOT / "migrations"
+
+
+def _semantic_models(slug_dir: Path) -> list[Path]:
+    """Return the semantic model folders built for a migration (empty if none exist yet)."""
+    fabric = slug_dir / "fabric"
+    return sorted(p for p in fabric.glob("*.SemanticModel") if p.is_dir()) if fabric.is_dir() else []
+
+
+def _rel(path: Path) -> str:
+    """Repo-relative path when possible, else absolute (--migrations-dir may point outside the repo)."""
+    try:
+        return str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def build_index(migrations_dir: Path = MIGRATIONS_DIR) -> dict[str, list[dict[str, Any]]]:
+    """Map every published-datasource dedup key -> the migrations that consume it.
+
+    Each entry records whether that migration actually produced a semantic model, which is what makes
+    it a reuse candidate rather than merely another consumer.
+    """
+    index: dict[str, list[dict[str, Any]]] = {}
+    if not migrations_dir.is_dir():
+        return index
+    for spec_path in sorted(migrations_dir.glob("*/migration-spec.json")):
+        try:
+            spec = json.loads(spec_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            log.warning("  !  skipping unreadable spec %s (%s)", spec_path, exc)
+            continue
+        slug_dir = spec_path.parent
+        for ds in spec.get("data_sources", []):
+            published = ds.get("published_datasource") or {}
+            key = published.get("key")
+            if not key:
+                continue
+            index.setdefault(key, []).append(
+                {
+                    "slug": slug_dir.name,
+                    "name": published.get("id"),
+                    "site": published.get("site"),
+                    "semantic_models": [_rel(p) for p in _semantic_models(slug_dir)],
+                }
+            )
+    return index
+
+
+def _reuse_candidate(entries: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """Pick the first consumer that actually built a semantic model - that model is the one to reuse."""
+    return next((e for e in entries if e["semantic_models"]), None)
+
+
+def cmd_scan(migrations_dir: Path) -> int:
+    """Print every published data source found across all migrations and who consumes it."""
+    index = build_index(migrations_dir)
+    if not index:
+        log.info("No published (sqlproxy) data sources found in any migration-spec.json.")
+        log.info("All parsed workbooks use embedded data sources - no shared-model de-duplication needed.")
+        return 0
+    log.info("Published data sources across %d migration(s):", len(index))
+    for key, entries in sorted(index.items()):
+        first = entries[0]
+        log.info("\n  %s   (%s on site %s)", key, first["name"] or "?", first["site"] or "?")
+        for entry in entries:
+            models = ", ".join(entry["semantic_models"]) or "<no semantic model built>"
+            log.info("      - %-40s %s", entry["slug"], models)
+        if len(entries) > 1:
+            log.info("      => SHARED by %d workbooks: they must bind to ONE semantic model.", len(entries))
+    return 0
+
+
+def _report_key(key: str, migrations_dir: Path, exclude_slug: str | None = None) -> int:
+    """Look up one dedup key; tell the caller whether to reuse an existing model or build it."""
+    entries = [e for e in build_index(migrations_dir).get(key, []) if e["slug"] != exclude_slug]
+    candidate = _reuse_candidate(entries)
+    if candidate:
+        log.info("ALREADY MIGRATED: published data source '%s'", key)
+        log.info("  built in migration : %s", candidate["slug"])
+        for model in candidate["semantic_models"]:
+            log.info("  semantic model     : %s", model)
+        log.info(
+            "\n  ACTION: do NOT rebuild this model. Bind this migration's report to the existing\n"
+            "  semantic model above (report definition.pbir -> byPath/byConnection), and only add\n"
+            "  measures the new workbook genuinely needs. Rebuilding creates a duplicate model that\n"
+            "  will drift from the shared one."
+        )
+        return 0
+    if entries:
+        log.info("KNOWN but NOT YET BUILT: '%s' is referenced by %s", key, ", ".join(e["slug"] for e in entries))
+        log.info("  ACTION: build the semantic model ONCE here; later workbooks will reuse it.")
+        return 1
+    log.info("NEW: published data source '%s' has not been migrated yet.", key)
+    log.info("  ACTION: build its semantic model ONCE in this migration so later workbooks can reuse it.")
+    return 1
+
+
+def cmd_spec(spec_path: Path, migrations_dir: Path) -> int:
+    """Resolve every published data source declared by one migration-spec.json."""
+    spec = json.loads(spec_path.read_text(encoding="utf-8"))
+    keys = [
+        (ds.get("published_datasource") or {}).get("key")
+        for ds in spec.get("data_sources", [])
+        if (ds.get("published_datasource") or {}).get("key")
+    ]
+    if not keys:
+        log.info("No published (sqlproxy) data source in %s - nothing to de-duplicate.", spec_path)
+        return 2
+    worst = 0
+    for key in keys:
+        log.info("")
+        worst = max(worst, _report_key(key, migrations_dir, exclude_slug=spec_path.parent.name))
+    return worst
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--scan", action="store_true", help="List every published data source and its consumers")
+    group.add_argument("--key", help="Look up one dedup key, e.g. finance/salesmaster")
+    group.add_argument("--spec", type=Path, help="Resolve every published data source in a migration-spec.json")
+    parser.add_argument("--migrations-dir", type=Path, default=MIGRATIONS_DIR, help="Override the migrations folder")
+    args = parser.parse_args(argv)
+
+    if args.scan:
+        return cmd_scan(args.migrations_dir)
+    if args.key:
+        return _report_key(args.key, args.migrations_dir)
+    return cmd_spec(args.spec.resolve(), args.migrations_dir)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/fixtures/published_datasource.twb
+++ b/tests/fixtures/published_datasource.twb
@@ -1,0 +1,45 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<workbook source-build='2023.1.0 (20231.23.0512.1georgia)' source-platform='win' version='18.1' xmlns:user='http://www.tableausoftware.com/xml/user'>
+  <datasources>
+    <datasource caption='Sales Master' name='sqlproxy.1rfw7xb1xv29kt1cv7fne0cre0xx' version='18.1'>
+      <repository-location derived-from='https://tableau.contoso.com/t/Finance/datasources/SalesMaster?rev=1.0' id='SalesMaster_oldname' path='/t/Finance/datasources' revision='1.0' site='Finance' />
+      <connection class='sqlproxy' dbname='SalesMaster' server='https://tableau.contoso.com'>
+        <relation name='sqlproxy' table='[sqlproxy]' type='table' />
+      </connection>
+      <column caption='Sales' datatype='real' name='[Sales]' role='measure' type='quantitative' />
+      <column caption='Region' datatype='string' name='[Region]' role='dimension' type='nominal' />
+      <column caption='Workbook Local Ratio' datatype='real' name='[Workbook Local Ratio]' role='measure' type='quantitative'>
+        <calculation class='tableau' formula='SUM([Sales]) / 100' />
+      </column>
+    </datasource>
+  </datasources>
+  <worksheets>
+    <worksheet name='Sales by Region'>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption='Sales Master' name='sqlproxy.1rfw7xb1xv29kt1cv7fne0cre0xx' />
+          </datasources>
+          <datasource-dependencies datasource='sqlproxy.1rfw7xb1xv29kt1cv7fne0cre0xx'>
+            <column caption='Sales' datatype='real' name='[Sales]' role='measure' type='quantitative' />
+            <column caption='Region' datatype='string' name='[Region]' role='dimension' type='nominal' />
+          </datasource-dependencies>
+        </view>
+        <panes>
+          <pane>
+            <mark class='Bar' />
+          </pane>
+        </panes>
+        <rows>[sqlproxy.1rfw7xb1xv29kt1cv7fne0cre0xx].[sum:Sales:qk]</rows>
+        <cols>[sqlproxy.1rfw7xb1xv29kt1cv7fne0cre0xx].[none:Region:nk]</cols>
+      </table>
+    </worksheet>
+  </worksheets>
+  <dashboards>
+    <dashboard name='Overview'>
+      <zones>
+        <zone h='100000' id='4' name='Sales by Region' w='100000' x='0' y='0' />
+      </zones>
+    </dashboard>
+  </dashboards>
+</workbook>

--- a/tests/fixtures/standalone_datasource.tds
+++ b/tests/fixtures/standalone_datasource.tds
@@ -1,0 +1,17 @@
+<?xml version='1.0' encoding='utf-8' ?>
+
+<datasource caption='Standalone Sales' formatted-name='postgres.1of3kl00aoax5d1a1ejma1397430' inline='true' source-platform='win' version='10.0' xmlns:user='http://www.tableausoftware.com/xml/user'>
+  <repository-location />
+  <connection authentication='username-password' class='postgres' dbname='SalesDW' odbc-native-protocol='yes' one-time-sql='' port='5432' server='db.contoso.local' username='reader'>
+    <relation name='orders' table='[public].[orders]' type='table' />
+  </connection>
+  <aliases enabled='yes' />
+  <column datatype='integer' name='[Number of Records]' role='measure' type='quantitative' user:auto-column='numrec'>
+    <calculation class='tableau' formula='1' />
+  </column>
+  <column caption='Amount' datatype='real' name='[amount]' role='measure' type='quantitative' />
+  <column caption='Region' datatype='string' name='[region]' role='dimension' type='nominal' />
+  <column caption='Amount Scaled' datatype='real' name='[Calculation_357754699576291328]' role='measure' type='quantitative'>
+    <calculation class='tableau' formula='[amount] * 100' />
+  </column>
+</datasource>

--- a/tests/test_parse_tableau.py
+++ b/tests/test_parse_tableau.py
@@ -13,6 +13,8 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 from parse_tableau import parse_workbook  # noqa: E402  (path insert must precede this import)
 
 FIXTURE = Path(__file__).resolve().parent / "fixtures" / "minimal.twb"
+PUBLISHED_FIXTURE = Path(__file__).resolve().parent / "fixtures" / "published_datasource.twb"
+TDS_FIXTURE = Path(__file__).resolve().parent / "fixtures" / "standalone_datasource.tds"
 
 
 def test_parses_top_level_shape():
@@ -240,3 +242,74 @@ def test_floating_dashboard_paramctrl_and_bitmap_zone_types_resolved():
     assert set(children_by_type) == {"parameter", "worksheet", "image"}
     assert children_by_type["parameter"]["field_id"] == spec["parameters"][0]["id"]
     assert children_by_type["worksheet"]["worksheet_id"] == spec["worksheets"][0]["id"]
+
+
+def test_embedded_datasource_is_not_flagged_as_published():
+    """A workbook-level <repository-location> (Tableau Public workbooks always carry one) must NOT be
+    mistaken for a published *datasource*; only a datasource-scoped one counts."""
+    spec = parse_workbook(FIXTURE)
+    assert all("published_datasource" not in ds for ds in spec["data_sources"])
+
+
+def test_published_datasource_detected_with_stable_dedup_key():
+    spec = parse_workbook(PUBLISHED_FIXTURE)
+    ds = spec["data_sources"][0]
+    assert ds["connection"]["class"] == "sqlproxy"
+    published = ds["published_datasource"]
+    assert published["id"] == "SalesMaster"
+    assert published["site"] == "Finance"
+    assert published["derived_from"].endswith("/datasources/SalesMaster?rev=1.0")
+    # The dedup key deliberately excludes revision + server host so the SAME published datasource
+    # resolves identically across workbooks (and across republishes) -> one shared semantic model.
+    assert published["key"] == "finance/salesmaster"
+    assert published["revision"] not in published["key"]
+
+
+def test_published_datasource_name_survives_a_stale_id_attribute():
+    """Regression, found against a REAL Tableau Cloud workbook (vimosh0812/ai-bi-assistant new-ds.twb):
+    the datasource had been renamed, leaving repository-location@id='new' while derived-from, dbname
+    and caption all said 'dandan003'. Keying on @id would give two workbooks that share ONE published
+    datasource two different keys, defeating de-duplication."""
+    spec = parse_workbook(PUBLISHED_FIXTURE)
+    published = spec["data_sources"][0]["published_datasource"]
+    assert published["id_attribute"] == "SalesMaster_oldname"  # the stale value, kept for audit
+    assert published["name_source"] == "derived-from"  # authoritative source won
+    assert published["key"] == "finance/salesmaster"  # stale @id did NOT leak into the key
+
+
+def test_standalone_tds_parses_into_data_sources_and_calculations():
+    """A .tds has `<datasource>` as its ROOT (no <workbook><datasources> wrapper). Before this was
+    handled the parser returned ZERO data sources *without erroring* -- a silent failure for exactly
+    the artifact we tell users to export when a workbook points at a published data source."""
+    spec = parse_workbook(TDS_FIXTURE)
+    assert len(spec["data_sources"]) == 1
+    ds = spec["data_sources"][0]
+    assert ds["connection"]["class"] == "postgres"
+    formulas = {f["caption"]: f["tableau_formula"] for f in ds["fields"] if f.get("tableau_formula")}
+    assert formulas["Amount Scaled"] == "[amount] * 100"
+    # A .tds legitimately has no worksheets/dashboards.
+    assert spec["worksheets"] == []
+    assert spec["dashboards"] == []
+
+
+def test_empty_repository_location_in_tds_is_not_a_published_datasource():
+    """Standalone .tds files carry an EMPTY `<repository-location />` placeholder even when they are
+    not published (verified against tableau/document-api-python's datasource_test.tds). The element
+    alone must not trigger the published-datasource flag, or every .tds would false-positive."""
+    spec = parse_workbook(TDS_FIXTURE)
+    assert "published_datasource" not in spec["data_sources"][0]
+    assert not [limit for limit in spec["limitations_encountered"] if "PUBLISHED Tableau data source" in limit["issue"]]
+
+
+def test_published_datasource_raises_high_severity_limitation():
+    spec = parse_workbook(PUBLISHED_FIXTURE)
+    entries = [
+        limit
+        for limit in spec["limitations_encountered"]
+        if limit["severity"] == "high" and "PUBLISHED Tableau data source" in limit["issue"]
+    ]
+    assert len(entries) == 1
+    issue = entries[0]["issue"]
+    assert ".tds" in issue  # tells the user which artifact to export
+    assert "finance/salesmaster" in issue  # carries the dedup key
+    assert "bind every downstream report" in issue  # states the shared-model rule


### PR DESCRIPTION
Discovered in the field: a customer's estate used Tableau **published data sources**, which the toolkit did not handle.

## The gap
Unlike Power BI (which *always* splits a `.pbix` into semantic model + report on publish), Tableau **embeds** the datasource in the workbook by default. Publishing a Data Source separately is an explicit choice — and when a workbook connects to one, the `.twb` only *points* at it:

```xml
<datasource caption='DART_TABLE_META' name='sqlproxy.1mf967k1j67f261btj9ay0wrm4tu'>
  <repository-location id='DART_TABLE_META' path='/t/NHSX_DEV/datasources' site='NHSX_DEV' />
  <connection class='sqlproxy' dbname='DART_TABLE_META' ...>
```

The datasource's connection details, custom SQL and **calculated-field formulas live server-side, not in the workbook** — so parsing the `.twb` alone silently under-reported them. Calcs the author added *on top of* the published source *do* appear, which made the gap partial and easy to miss.

**And the multiplier:** one published datasource usually feeds **many** workbooks. That should become **one semantic model with many reports bound to it** — not a near-duplicate model per workbook.

## What this adds
- **Detection + stable dedup key.** `data_sources[].published_datasource` with `key = <site>/<name>` (lowercased, excluding revision + host), plus a high-severity limitation telling the user to export the `.tds` and stating the shared-model rule.
- **`.tds` / `.tdsx` parsing.** Previously, parsing a `.tds` returned **zero data sources without erroring** — a silent failure for the exact artifact the new flag asks users to export.
- **`scripts/published_datasource_registry.py`** — indexes the dedup key across all migrations (`--scan` / `--key` / `--spec`). Derives purely from committed specs, so there is no registry file to hand-maintain or drift. Exit `0` = already migrated (reuse that model), `1` = build once here.
- **Agent wiring** — mandatory step 4 in `tableau-migrator`, step 0 in `pbi-semantic-builder`.

## Two bugs only REAL files could have found
Verified against **7 real public Tableau files** (downloaded locally, **none committed** — mixed licenses):

1. **Stale `@id`.** `vimosh0812/ai-bi-assistant/new-ds.twb` (real Tableau Cloud) carried `repository-location@id='new'` after its datasource was renamed to `dandan003`, while `derived-from`, `dbname` and `caption` all agreed on the real name. Keying on `@id` would have split **one** shared datasource into **two** keys — creating the exact duplicate models this feature prevents. Name now resolves `derived-from` → `dbname` → `@id`, with `id_attribute` kept for audit.
2. **Empty `<repository-location />` false positive.** Standalone `.tds` files carry that placeholder even when *not* published (confirmed in `tableau/document-api-python`'s `datasource_test.tds`), so every `.tds` would have been mis-flagged. Detection now requires real server identity or a `sqlproxy` connection.

### Real files validated
| File | Resolved key | Via |
|---|---|---|
| `multiple_connections.twb` (on-prem, no site) | `xytestv1` | `dbname` |
| `new-ds.twb` (Cloud, **renamed**) | `vimosh01-…/dandan003` | `derived-from` |
| `testworkbook.twb` | `sales_by_monthtestuser` | `dbname` |
| `DART_Table_Metadata.twb` (NHS, Cloud) | `nhsx_dev/dart_table_meta` | `dbname` |
| `world.tds` / `datasource_test.tds` / `field_change_test.tds` | *(correctly not flagged)* | — |

Both edge cases are locked in as regression tests using **synthetic** fixtures modelled on the observed structure — no third-party content committed.

## Verification
**26/26 tests (was 20) · ruff clean · pylint 10.00/10 · preflight exit 0.**

Cloud/publishing work remains parked per prior decision and is not in this PR.
