### PR TITLE
Verify and document shared-model binding: no copying needed, locally or in cloud

### DIFF
--- a/.github/agents/pbi-report-builder.agent.md
+++ b/.github/agents/pbi-report-builder.agent.md
@@ -217,7 +217,11 @@ every screenshot-based design review, on both the initial build and every later 
 2. **If only the older skill copy is active**, do the equivalent checks manually before every
    screenshot review: every `visual.json` field reference resolves against the real TMDL; every page
    is listed in `pages/pages.json`; no two visuals overlap; `definition.pbir`'s model reference is
-   correct; and every table/matrix `Values` well matches the shape called out in the Gotchas below
+   correct — note it may legitimately point **outside** this migration folder when the model is shared
+   across workbooks (a Tableau *published* data source migrates to ONE semantic model). A relative
+   cross-folder `byPath` like `"../../<other-slug>/fabric/<Name>.SemanticModel"` is verified to resolve
+   in Desktop; do **not** "fix" it by copying the `.SemanticModel` folder in beside your report. Cloud
+   equivalent: `{"byConnection": {"connectionString": "semanticmodelid=<guid>"}}`. and every table/matrix `Values` well matches the shape called out in the Gotchas below
    (no suspicious single-active-field-with-inactive-siblings pattern).
 3. **Only after structural validation passes**, do the visual/numeric Desktop screenshot review.
 4. **Don't treat a clean Bridge/MCP response as proof the report renders error-free.** As of this

--- a/.github/agents/pbi-semantic-builder.agent.md
+++ b/.github/agents/pbi-semantic-builder.agent.md
@@ -59,6 +59,12 @@ field is used inside an aggregated shelf reference (`sum:`, `avg:` prefix in the
    - **exit 0 (already migrated):** do **NOT** rebuild. Reuse the semantic model it names; add only
      measures this workbook genuinely needs that the shared model lacks, and report back that you
      reused it. A duplicate model will drift from the shared one — that is the whole failure mode.
+     **Neither target requires copying the model** (verified 2026-07): **locally**, the report's
+     `definition.pbir` takes a *relative* `byPath` that may point **outside** its own migration folder
+     (`{"byPath": {"path": "../../<other-slug>/fabric/<Name>.SemanticModel"}}`) — Power BI Desktop
+     resolves it and loads the shared model's tables; **in the cloud**, publish the model once and each
+     report uses `{"byConnection": {"connectionString": "semanticmodelid=<guid>"}}`. Copying the
+     `.SemanticModel` folder per migration re-creates the duplication this check exists to prevent.
    - **exit 1 (not yet built):** build it **once**, here, so later workbooks reuse it.
    Also note the workbook does **not** contain that datasource's own calculated-field formulas (they
    live server-side). If the orchestrator supplied a parsed `.tds`/`.tdsx` spec, treat **it** as the

--- a/scripts/published_datasource_registry.py
+++ b/scripts/published_datasource_registry.py
@@ -118,9 +118,18 @@ def _report_key(key: str, migrations_dir: Path, exclude_slug: str | None = None)
             log.info("  semantic model     : %s", model)
         log.info(
             "\n  ACTION: do NOT rebuild this model. Bind this migration's report to the existing\n"
-            "  semantic model above (report definition.pbir -> byPath/byConnection), and only add\n"
-            "  measures the new workbook genuinely needs. Rebuilding creates a duplicate model that\n"
-            "  will drift from the shared one."
+            "  semantic model above, and only add measures the new workbook genuinely needs.\n"
+            "  Rebuilding creates a duplicate model that will drift from the shared one.\n"
+            "\n  HOW TO BIND (no copying needed in either target - verified 2026-07):\n"
+            "    LOCAL  .Report/definition.pbir -> datasetReference.byPath.path with a RELATIVE path\n"
+            "           that may point OUTSIDE this migration folder, e.g.\n"
+            '             {"byPath": {"path": "../../<other-slug>/fabric/<Name>.SemanticModel"}}\n'
+            "           Power BI Desktop resolves cross-folder byPath (confirmed by opening such a\n"
+            "           .pbip: the shared model's tables/columns loaded), so ONE model on disk can\n"
+            "           serve many reports. Do not copy the .SemanticModel folder per migration.\n"
+            "    CLOUD  publish the model ONCE, then each report uses\n"
+            '             {"byConnection": {"connectionString": "semanticmodelid=<model guid>"}}\n'
+            "           which references the published model directly."
         )
         return 0
     if entries:


### PR DESCRIPTION
Answers a practical question left open by #15/#16: when several Tableau workbooks share **one** published data source, they should map to **one** Power BI semantic model — but does the **local** (PBIP) case force us to *copy* that model into every migration folder, re-creating the very duplication we're trying to avoid?

## Tested, not assumed
Built a PBIP whose report `definition.pbir` used:
```json
{ "byPath": { "path": "../../_shared/SharedModel.SemanticModel" } }
```
with the model deliberately placed **outside** the report's own folder, opened it through the Desktop bridge, and probed the live model:

```
port=60537  table='Health Data'
columns (20): ['Health Data[Date]', 'Health Data[Weight (kg)]', ...]
```

The shared model's table and all 20 columns loaded → **Desktop resolves a cross-folder relative `byPath`**. (`validate` also returned 0 errors, but per this repo's own rule that's *necessary, not sufficient* — the Desktop open is what settles it.)

## Conclusion: no copying needed in either target
| Target | Binding | Copy needed? |
|---|---|---|
| **Local (PBIP)** | `{"byPath": {"path": "../../<slug>/fabric/<X>.SemanticModel"}}` | **No** |
| **Cloud** | `{"byConnection": {"connectionString": "semanticmodelid=<guid>"}}` | **No** |

One model on disk (or one published model) serves N reports.

## Documented where an agent actually hits it
- **`published_datasource_registry.py`** now prints a concrete **HOW TO BIND** for both targets next to its "do not rebuild" verdict.
- **`pbi-semantic-builder`** — reuse instructions state plainly that copying the `.SemanticModel` folder per migration re-creates the duplication the check exists to prevent.
- **`pbi-report-builder`** — a model reference pointing *outside* the migration folder is **legitimate** for a shared model and must not be "fixed" by copying the model in beside the report. This one matters: it's exactly the kind of thing a well-meaning agent would otherwise "correct".

**Verification:** 27/27 tests · ruff clean · pylint 10.00/10. Desktop instance closed, temp artifacts removed.
