### PR TITLE
Add a routing README to migrations/, which browsers currently land in blank

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,8 +237,8 @@ tests/                   pytest suite + XML fixtures for the parser
 ```
 
 All three share the same shape (`source/`, `migration-spec.json`, `fabric/`); a data-source migration
-simply has no `.Report`. See [`migrations/workbooks/README.md`](migrations/workbooks/README.md) and
-[`migrations/datasources/README.md`](migrations/datasources/README.md) for how to start your own.
+simply has no `.Report`. To start your own, see [`migrations/README.md`](migrations/README.md) — it
+routes you to the right tree and explains why data sources are migrated first.
 
 </details>
 

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -1,0 +1,37 @@
+# `migrations/` — your migrations go here
+
+**Both folders start empty.** This repo's 16 worked examples live in [`../examples/`](../examples/),
+kept separate so our demo content never mixes with real customer work.
+
+## Which folder?
+
+It depends on what the Tableau source *produces* in Power BI:
+
+| You have | Put it in | It produces |
+|---|---|---|
+| A workbook (`.twb` / `.twbx`) | [`workbooks/<slug>/`](workbooks/) | a semantic model **+ a report** |
+| A published data source (`.tds` / `.tdsx`) | [`datasources/<slug>/`](datasources/) | a semantic model, **no report** |
+
+Not sure whether your workbook uses a published data source? You don't have to guess — parse it and
+the spec will tell you:
+
+```
+python scripts/parse_tableau.py <workbook>.twbx -o <spec>.json
+python scripts/published_datasource_registry.py --spec <spec>.json
+```
+
+Tableau **embeds** data sources by default, so most workbooks have none and go straight into
+`workbooks/`. A published one shows up as `connection class='sqlproxy'`.
+
+## Do data sources first
+
+When a workbook does use a published data source, migrate the **data source first**, then point the
+workbook's report at the model it produced. One published data source is often shared by many
+workbooks, so rebuilding it per workbook creates copies that drift apart.
+
+`scripts/tableau_lineage.py --plan` orders a whole Tableau estate by exactly this leverage (which
+data sources unblock the most workbooks). The registry then stops the duplicate work: it tracks who
+owns each shared model, and reports `ALREADY MIGRATED` with the concrete binding to use.
+
+Full per-folder instructions: [`workbooks/README.md`](workbooks/README.md) ·
+[`datasources/README.md`](datasources/README.md)


### PR DESCRIPTION
## Why

Moving the 16 examples out left `migrations/` **bare**. GitHub renders a folder's `README.md` when you browse into it — and there wasn't one. So the exact moment a user has to choose between `workbooks/` and `datasources/` was the one moment nothing answered them.

The root README *does* explain the layout, but that section lives inside a collapsed `<details>` block, so it's a click away and easy to miss.

## What it says

Deliberately thin — only what you **cannot** infer from the folder listing:

- **Which tree**, keyed on what the Tableau source *produces* in Power BI: a workbook yields a semantic model **+ report**; a published data source yields a model with **no report**.
- **How to check rather than guess.** Tableau *embeds* data sources by default, so most workbooks have none; a published one only shows up as `connection class='sqlproxy'`. The parse + registry commands answer it definitively.
- **Why data sources go first.** One published data source is often shared by many workbooks, so rebuilding it per workbook creates copies that drift apart.

## What it deliberately does NOT say

It doesn't restate the per-folder shape — that stays in the two child READMEs, which it links to. Three files describing one layout is *how docs drift*, which is precisely what the preceding commits had to clean up.

The root README now links here instead of to both children: one link to keep current rather than two.

## Verified

Every documented flag exists (`--spec`, `--scan`, `--key`, `--plan`) · all 5 links resolve · repo-wide link check clean · 51 tests pass · privacy gate exit 0.
