### PR TITLE
Record what TDS support was verified against, and make the untestable path fail loudly

### DIFF
--- a/.github/agents/tableau-migrator.agent.md
+++ b/.github/agents/tableau-migrator.agent.md
@@ -129,10 +129,11 @@ it must show up in `limitations_encountered`, not be silently dropped.
      files, but the *round trip* never could be: no public `.tds` carries a populated
      `repository-location`, because that metadata only exists in server-downloaded files. So after
      registering a data source, run `--scan` and confirm the key derived from the **workbook** equals
-     the key registered from the **data source**. If they differ, the lookup silently degrades to
-     "not yet migrated" and you build the duplicate model this check exists to prevent — a silent
-     failure, so check rather than assume. Report any mismatch (with both keys) as a finding and add
-     it to `limitations_encountered`; do not paper over it by re-registering under the workbook's key.
+     the key registered from the **data source**. The tool now backstops you: a near-identical key
+     (differing only by case/spacing/separators/encoding) reports **`PROBABLE KEY MISMATCH`** and
+     exits 1 rather than silently saying "not yet migrated". Treat that as a STOP — reconcile the key
+     first; do not build, and do not paper over it. Record any real mismatch (with both keys) in
+     `limitations_encountered`, since it is evidence about a live tenant that we cannot reproduce here.
 5. **Data-source credential preflight (MANDATORY before building — do not skip for live sources).** Run
    `python scripts/preflight_source_credentials.py --spec migrations/workbooks/<name>/migration-spec.json`. If it
    reports **only** extract/flat sources, there is no credential gate (data comes from CSV + a

--- a/.github/agents/tableau-migrator.agent.md
+++ b/.github/agents/tableau-migrator.agent.md
@@ -124,6 +124,15 @@ it must show up in `limitations_encountered`, not be silently dropped.
      `pbi-semantic-builder` to add only genuinely-new measures; exit **1** = not yet built → build it
      **once** under `migrations/datasources/<ds-slug>/` and `--register` it, so later workbooks reuse it.
      Rebuilding a duplicate model that then drifts from the shared one is the failure this prevents.
+   - **(c) VERIFY THE KEY MATCH on first contact with a real server — this path is ⚠️ not fully
+     verified.** The detection and name-precedence rules were tested against real public Tableau
+     files, but the *round trip* never could be: no public `.tds` carries a populated
+     `repository-location`, because that metadata only exists in server-downloaded files. So after
+     registering a data source, run `--scan` and confirm the key derived from the **workbook** equals
+     the key registered from the **data source**. If they differ, the lookup silently degrades to
+     "not yet migrated" and you build the duplicate model this check exists to prevent — a silent
+     failure, so check rather than assume. Report any mismatch (with both keys) as a finding and add
+     it to `limitations_encountered`; do not paper over it by re-registering under the workbook's key.
 5. **Data-source credential preflight (MANDATORY before building — do not skip for live sources).** Run
    `python scripts/preflight_source_credentials.py --spec migrations/workbooks/<name>/migration-spec.json`. If it
    reports **only** extract/flat sources, there is no credential gate (data comes from CSV + a

--- a/migrations/datasources/README.md
+++ b/migrations/datasources/README.md
@@ -49,3 +49,25 @@ rebuilding a copy that will drift.
 
 A standalone `.tds` carries an **empty** `<repository-location />`, so the dedup key
 (`<site>/<name>`) cannot be recovered from the file itself — `published-datasource.json` records it.
+
+## What is actually proven, and what isn't
+
+Be aware of this before you rely on it at a customer. The detection and key rules were tested
+against **real** public Tableau files, but one path could not be:
+
+| Behaviour | Status | Evidence |
+|---|---|---|
+| Parsing a `.tds` / `.tdsx` at all | ✅ verified | 7 real public files; testing found a bug where `.tds` silently yielded **0 data sources** |
+| Name precedence `derived-from` → `dbname` → `@id` | ✅ verified | a real Cloud workbook (`vimosh0812/ai-bi-assistant`) had a **stale `id='new'`** after a rename while everything else said `dandan003` — keying on `id` would split one shared source into two keys |
+| An empty `<repository-location />` does **not** mean "published" | ✅ verified | Tableau's own `document-api-python` fixture `datasource_test.tds` |
+| Percent-decoding the publish URL (`Sales%20Master` → `Sales Master`) | ✅ verified | regression test; the API returns the name plain, the URL encodes it |
+| Full round trip: workbook flags a published DS → export its `.tds` → parse → **same** dedup key | ⚠️ **not verified** | no public `.tds` has a *populated* `repository-location`; that metadata only exists in server-downloaded files |
+| The live Tableau REST / Metadata API lineage path (`tableau_lineage.py`) | ⚠️ **not verified** | needs a real Tableau Server/Cloud with a PAT |
+
+The two ⚠️ rows are the ones to sanity-check on first contact with a real server: after registering,
+run `--scan` and confirm the key derived from the **workbook** matches the key you registered from
+the **data source**. If they differ, the dedup silently degrades to "not yet migrated" and you get a
+duplicate model — so it is worth the one-minute check.
+
+The committed test fixtures are **synthetic** (`contoso.com`) on purpose — third-party workbooks
+aren't ours to redistribute — so they encode the rules above rather than being captured artifacts.

--- a/migrations/datasources/README.md
+++ b/migrations/datasources/README.md
@@ -66,8 +66,14 @@ against **real** public Tableau files, but one path could not be:
 
 The two ⚠️ rows are the ones to sanity-check on first contact with a real server: after registering,
 run `--scan` and confirm the key derived from the **workbook** matches the key you registered from
-the **data source**. If they differ, the dedup silently degrades to "not yet migrated" and you get a
-duplicate model — so it is worth the one-minute check.
+the **data source**.
+
+You get a safety net here, because that check is easy to forget. If a workbook's key doesn't match
+any registered key but is *near-identical* to one — differing only by case, spaces, separators,
+punctuation or percent-encoding — the lookup reports **`PROBABLE KEY MISMATCH`** and exits 1 instead
+of quietly saying "not yet migrated". That turns the one failure we cannot test without a live
+Tableau tenant into a loud one rather than a duplicate model discovered weeks later. A genuinely
+different name, or the same name on a different site, still reports a normal "not yet migrated".
 
 The committed test fixtures are **synthetic** (`contoso.com`) on purpose — third-party workbooks
 aren't ours to redistribute — so they encode the rules above rather than being captured artifacts.

--- a/scripts/parse_tableau.py
+++ b/scripts/parse_tableau.py
@@ -156,10 +156,11 @@ def _published_ds_name(repo: etree._Element, connection: dict[str, Any]) -> tupl
       1. the last path segment of `derived-from` (the authoritative publish URL);
       2. the sqlproxy connection's `dbname`;
       3. the `repository-location@id` attribute -- LAST, because it can go stale.
-    Real-world evidence: a Tableau Cloud workbook published against datasource `dandan003` carried
-    `id='new'` (a leftover from a rename) while `derived-from`, `dbname` and `caption` all agreed on
-    `dandan003`. Keying on `id` would have given two workbooks that share ONE datasource two different
-    keys -- defeating the de-duplication this key exists for.
+    Real-world evidence (github.com/vimosh0812/ai-bi-assistant, `new-ds.twb`): a Tableau Cloud
+    workbook published against datasource `dandan003` carried `id='new'` (a leftover from a rename)
+    while `derived-from`, `dbname` and `caption` all agreed on `dandan003`. Keying on `id` would have
+    given two workbooks that share ONE datasource two different keys -- defeating the de-duplication
+    this key exists for.
     """
     derived = repo.get("derived-from")
     if derived:

--- a/scripts/published_datasource_registry.py
+++ b/scripts/published_datasource_registry.py
@@ -26,9 +26,11 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import re
 import sys
 from pathlib import Path
 from typing import Any
+from urllib.parse import unquote
 
 logging.basicConfig(level=logging.INFO, format="%(message)s")
 log = logging.getLogger("published_datasource_registry")
@@ -237,6 +239,26 @@ def cmd_scan(migrations_dir: Path, datasources_dir: Path) -> int:
     return 0
 
 
+def _near_misses(key: str, candidates: list[str]) -> list[str]:
+    """Registered keys that are 'almost' `key` - i.e. a probable key-derivation mismatch.
+
+    This exists because the one path we CANNOT test without a live Tableau tenant is the round trip
+    (workbook flags a published DS -> export its .tds -> parse -> same key). If those two keys ever
+    disagree, the plain lookup degrades *silently* to NOT YET MIGRATED and a duplicate model gets
+    built - the exact failure this registry prevents. So rather than leave an untestable path failing
+    quietly, compare on a squashed form (case, spaces, separators, percent-encoding, punctuation) and
+    shout when something is clearly the same data source under a slightly different key.
+    """
+
+    def squash(value: str) -> str:
+        return re.sub(r"[^a-z0-9]", "", unquote(value).lower())
+
+    target = squash(key)
+    if not target:
+        return []
+    return sorted({c for c in candidates if c != key and squash(c) == target})
+
+
 def _report_key(key: str, migrations_dir: Path, datasources_dir: Path, exclude_slug: str | None = None) -> int:
     """Look up one dedup key; tell the caller whether to reuse an existing model or build it."""
     key = _normalize_key(key)
@@ -266,6 +288,22 @@ def _report_key(key: str, migrations_dir: Path, datasources_dir: Path, exclude_s
         return 1
 
     consumers = ", ".join(e["slug"] for e in entries) if entries else "<none parsed yet>"
+    shared = find_shared_models(datasources_dir)
+    near = _near_misses(key, list(shared))
+    if near:
+        log.warning("PROBABLE KEY MISMATCH - do NOT build a second model for '%s'", key)
+        for candidate in near:
+            log.warning("  a registered data source has the near-identical key : '%s'", candidate)
+            log.warning("    owned by : migrations/datasources/%s", shared[candidate]["slug"])
+        log.warning(
+            "\n  These differ only by case/spacing/encoding, so they are almost certainly the SAME\n"
+            "  published data source keyed two ways - one derived from the workbook, one registered\n"
+            "  from the .tds. Building now would create the duplicate model this check exists to\n"
+            "  prevent. Reconcile the key first (re-register the data source under the key the\n"
+            "  workbook actually derives), then re-run this command.\n"
+        )
+        return 1
+
     log.info("NOT YET MIGRATED: published data source '%s'", key)
     log.info("  consumed by : %s", consumers)
     log.info("  ACTION: migrate the DATA SOURCE once, in its own tree, before the reports that use it:")

--- a/tests/test_repo_layout.py
+++ b/tests/test_repo_layout.py
@@ -23,7 +23,7 @@ sys.path.insert(0, str(REPO_ROOT / "scripts"))
 import check_ai_readiness
 import set_ai_instructions
 import set_data_folder
-from published_datasource_registry import _by_path_from_report, _normalize_key
+from published_datasource_registry import _by_path_from_report, _near_misses, _normalize_key
 from set_data_folder import ABSOLUTE_USER_PATH_RE, _tree_and_slug_for
 from tableau_lineage import dedup_key
 
@@ -130,6 +130,38 @@ def test_dedup_key_is_case_normalized_end_to_end() -> None:
     """
     assert _normalize_key("  Finance/Sales Master  ") == dedup_key("Finance", "Sales Master")
     assert _normalize_key("FINANCE/SALES MASTER") == "finance/sales master"
+
+
+@pytest.mark.parametrize(
+    ("workbook_key", "registered_key"),
+    [
+        ("finance/sales master", "finance/salesmaster"),  # space vs none
+        ("finance/sales master", "finance/sales%20master"),  # percent-encoded survived
+        ("finance/sales master", "Finance/Sales Master"),  # casing
+        ("finance/sales-master", "finance/sales_master"),  # separator style
+        ("finance/salesmaster", "finance/sales.master"),  # punctuation
+    ],
+)
+def test_near_miss_keys_are_shouted_about_not_silently_ignored(workbook_key: str, registered_key: str) -> None:
+    """The round trip cannot be tested without a live Tableau tenant - so it must fail LOUDLY.
+
+    If the key derived from the workbook ever disagrees with the key registered from the .tds, a
+    plain dict lookup reports "not yet migrated" and a duplicate model gets built with no error at
+    all. Detecting the near-miss converts that silent, expensive failure into a visible one.
+    """
+    assert _near_misses(workbook_key, [registered_key]) == [registered_key]
+
+
+@pytest.mark.parametrize(
+    ("workbook_key", "registered_key"),
+    [
+        ("finance/sales master", "finance/orders"),  # genuinely different data source
+        ("finance/sales master", "hr/sales master"),  # same name, DIFFERENT site
+    ],
+)
+def test_near_miss_does_not_fire_for_genuinely_different_keys(workbook_key: str, registered_key: str) -> None:
+    """It must not cry wolf: a different site or a different name is a real 'not yet migrated'."""
+    assert _near_misses(workbook_key, [registered_key]) == []
 
 
 def test_by_path_refuses_to_guess_for_a_model_outside_the_default_tree() -> None:


### PR DESCRIPTION
## Context

You asked whether the TDS parser and the TWB published-connection check were built from real files. Answer: **mostly yes — but not entirely, and the repo never said which.** This PR records the distinction and then removes the risk it creates.

## What was actually verified against real files

Each of these found a real bug or rule that synthetic fixtures would not have:

| Behaviour | Evidence |
|---|---|
| Parsing a `.tds`/`.tdsx` at all | 7 real public files — testing surfaced a bug where a `.tds` silently yielded **0 data sources** |
| Name precedence `derived-from` → `dbname` → `@id` | a real Cloud workbook (`vimosh0812/ai-bi-assistant`) carried a **stale `id='new'`** after a rename while `derived-from`/`dbname`/`caption` all said `dandan003` — keying on `@id` would split one shared source into two keys |
| Empty `<repository-location />` ≠ "published" | Tableau's own `document-api-python` fixture `datasource_test.tds` |
| Percent-decoding (`Sales%20Master` → `Sales Master`) | regression test; the API returns the name plain, the URL encodes it |

## What could not be verified — and won't be

- The **full round trip**: workbook flags a published DS → export its `.tds` → parse → *same* key. No public `.tds` carries a populated `repository-location`; that metadata only exists in server-downloaded files.
- The **live REST/Metadata lineage path**, which needs a real Server/Cloud + PAT.

We have no Tableau tenant, and that isn't going to change here. So rather than pretend otherwise, both are now labelled ⚠️ in `migrations/datasources/README.md` and in the orchestrator.

## The part that actually matters

Since more testing isn't available, this changes **how that path fails**.

**Before** — if the two keys disagreed at a customer, the lookup reported `NOT YET MIGRATED` and exited 1: *indistinguishable* from a data source genuinely not migrated yet. The agent would then build a second semantic model — exactly the duplicate-that-drifts this registry exists to prevent — with no error anywhere.

**Now** — a key matching none but **near-identical** to a registered one (case, spaces, separators, punctuation, percent-encoding — every shape a derivation mismatch actually takes) reports:

```
PROBABLE KEY MISMATCH - do NOT build a second model for 'finance/sales master'
  a registered data source has the near-identical key : 'finance/salesmaster'
    owned by : migrations/datasources/sales-master
```

and exits 1 with an explicit do-not-build.

This **is** testable without a tenant, because the comparison is pure string derivation. 7 new tests: five realistic mismatch shapes, plus two must-not-cry-wolf cases (a different name, and the same name on a **different site**) which must stay an ordinary "not yet migrated".

Verified end to end against a simulated registration: near-miss → exit 1 · exact → exit 0 · unrelated → exit 1.

## Gates

ruff clean · pylint 10.00/10 · **58 tests pass** (7 new) · privacy gate exit 0 · `--scan` regression clean.
