### PR TITLE
Deliver shared conventions to subagents, persist the refresh, harden the M checker

### DIFF
--- a/.github/agents/pbi-migration-validator.agent.md
+++ b/.github/agents/pbi-migration-validator.agent.md
@@ -3,6 +3,78 @@ name: pbi-migration-validator
 description: Read-only reviewer that critiques a built Power BI report against its Tableau source, figure-by-figure and as a whole dashboard, on both visual and numeric fidelity. Reports discrepancies back to the orchestrator for routing to pbi-semantic-builder/pbi-report-builder - never edits TMDL/PBIR files itself.
 ---
 
+<!-- BEGIN:shared-conventions -->
+> **Inherited from [`AGENTS.md`](../../AGENTS.md) — do not edit here.**
+> A custom-agent subagent receives ONLY this persona file: repo-level instruction files do not
+> reach it (verified). So these conventions are generated into every agent by
+> `scripts/sync_agent_conventions.py`, and CI fails if a copy drifts. Edit `AGENTS.md`, then
+> re-run that script.
+
+## Shared agent conventions (all agents inherit these)
+
+- **Cite your source.** Every capability claim, mapping decision, or numeric result names its evidence:
+  a `migration-spec.json` field, a TMDL/PBIR path + line, a live `EVALUATE` result, or a doc URL.
+  "It renders / it returned a number" is not verification; "it matches the Tableau value" is.
+- **Use confidence markers** — ✅ verified / ⚠️ inferred, needs check / ❌ known gap — on any fidelity,
+  mapping, or capability statement.
+- **Own your layer; don't cross it.** `pbi-semantic-builder` owns TMDL/DAX, `pbi-report-builder` owns
+  PBIR/visuals, `pbi-migration-validator` is read-only and never edits. A subagent never "just fixes"
+  a finding another agent owns — it reports; the orchestrator routes.
+- **Research first, then a human in the loop for uncertain PBIR.** For any visual/encoding whose PBIR
+  JSON is undocumented, verify feasibility against Microsoft Learn + the `powerbi-report-author` CLI
+  first; if the exact JSON is still unknown, ask the human to build it once in Desktop and reuse the
+  resulting `visual.json` as ground truth (see `pbi-report-builder.agent.md`). Do not guess-and-iterate
+  blindly — `validate` passes structurally-valid-but-wrong encodings.
+- **Structural validation is necessary, not sufficient.** `powerbi-report-author validate` and TMDL
+  deserialization pass many defects that only surface in Desktop (field-parameter `sourceColumn`
+  brackets, the `'Table'[Col]=[Measure]` PLACEHOLDER error, flat-lined trend measures). Verify in
+  Desktop with data before declaring a page done. **Worse: `validate` SILENTLY SKIPS all JSON-schema
+  checks when it can't fetch the visualContainer schema** — it prints `PBIR_SCHEMA_UNREACHABLE` and
+  still reports "0 errors" even for structurally broken PBIR (the declared `2.11.0` schema 404s; `2.9.0`
+  is the newest published). Treat that warning as "schema validation did NOT run" and confirm with a
+  Desktop open-test (a schema violation shows an error dialog on open) or an offline `ajv` harness
+  against the real 2.9.0-family schemas.
+- **Keep `limitations_encountered` alive** through the whole build **and** fix phase; every bug found
+  and fixed later is itself worth recording. Regenerate it from the final artifacts before sign-off so
+  stale entries don't mislead the validator.
+- **Surface complexity mismatches proactively.** If the parsed workbook implies more effort than the
+  user assumes (many LOD/table-calc fields, extract-only data with no upstream, >20 floating-layout
+  worksheets), say so before building rather than discovering it mid-migration.
+- **NEVER block silently on an external system — time-box it, then ASK.** This is a hard rule, from a
+  real user report: an agent sat on "Testing live Snowflake connectivity" for **129 minutes / 298 tool
+  calls**, retrying without ever surfacing the problem, until the user intervened and suggested taking
+  the credential from Power BI Desktop. Waiting is not progress, and a credential is something only a
+  human can supply — no number of retries will conjure one.
+  - **Cap it: ~2 minutes or 3 attempts, whichever comes first** — for **any** unresponsive external
+    system, not just credentials: a database/warehouse/gateway/tenant connection, an MCP server, an
+    XMLA refresh, **and the Power BI Desktop bridge** (`open`/`reload`/`screenshot`). A "kill the
+    process and relaunch" recovery is an unbounded retry loop unless you cap the relaunches too —
+    cap them at 2, then ask.
+  - On hitting the cap, **STOP and ask the user a specific, actionable question** — name the system,
+    the server, what you tried, and the concrete options (e.g. "sign in interactively in Desktop", or
+    "give me a PAT/key"). Never re-run the same call hoping for a different result. Ask in your normal
+    reply — there is no `ask_user` tool.
+  - **Report elapsed time in your progress updates** whenever an operation exceeds ~60s, so a stall is
+    visible rather than looking like work.
+  - If a credential is already cached in **Power BI Desktop**, prefer that path — it is usually the
+    fastest unblock, and `scripts/probe_desktop_query.py` tells you definitively whether it worked.
+  - The same cap applies to any tool call that has hung once: the second identical retry needs a
+    reason, and the third needs the user.
+- **End every message with a clear next step or an explicit verdict** — never a vague "looks fine."
+- **Durable learnings go in committed files** (the agent `Gotchas` sections and
+  `docs/tableau-dax-translation-guide.md`), never in a git-ignored scratch folder — that is how each
+  real migration permanently improves the toolkit.
+- **Clean up after yourself when you finish.** (a) **Close any Power BI Desktop instance you opened.**
+  In a parallel batch, orphaned Desktop instances (+ their child `msmdsrv`) cause Desktop-bridge
+  contention that blocks later agents from opening/rendering — a real bottleneck. Close the instance
+  you pinned your screenshots to: `Stop-Process -Id <your literal pid> -Force` (map instance→migration
+  by `MainWindowTitle`; note the shell guard rejects looped/variable `-Id`, and `$pid` is a read-only
+  automatic variable, so use literal PIDs). **Never** close a sibling's instance, and don't close one
+  mid-handoff that a peer still needs (e.g. a validator awaiting a semantic-builder's fix). (b) **Remove
+  scratch/temp files you created** (ajv harnesses in `%TEMP%`, `.pbip` cache/backups, one-off probe
+  scripts) — keep only committed deliverables plus the re-runnable `_build/` scripts; confirm nothing
+  scratch leaked into git before reporting done.
+<!-- END:shared-conventions -->
 # PBI Migration Validator — Subagent
 
 You are the closing-the-loop critic. You are invoked by the `tableau-migrator` orchestrator **after**

--- a/.github/agents/pbi-report-builder.agent.md
+++ b/.github/agents/pbi-report-builder.agent.md
@@ -3,6 +3,78 @@ name: pbi-report-builder
 description: Builds a Power BI PBIR report from a Tableau migration-spec.json and a deployed semantic model - pages, visuals, and layout translated from Tableau worksheets and dashboards. Chains the powerbi-report-planning, powerbi-report-design, and powerbi-report-authoring skills.
 ---
 
+<!-- BEGIN:shared-conventions -->
+> **Inherited from [`AGENTS.md`](../../AGENTS.md) — do not edit here.**
+> A custom-agent subagent receives ONLY this persona file: repo-level instruction files do not
+> reach it (verified). So these conventions are generated into every agent by
+> `scripts/sync_agent_conventions.py`, and CI fails if a copy drifts. Edit `AGENTS.md`, then
+> re-run that script.
+
+## Shared agent conventions (all agents inherit these)
+
+- **Cite your source.** Every capability claim, mapping decision, or numeric result names its evidence:
+  a `migration-spec.json` field, a TMDL/PBIR path + line, a live `EVALUATE` result, or a doc URL.
+  "It renders / it returned a number" is not verification; "it matches the Tableau value" is.
+- **Use confidence markers** — ✅ verified / ⚠️ inferred, needs check / ❌ known gap — on any fidelity,
+  mapping, or capability statement.
+- **Own your layer; don't cross it.** `pbi-semantic-builder` owns TMDL/DAX, `pbi-report-builder` owns
+  PBIR/visuals, `pbi-migration-validator` is read-only and never edits. A subagent never "just fixes"
+  a finding another agent owns — it reports; the orchestrator routes.
+- **Research first, then a human in the loop for uncertain PBIR.** For any visual/encoding whose PBIR
+  JSON is undocumented, verify feasibility against Microsoft Learn + the `powerbi-report-author` CLI
+  first; if the exact JSON is still unknown, ask the human to build it once in Desktop and reuse the
+  resulting `visual.json` as ground truth (see `pbi-report-builder.agent.md`). Do not guess-and-iterate
+  blindly — `validate` passes structurally-valid-but-wrong encodings.
+- **Structural validation is necessary, not sufficient.** `powerbi-report-author validate` and TMDL
+  deserialization pass many defects that only surface in Desktop (field-parameter `sourceColumn`
+  brackets, the `'Table'[Col]=[Measure]` PLACEHOLDER error, flat-lined trend measures). Verify in
+  Desktop with data before declaring a page done. **Worse: `validate` SILENTLY SKIPS all JSON-schema
+  checks when it can't fetch the visualContainer schema** — it prints `PBIR_SCHEMA_UNREACHABLE` and
+  still reports "0 errors" even for structurally broken PBIR (the declared `2.11.0` schema 404s; `2.9.0`
+  is the newest published). Treat that warning as "schema validation did NOT run" and confirm with a
+  Desktop open-test (a schema violation shows an error dialog on open) or an offline `ajv` harness
+  against the real 2.9.0-family schemas.
+- **Keep `limitations_encountered` alive** through the whole build **and** fix phase; every bug found
+  and fixed later is itself worth recording. Regenerate it from the final artifacts before sign-off so
+  stale entries don't mislead the validator.
+- **Surface complexity mismatches proactively.** If the parsed workbook implies more effort than the
+  user assumes (many LOD/table-calc fields, extract-only data with no upstream, >20 floating-layout
+  worksheets), say so before building rather than discovering it mid-migration.
+- **NEVER block silently on an external system — time-box it, then ASK.** This is a hard rule, from a
+  real user report: an agent sat on "Testing live Snowflake connectivity" for **129 minutes / 298 tool
+  calls**, retrying without ever surfacing the problem, until the user intervened and suggested taking
+  the credential from Power BI Desktop. Waiting is not progress, and a credential is something only a
+  human can supply — no number of retries will conjure one.
+  - **Cap it: ~2 minutes or 3 attempts, whichever comes first** — for **any** unresponsive external
+    system, not just credentials: a database/warehouse/gateway/tenant connection, an MCP server, an
+    XMLA refresh, **and the Power BI Desktop bridge** (`open`/`reload`/`screenshot`). A "kill the
+    process and relaunch" recovery is an unbounded retry loop unless you cap the relaunches too —
+    cap them at 2, then ask.
+  - On hitting the cap, **STOP and ask the user a specific, actionable question** — name the system,
+    the server, what you tried, and the concrete options (e.g. "sign in interactively in Desktop", or
+    "give me a PAT/key"). Never re-run the same call hoping for a different result. Ask in your normal
+    reply — there is no `ask_user` tool.
+  - **Report elapsed time in your progress updates** whenever an operation exceeds ~60s, so a stall is
+    visible rather than looking like work.
+  - If a credential is already cached in **Power BI Desktop**, prefer that path — it is usually the
+    fastest unblock, and `scripts/probe_desktop_query.py` tells you definitively whether it worked.
+  - The same cap applies to any tool call that has hung once: the second identical retry needs a
+    reason, and the third needs the user.
+- **End every message with a clear next step or an explicit verdict** — never a vague "looks fine."
+- **Durable learnings go in committed files** (the agent `Gotchas` sections and
+  `docs/tableau-dax-translation-guide.md`), never in a git-ignored scratch folder — that is how each
+  real migration permanently improves the toolkit.
+- **Clean up after yourself when you finish.** (a) **Close any Power BI Desktop instance you opened.**
+  In a parallel batch, orphaned Desktop instances (+ their child `msmdsrv`) cause Desktop-bridge
+  contention that blocks later agents from opening/rendering — a real bottleneck. Close the instance
+  you pinned your screenshots to: `Stop-Process -Id <your literal pid> -Force` (map instance→migration
+  by `MainWindowTitle`; note the shell guard rejects looped/variable `-Id`, and `$pid` is a read-only
+  automatic variable, so use literal PIDs). **Never** close a sibling's instance, and don't close one
+  mid-handoff that a peer still needs (e.g. a validator awaiting a semantic-builder's fix). (b) **Remove
+  scratch/temp files you created** (ajv harnesses in `%TEMP%`, `.pbip` cache/backups, one-off probe
+  scripts) — keep only committed deliverables plus the re-runnable `_build/` scripts; confirm nothing
+  scratch leaked into git before reporting done.
+<!-- END:shared-conventions -->
 # PBI Report Builder — Subagent
 
 You turn a `migration-spec.json` plus a deployed semantic model (from `pbi-semantic-builder`) into a
@@ -442,7 +514,14 @@ Superstore build.
   `application.state.get` / `report.snapshot.capture` / `file.reload`), and PBIP stores no data cache,
   so a freshly-opened import
   report renders **empty** ("tables have incomplete or no data"). A clean screenshot with empty visuals
-  is an unrefreshed-model artifact, not a binding defect. **Workaround (proven):** refresh via TOM/XMLA
+  is an unrefreshed-model artifact, not a binding defect. **First check whether you even need to
+  refresh:** pbi-semantic-builder step 10 now hands over a model that is already refreshed AND
+  saved, which persists the data to `<Name>.SemanticModel/.pbi/cache.abf` and survives reopening
+  (verified 2026-07-30). Run `python scripts/refresh_pbip_model.py --pid <pid> --verify-only` — if
+  it reports `DATA_OK` you are done. If it reports `NO_DATA`, run the same script WITHOUT
+  `--verify-only` rather than hand-rolling the XMLA dance; it also saves, so the next open keeps
+  the data. Note the cache is discarded whenever `definition/*.tmdl` becomes newer than it, so any
+  model edit means re-running it. **Workaround (proven):** refresh via TOM/XMLA
   against the child `msmdsrv` port — load `Microsoft.AnalysisServices.AdomdClient` (copy the DLL out of
   WindowsApps first; direct load = Access Denied), find the port via `Get-NetTCPConnection`, resolve the
   catalog GUID via `$SYSTEM.DBSCHEMA_CATALOGS`, and `ExecuteNonQuery` a TMSL

--- a/.github/agents/pbi-semantic-builder.agent.md
+++ b/.github/agents/pbi-semantic-builder.agent.md
@@ -3,6 +3,78 @@ name: pbi-semantic-builder
 description: Builds a Fabric Power BI semantic model (TMDL) from a Tableau migration-spec.json - tables, relationships, and DAX measures translated from Tableau calculated fields. Uses the semantic-model-authoring skill plus the Power BI modeling MCP for read-only DAX validation.
 ---
 
+<!-- BEGIN:shared-conventions -->
+> **Inherited from [`AGENTS.md`](../../AGENTS.md) — do not edit here.**
+> A custom-agent subagent receives ONLY this persona file: repo-level instruction files do not
+> reach it (verified). So these conventions are generated into every agent by
+> `scripts/sync_agent_conventions.py`, and CI fails if a copy drifts. Edit `AGENTS.md`, then
+> re-run that script.
+
+## Shared agent conventions (all agents inherit these)
+
+- **Cite your source.** Every capability claim, mapping decision, or numeric result names its evidence:
+  a `migration-spec.json` field, a TMDL/PBIR path + line, a live `EVALUATE` result, or a doc URL.
+  "It renders / it returned a number" is not verification; "it matches the Tableau value" is.
+- **Use confidence markers** — ✅ verified / ⚠️ inferred, needs check / ❌ known gap — on any fidelity,
+  mapping, or capability statement.
+- **Own your layer; don't cross it.** `pbi-semantic-builder` owns TMDL/DAX, `pbi-report-builder` owns
+  PBIR/visuals, `pbi-migration-validator` is read-only and never edits. A subagent never "just fixes"
+  a finding another agent owns — it reports; the orchestrator routes.
+- **Research first, then a human in the loop for uncertain PBIR.** For any visual/encoding whose PBIR
+  JSON is undocumented, verify feasibility against Microsoft Learn + the `powerbi-report-author` CLI
+  first; if the exact JSON is still unknown, ask the human to build it once in Desktop and reuse the
+  resulting `visual.json` as ground truth (see `pbi-report-builder.agent.md`). Do not guess-and-iterate
+  blindly — `validate` passes structurally-valid-but-wrong encodings.
+- **Structural validation is necessary, not sufficient.** `powerbi-report-author validate` and TMDL
+  deserialization pass many defects that only surface in Desktop (field-parameter `sourceColumn`
+  brackets, the `'Table'[Col]=[Measure]` PLACEHOLDER error, flat-lined trend measures). Verify in
+  Desktop with data before declaring a page done. **Worse: `validate` SILENTLY SKIPS all JSON-schema
+  checks when it can't fetch the visualContainer schema** — it prints `PBIR_SCHEMA_UNREACHABLE` and
+  still reports "0 errors" even for structurally broken PBIR (the declared `2.11.0` schema 404s; `2.9.0`
+  is the newest published). Treat that warning as "schema validation did NOT run" and confirm with a
+  Desktop open-test (a schema violation shows an error dialog on open) or an offline `ajv` harness
+  against the real 2.9.0-family schemas.
+- **Keep `limitations_encountered` alive** through the whole build **and** fix phase; every bug found
+  and fixed later is itself worth recording. Regenerate it from the final artifacts before sign-off so
+  stale entries don't mislead the validator.
+- **Surface complexity mismatches proactively.** If the parsed workbook implies more effort than the
+  user assumes (many LOD/table-calc fields, extract-only data with no upstream, >20 floating-layout
+  worksheets), say so before building rather than discovering it mid-migration.
+- **NEVER block silently on an external system — time-box it, then ASK.** This is a hard rule, from a
+  real user report: an agent sat on "Testing live Snowflake connectivity" for **129 minutes / 298 tool
+  calls**, retrying without ever surfacing the problem, until the user intervened and suggested taking
+  the credential from Power BI Desktop. Waiting is not progress, and a credential is something only a
+  human can supply — no number of retries will conjure one.
+  - **Cap it: ~2 minutes or 3 attempts, whichever comes first** — for **any** unresponsive external
+    system, not just credentials: a database/warehouse/gateway/tenant connection, an MCP server, an
+    XMLA refresh, **and the Power BI Desktop bridge** (`open`/`reload`/`screenshot`). A "kill the
+    process and relaunch" recovery is an unbounded retry loop unless you cap the relaunches too —
+    cap them at 2, then ask.
+  - On hitting the cap, **STOP and ask the user a specific, actionable question** — name the system,
+    the server, what you tried, and the concrete options (e.g. "sign in interactively in Desktop", or
+    "give me a PAT/key"). Never re-run the same call hoping for a different result. Ask in your normal
+    reply — there is no `ask_user` tool.
+  - **Report elapsed time in your progress updates** whenever an operation exceeds ~60s, so a stall is
+    visible rather than looking like work.
+  - If a credential is already cached in **Power BI Desktop**, prefer that path — it is usually the
+    fastest unblock, and `scripts/probe_desktop_query.py` tells you definitively whether it worked.
+  - The same cap applies to any tool call that has hung once: the second identical retry needs a
+    reason, and the third needs the user.
+- **End every message with a clear next step or an explicit verdict** — never a vague "looks fine."
+- **Durable learnings go in committed files** (the agent `Gotchas` sections and
+  `docs/tableau-dax-translation-guide.md`), never in a git-ignored scratch folder — that is how each
+  real migration permanently improves the toolkit.
+- **Clean up after yourself when you finish.** (a) **Close any Power BI Desktop instance you opened.**
+  In a parallel batch, orphaned Desktop instances (+ their child `msmdsrv`) cause Desktop-bridge
+  contention that blocks later agents from opening/rendering — a real bottleneck. Close the instance
+  you pinned your screenshots to: `Stop-Process -Id <your literal pid> -Force` (map instance→migration
+  by `MainWindowTitle`; note the shell guard rejects looped/variable `-Id`, and `$pid` is a read-only
+  automatic variable, so use literal PIDs). **Never** close a sibling's instance, and don't close one
+  mid-handoff that a peer still needs (e.g. a validator awaiting a semantic-builder's fix). (b) **Remove
+  scratch/temp files you created** (ajv harnesses in `%TEMP%`, `.pbip` cache/backups, one-off probe
+  scripts) — keep only committed deliverables plus the re-runnable `_build/` scripts; confirm nothing
+  scratch leaked into git before reporting done.
+<!-- END:shared-conventions -->
 # PBI Semantic Builder — Subagent
 
 You turn a `migration-spec.json` (produced by `scripts/parse_tableau.py` from a Tableau workbook)
@@ -131,18 +203,23 @@ field is used inside an aggregated shelf reference (`sum:`, `avg:` prefix in the
 8. **Check the M before Desktop sees it — `python scripts/check_m_syntax.py <Name>.SemanticModel`.**
    Desktop reports a broken query only as `M Engine error: 'Microsoft.Data.Mashup.Preview; Token ','
    expected.'` — with **no file, no line and no expression** — which a real user hit repeatedly and
-   could not act on. This gives you `file:line:col` and the offending text, and catches the shapes
-   that actually recur in generated M: a trailing comma before `}` (the usual culprit), unbalanced
-   `()`/`[]`/`{}`, a `let` with no `in`, an unterminated string, and a dropped comma in a list. It is
-   offline and instant, so run it after every M edit — never hand a model to Desktop unchecked.
+   could not act on. This gives you `file:line:col` and the offending text for the shapes that recur
+   in generated M: a trailing comma before a closer (the usual culprit), unbalanced `()`/`[]`/`{}`,
+   `let` without `in`, and unterminated strings/comments.
    **Nothing else in the local loop catches this** — measured 2026-07-30 against a model whose only
    fault was a trailing comma: `connection_operations` **ConnectFolder** reported *"Successfully
    loaded database"* with `tablesLoaded: 1`; `partition_operations` **RefreshWithXMLA** could not even
    run (*"A disconnected object is read only and cannot be refreshed"*); and `dax_query_operations`
    **Validate** returned *"DAX query operations are not supported on offline connections"*. TMDL
    deserialization treats M as an opaque string, so the mashup engine never sees it until Desktop
-   opens the `.pbip`. This is the concrete instance of the repo-wide rule that structural validation
-   is necessary but not sufficient.
+   opens the `.pbip`.
+   **Know its limits — it is a structural checker, not an M parser.** An adversarial review measured
+   roughly **10% recall on arbitrary broken M**: it does NOT catch a missing comma between call
+   arguments or `let` steps, a missing `=` in a record field, `if` without `then`, a stray semicolon,
+   smart quotes, or a truncated expression. So **a clean result is not proof the model opens** — it
+   only rules out the specific shapes above. Treat a finding as almost certainly real (its false
+   positives are pinned by regression tests) and a clean run as "one class of defect excluded";
+   step 9's refresh against real data is what actually proves the M is valid.
 9. **Validate a sample — this is mandatory and works offline.** For at least the non-trivial translated
    measures (anything that wasn't a pure passthrough), run a real `EVALUATE` and sanity-check output
    shape and spot values. On a local PBIP use `powerbi-modeling-mcp` → `connection_operations`
@@ -150,8 +227,35 @@ field is used inside an aggregated shelf reference (`sum:`, `avg:` prefix in the
    (`semantic-model-consumption` is an optional convenience from the `fabric-skills` plugin and requires
    a published model — never depend on it). Flag anything that can't be verified against a known
    Tableau value.
-10. **Report back to the orchestrator**: semantic model location (local PBIP path, plus workspace + item
-   only if actually deployed), a table→field
+10. **HANDOFF GATE — refresh, SAVE, and prove it, before you report done.** The report builder must
+    receive a model that already has data. Run:
+    ```
+    python scripts/refresh_pbip_model.py --pid <desktop-pid>
+    ```
+    It refreshes over XMLA, saves via UI Automation, and only reports `REFRESH: DATA_OK + PERSISTED`
+    when a real row came back **and** the cache file advanced. Anything else is a failure — do not
+    hand over.
+    **Why a save is required, and why it kept being missed:** Desktop *does* persist a PBIP's data,
+    to `<Name>.SemanticModel/.pbi/cache.abf` (gitignored — it is data), but **only on save**. An XMLA
+    refresh populates the in-memory model and leaves the file dirty, and the Desktop Bridge CLI has
+    **no save verb** (`status`/`manifest`/`open`/`reload`/`screenshot`/`screenshot-all`) — so the
+    refresh was routinely lost. It is a missing capability, not carelessness. `SendKeys` does not
+    work either (`SetForegroundWindow` is refused, so Ctrl+S lands on the wrong window); the script
+    uses UI Automation's InvokePattern, which needs no focus. Verified end to end 2026-07-30:
+    refresh → save → `cache.abf` updated → close Desktop → reopen → `DATA_OK` **without refreshing**.
+    **Order matters — the cache dies if the definition changes after it.** Desktop discards
+    `cache.abf` when `definition/*.tmdl` is newer (verified: a model with a valid 113 KB cache opened
+    `NO_DATA` because its TMDL had been touched a week later). So make **every** model edit first,
+    then refresh, then save. Anything that rewrites TMDL afterwards invalidates it — including this
+    repo's own `scripts/set_data_folder.py --sanitize`, which you must run before committing, so the
+    committed state always has a stale cache. That is fine (it is gitignored); just re-refresh if you
+    edit the model again.
+    Before reporting done, confirm ALL of: model deserializes; `check_m_syntax.py` clean; every
+    measure/column has a description; AI instructions stamped **and `qnaEnabled: true`**; sample
+    `EVALUATE` verified; and `REFRESH: DATA_OK + PERSISTED`.
+11. **Report back to the orchestrator**: semantic model location (local PBIP path, plus workspace + item
+   only if actually deployed), **the Desktop PID you left it open on (or that you closed it)**, the
+   refresh/persist result, a table→field
    count summary, which calculated fields became measures vs. columns, which idioms were simplified
    away (parameter-equality, pivot reshape) and why, and any new `limitations_encountered` entries
    (append them to `migration-spec.json` so the report builder and final summary see them).

--- a/.github/agents/tableau-migrator.agent.md
+++ b/.github/agents/tableau-migrator.agent.md
@@ -3,6 +3,78 @@ name: tableau-migrator
 description: Orchestrates end-to-end migration of a Tableau workbook (.twb/.twbx) to a Microsoft Fabric Power BI semantic model + report. Parses the workbook, then delegates to the pbi-semantic-builder, pbi-report-builder, and pbi-migration-validator subagents.
 ---
 
+<!-- BEGIN:shared-conventions -->
+> **Inherited from [`AGENTS.md`](../../AGENTS.md) — do not edit here.**
+> A custom-agent subagent receives ONLY this persona file: repo-level instruction files do not
+> reach it (verified). So these conventions are generated into every agent by
+> `scripts/sync_agent_conventions.py`, and CI fails if a copy drifts. Edit `AGENTS.md`, then
+> re-run that script.
+
+## Shared agent conventions (all agents inherit these)
+
+- **Cite your source.** Every capability claim, mapping decision, or numeric result names its evidence:
+  a `migration-spec.json` field, a TMDL/PBIR path + line, a live `EVALUATE` result, or a doc URL.
+  "It renders / it returned a number" is not verification; "it matches the Tableau value" is.
+- **Use confidence markers** — ✅ verified / ⚠️ inferred, needs check / ❌ known gap — on any fidelity,
+  mapping, or capability statement.
+- **Own your layer; don't cross it.** `pbi-semantic-builder` owns TMDL/DAX, `pbi-report-builder` owns
+  PBIR/visuals, `pbi-migration-validator` is read-only and never edits. A subagent never "just fixes"
+  a finding another agent owns — it reports; the orchestrator routes.
+- **Research first, then a human in the loop for uncertain PBIR.** For any visual/encoding whose PBIR
+  JSON is undocumented, verify feasibility against Microsoft Learn + the `powerbi-report-author` CLI
+  first; if the exact JSON is still unknown, ask the human to build it once in Desktop and reuse the
+  resulting `visual.json` as ground truth (see `pbi-report-builder.agent.md`). Do not guess-and-iterate
+  blindly — `validate` passes structurally-valid-but-wrong encodings.
+- **Structural validation is necessary, not sufficient.** `powerbi-report-author validate` and TMDL
+  deserialization pass many defects that only surface in Desktop (field-parameter `sourceColumn`
+  brackets, the `'Table'[Col]=[Measure]` PLACEHOLDER error, flat-lined trend measures). Verify in
+  Desktop with data before declaring a page done. **Worse: `validate` SILENTLY SKIPS all JSON-schema
+  checks when it can't fetch the visualContainer schema** — it prints `PBIR_SCHEMA_UNREACHABLE` and
+  still reports "0 errors" even for structurally broken PBIR (the declared `2.11.0` schema 404s; `2.9.0`
+  is the newest published). Treat that warning as "schema validation did NOT run" and confirm with a
+  Desktop open-test (a schema violation shows an error dialog on open) or an offline `ajv` harness
+  against the real 2.9.0-family schemas.
+- **Keep `limitations_encountered` alive** through the whole build **and** fix phase; every bug found
+  and fixed later is itself worth recording. Regenerate it from the final artifacts before sign-off so
+  stale entries don't mislead the validator.
+- **Surface complexity mismatches proactively.** If the parsed workbook implies more effort than the
+  user assumes (many LOD/table-calc fields, extract-only data with no upstream, >20 floating-layout
+  worksheets), say so before building rather than discovering it mid-migration.
+- **NEVER block silently on an external system — time-box it, then ASK.** This is a hard rule, from a
+  real user report: an agent sat on "Testing live Snowflake connectivity" for **129 minutes / 298 tool
+  calls**, retrying without ever surfacing the problem, until the user intervened and suggested taking
+  the credential from Power BI Desktop. Waiting is not progress, and a credential is something only a
+  human can supply — no number of retries will conjure one.
+  - **Cap it: ~2 minutes or 3 attempts, whichever comes first** — for **any** unresponsive external
+    system, not just credentials: a database/warehouse/gateway/tenant connection, an MCP server, an
+    XMLA refresh, **and the Power BI Desktop bridge** (`open`/`reload`/`screenshot`). A "kill the
+    process and relaunch" recovery is an unbounded retry loop unless you cap the relaunches too —
+    cap them at 2, then ask.
+  - On hitting the cap, **STOP and ask the user a specific, actionable question** — name the system,
+    the server, what you tried, and the concrete options (e.g. "sign in interactively in Desktop", or
+    "give me a PAT/key"). Never re-run the same call hoping for a different result. Ask in your normal
+    reply — there is no `ask_user` tool.
+  - **Report elapsed time in your progress updates** whenever an operation exceeds ~60s, so a stall is
+    visible rather than looking like work.
+  - If a credential is already cached in **Power BI Desktop**, prefer that path — it is usually the
+    fastest unblock, and `scripts/probe_desktop_query.py` tells you definitively whether it worked.
+  - The same cap applies to any tool call that has hung once: the second identical retry needs a
+    reason, and the third needs the user.
+- **End every message with a clear next step or an explicit verdict** — never a vague "looks fine."
+- **Durable learnings go in committed files** (the agent `Gotchas` sections and
+  `docs/tableau-dax-translation-guide.md`), never in a git-ignored scratch folder — that is how each
+  real migration permanently improves the toolkit.
+- **Clean up after yourself when you finish.** (a) **Close any Power BI Desktop instance you opened.**
+  In a parallel batch, orphaned Desktop instances (+ their child `msmdsrv`) cause Desktop-bridge
+  contention that blocks later agents from opening/rendering — a real bottleneck. Close the instance
+  you pinned your screenshots to: `Stop-Process -Id <your literal pid> -Force` (map instance→migration
+  by `MainWindowTitle`; note the shell guard rejects looped/variable `-Id`, and `$pid` is a read-only
+  automatic variable, so use literal PIDs). **Never** close a sibling's instance, and don't close one
+  mid-handoff that a peer still needs (e.g. a validator awaiting a semantic-builder's fix). (b) **Remove
+  scratch/temp files you created** (ajv harnesses in `%TEMP%`, `.pbip` cache/backups, one-off probe
+  scripts) — keep only committed deliverables plus the re-runnable `_build/` scripts; confirm nothing
+  scratch leaked into git before reporting done.
+<!-- END:shared-conventions -->
 # Tableau Migrator — Orchestrator Agent
 
 You are the entry point for migrating a Tableau workbook to Power BI on Microsoft Fabric. You

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -45,3 +45,6 @@ jobs:
 
       - name: M syntax gate - catch Desktop's unlocalised "Token ',' expected" first
         run: uv run python scripts/check_m_syntax.py --all
+
+      - name: Shared conventions reach every agent (a subagent sees ONLY its persona)
+        run: uv run python scripts/sync_agent_conventions.py --check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,8 +2,16 @@
 
 This file is auto-loaded by GitHub Copilot CLI (and other agent runtimes) for every session in this
 repository. It has two jobs: (1) tell you (or a fresh contributor) exactly which Copilot **plugins and
-MCP servers** this toolkit needs so the repo is self-configuring, and (2) hold the **conventions every
-agent inherits**, so the individual `.github/agents/*.agent.md` files stay lean and don't restate them.
+MCP servers** this toolkit needs so the repo is self-configuring, and (2) hold the **canonical copy of
+the shared agent conventions**, which `scripts/sync_agent_conventions.py` generates into every
+`.github/agents/*.agent.md`.
+
+> **Why generated, not inherited:** a custom-agent **subagent** receives ONLY its own persona file —
+> this file, `.github/copilot-instructions.md` and user-global instructions do **not** reach it
+> (verified 2026-07-30 with a sentinel experiment; all four agents confirmed independently). There is
+> no `include`/`extends` mechanism. So the conventions below are *duplicated* into each agent on
+> purpose, and CI fails if a copy drifts. **Edit them here, then run
+> `python scripts/sync_agent_conventions.py`** — never edit the copy inside an agent file.
 
 > **VS Code users:** VS Code Copilot auto-loads `.github/copilot-instructions.md`, *not* this file.
 > That pointer file duplicates only the session-start step below and defers everything else here, so
@@ -156,6 +164,7 @@ cloning to confirm the machine is configured.
 
 ---
 
+<!-- BEGIN:shared-conventions -->
 ## Shared agent conventions (all agents inherit these)
 
 - **Cite your source.** Every capability claim, mapping decision, or numeric result names its evidence:
@@ -191,11 +200,15 @@ cloning to confirm the machine is configured.
   calls**, retrying without ever surfacing the problem, until the user intervened and suggested taking
   the credential from Power BI Desktop. Waiting is not progress, and a credential is something only a
   human can supply — no number of retries will conjure one.
-  - **Cap it: ~2 minutes or 3 attempts, whichever comes first**, for any connect / refresh / sign-in /
-    connectivity test against a database, warehouse, gateway or tenant.
+  - **Cap it: ~2 minutes or 3 attempts, whichever comes first** — for **any** unresponsive external
+    system, not just credentials: a database/warehouse/gateway/tenant connection, an MCP server, an
+    XMLA refresh, **and the Power BI Desktop bridge** (`open`/`reload`/`screenshot`). A "kill the
+    process and relaunch" recovery is an unbounded retry loop unless you cap the relaunches too —
+    cap them at 2, then ask.
   - On hitting the cap, **STOP and ask the user a specific, actionable question** — name the system,
     the server, what you tried, and the concrete options (e.g. "sign in interactively in Desktop", or
-    "give me a PAT/key"). Never re-run the same call hoping for a different result.
+    "give me a PAT/key"). Never re-run the same call hoping for a different result. Ask in your normal
+    reply — there is no `ask_user` tool.
   - **Report elapsed time in your progress updates** whenever an operation exceeds ~60s, so a stall is
     visible rather than looking like work.
   - If a credential is already cached in **Power BI Desktop**, prefer that path — it is usually the
@@ -216,3 +229,4 @@ cloning to confirm the machine is configured.
   scratch/temp files you created** (ajv harnesses in `%TEMP%`, `.pbip` cache/backups, one-off probe
   scripts) — keep only committed deliverables plus the re-runnable `_build/` scripts; confirm nothing
   scratch leaked into git before reporting done.
+<!-- END:shared-conventions -->

--- a/scripts/check_m_syntax.py
+++ b/scripts/check_m_syntax.py
@@ -46,7 +46,7 @@ log = logging.getLogger("check_m_syntax")
 
 PAIRS = {"(": ")", "[": "]", "{": "}"}
 CLOSERS = {v: k for k, v in PAIRS.items()}
-_NUMBER_RE = re.compile(r"[0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+)?")
+_NUMBER_RE = re.compile(r"0[xX][0-9a-fA-F]+|[0-9]+(\.[0-9]+)?([eE][+-]?[0-9]+)?")
 _IDENT_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*")
 
 # Keywords that legitimately introduce or continue an expression, so an identifier following one of
@@ -54,6 +54,7 @@ _IDENT_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*")
 M_KEYWORDS = {
     "and",
     "as",
+    "catch",
     "each",
     "else",
     "error",
@@ -257,30 +258,61 @@ def _check_delimiters(tokens: list[Token], add: Callable[[str, str, int, int], N
         add("UNBALANCED", f"'{opener.text}' is never closed", opener.line, opener.col)
 
 
-def _check_expression(path: Path, text: str, offset_line: int = 0) -> list[Finding]:
-    """Structural checks over one M expression."""
+def _bracket_depths(tokens: list[Token]) -> list[int]:
+    """Bracket nesting depth at each token, so `[...]` contents can be excluded from keyword counts."""
+    depths: list[int] = []
+    depth = 0
+    for tok in tokens:
+        if tok.kind == "punct" and tok.text == "[":
+            depth += 1
+        depths.append(depth)
+        if tok.kind == "punct" and tok.text == "]":
+            depth = max(0, depth - 1)
+    return depths
+
+
+def _check_let_in(tokens: list[Token], add: Callable[[str, str, int, int], None]) -> None:
+    """Every `let` needs a matching `in`.
+
+    Counted only at bracket depth 0: `let` and `in` are legal generalized FIELD NAMES inside `[...]`
+    (`[let = 1]`, `each [in]`), and counting those produced a bogus LET_WITHOUT_IN on valid M.
+    """
+    depths = _bracket_depths(tokens)
+    top = [t for t, d in zip(tokens, depths, strict=True) if d == 0 and t.kind == "keyword"]
+    lets = sum(1 for t in top if t.text == "let")
+    ins = sum(1 for t in top if t.text == "in")
+    if lets > ins:
+        first = next(t for t in top if t.text == "let")
+        add("LET_WITHOUT_IN", f"{lets} 'let' but {ins} 'in' - every let needs a matching in", first.line, first.col)
+
+
+def _check_expression(path: Path, text: str, offset_line: int = 0, first_col: int = 0) -> list[Finding]:
+    """Structural checks over one M expression.
+
+    `first_col` shifts columns on the expression's FIRST line, which in TMDL starts partway along
+    (`source = let ...`). Without it a reported column is short by the length of that prefix, and
+    localisation is the entire value of this tool.
+    """
     findings: list[Finding] = []
     tokens, scan_errors = _tokenize(text)
 
     def add(kind: str, detail: str, line: int, col: int) -> None:
-        findings.append(Finding(path, line + offset_line, col, kind, detail, _snippet(text, line)))
+        shifted = col + first_col if line == 1 else col
+        findings.append(Finding(path, line + offset_line, shifted, kind, detail, _snippet(text, line)))
 
     for message, line, col in scan_errors:
         add("UNTERMINATED", f"{message} - the expression ends inside it", line, col)
 
     _check_delimiters(tokens, add, offset_line)
+    _check_let_in(tokens, add)
 
-    lets = sum(1 for t in tokens if t.kind == "keyword" and t.text == "let")
-    ins = sum(1 for t in tokens if t.kind == "keyword" and t.text == "in")
-    if lets > ins:
-        first = next(t for t in tokens if t.kind == "keyword" and t.text == "let")
-        add("LET_WITHOUT_IN", f"{lets} 'let' but {ins} 'in' - every let needs a matching in", first.line, first.col)
-
-    findings.extend(_check_missing_separator(path, text, tokens, offset_line))
+    findings.extend(_check_missing_separator(path, text, tokens, offset_line, first_col))
     return findings
 
 
-def _check_missing_separator(path: Path, text: str, tokens: list[Token], offset_line: int) -> list[Finding]:
+def _check_missing_separator(
+    path: Path, text: str, tokens: list[Token], offset_line: int, first_col: int = 0
+) -> list[Finding]:
     """Two values side by side inside a list literal, i.e. a dropped comma.
 
     Deliberately scoped to `{...}` only. `[...]` is ambiguous in M: it is a record literal
@@ -310,7 +342,7 @@ def _check_missing_separator(path: Path, text: str, tokens: list[Token], offset_
                 Finding(
                     path,
                     tok.line + offset_line,
-                    tok.col,
+                    tok.col + (first_col if tok.line == 1 else 0),
                     "MISSING_SEPARATOR",
                     f"'{prev.text}' is followed by '{tok.text}' with no comma between them inside a '{{' list literal",
                     _snippet(text, tok.line),
@@ -319,8 +351,31 @@ def _check_missing_separator(path: Path, text: str, tokens: list[Token], offset_
     return findings
 
 
-def _iter_m_blocks(path: Path) -> list[tuple[str, int]]:
-    """Every M expression in a .tmdl file, with the line it starts on.
+def _collect_body(lines: list[str], idx: int, indent: int, metadata_re: re.Pattern[str]) -> tuple[list[str], int]:
+    """Continuation lines of one TMDL expression, and where scanning should resume.
+
+    A TMDL metadata key only ends the block when it sits at a SIBLING indent. Matching it anywhere
+    truncated valid M that merely uses one as an identifier (`let mode = 1 in mode`), which then
+    reported a bogus LET_WITHOUT_IN.
+    """
+    body: list[str] = []
+    while idx < len(lines):
+        current = lines[idx]
+        if current.strip() and (len(current) - len(current.lstrip())) <= indent:
+            break
+        metadata = metadata_re.match(current)
+        if metadata and len(metadata.group(1)) <= indent + 1:
+            break
+        body.append(current)
+        idx += 1
+    return body, idx
+
+
+def _iter_m_blocks(path: Path) -> list[tuple[str, int, int]]:  # pylint: disable=too-many-locals
+    """Every M expression in a .tmdl file, with the line it starts on, and its starting column.
+
+    One cohesive line scanner; splitting it further would spread the TMDL shape knowledge across
+    helpers that each only make sense together, so the local count is accepted deliberately.
 
     Two shapes carry M: a model-level `expression <Name> = <M>` (expressions.tmdl) and a table
     partition declared `partition <Name> = m` (tables/*.tmdl).
@@ -330,11 +385,17 @@ def _iter_m_blocks(path: Path) -> list[tuple[str, int]]:
     separator). Reading those as M produced 64 false positives across the committed examples, so the
     partition's declared source type decides whether its `source =` is checked at all.
     """
-    text = path.read_text(encoding="utf-8")
+    text = path.read_text(encoding="utf-8", errors="replace").lstrip("\ufeff")
     lines = text.splitlines()
     blocks: list[tuple[str, int]] = []
     partition_re = re.compile(r"^\s*partition\s+.+?=\s*(\w+)\s*$")
-    starters = re.compile(r"^\s*(expression\s+.+?=|source\s*=)\s*(.*)$")
+    # `'quoted name'` first: TMDL requires quoting a name containing '=', and a non-greedy match
+    # would otherwise stop at the wrong equals sign and feed the tail into the M scanner.
+    starters = re.compile(r"^(\s*)(?:expression\s+(?:'[^']*'|[^=]+?)\s*=|source\s*=)\s*(.*)$")
+    # TMDL metadata keys only terminate the block at the SAME indent as a sibling property. Matching
+    # them anywhere truncated valid M that merely uses one as an identifier (`let mode = 1 in mode`),
+    # which then reported a bogus LET_WITHOUT_IN.
+    metadata_re = re.compile(r"^(\s*)(lineageTag|annotation|queryGroup|mode|dataType|isHidden)\b")
 
     idx = 0
     current_partition_kind: str | None = None
@@ -348,11 +409,13 @@ def _iter_m_blocks(path: Path) -> list[tuple[str, int]]:
         if not match:
             idx += 1
             continue
-        is_source = match.group(1).strip().startswith("source")
+        is_source = lines[idx].lstrip().startswith("source")
         if is_source and current_partition_kind not in (None, "m"):
             idx += 1
             continue
-        indent = len(lines[idx]) - len(lines[idx].lstrip())
+        indent = len(match.group(1))
+        # Column of the M text on the starter line, so a finding on it points at the real column.
+        first_col = len(lines[idx]) - len(match.group(2))
         body = [match.group(2)]
         start = idx + 1
         idx += 1
@@ -360,12 +423,12 @@ def _iter_m_blocks(path: Path) -> list[tuple[str, int]]:
             current = lines[idx]
             if current.strip() and (len(current) - len(current.lstrip())) <= indent:
                 break
-            # TMDL metadata lines are not part of the M expression.
-            if re.match(r"^\s*(lineageTag|annotation|queryGroup|mode|dataType|isHidden)\b", current):
+            metadata = metadata_re.match(current)
+            if metadata and len(metadata.group(1)) <= indent + 1:
                 break
             body.append(current)
             idx += 1
-        blocks.append(("\n".join(body), start))
+        blocks.append(("\n".join(body), start, first_col))
     return blocks
 
 
@@ -377,14 +440,25 @@ def _model_dirs(target: Path) -> list[Path]:
 
 def check_model(model_dir: Path) -> list[Finding]:
     """Every M expression in one .SemanticModel."""
+    return check_model_counted(model_dir)[0]
+
+
+def check_model_counted(model_dir: Path) -> tuple[list[Finding], int]:
+    """Findings plus HOW MANY M expressions were actually scanned.
+
+    The count matters: "no findings" and "nothing was checked" are the same output otherwise, and a
+    missing/empty/unreadable model would report a reassuring "M syntax OK" while proving nothing.
+    """
     findings: list[Finding] = []
+    scanned = 0
     definition = model_dir / "definition"
     files = sorted(definition.glob("expressions.tmdl")) + sorted(definition.glob("tables/*.tmdl"))
     for tmdl in files:
-        for block, start_line in _iter_m_blocks(tmdl):
+        for block, start_line, first_col in _iter_m_blocks(tmdl):
             if block.strip():
-                findings.extend(_check_expression(tmdl, block, offset_line=start_line - 1))
-    return findings
+                scanned += 1
+                findings.extend(_check_expression(tmdl, block, offset_line=start_line - 1, first_col=first_col))
+    return findings, scanned
 
 
 def main() -> int:
@@ -407,13 +481,26 @@ def main() -> int:
         return 0
 
     total = 0
+    scanned_total = 0
+    empty: list[Path] = []
     for model in targets:
-        findings = check_model(model)
+        findings, scanned = check_model_counted(model)
+        scanned_total += scanned
+        if scanned == 0:
+            empty.append(model)
         if findings:
             total += len(findings)
             log.error("M SYNTAX ERRORS in %s", model.relative_to(REPO_ROOT) if REPO_ROOT in model.parents else model)
             for finding in findings:
                 log.error("%s", finding.render(REPO_ROOT))
+
+    if empty:
+        # "clean" and "nothing was checked" must never look the same - an agent would read the
+        # reassuring line as proof its model is fine.
+        log.warning("NOT CHECKED - no M expressions found in %d target(s):", len(empty))
+        for model in empty:
+            log.warning("  %s", model)
+        log.warning("  (missing definition/, no `= m` partitions, or an unreadable path)")
 
     if total:
         log.error(
@@ -423,7 +510,16 @@ def main() -> int:
             len(targets),
         )
         return 1
-    log.info("M syntax OK - %d model(s) checked, no structural problems found.", len(targets))
+    if scanned_total == 0:
+        log.warning("NOTHING CHECKED - 0 M expressions scanned across %d target(s).", len(targets))
+        return 1
+    log.info(
+        "M syntax OK - %d M expression(s) across %d model(s), no structural problems found.\n"
+        "  NOTE: structural checks only (delimiters, separators, let/in, strings). This is not a full "
+        "M parser - a clean result does not prove the model opens.",
+        scanned_total,
+        len(targets),
+    )
     return 0
 
 

--- a/scripts/refresh_pbip_model.py
+++ b/scripts/refresh_pbip_model.py
@@ -1,0 +1,258 @@
+"""
+purpose: Refresh a local PBIP model in Power BI Desktop and PERSIST the result, so the next agent
+         (and the next Desktop open) sees real data instead of an empty model.
+usage:   python scripts/refresh_pbip_model.py [--pid <pbidesktop-pid>] [--tables "A" "B"] [--no-save]
+
+Why this exists
+---------------
+Two separate gaps kept biting real migrations:
+
+1. **The refresh itself was hand-rolled every time.** The only working path against a local PBIP is
+   TOM/XMLA over the child `msmdsrv` port, which means: discover the port, load ADOMD.NET, resolve
+   the catalog GUID, then send a TMSL `refresh`. Re-deriving that per migration is slow and easy to
+   get subtly wrong.
+
+2. **The refresh was not persisted.** Power BI Desktop DOES cache a PBIP's data - in
+   `<Name>.SemanticModel/.pbi/cache.abf` (gitignored, it is data) - but only when the file is
+   **saved**. An XMLA refresh populates the in-memory model and leaves the file dirty, so if nobody
+   saves, the cache is never written and the next agent opens an empty model and has to refresh
+   again (hitting the credential prompt all over again). The Desktop Bridge CLI has **no save verb**
+   (`status`/`manifest`/`open`/`reload`/`screenshot`/`screenshot-all`), which is exactly why this
+   kept being missed - it was a missing capability, not carelessness. We send Ctrl+S via the Windows
+   UI and then VERIFY with the bridge's own `hasUnsavedChanges` flag plus the cache file's timestamp.
+
+Cache invalidation (important)
+------------------------------
+Desktop discards `cache.abf` when the model **definition** is newer than the cache. Verified: a
+model whose `definition/*.tmdl` were touched a week after the cache was written opened with
+`NO_DATA` despite a 113 KB cache sitting right there. So: make ALL model edits FIRST, then refresh,
+then save. Anything that rewrites TMDL afterwards - including this repo's own
+`scripts/set_data_folder.py --sanitize`, which you must run before committing - invalidates it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+# ruff: noqa: E402  (the sys.path insert above must precede this import)
+# pylint: disable=wrong-import-position
+from probe_desktop_query import _load_adomd, discover_port, first_table
+
+SAVE_SETTLE_SECONDS = 3
+SAVE_TIMEOUT_SECONDS = 120
+
+
+def _catalog_id(conn) -> str:
+    """The database GUID a TMSL command must name, read from the server's own catalog DMV."""
+    cmd = conn.CreateCommand()
+    cmd.CommandText = "SELECT [CATALOG_NAME] FROM $SYSTEM.DBSCHEMA_CATALOGS"
+    reader = cmd.ExecuteReader()
+    try:
+        if not reader.Read():
+            raise RuntimeError("no catalog found on the Desktop Analysis Services instance")
+        return str(reader.GetValue(0))
+    finally:
+        reader.Close()
+
+
+def refresh(port: int, tables: list[str] | None) -> tuple[bool, str]:
+    """Send a TMSL refresh over XMLA. Returns (ok, message).
+
+    Refreshing named tables is preferred over the whole database: a full refresh can hang for
+    minutes on a large table that no report even uses.
+    """
+    adomd_connection = _load_adomd()
+    conn = adomd_connection(f"Data Source=localhost:{port}")
+    conn.Open()
+    try:
+        catalog = _catalog_id(conn)
+        if tables:
+            objects = [{"database": catalog, "table": t} for t in tables]
+        else:
+            objects = [{"database": catalog}]
+        tmsl = json.dumps({"refresh": {"type": "full", "objects": objects}})
+        cmd = conn.CreateCommand()
+        cmd.CommandText = tmsl
+        cmd.ExecuteNonQuery()
+        return True, f"refreshed {'/'.join(tables) if tables else 'entire database'} (catalog {catalog})"
+    finally:
+        conn.Close()
+
+
+def _bridge_status() -> dict:
+    """The Desktop Bridge's view of the running instances, including `hasUnsavedChanges`."""
+    result = subprocess.run(
+        ["npx", "--yes", "@microsoft/powerbi-desktop-bridge-cli", "status"],
+        capture_output=True,
+        text=True,
+        check=False,
+        shell=True,
+    )
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return {}
+
+
+def _instance(pid: int | None) -> dict | None:
+    for inst in _bridge_status().get("instances", []):
+        if pid is None or inst.get("pid") == pid:
+            return inst
+    return None
+
+
+def save(pid: int) -> tuple[bool, str]:
+    """Save the Desktop file, then verify the save actually happened.
+
+    The bridge has no save verb, so this drives the UI - but NOT with SendKeys. Verified 2026-07-30:
+    `SetForegroundWindow` (even with the `AttachThreadInput` workaround) is refused in this context,
+    so the Ctrl+S keystroke silently lands on whatever window has focus and the model stays dirty.
+    UI Automation's InvokePattern needs no foreground focus and works reliably - the same mechanism
+    `probe_desktop_credential.ps1` already uses against Desktop.
+
+    The result is never assumed: it is confirmed against the bridge's own `hasUnsavedChanges` flag.
+    """
+    before = _instance(pid)
+    if before is None:
+        return False, f"no Desktop Bridge instance for pid {pid}"
+    if not before.get("hasUnsavedChanges"):
+        return True, "nothing to save (hasUnsavedChanges already false)"
+
+    script = f"""
+Add-Type -AssemblyName UIAutomationClient, UIAutomationTypes
+$root = [System.Windows.Automation.AutomationElement]::RootElement
+$cond = New-Object System.Windows.Automation.PropertyCondition(
+    [System.Windows.Automation.AutomationElement]::ProcessIdProperty, {pid})
+$win = $root.FindFirst([System.Windows.Automation.TreeScope]::Children, $cond)
+if (-not $win) {{ Write-Output 'NO_WINDOW'; exit 1 }}
+$nameCond = New-Object System.Windows.Automation.PropertyCondition(
+    [System.Windows.Automation.AutomationElement]::NameProperty, 'Save')
+foreach ($el in $win.FindAll([System.Windows.Automation.TreeScope]::Descendants, $nameCond)) {{
+    try {{
+        $p = $el.GetCurrentPattern([System.Windows.Automation.InvokePattern]::Pattern)
+        $p.Invoke(); Write-Output 'INVOKED'; exit 0
+    }} catch {{ }}
+}}
+Write-Output 'NO_INVOKABLE_SAVE'; exit 1
+"""
+    subprocess.run(["powershell", "-NoProfile", "-Command", script], capture_output=True, text=True, check=False)
+
+    deadline = time.time() + SAVE_TIMEOUT_SECONDS
+    while time.time() < deadline:
+        time.sleep(SAVE_SETTLE_SECONDS)
+        current = _instance(pid)
+        if current is not None and not current.get("hasUnsavedChanges"):
+            return True, "saved via UI Automation (hasUnsavedChanges went false)"
+    return False, (
+        f"still dirty after {SAVE_TIMEOUT_SECONDS}s - Desktop may be showing a dialog. Ask the user "
+        "to press Ctrl+S in Power BI Desktop, then re-run with --verify-only."
+    )
+
+
+def cache_file(pid: int) -> Path | None:
+    """`<Name>.SemanticModel/.pbi/cache.abf` for the model this Desktop instance has open."""
+    inst = _instance(pid)
+    if inst is None or not inst.get("currentFilePath"):
+        return None
+    pbip = Path(inst["currentFilePath"])
+    matches = sorted(pbip.parent.glob("*.SemanticModel/.pbi/cache.abf"))
+    return matches[0] if matches else None
+
+
+def row_count(port: int) -> tuple[int, str]:
+    """Rows in the first queryable table - the gate of record.
+
+    A refresh that "succeeded" but returns no rows is not a refresh; only data proves the source was
+    reachable, the credential worked and the M was valid.
+    """
+    adomd_connection = _load_adomd()
+    conn = adomd_connection(f"Data Source=localhost:{port}")
+    conn.Open()
+    try:
+        table = first_table(conn)
+        cmd = conn.CreateCommand()
+        cmd.CommandText = f"EVALUATE ROW(\"n\", COUNTROWS('{table}'))"
+        reader = cmd.ExecuteReader()
+        rows = 0
+        while reader.Read():
+            value = reader.GetValue(0)
+            rows = int(value) if value is not None else 0
+        reader.Close()
+        return rows, table
+    finally:
+        conn.Close()
+
+
+def _refresh_and_save(pid: int, port: int, args: argparse.Namespace) -> int | None:
+    """Run the refresh and (unless suppressed) persist it. Returns an exit code, or None to continue."""
+    try:
+        ok, message = refresh(port, args.tables)
+    except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught
+        print(f"REFRESH: ERROR {type(exc).__name__}: {exc}")
+        return 2
+    print(f"  refresh: {message}" if ok else f"  refresh FAILED: {message}")
+
+    if not args.no_save:
+        saved, save_message = save(pid)
+        print(f"  save   : {save_message}")
+        if not saved:
+            print("REFRESH: NOT_PERSISTED (data is in memory only - the next open will be empty)")
+            return 1
+    return None
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point: refresh, save, and prove data is really there."""
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--pid", type=int, help="Power BI Desktop process id")
+    parser.add_argument("--port", type=int, help="Local AS port (default: auto-discover)")
+    parser.add_argument("--tables", nargs="*", help="Tables to refresh (default: whole database)")
+    parser.add_argument("--no-save", action="store_true", help="Refresh only; do NOT persist the cache")
+    parser.add_argument("--verify-only", action="store_true", help="Skip refresh/save; just report the state")
+    args = parser.parse_args(argv)
+
+    pid = args.pid
+    if pid is None:
+        inst = _instance(None)
+        pid = inst.get("pid") if inst else None
+    if pid is None:
+        print("REFRESH: ERROR no Power BI Desktop instance found (open the .pbip first)")
+        return 2
+
+    port = args.port or discover_port(pid)
+    before_cache = cache_file(pid)
+    before_stamp = before_cache.stat().st_mtime if before_cache and before_cache.exists() else 0.0
+
+    if not args.verify_only:
+        outcome = _refresh_and_save(pid, port, args)
+        if outcome is not None:
+            return outcome
+
+    rows, table = row_count(port)
+
+    after_cache = cache_file(pid)
+    after_stamp = after_cache.stat().st_mtime if after_cache and after_cache.exists() else 0.0
+    persisted = after_cache is not None and after_stamp > before_stamp
+
+    print(f"  data   : {rows} row(s) in '{table}'")
+    print(f"  cache  : {after_cache if after_cache else '<none>'}{' (updated)' if persisted else ''}")
+
+    if rows <= 0:
+        print("REFRESH: NO_DATA (refresh ran but the table is empty - check the source and credentials)")
+        return 1
+    if not args.no_save and not args.verify_only and not persisted:
+        print("REFRESH: NOT_PERSISTED (model has data in memory, but cache.abf did not update)")
+        return 1
+    print("REFRESH: DATA_OK" + ("" if args.no_save or args.verify_only else " + PERSISTED"))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/sync_agent_conventions.py
+++ b/scripts/sync_agent_conventions.py
@@ -1,0 +1,147 @@
+"""
+purpose: Copy the shared agent conventions from AGENTS.md into every .github/agents/*.agent.md,
+         because a custom-agent subagent receives ONLY its own persona file.
+usage:   python scripts/sync_agent_conventions.py          # write the block into every agent
+         python scripts/sync_agent_conventions.py --check  # CI gate: exit 1 if any agent has drifted
+
+Why this exists (measured, not assumed)
+---------------------------------------
+`AGENTS.md` calls itself "conventions every agent inherits, so the individual `.github/agents/*.agent.md`
+files stay lean and don't restate them". That premise is false for subagents.
+
+Verified 2026-07-30 with a sentinel experiment (a fixture AGENTS.md carrying unique tokens plus a
+probe persona):
+
+    invoked as a ROOT session   (`copilot --agent=probe`)  -> AGENTS.md sentinels PRESENT
+    invoked as a SUBAGENT       (via the Task tool)        -> AGENTS.md sentinels ABSENT
+
+All four real agents independently confirmed it; `pbi-semantic-builder` reported that "AGENTS.md"
+appears in its context exactly once - as a filename in a directory listing. `.github/copilot-instructions.md`
+and the user's global instructions are cut off the same way. There is no `include`/`extends`
+frontmatter and no documented inheritance mechanism: **text that is not in a `.agent.md` file does
+not reach that agent as a subagent.**
+
+The consequence was not theoretical. Conventions living only in AGENTS.md were silently no-ops, and
+the orchestrator had already written down the symptom without knowing the cause:
+"The shared convention tells each subagent to close its own instance when done, but in practice some
+don't" (tableau-migrator.agent.md).
+
+So the block is DUPLICATED into each persona on purpose. Four copies is exactly the redundancy
+AGENTS.md was written to avoid - but generation plus a CI gate makes drift impossible, whereas the
+"single source of truth" it replaces was invisible to 4 of 4 subagents. Deterministic duplication
+beats an elegant abstraction that does not execute.
+
+Reading it at runtime was considered and rejected: it costs a tool call, competes with a 40 KB
+persona, and is discretionary - and the agent that most needs the rule (one stuck in a retry loop)
+is precisely the one that will not pause to read a file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SOURCE = REPO_ROOT / "AGENTS.md"
+AGENTS_DIR = REPO_ROOT / ".github" / "agents"
+
+BEGIN = "<!-- BEGIN:shared-conventions -->"
+END = "<!-- END:shared-conventions -->"
+
+PREAMBLE = (
+    "> **Inherited from [`AGENTS.md`](../../AGENTS.md) — do not edit here.**\n"
+    "> A custom-agent subagent receives ONLY this persona file: repo-level instruction files do not\n"
+    "> reach it (verified). So these conventions are generated into every agent by\n"
+    "> `scripts/sync_agent_conventions.py`, and CI fails if a copy drifts. Edit `AGENTS.md`, then\n"
+    "> re-run that script.\n"
+)
+
+log = logging.getLogger("sync_agent_conventions")
+
+
+def canonical_block() -> str:
+    """The fenced conventions block from AGENTS.md, without its fences."""
+    text = SOURCE.read_text(encoding="utf-8")
+    if BEGIN not in text or END not in text:
+        raise SystemExit(f"{SOURCE.name} is missing the {BEGIN} / {END} fences")
+    body = text.split(BEGIN, 1)[1].split(END, 1)[0]
+    return body.strip("\n")
+
+
+def _rendered() -> str:
+    return f"{BEGIN}\n{PREAMBLE}\n{canonical_block()}\n{END}"
+
+
+def _split_frontmatter(text: str) -> tuple[str, str]:
+    """Return (frontmatter_including_fences, rest). The block goes right after the frontmatter.
+
+    Early context beats buried context: a 40 KB persona can push a late rule out of an agent's
+    effective attention, so the conventions sit immediately below the agent's own header.
+    """
+    if not text.startswith("---"):
+        return "", text
+    end = text.find("\n---", 3)
+    if end == -1:
+        return "", text
+    cut = text.find("\n", end + 1) + 1
+    return text[:cut], text[cut:]
+
+
+def apply_to(path: Path, write: bool) -> bool:
+    """Insert or refresh the block in one agent file. Returns True when the file is (or would be) changed."""
+    text = path.read_text(encoding="utf-8")
+    block = _rendered()
+
+    if BEGIN in text and END in text:
+        head, rest = text.split(BEGIN, 1)
+        _, tail = rest.split(END, 1)
+        updated = f"{head}{block}{tail}"
+    else:
+        frontmatter, body = _split_frontmatter(text)
+        updated = f"{frontmatter}\n{block}\n{body.lstrip(chr(10))}"
+
+    if updated == text:
+        return False
+    if write:
+        path.write_text(updated, encoding="utf-8")
+    return True
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--check", action="store_true", help="CI gate: report drift and exit 1, changing nothing")
+    args = parser.parse_args(argv)
+
+    agents = sorted(AGENTS_DIR.glob("*.agent.md"))
+    if not agents:
+        log.error("No agent files found under %s", AGENTS_DIR)
+        return 1
+
+    drifted = [p for p in agents if apply_to(p, write=not args.check)]
+
+    if args.check:
+        if drifted:
+            log.error("SHARED CONVENTIONS OUT OF SYNC - these agents do not carry the current AGENTS.md block:")
+            for path in drifted:
+                log.error("  %s", path.relative_to(REPO_ROOT))
+            log.error("\nRun `python scripts/sync_agent_conventions.py` and commit the result.")
+            log.error(
+                "This matters because a subagent receives ONLY its persona file - a convention that "
+                "lives only in AGENTS.md silently does not apply to it."
+            )
+            return 1
+        log.info("OK - all %d agent(s) carry the current shared conventions.", len(agents))
+        return 0
+
+    for path in drifted:
+        log.info("  updated %s", path.relative_to(REPO_ROOT))
+    log.info("done - %d of %d agent file(s) updated.", len(drifted), len(agents))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_check_m_syntax.py
+++ b/tests/test_check_m_syntax.py
@@ -18,7 +18,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
 # ruff: noqa: E402  (the sys.path insert above must precede this import)
-from check_m_syntax import _check_expression, _iter_m_blocks, check_model
+from check_m_syntax import _check_expression, _iter_m_blocks, check_model, check_model_counted
 
 DUMMY = Path("model.tmdl")
 
@@ -154,10 +154,64 @@ def test_committed_example_models_are_clean() -> None:
     assert not offenders, f"false positives on known-good models: {offenders}"
 
 
+@pytest.mark.parametrize(
+    ("expression", "why"),
+    [
+        ("let mode = 1 in mode", "an M step named `mode` is not a TMDL metadata key"),
+        ("let annotation = 1 in annotation", "same for `annotation`"),
+        ("[let = 1]", "`let` is a legal generalized field name"),
+        ("each [let value]", "field access may be named after a keyword"),
+        ("type table [let = text]", "and inside a type record"),
+        ("{try 1 catch () => 0}", "`catch` is valid M error handling"),
+        ("{0x0}", "hexadecimal literals are valid M"),
+    ],
+)
+def test_reported_false_positives_stay_fixed(expression: str, why: str) -> None:
+    """Every false positive an adversarial review found, pinned as a regression test.
+
+    Precision matters more than recall here: this runs in CI and inside an agent's build loop, so
+    crying wolf on valid M gets the tool switched off, which loses the entire benefit.
+    """
+    assert _check_expression(DUMMY, expression) == [], why
+
+
+def test_non_utf8_file_does_not_crash(tmp_path: Path) -> None:
+    """A stray non-UTF8 byte used to raise an uncaught UnicodeDecodeError traceback."""
+    tables = tmp_path / "B.SemanticModel" / "definition" / "tables"
+    tables.mkdir(parents=True)
+    (tables / "bad.tmdl").write_bytes(b"table \x96\n")
+    assert check_model(tmp_path / "B.SemanticModel") == []
+
+
+def test_nothing_checked_is_not_reported_as_clean(tmp_path: Path) -> None:
+    """ "No findings" and "nothing was scanned" must be distinguishable.
+
+    Otherwise a missing or unreadable model reports a reassuring "M syntax OK" while proving nothing,
+    and an agent takes that as a green light.
+    """
+    empty = tmp_path / "Empty.SemanticModel"
+    (empty / "definition").mkdir(parents=True)
+    findings, scanned = check_model_counted(empty)
+    assert findings == []
+    assert scanned == 0
+
+
+def test_column_accounts_for_the_tmdl_prefix(tmp_path: Path) -> None:
+    """An inline `source = ...` starts partway along the line; a short column misdirects the fix."""
+    tables = tmp_path / "C.SemanticModel" / "definition" / "tables"
+    tables.mkdir(parents=True)
+    line = "\t\tsource = let S = {1,} in S"
+    (tables / "T.tmdl").write_text(f"table T\n\tpartition T = m\n\t\tmode: import\n{line}\n", encoding="utf-8")
+    findings = check_model(tmp_path / "C.SemanticModel")
+    assert len(findings) == 1
+    # the offending comma is the one right before '}' - locate it in the real line
+    assert findings[0].col == line.index(",}") + 1
+
+
 def test_block_extraction_stops_at_tmdl_metadata() -> None:
     """`annotation`/`lineageTag` lines are TMDL, not M - swallowing them would corrupt the scan."""
     path = REPO_ROOT / "examples" / "health-tracker" / "fabric"
     expressions = next(path.glob("*.SemanticModel/definition/expressions.tmdl"))
     blocks = _iter_m_blocks(expressions)
     assert blocks
-    assert all("lineageTag" not in body and "annotation" not in body for body, _ in blocks)
+    assert all("lineageTag" not in body and "annotation" not in body for body, _, _ in blocks)


### PR DESCRIPTION
Three findings, all **measured** rather than assumed.

## 1. `AGENTS.md` never reached a single subagent

You suspected this. A sentinel experiment settles it — the **same** custom agent:

| Invocation | AGENTS.md sentinels | Persona sentinel |
|---|---|---|
| root session (`copilot --agent=…`) | **PRESENT** ×6 | PRESENT |
| **subagent** (Task tool) | **ABSENT** ×6 | PRESENT |

All four real agents confirmed independently — `pbi-semantic-builder` reported `AGENTS.md` appears in its context *exactly once, as a filename in a directory listing*. `.github/copilot-instructions.md` and user-global instructions are cut off the same way, and there is **no** `include`/`extends` frontmatter or documented inheritance.

So the retry cap from the last PR was a **no-op for the subagent that hung** — and it wasn't alone:

| Convention | Reached |
|---|---|
| Cite your source · confidence markers · own your layer · clean up after yourself · durable learnings | **zero agents** |

The orchestrator had already recorded the symptom without knowing the cause: *"The shared convention tells each subagent to close its own instance when done, but in practice some don't."*

**Fix:** `scripts/sync_agent_conventions.py` generates the fenced `AGENTS.md` block into every persona; `--check` is wired into CI so copies cannot drift. Four copies is exactly the redundancy `AGENTS.md` was written to avoid — but deterministic duplication beats an elegant abstraction that doesn't execute. Runtime-reading was rejected: it's discretionary, and a stuck agent is precisely the one that won't pause to read a file.

Also **generalised beyond credentials** — `pbi-report-builder` documents a bridge deadlock whose prescribed recovery is *"kill your PID and relaunch"*: an unbounded loop by construction.

## 2. The refresh literally could not be persisted

Desktop **does** cache PBIP data — in `<Name>.SemanticModel/.pbi/cache.abf` — but **only on save**, and the Desktop Bridge CLI has **no save verb**. An XMLA refresh leaves the file dirty, so the data died with the session. A missing capability, not carelessness.

`scripts/refresh_pbip_model.py` refreshes over XMLA and saves via **UI Automation `InvokePattern`** (SendKeys fails — `SetForegroundWindow` is refused even with `AttachThreadInput`, so Ctrl+S lands on the wrong window). It reports `DATA_OK + PERSISTED` only when a real row returned **and** the cache advanced.

**Verified end to end:** refresh → save → `cache.abf` updated → close Desktop → reopen → `DATA_OK` **without refreshing**.

Also measured: Desktop **discards the cache when `definition/*.tmdl` is newer** (a model with a valid 113 KB cache opened `NO_DATA` because its TMDL was touched a week later). The handoff gate therefore orders it explicitly — all edits, then refresh, then save — and warns that `set_data_folder.py --sanitize` invalidates it.

## 3. The M checker wasn't as good as it looked

An adversarial review measured **~10% recall and a 10% false-positive rate** and was right that it wasn't safe as a blocking gate. Every false positive it found is fixed and pinned by a regression test:

- a step named `mode`/`annotation` no longer truncates the block
- `let` as a generalized field name is no longer counted (`[let = 1]`, `each [let value]`)
- `catch` and hex literals recognised; quoted TMDL names containing `=` parse
- no longer crashes on non-UTF8; no longer prints a reassuring "M syntax OK" when **nothing was scanned**; reports the true column for inline expressions

Its limits are now stated **in the agent instruction** rather than implied: it excludes one class of defect, and a clean run is *not* proof the model opens. Step 10's refresh is what actually proves the M is valid.

## Gates

ruff clean · pylint **10.00/10** · **119 tests** · M gate clean · conventions-sync gate clean · privacy gate exit 0.
