### PR TITLE
Say what UI Automation is, and that using it here is a workaround

### DIFF
--- a/.github/agents/pbi-semantic-builder.agent.md
+++ b/.github/agents/pbi-semantic-builder.agent.md
@@ -241,7 +241,11 @@ field is used inside an aggregated shelf reference (`sum:`, `avg:` prefix in the
     **no save verb** (`status`/`manifest`/`open`/`reload`/`screenshot`/`screenshot-all`) — so the
     refresh was routinely lost. It is a missing capability, not carelessness. `SendKeys` does not
     work either (`SetForegroundWindow` is refused, so Ctrl+S lands on the wrong window); the script
-    uses UI Automation's InvokePattern, which needs no focus. Verified end to end 2026-07-30:
+    uses **UI Automation** — the Windows *accessibility* API that screen readers use to activate
+    controls — because its `InvokePattern` needs no foreground focus. Treat that as a workaround, not
+    a design: it depends on an element named "Save", so it breaks on ribbon changes and non-English
+    installs, and a modal dialog swallows it silently — which is why the script verifies the result
+    instead of assuming it. Verified end to end 2026-07-30:
     refresh → save → `cache.abf` updated → close Desktop → reopen → `DATA_OK` **without refreshing**.
     **Order matters — the cache dies if the definition changes after it.** Desktop discards
     `cache.abf` when `definition/*.tmdl` is newer (verified: a model with a valid 113 KB cache opened

--- a/scripts/refresh_pbip_model.py
+++ b/scripts/refresh_pbip_model.py
@@ -114,10 +114,17 @@ def save(pid: int) -> tuple[bool, str]:
     The bridge has no save verb, so this drives the UI - but NOT with SendKeys. Verified 2026-07-30:
     `SetForegroundWindow` (even with the `AttachThreadInput` workaround) is refused in this context,
     so the Ctrl+S keystroke silently lands on whatever window has focus and the model stays dirty.
-    UI Automation's InvokePattern needs no foreground focus and works reliably - the same mechanism
-    `probe_desktop_credential.ps1` already uses against Desktop.
 
-    The result is never assumed: it is confirmed against the bridge's own `hasUnsavedChanges` flag.
+    Instead we use **UI Automation (UIA)** - the Windows *accessibility* framework, the API screen
+    readers use to enumerate and activate controls on behalf of users with disabilities. It exposes
+    the app as a tree of elements with invokable patterns, and `InvokePattern` needs no foreground
+    focus, which is why it works here. `probe_desktop_credential.ps1` already uses it against Desktop.
+
+    Be clear-eyed that this is a WORKAROUND, not a design: an accessibility surface is not an
+    automation contract. It depends on an element literally named "Save", so it breaks on ribbon
+    changes and on non-English installs, it cannot run headless, and a modal dialog swallows the
+    invoke silently. Hence the result is never assumed - it is confirmed against the bridge's own
+    `hasUnsavedChanges` flag. If a real `save` verb ever ships, delete this and call it.
     """
     before = _instance(pid)
     if before is None:


### PR DESCRIPTION
Both `scripts/refresh_pbip_model.py` and `pbi-semantic-builder.agent.md` step 10 said *"UI Automation"* without saying what it is or why it is a concession.

**UIA is the Windows accessibility framework** — the API screen readers use to enumerate and activate controls on behalf of users with disabilities. We are using an assistive-technology surface to click a Save button, because the Desktop Bridge exposes no programmatic one.

Naming that plainly does two things:

1. **Explains the constraint** — `InvokePattern` needs no foreground focus, which is exactly why it works where `SendKeys` does not (`SetForegroundWindow` is refused for a background process, even with `AttachThreadInput`).
2. **Stops it reading as a deliberate design** someone might later "tidy up" into something more fragile.

An accessibility surface is not an automation contract: it depends on an element literally named `Save`, so it breaks on ribbon changes and non-English installs, it cannot run headless, and a modal dialog swallows the invoke silently — which is precisely why the script verifies against the bridge's own `hasUnsavedChanges` rather than assuming success.

Also leaves an exit note: **if a real `save` verb ever ships, delete this and call it.**

Docs only — no behaviour change. ruff clean · pylint 10.00/10 · 119 tests · conventions-sync gate clean.