### PR TITLE
Audit the agent profiles against GitHub's documented schema, and stop overclaiming

### DIFF
--- a/.github/agents/pbi-migration-validator.agent.md
+++ b/.github/agents/pbi-migration-validator.agent.md
@@ -1,6 +1,20 @@
 ---
 name: pbi-migration-validator
 description: Read-only reviewer that critiques a built Power BI report against its Tableau source, figure-by-figure and as a whole dashboard, on both visual and numeric fidelity. Reports discrepancies back to the orchestrator for routing to pbi-semantic-builder/pbi-report-builder - never edits TMDL/PBIR files itself.
+# DECLARED least-privilege, per GitHub's documented schema: an allow-list is the only real
+# enforcement for a read-only rule (prose instructions are advisory - an anti-pattern per the docs).
+# Omitting `edit`/`create`/`agent` is what would make "never edits TMDL/PBIR" a constraint, not a
+# request.
+#
+# MEASURED 2026-07-30: Copilot CLI did NOT apply this list - a probe of this agent came back still
+# holding `edit`, `create` and `task`. So on the CLI path this is a DECLARATION OF INTENT, honoured
+# where the platform implements it (GitHub.com / cloud agent); the prose rule in the body is what
+# actually does the work today. Do NOT treat this line as a sandbox or cite it as enforcement.
+#
+# `tool_search_tool` is listed deliberately: the Power BI MCP tools are DEFERRED and only reachable
+# after a tool search. Dropping it would leave `powerbi-*` listed-but-unreachable and silently kill
+# the numeric pass - the worst failure shape, because the validator would still look healthy.
+tools: ["read", "search", "execute", "web", "tool_search_tool", "powerbi-modeling-mcp/*", "powerbi-remote/*"]
 ---
 
 <!-- BEGIN:shared-conventions -->

--- a/.github/agents/tableau-migrator.agent.md
+++ b/.github/agents/tableau-migrator.agent.md
@@ -1,6 +1,10 @@
 ---
 name: tableau-migrator
 description: Orchestrates end-to-end migration of a Tableau workbook (.twb/.twbx) to a Microsoft Fabric Power BI semantic model + report. Parses the workbook, then delegates to the pbi-semantic-builder, pbi-report-builder, and pbi-migration-validator subagents.
+# This is the entry point a human drives deliberately - it runs a long, multi-phase, capacity-using
+# pipeline and delegates to three other agents. `disable-model-invocation: true` stops the model
+# auto-selecting it for some loosely-related request; it must be chosen explicitly.
+disable-model-invocation: true
 ---
 
 <!-- BEGIN:shared-conventions -->

--- a/scripts/sync_agent_conventions.py
+++ b/scripts/sync_agent_conventions.py
@@ -50,6 +50,15 @@ AGENTS_DIR = REPO_ROOT / ".github" / "agents"
 BEGIN = "<!-- BEGIN:shared-conventions -->"
 END = "<!-- END:shared-conventions -->"
 
+# GitHub documents a 30,000-character maximum for a custom agent prompt
+# (docs.github.com/en/copilot/reference/custom-agents-configuration).
+# Measured 2026-07-30: Copilot **CLI** does NOT enforce it - a ~48,000-char persona was probed at its
+# tail and every section came back verbatim. But the documented limit covers GitHub.com and the IDEs
+# too, so an over-cap persona is a portability risk: the same agent run GitHub-side may lose its tail,
+# and in these files the tail is the accumulated `## Gotchas` - precisely the hard-won learnings.
+# Hence a warning, not a failure: it keeps the number visible instead of letting it drift silently.
+PROMPT_CHAR_LIMIT = 30_000
+
 PREAMBLE = (
     "> **Inherited from [`AGENTS.md`](../../AGENTS.md) — do not edit here.**\n"
     "> A custom-agent subagent receives ONLY this persona file: repo-level instruction files do not\n"
@@ -109,6 +118,31 @@ def apply_to(path: Path, write: bool) -> bool:
     return True
 
 
+def prompt_size(path: Path) -> int:
+    """Characters in the agent's prompt - the markdown body, excluding YAML frontmatter."""
+    text = path.read_text(encoding="utf-8")
+    _, body = _split_frontmatter(text)
+    return len(body)
+
+
+def report_sizes(agents: list[Path]) -> list[Path]:
+    """Warn about personas over the documented prompt cap. Returns the over-cap files."""
+    over = [p for p in agents if prompt_size(p) > PROMPT_CHAR_LIMIT]
+    for path in sorted(agents, key=prompt_size, reverse=True):
+        size = prompt_size(path)
+        marker = "  OVER CAP" if size > PROMPT_CHAR_LIMIT else ""
+        log.info("  %6d chars (%3d%% of cap)  %s%s", size, 100 * size // PROMPT_CHAR_LIMIT, path.name, marker)
+    if over:
+        log.warning(
+            "%d persona(s) exceed GitHub's documented %d-char prompt cap. Copilot CLI does not "
+            "enforce it (measured), but GitHub-hosted runs may truncate - and the tail of these "
+            "files is the accumulated Gotchas. Trim before relying on the hosted path.",
+            len(over),
+            PROMPT_CHAR_LIMIT,
+        )
+    return over
+
+
 def main(argv: list[str] | None = None) -> int:
     """CLI entry point."""
     logging.basicConfig(level=logging.INFO, format="%(message)s")
@@ -135,6 +169,7 @@ def main(argv: list[str] | None = None) -> int:
             )
             return 1
         log.info("OK - all %d agent(s) carry the current shared conventions.", len(agents))
+        report_sizes(agents)
         return 0
 
     for path in drifted:


### PR DESCRIPTION
Researched what GitHub actually documents for custom agents **before** changing anything — the previous session's finding needed validating, not assuming.

## Confirmed: subagent isolation is intended design, not a bug

Four official sources. The strongest is the SDK fleet-mode doc:

> **"Provide each sub-agent with complete context; sub-agents are stateless across calls."**

A subagent's window is initialised from its own profile plus the delegated task, and nothing else — **skills aren't inherited either**. The docs also confirm `@file` includes work in `AGENTS.md`/`copilot-instructions.md` but **not** in `.agent.md`. So generating the block into each profile with a CI drift check is the only documented approach. **The workaround stands.**

## What we were missing — we used 2 of ~9 frontmatter fields

### `tools` — and the probe is the interesting part

GitHub documents the allow-list as the **only real enforcement**; prose is advisory, and *"MANDATORY prose without enforcement"* is a named anti-pattern. Our validator is documented *"read-only, never edits"* and had full edit access.

I declared an allow-list — **then tested it. Copilot CLI did not apply it.** The agent came back still holding `edit`, `create` and `task`.

So it ships as a **declaration of intent**, honoured where the platform implements it, with a comment saying plainly it is *not* enforcement today. Shipping a control that merely *looks* enforced is the same false-assurance failure as `validate` printing "0 errors" after `PBIR_SCHEMA_UNREACHABLE`.

The probe also caught two things I'd reasoned about **wrongly**:
- `create` is a **separate tool** from `edit` — an allow-list handles it, *"omit edit"* would not have
- the Power BI MCP tools are **deferred** — unreachable without `tool_search_tool`, so omitting it would leave them listed-but-dead and **silently kill the numeric pass**

### `disable-model-invocation` on the orchestrator
It drives a long, capacity-using, three-subagent pipeline — it should be chosen deliberately, never auto-selected.

### Prompt size
GitHub documents a **30,000-char cap**; three of four personas exceed it (semantic-builder at **158%**), and the part past the cap is the accumulated Gotchas.

Probed that too: **the CLI does not truncate** — a ~48k persona quoted its own final section back verbatim. So it's a *portability* risk for GitHub-hosted runs, not a live break. Now surfaced as a warning by `sync_agent_conventions.py --check` so it can't drift unnoticed.

## Deliberately not done

**Pinning `model` per agent.** The docs recommend it, but a pinned model can be unavailable on someone else's plan, and this repo already lets the operator choose. Recording the reasoning rather than silently skipping it.

**Gates:** ruff clean · pylint 10.00/10 · 126 tests · YAML frontmatter validated · conventions-sync green.