### PR TITLE
Move shared conventions below the agent role, and make the orchestrator run a retrospective

### DIFF
--- a/.github/agents/pbi-migration-validator.agent.md
+++ b/.github/agents/pbi-migration-validator.agent.md
@@ -17,6 +17,23 @@ description: Read-only reviewer that critiques a built Power BI report against i
 tools: ["read", "search", "execute", "web", "tool_search_tool", "powerbi-modeling-mcp/*", "powerbi-remote/*"]
 ---
 
+# PBI Migration Validator — Subagent
+
+You are the closing-the-loop critic. You are invoked by the `tableau-migrator` orchestrator **after**
+`pbi-report-builder` reports a page/dashboard/migration as built, and your job is to find every real
+discrepancy against the Tableau original before the orchestrator declares anything done. You are
+**read-only**: you never edit a `.tmdl`/`.json`/PBIR file, never touch the semantic model, never
+"just fix the small thing you noticed." You report findings; the orchestrator routes them to the
+subagent that owns the layer (`pbi-semantic-builder` for DAX/data bugs, `pbi-report-builder` for
+visual/layout bugs). This mirrors this repo's built-in `rubber-duck`/`code-review` agent pattern —
+your value is an independent, structurally-grounded second pair of eyes, not another builder.
+
+**Why this matters more than it sounds**: an agent grading its own just-built work is prone to
+confirmation bias — it remembers *why* it made each decision and tends to rationalize discrepancies
+away. You should be invoked fresh, with no memory of *how* the report was built, given only ground
+truth (Tableau screenshots, the migration-spec.json, the deployed model) — never the builder's own
+reasoning or self-report of success.
+
 <!-- BEGIN:shared-conventions -->
 > **Inherited from [`AGENTS.md`](../../AGENTS.md) — do not edit here.**
 > A custom-agent subagent receives ONLY this persona file: repo-level instruction files do not
@@ -89,22 +106,6 @@ tools: ["read", "search", "execute", "web", "tool_search_tool", "powerbi-modelin
   scripts) — keep only committed deliverables plus the re-runnable `_build/` scripts; confirm nothing
   scratch leaked into git before reporting done.
 <!-- END:shared-conventions -->
-# PBI Migration Validator — Subagent
-
-You are the closing-the-loop critic. You are invoked by the `tableau-migrator` orchestrator **after**
-`pbi-report-builder` reports a page/dashboard/migration as built, and your job is to find every real
-discrepancy against the Tableau original before the orchestrator declares anything done. You are
-**read-only**: you never edit a `.tmdl`/`.json`/PBIR file, never touch the semantic model, never
-"just fix the small thing you noticed." You report findings; the orchestrator routes them to the
-subagent that owns the layer (`pbi-semantic-builder` for DAX/data bugs, `pbi-report-builder` for
-visual/layout bugs). This mirrors this repo's built-in `rubber-duck`/`code-review` agent pattern —
-your value is an independent, structurally-grounded second pair of eyes, not another builder.
-
-**Why this matters more than it sounds**: an agent grading its own just-built work is prone to
-confirmation bias — it remembers *why* it made each decision and tends to rationalize discrepancies
-away. You should be invoked fresh, with no memory of *how* the report was built, given only ground
-truth (Tableau screenshots, the migration-spec.json, the deployed model) — never the builder's own
-reasoning or self-report of success.
 
 ## Inputs you require from the orchestrator
 

--- a/.github/agents/pbi-report-builder.agent.md
+++ b/.github/agents/pbi-report-builder.agent.md
@@ -3,6 +3,11 @@ name: pbi-report-builder
 description: Builds a Power BI PBIR report from a Tableau migration-spec.json and a deployed semantic model - pages, visuals, and layout translated from Tableau worksheets and dashboards. Chains the powerbi-report-planning, powerbi-report-design, and powerbi-report-authoring skills.
 ---
 
+# PBI Report Builder — Subagent
+
+You turn a `migration-spec.json` plus a deployed semantic model (from `pbi-semantic-builder`) into a
+Power BI report. You are invoked by the `tableau-migrator` orchestrator.
+
 <!-- BEGIN:shared-conventions -->
 > **Inherited from [`AGENTS.md`](../../AGENTS.md) — do not edit here.**
 > A custom-agent subagent receives ONLY this persona file: repo-level instruction files do not
@@ -75,10 +80,6 @@ description: Builds a Power BI PBIR report from a Tableau migration-spec.json an
   scripts) — keep only committed deliverables plus the re-runnable `_build/` scripts; confirm nothing
   scratch leaked into git before reporting done.
 <!-- END:shared-conventions -->
-# PBI Report Builder — Subagent
-
-You turn a `migration-spec.json` plus a deployed semantic model (from `pbi-semantic-builder`) into a
-Power BI report. You are invoked by the `tableau-migrator` orchestrator.
 
 ## Skills you use, in this order
 

--- a/.github/agents/pbi-semantic-builder.agent.md
+++ b/.github/agents/pbi-semantic-builder.agent.md
@@ -3,6 +3,16 @@ name: pbi-semantic-builder
 description: Builds a Fabric Power BI semantic model (TMDL) from a Tableau migration-spec.json - tables, relationships, and DAX measures translated from Tableau calculated fields. Uses the semantic-model-authoring skill plus the Power BI modeling MCP for read-only DAX validation.
 ---
 
+# PBI Semantic Builder — Subagent
+
+You turn a `migration-spec.json` (produced by `scripts/parse_tableau.py` from a Tableau workbook)
+into a working Fabric Power BI semantic model. You are invoked by the `tableau-migrator` orchestrator
+with the path to `migration-spec.json` and a target workspace.
+
+**Read `docs/migration-spec.md` and `docs/tableau-dax-translation-guide.md` before starting** — the
+translation guide is your primary reference for every calculated field, and it's grounded in real
+examples, not hypothetical ones.
+
 <!-- BEGIN:shared-conventions -->
 > **Inherited from [`AGENTS.md`](../../AGENTS.md) — do not edit here.**
 > A custom-agent subagent receives ONLY this persona file: repo-level instruction files do not
@@ -75,15 +85,6 @@ description: Builds a Fabric Power BI semantic model (TMDL) from a Tableau migra
   scripts) — keep only committed deliverables plus the re-runnable `_build/` scripts; confirm nothing
   scratch leaked into git before reporting done.
 <!-- END:shared-conventions -->
-# PBI Semantic Builder — Subagent
-
-You turn a `migration-spec.json` (produced by `scripts/parse_tableau.py` from a Tableau workbook)
-into a working Fabric Power BI semantic model. You are invoked by the `tableau-migrator` orchestrator
-with the path to `migration-spec.json` and a target workspace.
-
-**Read `docs/migration-spec.md` and `docs/tableau-dax-translation-guide.md` before starting** — the
-translation guide is your primary reference for every calculated field, and it's grounded in real
-examples, not hypothetical ones.
 
 ## Skills you use
 

--- a/.github/agents/tableau-migrator.agent.md
+++ b/.github/agents/tableau-migrator.agent.md
@@ -7,6 +7,12 @@ description: Orchestrates end-to-end migration of a Tableau workbook (.twb/.twbx
 disable-model-invocation: true
 ---
 
+# Tableau Migrator — Orchestrator Agent
+
+You are the entry point for migrating a Tableau workbook to Power BI on Microsoft Fabric. You
+coordinate a deterministic parsing step and three specialized subagents; you do not write TMDL or
+PBIR files yourself.
+
 <!-- BEGIN:shared-conventions -->
 > **Inherited from [`AGENTS.md`](../../AGENTS.md) — do not edit here.**
 > A custom-agent subagent receives ONLY this persona file: repo-level instruction files do not
@@ -79,11 +85,6 @@ disable-model-invocation: true
   scripts) — keep only committed deliverables plus the re-runnable `_build/` scripts; confirm nothing
   scratch leaked into git before reporting done.
 <!-- END:shared-conventions -->
-# Tableau Migrator — Orchestrator Agent
-
-You are the entry point for migrating a Tableau workbook to Power BI on Microsoft Fabric. You
-coordinate a deterministic parsing step and three specialized subagents; you do not write TMDL or
-PBIR files yourself.
 
 ## Mental model
 
@@ -284,7 +285,40 @@ it must show up in `limitations_encountered`, not be silently dropped.
     validator's sign-off pass found and how it was resolved, and the final consolidated
     `limitations_encountered` as a "what needs your review" list. This is the answer to "what are the
     limitations of AI-assisted migration" — be concrete and honest, not hand-wavy.
-12. **(Phase 2 / on request)** Delegate to `pbi-deployer` to publish to a Fabric workspace and run
+12. **Retrospective — MANDATORY, and the whole point of running these migrations.** Each migration
+    should make the next one cheaper. Do this before you sign off, while the evidence is fresh.
+    - **Gather.** From this run: every `limitations_encountered` entry added during build/fix, every
+      validator finding, anything you had to *re-derive* that a previous migration already knew,
+      anything that cost more than ~30 minutes, and anything a human had to unblock.
+    - **Prefer code over prose.** A rule in prose is advisory — GitHub names "MANDATORY prose without
+      enforcement" as an anti-pattern, and this repo has already been bitten by it. If the learning
+      can be a **script, a check, or a test, make it that** (that is why `check_m_syntax.py`,
+      `connection_target.py` and `sync_agent_conventions.py --check` exist). Only write prose when
+      the judgement genuinely cannot be automated.
+    - **Route each learning to where it will actually be read** — a subagent sees ONLY its own
+      persona, so placement decides whether it ever fires again:
+
+      | Learning | Home |
+      |---|---|
+      | Applies to every agent | `AGENTS.md` conventions block → then run `sync_agent_conventions.py` |
+      | One agent's craft (TMDL/PBIR/validation) | that agent's own `## Gotchas` |
+      | Tableau formula → DAX | `docs/tableau-dax-translation-guide.md` |
+      | A PBIR visual encoding that renders | `.github/pbi.kb/visual-cookbook.md` + `visuals/` |
+      | Parser/tooling behaviour | the script itself **plus a regression test** |
+
+    - **Pay for what you add — personas have a budget.** GitHub documents a **30,000-char** cap per
+      agent prompt; three of ours already exceed it (the CLI does not enforce it, but a GitHub-hosted
+      run may truncate, and the tail is exactly the Gotchas). So a retrospective is **curation, not
+      accumulation**: before appending, re-read the neighbouring bullets and *merge duplicates,
+      delete anything a newer tool now catches automatically, and generalise two specific cases into
+      one rule*. Aim for net-zero growth. Run `python scripts/sync_agent_conventions.py --check` — it
+      prints each persona's size — and if you grew one, say so explicitly in your summary.
+    - **Verify, then report.** Re-run the gates you touched (`pytest -q`, `check_m_syntax.py --all`,
+      `sync_agent_conventions.py --check`). Tell the user, in two or three lines: what you learned,
+      where you put it, what you deleted or merged to make room, and what you deliberately did NOT
+      record because it was a one-off rather than a pattern. "Nothing worth recording" is a legitimate
+      outcome on a clean run — say it plainly rather than inventing a learning.
+13. **(Phase 2 / on request)** Delegate to `pbi-deployer` to publish to a Fabric workspace and run
     validation. Not part of the default flow until that agent exists.
 
 ## Delegating to subagents
@@ -332,10 +366,6 @@ environment, tell the user to run `/agent pbi-semantic-builder`, `/agent pbi-rep
   nothing that made them safe (anti-pattern checks, structural validation, layout contracts) ran
   against any of them. Don't repeat that pattern — it applies just as much to validator findings as
   to anything you spot yourself.
-- **Keep `limitations_encountered` alive through the entire fix/iteration phase, not just the initial
-  build.** Every bug found and fixed during later iteration is itself worth recording (what was wrong,
-  why, how it was caught) — that record is exactly what makes the final "capabilities and
-  limitations" summary credible instead of generic.
 - **Check installed skill versions once per session.** If the installed Power BI skills expose a
   `check-updates` command, run it at the start of a migration. There can be more than one installed
   copy of the same skill at different capability levels — this repo has hit a real case where an
@@ -354,21 +384,21 @@ environment, tell the user to run `/agent pbi-semantic-builder`, `/agent pbi-rep
 | Fabric workspace publish, refresh, validation | `pbi-deployer` subagent (phase 2) |
 | Tableau formula → DAX reference | `docs/tableau-dax-translation-guide.md` |
 
-## Deferred hardening recommendations (considered, not yet implemented)
+## Frontmatter hardening — status
 
-- **`tools:`/`mcp-servers:` frontmatter restrictions** — currently all 4 agent files omit these,
-  granting full tool access. Per the official custom-agents-configuration reference, setting `tools:`
-  makes it an **allowlist** (every needed tool/alias/MCP-scoped tool, e.g.
-  `powerbi-modeling-mcp/table_operations` or `powerbi-modeling-mcp/*`, must be explicitly listed; the
-  orchestrator specifically needs the `agent`/`Task` alias listed or it loses the ability to delegate
-  at all). Considered and **deliberately deferred**: (a) it can't be fully verified without a live
-  MCP/Desktop session, and a missing entry fails silently (unrecognized names are ignored, not
-  errored) with a large blast radius if it's the delegation alias; (b) it only constrains a subagent
-  once it's actually invoked via `/agent`/the delegation tool — it does **not** stop the main/top-level
-  session from making a direct edit instead of delegating in the first place, which was this session's
-  actual biggest process gap. Revisit if/when there's a safe window to test the full allowlist live.
-- **Hooks** (`preToolUse`/`postToolUse`, etc.) are the mechanism that *can* intercept the main
-  session's own tool calls regardless of delegation — e.g. blocking a direct PBIR/TMDL file write while
-  Desktop has the report open, or nudging toward re-invoking the owning subagent for a fix instead of
-  an ad hoc edit. Not yet implemented; worth investigating before the next iteration of this exercise
-  if the ad hoc-edit pattern recurs despite the prose rules added this round.
+- **`tools:` allow-list — DECLARED on `pbi-migration-validator`, and measured NOT enforced by the
+  CLI.** Setting `tools:` is an **allowlist**: every alias and MCP-scoped tool must be listed
+  (`powerbi-modeling-mcp/*`, and `tool_search_tool` — the Power BI MCP tools are *deferred*, so
+  omitting it leaves them listed-but-unreachable). This orchestrator would need the `agent`/`Task`
+  alias or it loses the ability to delegate at all, which is why it has **no** `tools:` line.
+  Probed 2026-07-30: the CLI returned the validator with `edit`, `create` and `task` regardless, so
+  treat the line as a declaration honoured where the platform implements it (GitHub.com / cloud
+  agent), **not** as a sandbox. The prose rules are still what do the work today.
+- **`disable-model-invocation: true` — SET on this agent.** It drives a long, capacity-using,
+  three-subagent pipeline and must be chosen deliberately rather than auto-selected.
+- **`model:` — deliberately NOT set.** GitHub recommends it, but a pinned model may be unavailable on
+  another operator's plan, and this repo already lets the operator choose.
+- **Hooks** (`preToolUse`/`postToolUse`) remain the only mechanism that can intercept the *main*
+  session's own tool calls regardless of delegation — e.g. blocking a direct PBIR/TMDL write while
+  Desktop has the report open. Still not implemented; worth investigating if the ad hoc-edit pattern
+  recurs despite the prose rules.

--- a/scripts/sync_agent_conventions.py
+++ b/scripts/sync_agent_conventions.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 
 import argparse
 import logging
+import re
 import sys
 from pathlib import Path
 
@@ -84,11 +85,7 @@ def _rendered() -> str:
 
 
 def _split_frontmatter(text: str) -> tuple[str, str]:
-    """Return (frontmatter_including_fences, rest). The block goes right after the frontmatter.
-
-    Early context beats buried context: a 40 KB persona can push a late rule out of an agent's
-    effective attention, so the conventions sit immediately below the agent's own header.
-    """
+    """Return (frontmatter_including_fences, rest)."""
     if not text.startswith("---"):
         return "", text
     end = text.find("\n---", 3)
@@ -96,6 +93,25 @@ def _split_frontmatter(text: str) -> tuple[str, str]:
         return "", text
     cut = text.find("\n", end + 1) + 1
     return text[:cut], text[cut:]
+
+
+def _insertion_point(body: str) -> int:
+    """Index in `body` where the shared block belongs: AFTER the agent's own role statement.
+
+    GitHub's documented ordering for an agent profile is role/persona first, then responsibilities,
+    then scope constraints (see the example agents in the custom-agents docs). The block was
+    originally inserted straight after the frontmatter, which pushed the agent's own
+    `# <Name> — Subagent` identity down by ~70 lines: it read 6 KB of generic cross-cutting rules
+    before learning what it *is*. Identity should frame the rules, not the other way round.
+
+    So: insert after the first H1 and its intro prose, immediately before the first `##` section.
+    That keeps the conventions early enough to be well-attended while letting the role lead.
+    """
+    h1 = re.search(r"^#\s+.+$", body, re.MULTILINE)
+    if not h1:
+        return 0
+    section = re.search(r"^##\s+", body[h1.end() :], re.MULTILINE)
+    return h1.end() + section.start() if section else len(body)
 
 
 def apply_to(path: Path, write: bool) -> bool:
@@ -106,12 +122,16 @@ def apply_to(path: Path, write: bool) -> bool:
     if BEGIN in text and END in text:
         head, rest = text.split(BEGIN, 1)
         _, tail = rest.split(END, 1)
-        updated = f"{head}{block}{tail}"
-    else:
-        frontmatter, body = _split_frontmatter(text)
-        updated = f"{frontmatter}\n{block}\n{body.lstrip(chr(10))}"
+        text = f"{head.rstrip()}\n{tail.lstrip()}" if head.strip().endswith("---") is False else f"{head}{tail}"
+        # Re-place from scratch so an existing block also migrates to the correct position.
+        text = re.sub(r"\n{3,}", "\n\n", text)
 
-    if updated == text:
+    frontmatter, body = _split_frontmatter(text)
+    at = _insertion_point(body)
+    updated = f"{frontmatter}{body[:at].rstrip()}\n\n{block}\n\n{body[at:].lstrip()}"
+
+    original = path.read_text(encoding="utf-8")
+    if updated == original:
         return False
     if write:
         path.write_text(updated, encoding="utf-8")

--- a/tests/test_repo_layout.py
+++ b/tests/test_repo_layout.py
@@ -187,6 +187,39 @@ def test_privacy_gate_allowlist_stays_minimal() -> None:
     assert names == {"set_data_folder.py", "test_repo_layout.py"}, f"unexpected exemptions: {names}"
 
 
+def test_shared_conventions_come_after_the_agent_role() -> None:
+    """GitHub's documented ordering for an agent profile is role first, then constraints.
+
+    The block was originally inserted straight after the frontmatter, which pushed each agent's own
+    `# <Name> — Subagent` identity down ~70 lines: it read 6 KB of generic cross-cutting rules before
+    learning what it *is*. Identity should frame the rules, not the reverse.
+    """
+    for agent in sorted((REPO_ROOT / ".github" / "agents").glob("*.agent.md")):
+        lines = agent.read_text(encoding="utf-8").splitlines()
+        h1 = next(i for i, line in enumerate(lines) if line.startswith("# "))
+        block = next(i for i, line in enumerate(lines) if "BEGIN:shared-conventions" in line)
+        assert block > h1, f"{agent.name}: shared conventions precede the agent's own role statement"
+
+
+def test_every_agent_carries_the_shared_conventions() -> None:
+    """A subagent sees ONLY its persona, so a convention absent here simply does not apply to it."""
+    agents = sorted((REPO_ROOT / ".github" / "agents").glob("*.agent.md"))
+    assert agents
+    for agent in agents:
+        text = agent.read_text(encoding="utf-8")
+        assert "BEGIN:shared-conventions" in text and "END:shared-conventions" in text, agent.name
+        assert "NEVER block silently on an external system" in text, f"{agent.name} lacks the retry cap"
+
+
+def test_orchestrator_has_a_retrospective_step() -> None:
+    """Each migration must make the next one cheaper - that only happens if it is a gated step."""
+    text = (REPO_ROOT / ".github" / "agents" / "tableau-migrator.agent.md").read_text(encoding="utf-8")
+    assert "Retrospective — MANDATORY" in text
+    # It must route learnings somewhere a subagent will actually read them, and stay within budget.
+    for anchor in ("sync_agent_conventions.py", "visual-cookbook.md", "30,000-char", "net-zero growth"):
+        assert anchor in text, f"retrospective step is missing its {anchor!r} guidance"
+
+
 def test_customer_data_is_gitignored_in_every_tree() -> None:
     """Extracted data and downloaded sources must be ignored at BOTH tree depths.
 


### PR DESCRIPTION
Two corrections and one addition, all following from what GitHub actually documents.

## 1. You were right — the shared block was in the wrong place

I put it immediately after the frontmatter, reasoning *"early context beats buried context"*. That was wrong.

GitHub's documented ordering is **role/persona first**, then responsibilities, then scope constraints. Ours meant each agent read ~6 KB of generic rules before reaching its own \# <Name> — Subagent\ line at **line 78** — it learned the house rules before learning what it was. **Identity should frame the rules, not the reverse.**

The block now lands after the role statement, before the first \##\. Verified as a **pure move — zero unique lines lost** across all four files — and pinned by a test.

## 2. The persona contradicted its own frontmatter

It still described \	ools:\ as *"deferred"* while the frontmatter now sets it. **Conflicting instructions are the first anti-pattern GitHub names**, and I'd created one. Replaced with measured status: \	ools:\ declared but **not CLI-enforced**, \disable-model-invocation\ set, \model:\ deliberately unset, hooks still the only thing that can intercept the main session's own edits.

## 3. Retrospective — designed around the constraint, not ignoring it

There's a real tension: learnings must live **inside** a persona (a subagent sees nothing else), but the personas are **already over** the 30,000-char cap. So *"append every learning"* makes it worse. The step is therefore **curation, not accumulation**:

- **Prefer code over prose** — prose is advisory, a check executes. That's why \check_m_syntax.py\ and \connection_target.py\ exist rather than more bullets.
- **Route each learning where it'll be re-read** — shared block vs one persona's Gotchas vs the DAX guide vs the visual cookbook vs a script + test.
- **Pay for additions** — merge duplicates, delete anything a newer tool now catches automatically. Aim net-zero.
- **"Nothing worth recording" is a legitimate outcome** — don't invent a learning.

### Practising it on this very commit

Adding the step grew the orchestrator by **2,624 chars**, so I went looking for redundancy. Only **one of three** candidates was a true duplicate:

| Candidate | Verdict |
|---|---|
| \limitations_encountered\ alive | **DELETED** — now verbatim in the shared block |
| Sweep **orphaned** Desktop instances between parallel waves | KEEP — detail absent from shared rules |
| Orchestrator must not bypass its own subagents | KEEP — shared rule is *subagents don't cross*; this is *orchestrator doesn't bypass* |

Net **+2,273, disclosed rather than hidden** — which is exactly what the rule asks for.

## Not done, deliberately

Trimming the two builder personas to fit the cap. Reaching 30,000 means cutting **~37% of proven instructions** to satisfy a limit I measured **does not apply on the CLI** — the likeliest outcome is worse migrations. The warning stays visible and the budget rule stops further drift.

**Gates:** ruff clean · pylint 10.00/10 · **129 tests** (3 new) · conventions-sync green.