### PR TITLE
Correct three refuted agent-architecture claims; resolve the skill-visibility experiment

### DIFF
--- a/docs/agent-architecture.md
+++ b/docs/agent-architecture.md
@@ -5,8 +5,14 @@ on assumptions that turned out to be wrong. This is the researched, cited baseli
 actually documents, what was measured here, and what is still unknown. Read it before changing
 anything under `.github/agents/`.
 
-Last verified **2026-07-30** against docs.github.com. This area moves fast; re-check before relying
-on a claim.
+Last verified **2026-07-31**, by fetching the primary sources directly (not via a research summary)
+and by running the §6.1 subagent experiment. This area moves fast; re-check before relying on a claim.
+
+> **Corrections landed 2026-07-31.** Three claims in the previous revision were wrong and had been
+> written from an unverified research summary: (a) "there is no `skills` property" — there is one, on
+> the SDK surface (§2); (b) the 10 KB `additionalContext` cap was attributed to hooks generally — it
+> is documented for `postToolUse` only (§4); (c) `subagentStart`'s `additionalContext` field name was
+> labelled "inferred" — it is documented (§4). Cite the primary source, not this file, when it matters.
 
 ---
 
@@ -51,8 +57,21 @@ Canonical reference: <https://docs.github.com/en/copilot/reference/custom-agents
 | `infer` | **Retired** — use the two booleans above |
 | `deferred-tool-loading` | Appears in the tool-search docs, absent from the canonical reference — treat as unverified |
 
-**There is no `skills` property.** Checked against the GitHub reference, the VS Code reference, the
-plugin manifest schema and the agentskills.io spec. If you see that claim, ask for a doc URL.
+**`skills` — surface-dependent, and the earlier "no such property" claim was wrong.** A `skills`
+property **does** exist, on the **SDK** agent-definition surface, and it does exactly what per-agent
+progressive disclosure needs:
+
+> `| skills | string[] | Skill names to preload into the agent's context at startup |`
+> "When specified, the **full content** of each listed skill is eagerly injected into the agent's
+> context at startup — the agent doesn't need to invoke a skill tool; the instructions are already
+> present. Skills are **opt-in**: agents receive no skills by default, and sub-agents do not inherit
+> skills from the parent. Skill names are resolved from the session-level `skillDirectories`."
+> — <https://github.com/github/copilot-sdk/blob/main/docs/features/custom-agents.md>
+
+It is **absent from the `.agent.md` YAML frontmatter table** at the canonical reference above, so it
+is not known to apply to the markdown persona files this repo uses. Do not write `skills:` into an
+`.agent.md` and assume it works — §6.1 measured that repo-local skills do not even reach a subagent's
+skill registry. Treat it as: *documented for SDK-defined agents, unverified for `.agent.md`.*
 
 VS Code-only (ignored elsewhere): `argument-hint`, `agents`, `handoffs`, `hooks`.
 
@@ -83,23 +102,40 @@ name, and can inject `additionalContext` that is prepended to the subagent's pro
 carries `sessionId`, `timestamp`, `cwd`, `transcriptPath`, `agentName`, `agentDisplayName`,
 `agentDescription`.
 
-That makes it the documented mechanism for **per-agent progressive disclosure** — the thing the
-missing `skills` property would have provided. Crucially, injected context counts against the
-**context window**, not the 30,000-char persona cap.
+That makes it the documented mechanism for **per-agent progressive disclosure** — the thing a
+frontmatter `skills` property would have provided on the `.agent.md` surface. Crucially, injected
+context counts against the **context window**, not the 30,000-char persona cap.
+
+The `additionalContext` field name for this event is **documented, not inferred**: the events table
+states "Optional — cannot block creation, but `additionalContext` is prepended to the subagent's
+prompt." Note there is no dedicated TypeScript *Output* block for `subagentStart` (unlike
+`postToolUse` and `notification`, which have explicit ones) — only that sentence.
 
 Notes worth knowing before building on it:
 - The built-in `general-purpose` agent does **not** emit `subagentStart`/`subagentStop`. Custom
   agents do.
 - It can inject but **cannot block** subagent creation.
-- ~10 KB cap documented for the *combined* `additionalContext` of multiple hooks; the single-hook cap
-  is undocumented.
+- The **~10 KB cap is documented for `postToolUse` only** — "When multiple hooks return
+  `additionalContext`, the results are joined with a double newline and capped at 10 KB." No cap is
+  stated anywhere for `subagentStart`. Do not assume the two behave alike.
+- `subagentStart` **also fires under Copilot cloud agent** (events table, Cloud agent column:
+  "Fires."), so a hook-based design is not automatically broken on the hosted path.
 - `preToolUse` payload has **no `agentName`** — so a global `preToolUse` hook cannot cheaply say
   "block edits *only* for the validator".
+- **A repo hook is not a guarantee you control.** Hooks load from six places — policy-level
+  (machine-wide, and *cannot* be switched off by `disableAllHooks`), `.github/hooks/*.json`,
+  user-level `~/.copilot/hooks/`, inline `hooks` in `.github/copilot/settings.json`, inline `hooks`
+  in `~/.copilot/settings.json`, and plugin-contributed hooks. Any contributor can set
+  `disableAllHooks: true` in their repository `settings.json` and silently disable **every** repo
+  hook for their sessions. That is the decisive argument against moving anything load-bearing out of
+  the personas and into a hook — see §5.
 
-⚠️ **Untested here.** A probe hook in `.github/hooks/subagent-context.json` did not fire when a
-subagent was invoked in a session that started **before** the file existed — no log line was written.
-That is consistent with hooks being loaded at session start, like instruction files and skills. See
-§6 for the experiment that settles it.
+⚠️ **Measured 2026-07-31: the probe hook never executed.** `.github/hooks/subagent-context.json` +
+`scripts/hooks/probe_subagent_start.ps1` wrote **no** `_hook_probe.log` line when a custom subagent
+was invoked, and the subagent reported nothing prepended to its prompt (it begins directly with its
+own `#` heading). The session predated the hook file, which is consistent with hooks being snapshotted
+at session start — so this is "not loaded", **not** "fires but wrong output field". Re-run in a fresh
+session to separate the two; §6.2 has the outcome table.
 
 ## 5. What currently lives where
 
@@ -117,31 +153,69 @@ anti-pattern ("requests to refer to external resources") is about *unresolved am
 ("conform to styleguide.md"), not an imperative, verifiable step. But it is still **discretionary**:
 an agent may skip it.
 
-## 6. Open experiments — run these in a FRESH session
+### Why the shared block stays generated into the personas
 
-Both probes below were inconclusive only because this session predated the files. Hooks, skills and
-instruction files all appear to be snapshotted at session start, so **restart the CLI first**.
+It is tempting to move the ~6 KB shared-conventions block out of all four personas and into a
+`subagentStart` hook, reclaiming ~24 KB of budget. **Don't** — at least not for the conventions that
+must always hold. Ranked by how they fail:
 
-1. **Do repository skills reach a subagent?**
-   `.github/skills/sentinel-probe/SKILL.md` contains `SKILL_SENTINEL_ZEPHYR_74193`.
-   Start a fresh session → confirm the skill is listed → invoke a custom subagent → ask it to quote
-   the token *without* telling it the value.
-   - Quotes it → repo skills reach subagents; skills become the clean home for reference material.
-   - Cannot → skills are root-only; hook injection is required.
-   - Only after being told "use the sentinel-probe skill" → available but not auto-triggered; record
-     that as a third distinct outcome.
-   Note: a subagent probed here *did* see plugin-provided skills while not seeing this repo-local
-   one, so the discriminator may be *registration*, not the subagent boundary.
+| Mechanism | Fails when | Failure mode |
+|---|---|---|
+| Generated into the persona | never — it is the prompt | — |
+| `subagentStart` hook | contributor sets `disableAllHooks`; hook file added mid-session; IDE/other runtime that does not run repo hooks; fresh clone before trust is granted | **silent** — the agent simply behaves as if the rules never existed |
+| Repo-local skill | always, inside a subagent (§6.1) | silent |
 
-2. **Does `subagentStart` fire and inject?**
+The hook's failure mode is the disqualifier: nothing errors, the conventions just quietly stop
+applying, and the first symptom is an agent doing the exact thing the block forbids (retrying a dead
+credential for two hours, editing a layer it does not own). Duplication that CI keeps in sync is the
+cheaper problem. **Rule: anything whose absence is silent and harmful stays inline; a hook may only
+*supplement*.** If the persona budget must come down, cut per-agent Gotchas that have gone stale —
+that is what orchestrator step 12 is for.
+
+## 6. Experiments — one resolved, one still open
+
+1. **Do repository skills reach a subagent? — ✅ RESOLVED 2026-07-31: NO.**
+   `.github/skills/sentinel-probe/SKILL.md` contains `SKILL_SENTINEL_ZEPHYR_74193`. A
+   `pbi-migration-validator` subagent was asked to quote it **without being told the value**, and
+   **under a no-tools rule** so it could not read the file and fake a hit. Result:
+
+   | Probe | Result |
+   |---|---|
+   | `sentinel-probe` skill (repo-local, `.github/skills/`) | **ABSENT** — not in the subagent's skill registry at all, not even by name |
+   | Its `SKILL_SENTINEL_*` token | **ABSENT** |
+   | `HOOK_SENTINEL_*` (see §6.2) | **ABSENT** — nothing prepended; prompt begins at its own `#` heading |
+   | *Control:* own persona | **PRESENT** |
+   | *Control:* generated shared-conventions block | **PRESENT**, quoted verbatim |
+   | *Control:* `AGENTS.md` | **ABSENT** — as predicted |
+
+   Two findings, both load-bearing:
+   - **Repo-local skills are root-only.** The parent session lists `sentinel-probe` with
+     `<location>project</location>`; the subagent listed **91** skills — every one of them from a
+     plugin or from user-global `~/.copilot/skills/` — and **no** project-local skill. The
+     discriminator is *registration scope*, not merely the subagent boundary.
+   - **No skill's body is ever injected**, for any skill, in a subagent. 26 arrived as
+     name + description, 65 as a bare name in an "Additional skills available (invoke by name)"
+     list. So a skill can at best be *invoked* by name — it can never silently carry content the way
+     the SDK's `skills:` preload does (§2).
+
+   **Consequence for persona authoring:** an instruction of the form "use the `<x>` skill" is not
+   reliable for a **repo-local** skill inside a subagent, because the name is not registered there.
+   Prefer an explicit **file path** — "read `.github/skills/<x>/SKILL.md`" — which is an ordinary
+   `view` call and demonstrably works. Promoting the skill into a plugin/global collection is the
+   other fix, and is what would make the name resolvable.
+
+2. **Does `subagentStart` fire and inject? — ⬜ STILL OPEN (needs a fresh session).**
    `.github/hooks/subagent-context.json` + `scripts/hooks/probe_subagent_start.ps1` log the payload
    to `_hook_probe.log` and inject `HOOK_SENTINEL_ORBIT_58231`.
-   Fresh session → invoke `pbi-migration-validator` → check both.
-   - Log written **and** sentinel visible → the mechanism works; migrate the shared block to a hook
-     and reclaim ~6 KB × 4 of persona budget.
-   - Log written, sentinel absent → hook fires but the output field/shape is wrong; fix the script.
-   - No log → hook is not being loaded at all; check location and precedence before designing around
-     it.
+   Measured 2026-07-31: **no log, no sentinel** — but that session predated the hook file, so it only
+   shows "not loaded", not "does not work". **Restart the CLI**, then invoke `pbi-migration-validator`
+   and check both:
+   - Log written **and** sentinel visible → the mechanism works; a hook *could* carry supplementary
+     context. Even then, see §5 before moving anything load-bearing into it.
+   - Log written, sentinel absent → hook fires but the output shape is wrong. The field name itself
+     is documented (§4), so suspect the JSON envelope or the exit code.
+   - No log again, in a session that started *after* the file existed → the hook is genuinely not
+     loading; check location and precedence before designing around it.
 
 3. **Is the `tools` allow-list enforced on the current CLI?** Re-run the validator probe: ask whether
    it holds `edit`/`create`/`task`. Last measured 2026-07-30: not enforced.
@@ -150,9 +224,12 @@ instruction files all appear to be snapshotted at session start, so **restart th
 
 Recorded so nobody re-derives them or fills the gap with a plausible guess:
 
-1. Whether repository skills are visible inside a custom-agent subagent.
-2. The explicit output schema for `subagentStart` (the `additionalContext` field name is inferred
-   from sibling hooks).
+1. Whether a repo-local skill, once *named* in a persona, can still be **invoked** from inside a
+   subagent. (That it is not *listed* there is now measured — §6.1. The narrower question of whether
+   invocation-by-name resolves anyway is untested; prefer a file path either way.)
+2. Whether `subagentStart`'s `additionalContext` has any size cap. The **field name is documented**
+   (§4) — that entry previously said it was inferred, which was wrong. What is genuinely missing is a
+   dedicated Output block and any stated cap; the 10 KB figure belongs to `postToolUse`.
 3. Whether `deferred-tool-loading` is a supported frontmatter property.
 4. Whether `tools` is enforced on CLI specifically (docs don't split CLI vs cloud).
 5. What happens when a persona exceeds 30,000 chars on each surface.


### PR DESCRIPTION
Verifies `docs/agent-architecture.md` against the primary sources directly — the doc had been written
from a research agent's summary that was never independently checked — and resolves the skill-visibility
experiment it left open.

## Three claims were refuted

| Claim (previous revision) | Verdict | Reality |
|---|---|---|
| "**There is no `skills` property.** Checked against the GitHub reference, the VS Code reference, the plugin manifest schema and the agentskills.io spec." | **REFUTED** | One exists on the **SDK** agent-definition surface: `skills: string[]` — "the **full content** of each listed skill is eagerly injected into the agent's context at startup". The old check omitted the Copilot SDK, the very surface the doc cites elsewhere. It *is* absent from the `.agent.md` frontmatter table, so it stays unverified for our personas — but the flat denial was false. |
| "~10 KB cap documented for the *combined* `additionalContext` of multiple hooks" | **PARTIALLY CORRECT** | Documented for **`postToolUse` only**. Nothing is stated for `subagentStart`. |
| "the `additionalContext` field name is inferred from sibling hooks" | **REFUTED** | Documented outright: `subagentStart` → "cannot block creation, but `additionalContext` is prepended to the subagent's prompt." |

Confirmed unchanged: the fleet-mode quote exists verbatim (though it is a *best-practice bullet*, so it
prescribes rather than documents the isolation); the 30,000-char cap with docs silent on overflow;
`general-purpose` as sole non-emitter; no `agentName` on `preToolUse`; `.github/hooks/*.json`;
`name` Optional / `description` Required; `deferred-tool-loading` absent from the official table. All
three cited URLs return 200.

## Experiment §6.1 is resolved: repo-local skills do NOT reach a subagent

A `pbi-migration-validator` subagent was asked to quote `SKILL_SENTINEL_ZEPHYR_74193` **without being
told the value**, under a **no-tools rule** so it could not read the file and fake a hit.

| Probe | Result |
|---|---|
| `sentinel-probe` (repo-local `.github/skills/`) | **ABSENT** — not in its registry, not even by name |
| `HOOK_SENTINEL_*` | **ABSENT** — nothing prepended |
| *Control:* own persona | **PRESENT** |
| *Control:* generated shared-conventions block | **PRESENT**, quoted verbatim |
| *Control:* `AGENTS.md` | **ABSENT** — as predicted |

The parent session lists `sentinel-probe` as `<location>project</location>`; the subagent listed **91**
skills, every one from a plugin or user-global `~/.copilot/skills/`, and **no** project-local skill. The
discriminator is **registration scope**. Also: **no skill's body is ever injected** in a subagent — 26
arrived as name+description, 65 as a bare name.

## ⚠️ This affects the in-flight cloud branches

`copilot/refactor-ai-instructions-module` and `copilot/bug-fix-sibling-model-cache` add
`.github/skills/pbip-model-refresh/` and rely on the persona naming it. Per the measurement above, a
**repo-local** skill name is not registered inside a subagent — so prefer the explicit path
**"read `.github/skills/pbip-model-refresh/SKILL.md`"** (an ordinary `view` call, demonstrably works)
over "use the `pbip-model-refresh` skill". Promoting the skill to a plugin/global collection is the
alternative fix. The bundles themselves are still the right call — portability and budget arguments are
unaffected.

Those branches also edit this file, so expect a small conflict in §1 / §5 / §6.1 / §7.1. **Their §1 SDK
citation and mine agree** — keep either. For §6.1 and §7.1, **this branch wins**: it has the measured
result, whereas the cloud branch still frames it as open. Note the cloud branch also leaves an internal
contradiction — its §1 quotes the SDK skills docs while §2 still reads "There is no `skills` property";
this PR fixes §2.

## Why the shared block stays in the personas

Added §5.1 recording the decision, because "move it to a `subagentStart` hook and reclaim ~24 KB" keeps
resurfacing. Hooks load from six places, and any contributor can set `disableAllHooks: true` in their
repository `settings.json` to silently disable **every** repo hook. The failure mode is the
disqualifier: nothing errors, the conventions just stop applying, and the first symptom is an agent
doing exactly what the block forbids. **Rule: anything whose absence is silent and harmful stays
inline; a hook may only supplement.**

## Verification

- `python scripts/sync_agent_conventions.py --check` → `OK - all 4 agent(s) carry the current shared conventions.` (exit 0)
- Docs-only change; no code touched. Persona sizes unchanged (48.0k / 46.1k / 32.6k / 17.7k).
- §6.2 (`subagentStart` firing) remains **open** — needs a session started *after* the hook file exists.
  No log was written, which shows "not loaded", not "does not work".
