### PR TITLE
Publish the reusable skills as an installable Copilot marketplace plugin

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,8 +60,14 @@ pylint .github/skills/powerbi-ai-readiness/scripts      # module name, so a comb
 
 `scripts/probe_desktop_query.py`, `scripts/refresh_pbip_model.py`, `scripts/set_ai_instructions.py`
 and `scripts/check_ai_readiness.py` are **forwarding shims** that `runpy` the bundled copies, so the
-existing `python scripts/…` invocations in the personas keep working. Delete them once every caller
-points at the skill path.
+existing `python scripts/…` invocations in the personas keep working.
+
+**Think before deleting them.** The stated goal was "delete once every caller points at the skill
+path", but measure the cost first: the personas call these short paths in ~10 places, and rewriting
+each to `python .github/skills/<bundle>/scripts/<name>.py` makes every persona *longer* — which fights
+the 30,000-char cap that motivated the bundles in the first place (`docs/agent-architecture.md` §5).
+A four-line shim that `tests/test_skills.py` proves still reaches its target is cheap; the personas are
+not. Delete them only if they actually go stale, not to tick off the plan.
 
 A bundled script must not assume its depth below the repo root — `parents[N]` resolves to the skill
 folder, where every glob silently matches nothing. Walk up for a known migration tree instead (see

--- a/docs/agent-architecture.md
+++ b/docs/agent-architecture.md
@@ -275,8 +275,26 @@ silent-failure category above.
    — 91 names, every one from a plugin or user-global directory, no project-local entry. So naming
    the skill in the persona is **not** a workaround for it being unlisted; both paths fail. Use an
    explicit **file path** — "read `.github/skills/<x>/SKILL.md`" — which is an ordinary `view` call
-   and demonstrably works. Promoting the bundle into a plugin/global collection is the only fix that
-   would make the *name* resolve.
+   and demonstrably works.
+
+   **The fix is to publish, and it is proven end to end (2026-07-31).** Packaging the two
+   source-tool-agnostic bundles as a marketplace plugin makes the name resolve:
+
+   ```
+   copilot plugin marketplace add Guust-Franssens/powerbi-migration-skills
+   copilot plugin install powerbi-migration-skills@powerbi-migration-collection
+   → Plugin "powerbi-migration-skills" installed successfully. Installed 2 skills.
+   ```
+
+   A **fresh** session then lists both, and invoking one by name returns its body:
+   `skill(powerbi-ai-readiness)` → `# Power BI AI readiness`. Built by
+   `scripts/build_plugin.py`; see §5 for why it publishes to a separate repo.
+
+   ⚠️ **Two traps when testing this.** (a) Skills are snapshotted at **session start** — a plugin
+   installed mid-session is invisible to that session *and* its subagents, which looks exactly like a
+   broken plugin. Restart before concluding anything. (b) In non-interactive `-p` mode, subagents get
+   **no `skill` tool at all** (`Tool 'skill' is not available.`), so `-p` cannot test the subagent hop.
+   Neither is a defect in the plugin; both produce convincing false negatives.
 
 2. **Does `subagentStart` fire and inject? — ⬜ STILL OPEN (needs a fresh session).**
    `.github/hooks/subagent-context.json` + `scripts/hooks/probe_subagent_start.ps1` log the payload

--- a/docs/agent-architecture.md
+++ b/docs/agent-architecture.md
@@ -151,7 +151,7 @@ session to separate the two; §6.2 has the outcome table.
 | `docs/migration-spec.md` (9k) | External; same instruction | Same |
 | `.github/pbi.kb/visual-cookbook.md` (10k) | External; referenced at point of use | Same |
 | `.github/skills/pbip-model-refresh/` (SKILL.md + `scripts/` + `tests/`) | Repo-local **skill bundle** | **Only if the persona points at the path.** §6.1 measured that a repo-local skill is not in a subagent's registry at all, so the *name* does not resolve there — the persona must say **"read `.github/skills/pbip-model-refresh/SKILL.md`"**, which is an ordinary `view` call and does reach a subagent |
-| `.github/skills/powerbi-ai-readiness/` (SKILL.md + `scripts/` + `tests/`) | Repo-local **skill bundle** | Same — `pbi-semantic-builder` must read it **by path**. It absorbs `docs/ai-instructions-authoring-guide.md` (now a stub) and is *meant* to absorb that persona's ~7.3 KB "Prep the model for AI" section — two copies of one recipe that had already diverged (§8). **The persona edit is pending:** `.github/agents/` is off-limits to the Copilot coding agent, so until a maintainer replaces those lines with the one-line read-by-path imperative, the third copy is still there and no budget is reclaimed |
+| `.github/skills/powerbi-ai-readiness/` (SKILL.md + `scripts/` + `tests/`) | Repo-local **skill bundle** | Same — `pbi-semantic-builder` reads it **by path** (done, #33). It absorbed `docs/ai-instructions-authoring-guide.md` (now a stub) and that persona's ~7.3 KB "Prep the model for AI" section — two copies of one recipe that had already diverged (§8), now one |
 | Per-agent Gotchas | Inline in each persona | Yes |
 
 An **explicit instruction to read a file** is a normal tool call and does reach a subagent — this is
@@ -216,6 +216,27 @@ credential for two hours, editing a layer it does not own). Duplication that CI 
 cheaper problem. **Rule: anything whose absence is silent and harmful stays inline; a hook may only
 *supplement*.** If the persona budget must come down, cut per-agent Gotchas that have gone stale —
 that is what orchestrator step 12 is for.
+
+**The same rule blocks the obvious next trim, so state it before someone tries it.** `Gotchas`
+sections are ~36% of `pbi-report-builder` (16,788 chars across three), which makes them the fattest
+remaining target — but relocating them into `.github/pbi.kb/` puts them in the *discretionary* row of
+the §5 table, and a gotcha the agent stops seeing is a defect it silently repeats. Gotchas are the
+"absence is silent and harmful" category almost by definition. The only safe reduction is **deleting
+ones with evidence they are obsolete** (fixed upstream, superseded by a script gate), which needs a
+real migration's retrospective — not a guess.
+
+Budget after #33 pointed `pbi-semantic-builder` at both bundles:
+
+| Persona | chars | % of 30k cap |
+|---|---|---|
+| `pbi-report-builder` | 46,051 | 153% |
+| `pbi-semantic-builder` | 42,796 | 142% (was 160% / 48,049) |
+| `tableau-migrator` | 32,574 | 108% |
+| `pbi-migration-validator` | 17,677 | 58% |
+
+Three are still over. That is a **portability risk, not a live bug** — Copilot CLI was measured not to
+enforce the cap (§2), and the hosted failure mode is untested. Track it; don't panic-trim into the
+silent-failure category above.
 
 ## 6. Experiments — one resolved, one still open
 

--- a/scripts/build_plugin.py
+++ b/scripts/build_plugin.py
@@ -1,0 +1,223 @@
+"""
+purpose: build an installable GitHub Copilot CLI marketplace from this repo's skill bundles, so the
+         source-tool-agnostic ones can be installed as a plugin and referenced BY NAME from agent
+         personas. A repo-local `.github/skills/` bundle is NOT registered in a subagent's skill
+         registry - the `skill` tool rejects the name outright (docs/agent-architecture.md section
+         6.1) - so path-reading is the only option today. Plugin-provided skills ARE registered, which
+         is the whole reason this build exists.
+
+         The marketplace is published to a SEPARATE, thin repo on purpose: `/plugin marketplace add`
+         clones the whole repository, and this one carries ~108 MB of history plus ~62 MB of tracked
+         files to deliver ~26 KB of skills.
+
+usage:   python scripts/build_plugin.py --out dist/marketplace
+         python scripts/build_plugin.py --out dist/marketplace --check   # verify only, exit 1 on drift
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SKILLS_DIR = REPO_ROOT / ".github" / "skills"
+
+MARKETPLACE_NAME = "powerbi-migration-collection"
+PLUGIN_NAME = "powerbi-migration-skills"
+VERSION = "0.1.0"
+PUBLISH_REPO = "https://github.com/Guust-Franssens/powerbi-migration-skills"
+
+# Only source-tool-agnostic bundles ship. `sentinel-probe` is a diagnostic, and anything
+# Tableau-specific belongs in the migration repo's personas, not in a reusable plugin.
+SHIPPED_SKILLS = ("powerbi-ai-readiness", "pbip-model-refresh")
+
+PLUGIN_DESCRIPTION = (
+    "Make a Power BI semantic model AI-ready and persist a refreshed local PBIP. "
+    "Descriptions, enumerated domains, model-level AI instructions (CustomInstructions) and the "
+    "qnaEnabled switch that silently voids them; plus refreshing a PBIP in Power BI Desktop and "
+    "saving it headlessly to cache.abf via AMO ImageSave. Source-tool agnostic - the input is "
+    "already a Power BI model - so it applies to Tableau, Qlik and Cognos migrations alike."
+)
+
+KEYWORDS = [
+    "powerbi",
+    "power-bi",
+    "semantic-model",
+    "tmdl",
+    "pbip",
+    "copilot",
+    "ai-readiness",
+    "migration",
+    "tableau",
+    "fabric",
+]
+
+README = """# Power BI migration skills
+
+Reusable GitHub Copilot CLI skills for getting a **Power BI semantic model** production-ready:
+making it answer natural-language questions correctly, and persisting a refreshed local PBIP.
+
+Both skills are **source-tool agnostic** — the input is already a Power BI model — so they apply
+equally to a Tableau, Qlik or Cognos migration.
+
+## Install
+
+```
+/plugin marketplace add {repo_slug}
+/plugin install {plugin}@{marketplace}
+```
+
+## What's included
+
+| Skill | Use it for |
+|---|---|
+| `powerbi-ai-readiness` | Descriptions, enumerated categorical domains, model-level AI instructions (`CustomInstructions`), and the `qnaEnabled` switch that silently voids all of it |
+| `pbip-model-refresh` | Refreshing a local PBIP/TMDL model in Power BI Desktop and persisting it to `.pbi/cache.abf` headlessly via AMO `ImageSave`, with strict pid binding |
+
+## Why a plugin and not a repo-local skill
+
+A skill committed to a consuming repo's `.github/skills/` is **not** registered inside a Copilot
+custom-agent subagent — the `skill` tool rejects the name:
+
+```
+Skill "<name>" not found. Available skills: ...
+```
+
+Plugin-provided skills *are* registered, so an agent persona can reference them **by name** instead
+of reading a file path. That is the entire reason this marketplace exists.
+
+## Source
+
+Generated from [{source_repo}]({source_repo_url}) by `scripts/build_plugin.py`.
+Each skill folder is self-contained — `SKILL.md` plus its own `scripts/` and `tests/` — and the
+source repo's CI proves that by copying the folder to a temp directory and running its tests there
+with the source repo unimportable.
+
+Do not edit these files here; edit them in the source repo and re-publish.
+"""
+
+
+def shipped_skill_dirs() -> list[Path]:
+    """The bundles selected for publication, verified to exist."""
+    dirs = []
+    for name in SHIPPED_SKILLS:
+        path = SKILLS_DIR / name
+        if not (path / "SKILL.md").is_file():
+            raise SystemExit(f"BUILD: ERROR no SKILL.md for '{name}' at {path}")
+        dirs.append(path)
+    return dirs
+
+
+def marketplace_manifest() -> dict:
+    """The `.claude-plugin/marketplace.json` contract Copilot CLI reads."""
+    return {
+        "name": MARKETPLACE_NAME,
+        "metadata": {
+            "description": "Reusable Power BI semantic-model skills for GitHub Copilot CLI",
+            "version": VERSION,
+        },
+        "owner": {"name": "Guust Franssens"},
+        "plugins": [
+            {
+                "name": PLUGIN_NAME,
+                "source": f"./plugins/{PLUGIN_NAME}",
+                "description": PLUGIN_DESCRIPTION,
+                "version": VERSION,
+                "skills": [f"./skills/{name}" for name in SHIPPED_SKILLS],
+                "agents": [],
+                "repository": PUBLISH_REPO,
+                "keywords": KEYWORDS,
+                "license": "MIT",
+            }
+        ],
+    }
+
+
+def build(out: Path) -> None:
+    """Generate the whole marketplace tree at `out`, replacing anything already there."""
+    skills = shipped_skill_dirs()
+
+    if out.exists():
+        shutil.rmtree(out)
+    plugin_skills = out / "plugins" / PLUGIN_NAME / "skills"
+    plugin_skills.mkdir(parents=True)
+
+    for skill in skills:
+        shutil.copytree(
+            skill,
+            plugin_skills / skill.name,
+            ignore=shutil.ignore_patterns("__pycache__", ".pytest_cache", "*.pyc"),
+        )
+
+    manifest_dir = out / ".claude-plugin"
+    manifest_dir.mkdir()
+    (manifest_dir / "marketplace.json").write_text(
+        json.dumps(marketplace_manifest(), indent=2) + "\n", encoding="utf-8"
+    )
+
+    slug = PUBLISH_REPO.rsplit("github.com/", 1)[-1]
+    (out / "README.md").write_text(
+        README.format(
+            repo_slug=slug,
+            plugin=PLUGIN_NAME,
+            marketplace=MARKETPLACE_NAME,
+            source_repo="Guust-Franssens/tableau-to-powerbi-migration",
+            source_repo_url="https://github.com/Guust-Franssens/tableau-to-powerbi-migration",
+        ),
+        encoding="utf-8",
+    )
+    (out / ".gitignore").write_text("__pycache__/\n*.pyc\n.pytest_cache/\n", encoding="utf-8")
+
+
+def describe(out: Path) -> int:
+    """Print what was produced; returns the total file count."""
+    files = sorted(p for p in out.rglob("*") if p.is_file())
+    total = sum(p.stat().st_size for p in files)
+    print(f"BUILD: {out}")
+    print(f"  marketplace : {MARKETPLACE_NAME}")
+    print(f"  plugin      : {PLUGIN_NAME} v{VERSION}")
+    print(f"  skills      : {', '.join(SHIPPED_SKILLS)}")
+    print(f"  files       : {len(files)} totalling {total / 1024:.1f} KB")
+    return len(files)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Build the marketplace, or verify an existing build matches the current bundles."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", default="dist/marketplace", help="output directory")
+    parser.add_argument("--check", action="store_true", help="verify only; exit 1 if it would change")
+    args = parser.parse_args(argv)
+
+    out = (REPO_ROOT / args.out).resolve() if not Path(args.out).is_absolute() else Path(args.out)
+
+    if args.check:
+        if not out.exists():
+            print(f"BUILD: ERROR --check but nothing built at {out}")
+            return 1
+        existing = {p.relative_to(out): p.read_bytes() for p in out.rglob("*") if p.is_file()}
+        scratch = out.parent / f"{out.name}.check"
+        build(scratch)
+        fresh = {p.relative_to(scratch): p.read_bytes() for p in scratch.rglob("*") if p.is_file()}
+        shutil.rmtree(scratch)
+        if existing != fresh:
+            drifted = sorted({*existing} ^ {*fresh}) or [k for k in existing if k in fresh and existing[k] != fresh[k]]
+            print("BUILD: DRIFT - rebuild required. Differing paths:")
+            for path in drifted[:10]:
+                print(f"  {path}")
+            return 1
+        print("BUILD: OK - published tree matches the current skill bundles.")
+        return 0
+
+    build(out)
+    describe(out)
+    print("\nNext: publish the contents of that folder to the marketplace repo, then:")
+    print(f"  /plugin marketplace add {PUBLISH_REPO.rsplit('github.com/', 1)[-1]}")
+    print(f"  /plugin install {PLUGIN_NAME}@{MARKETPLACE_NAME}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_build_plugin.py
+++ b/tests/test_build_plugin.py
@@ -1,0 +1,91 @@
+"""Regression tests for the marketplace build (`scripts/build_plugin.py`).
+
+The published plugin is what makes a skill's *name* resolve inside a custom-agent subagent - a
+repo-local `.github/skills/` bundle does not (see `docs/agent-architecture.md` section 6.1). So a
+silently broken build is a silently broken persona instruction, which is why these run in CI even
+though the artifact itself is gitignored.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import build_plugin  # noqa: E402  (needs the sys.path insert above)
+
+
+@pytest.fixture(name="built")
+def _built(tmp_path: Path) -> Path:
+    """A full marketplace tree, built into a temp dir."""
+    out = tmp_path / "marketplace"
+    build_plugin.build(out)
+    return out
+
+
+def test_every_shipped_skill_actually_exists_in_this_repo() -> None:
+    """Renaming or deleting a bundle must fail the build loudly, not publish a broken plugin."""
+    for name in build_plugin.SHIPPED_SKILLS:
+        skill = build_plugin.SKILLS_DIR / name / "SKILL.md"
+        assert skill.is_file(), f"{name} is in SHIPPED_SKILLS but {skill} does not exist"
+
+
+def test_the_manifest_is_the_shape_copilot_reads(built: Path) -> None:
+    """`.claude-plugin/marketplace.json` must match the contract, mirroring microsoft/skills-for-fabric."""
+    manifest = json.loads((built / ".claude-plugin" / "marketplace.json").read_text(encoding="utf-8"))
+
+    assert manifest["name"] == build_plugin.MARKETPLACE_NAME
+    assert len(manifest["plugins"]) == 1
+
+    plugin = manifest["plugins"][0]
+    assert plugin["name"] == build_plugin.PLUGIN_NAME
+    assert plugin["source"] == f"./plugins/{build_plugin.PLUGIN_NAME}"
+    for key in ("description", "version", "skills", "repository", "license"):
+        assert plugin[key], f"plugin.{key} must not be empty"
+
+
+def test_every_skill_the_manifest_declares_is_present_at_that_path(built: Path) -> None:
+    """A declared-but-missing skill path is the exact failure that yields a plugin that installs empty."""
+    manifest = json.loads((built / ".claude-plugin" / "marketplace.json").read_text(encoding="utf-8"))
+    plugin = manifest["plugins"][0]
+    source = built / Path(plugin["source"])
+
+    for declared in plugin["skills"]:
+        resolved = (source / Path(declared)).resolve()
+        assert resolved.is_dir(), f"manifest declares {declared} but {resolved} is not a directory"
+        assert (resolved / "SKILL.md").is_file(), f"{declared} has no SKILL.md"
+
+
+def test_each_published_skill_travels_with_its_scripts_and_tests(built: Path) -> None:
+    """The copy-one-folder promise: a consumer installs the whole bundle, not just its markdown."""
+    skills = built / "plugins" / build_plugin.PLUGIN_NAME / "skills"
+    for name in build_plugin.SHIPPED_SKILLS:
+        assert (skills / name / "scripts").is_dir(), f"{name} published without its scripts/"
+        assert (skills / name / "tests").is_dir(), f"{name} published without its tests/"
+
+
+def test_no_build_artifacts_are_published(built: Path) -> None:
+    """`__pycache__` in a published plugin is noise at best and stale bytecode at worst."""
+    junk = [p for p in built.rglob("*") if p.name in {"__pycache__", ".pytest_cache"} or p.suffix == ".pyc"]
+    assert not junk, f"build published artifacts: {[str(p.relative_to(built)) for p in junk]}"
+
+
+def test_the_diagnostic_probe_skill_is_never_published() -> None:
+    """`sentinel-probe` is a context-visibility experiment, not something a consumer should install."""
+    assert "sentinel-probe" not in build_plugin.SHIPPED_SKILLS
+
+
+def test_check_detects_drift(tmp_path: Path) -> None:
+    """`--check` must fail when the published tree no longer matches the bundles, or it gates nothing."""
+    out = tmp_path / "marketplace"
+    build_plugin.build(out)
+    assert build_plugin.main(["--out", str(out), "--check"]) == 0
+
+    skill = build_plugin.SHIPPED_SKILLS[0]
+    (out / "plugins" / build_plugin.PLUGIN_NAME / "skills" / skill / "SKILL.md").write_text("drifted", encoding="utf-8")
+    assert build_plugin.main(["--out", str(out), "--check"]) == 1

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -213,20 +213,29 @@ def test_the_bundled_scripts_are_the_ones_the_shims_and_docs_point_at() -> None:
 
 
 def _markdown_outside_the_agents_dir() -> list[Path]:
-    """Every committed markdown file except agent personas and generated instruction instances.
+    """Every **tracked** markdown file except agent personas and generated instruction instances.
 
-    `.github/agents/` is excluded because that directory is off-limits to the Copilot coding agent
-    that packaged this skill: the persona still carries a compressed copy of the template, and
-    removing it is tracked maintainer follow-up. `ai-instructions.md` files are excluded because they
-    are *instances* of the template - filling it in is the point, not drift.
+    `.github/agents/` is excluded because the persona carries a deliberately compressed pointer to
+    the template rather than the template itself. `ai-instructions.md` files are excluded because
+    they are *instances* of the template - filling it in is the point, not drift.
+
+    Enumerated with `git ls-files`, not `rglob`. An earlier version walked the filesystem while
+    claiming to list committed files, so it also swept up **gitignored build output**: once
+    `scripts/build_plugin.py` copied the skills into `dist/marketplace/`, the template legitimately
+    existed twice on disk and this guard failed on an artifact nobody committed. Tracking is the
+    property the guard actually cares about.
     """
-    skip_dirs = {".git", ".venv", "node_modules", "__pycache__"}
+    tracked = subprocess.run(
+        ["git", "ls-files", "-z", "*.md"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
     return [
-        path
-        for path in sorted(REPO_ROOT.rglob("*.md"))
-        if not skip_dirs & set(path.relative_to(REPO_ROOT).parts)
-        and ".github/agents" not in path.relative_to(REPO_ROOT).as_posix()
-        and path.name != "ai-instructions.md"
+        REPO_ROOT / rel
+        for rel in sorted(filter(None, tracked.split("\0")))
+        if ".github/agents" not in rel and not rel.endswith("ai-instructions.md")
     ]
 
 


### PR DESCRIPTION
Makes the reusable half of this toolkit installable, and **proves it works end to end**.

## Why

A repo-local `.github/skills/` bundle is **not registered** in a custom-agent subagent — the `skill` tool rejects the name outright (`docs/agent-architecture.md` §6.1). Plugin-provided skills **are** registered. Publishing is therefore the only mechanism that makes `use the <name> skill` work, instead of the read-by-path workaround personas use today.

## Proven, not assumed

```
copilot plugin marketplace add Guust-Franssens/powerbi-migration-skills
  → Marketplace "powerbi-migration-collection" added successfully.

copilot plugin install powerbi-migration-skills@powerbi-migration-collection
  → Plugin "powerbi-migration-skills" installed successfully. Installed 2 skills.
```

Then, in a **fresh** session:

| Test | Result |
|---|---|
| Both skills present in the skills list | `powerbi-ai-readiness: YES` / `pbip-model-refresh: YES` |
| Invoke by name: `skill(powerbi-ai-readiness)` | **SUCCEED** — returned `# Power BI AI readiness`, our SKILL.md's actual first heading |

## Two traps that produce convincing false negatives

Both bit me while testing, and both are now recorded in §6.1:

1. **Skills are snapshotted at session start.** A plugin installed mid-session is invisible to that session *and* its subagents. My first subagent test failed with `Skill "powerbi-ai-readiness" not found` and the subagent concluded *"the defect is specific to this plugin"* — it was not. The frontmatter is structurally identical to a working `powerbi-authoring` skill; the session simply predated the install.
2. **In non-interactive `-p` mode, subagents get no `skill` tool at all** (`Tool 'skill' is not available.`), so `-p` cannot test the subagent hop.

## A separate repo, for weight not tidiness

`/plugin marketplace add` clones the whole repository. This one carries **~108 MB of git history plus ~62 MB of tracked files** to deliver **~26 KB of skills**. The generated marketplace is **13 files / 119 KB**.

Source of truth stays here where CI tests it; [the published repo](https://github.com/Guust-Franssens/powerbi-migration-skills) is generated and says so.

## What ships

Only the two source-tool-agnostic bundles — `powerbi-ai-readiness` and `pbip-model-refresh`. Both take a Power BI model as input, so they apply to Qlik and Cognos migrations too. The `sentinel-probe` diagnostic is excluded, and `test_the_diagnostic_probe_skill_is_never_published` enforces that.

Before publishing, both generated copies were run standalone from the built tree with this repo unimportable: **11 and 36 tests passed**.

## Latent bug this exposed and fixed

`tests/test_skills.py::_markdown_outside_the_agents_dir()` claimed to list *"every committed markdown file"* but walked the filesystem with `rglob`, so it swept up **gitignored build output**. Once the skills were copied into `dist/marketplace/`, the AI-instruction section template legitimately existed twice on disk and the drift guard failed on an artifact nobody committed. It now enumerates with `git ls-files` — the property the guard actually cares about. Mutation-checked: appending the canary heading to a tracked markdown file still fails it.

## Gates

195 passed · ruff clean · pylint 10.00/10 on `scripts/build_plugin.py` · conventions-sync OK.

Closes #32.
