### PR TITLE
Stop the marketplace rebuild from destroying the clone it publishes into

### DIFF
--- a/scripts/build_plugin.py
+++ b/scripts/build_plugin.py
@@ -18,7 +18,9 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import shutil
+import stat
 import sys
 from pathlib import Path
 
@@ -136,12 +138,40 @@ def marketplace_manifest() -> dict:
     }
 
 
+def _force_remove(func, path, _exc) -> None:
+    """`shutil.rmtree` error handler: clear the read-only bit and retry.
+
+    Git marks objects in `.git/objects` read-only, and on Windows `os.unlink` refuses those outright
+    with `PermissionError: [WinError 5]`. Without this, rebuilding into a directory that has ever
+    been a git clone fails.
+    """
+    os.chmod(path, stat.S_IWRITE)
+    func(path)
+
+
+def _clear_but_keep_git(out: Path) -> None:
+    """Empty `out` of generated content while preserving `.git`.
+
+    The publish workflow is clone -> rebuild -> commit -> push, so blowing away the whole directory
+    would delete the clone's history and turn every republish into a fresh `git init`. Only the
+    generated entries are removed.
+    """
+    for entry in out.iterdir():
+        if entry.name == ".git":
+            continue
+        if entry.is_dir():
+            shutil.rmtree(entry, onexc=_force_remove)
+        else:
+            entry.chmod(stat.S_IWRITE)
+            entry.unlink()
+
+
 def build(out: Path) -> None:
-    """Generate the whole marketplace tree at `out`, replacing anything already there."""
+    """Generate the whole marketplace tree at `out`, replacing any previously generated content."""
     skills = shipped_skill_dirs()
 
     if out.exists():
-        shutil.rmtree(out)
+        _clear_but_keep_git(out)
     plugin_skills = out / "plugins" / PLUGIN_NAME / "skills"
     plugin_skills.mkdir(parents=True)
 
@@ -173,8 +203,12 @@ def build(out: Path) -> None:
 
 
 def describe(out: Path) -> int:
-    """Print what was produced; returns the total file count."""
-    files = sorted(p for p in out.rglob("*") if p.is_file())
+    """Print what was produced; returns the generated file count.
+
+    `.git` is excluded: rebuilding into a clone is the intended workflow, and counting its objects
+    would report a plugin many times its real size.
+    """
+    files = sorted(p for p in out.rglob("*") if p.is_file() and ".git" not in p.relative_to(out).parts)
     total = sum(p.stat().st_size for p in files)
     print(f"BUILD: {out}")
     print(f"  marketplace : {MARKETPLACE_NAME}")
@@ -182,6 +216,20 @@ def describe(out: Path) -> int:
     print(f"  skills      : {', '.join(SHIPPED_SKILLS)}")
     print(f"  files       : {len(files)} totalling {total / 1024:.1f} KB")
     return len(files)
+
+
+def _generated_files(root: Path) -> dict[Path, bytes]:
+    """Every generated file under `root`, keyed by relative path, with `.git` excluded.
+
+    `.git` must be excluded or `--check` is useless on the very thing it is meant to guard: a clone
+    of the marketplace repo has git objects that the freshly-built scratch tree never will, so every
+    comparison would report drift.
+    """
+    return {
+        p.relative_to(root): p.read_bytes()
+        for p in root.rglob("*")
+        if p.is_file() and ".git" not in p.relative_to(root).parts
+    }
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -197,11 +245,11 @@ def main(argv: list[str] | None = None) -> int:
         if not out.exists():
             print(f"BUILD: ERROR --check but nothing built at {out}")
             return 1
-        existing = {p.relative_to(out): p.read_bytes() for p in out.rglob("*") if p.is_file()}
+        existing = _generated_files(out)
         scratch = out.parent / f"{out.name}.check"
         build(scratch)
-        fresh = {p.relative_to(scratch): p.read_bytes() for p in scratch.rglob("*") if p.is_file()}
-        shutil.rmtree(scratch)
+        fresh = _generated_files(scratch)
+        shutil.rmtree(scratch, onexc=_force_remove)
         if existing != fresh:
             drifted = sorted({*existing} ^ {*fresh}) or [k for k in existing if k in fresh and existing[k] != fresh[k]]
             print("BUILD: DRIFT - rebuild required. Differing paths:")

--- a/tests/test_build_plugin.py
+++ b/tests/test_build_plugin.py
@@ -9,6 +9,7 @@ though the artifact itself is gitignored.
 from __future__ import annotations
 
 import json
+import stat
 import sys
 from pathlib import Path
 
@@ -78,6 +79,37 @@ def test_no_build_artifacts_are_published(built: Path) -> None:
 def test_the_diagnostic_probe_skill_is_never_published() -> None:
     """`sentinel-probe` is a context-visibility experiment, not something a consumer should install."""
     assert "sentinel-probe" not in build_plugin.SHIPPED_SKILLS
+
+
+def test_rebuilding_preserves_a_git_clone(tmp_path: Path) -> None:
+    """The publish workflow is clone -> rebuild -> commit -> push, so a rebuild must not nuke `.git`.
+
+    It used to: `build()` called `shutil.rmtree(out)` unconditionally, which (a) deleted the clone's
+    history, turning every republish into a fresh `git init`, and (b) crashed outright on Windows with
+    `PermissionError: [WinError 5]`, because git marks objects under `.git/objects` read-only and
+    `os.unlink` refuses those.
+    """
+    out = tmp_path / "marketplace"
+    build_plugin.build(out)
+
+    # Stand in for a clone: a .git dir containing a read-only object, exactly what tripped rmtree.
+    objects = out / ".git" / "objects" / "07"
+    objects.mkdir(parents=True)
+    marker = objects / "d19e41700f821b3fb26bbe25216b7e1bad6577"
+    marker.write_text("object", encoding="utf-8")
+    marker.chmod(stat.S_IREAD)
+    (out / ".git" / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
+
+    stale = out / "plugins" / build_plugin.PLUGIN_NAME / "skills" / "removed-skill"
+    stale.mkdir(parents=True)
+    (stale / "SKILL.md").write_text("gone next build", encoding="utf-8")
+
+    build_plugin.build(out)
+
+    assert marker.is_file(), "rebuild destroyed the clone's git objects"
+    assert (out / ".git" / "HEAD").is_file(), "rebuild destroyed .git/HEAD"
+    assert not stale.exists(), "rebuild left generated content from a previous run"
+    assert (out / ".claude-plugin" / "marketplace.json").is_file(), "rebuild did not regenerate the manifest"
 
 
 def test_check_detects_drift(tmp_path: Path) -> None:


### PR DESCRIPTION
Found by re-running `scripts/build_plugin.py` from master **after** publishing — it crashed outright:

```
PermissionError: [WinError 5] Access is denied:
  'dist\marketplace\.git\objects\07\d19e41700f821b3fb26bbe25216b7e1bad6577'
```

Three related defects, all from `build()` calling `shutil.rmtree(out)` unconditionally.

| # | Defect | Why it matters |
|---|---|---|
| 1 | **A rebuild deleted `.git`** | The publish workflow is clone → rebuild → commit → push. Wiping the output directory destroys the clone's history and turns every republish into a fresh `git init` — losing the repo's history silently |
| 2 | **It crashed on Windows first** | Git marks objects under `.git/objects` read-only and `os.unlink` refuses those. `rmtree` now runs with an `onexc` handler that clears the read-only bit and retries |
| 3 | **`--check` was useless on the thing it guards** | It compared the output tree against a freshly-built scratch tree — but a real clone has git objects the scratch tree never will, so it reported drift **every time**. Both sides now exclude `.git` via a shared `_generated_files()` helper |

`describe()` also counted `.git`, reporting the plugin as **45 files / 174.5 KB** instead of its real **13 files / 118.7 KB**.

## Regression test

`test_rebuilding_preserves_a_git_clone` reproduces the exact failure — a read-only object at the same path from the real traceback — and also asserts that stale generated content is still removed, so the fix cannot regress into "preserve everything".

## Verified against the real git-backed clone

```
build            → 13 files totalling 118.7 KB
.git             → survives
--check          → BUILD: OK - published tree matches the current skill bundles. (exit 0)
```

196 passed · ruff clean · pylint 10.00/10 · conventions-sync OK.
