### PR TITLE
Validate migration specs after agent appends

### DIFF
--- a/.github/agents/pbi-report-builder.agent.md
+++ b/.github/agents/pbi-report-builder.agent.md
@@ -235,7 +235,7 @@ it is slow, and `validate` will not catch a wrong encoding.
    survive a landing re-run.
 7. Report back: what you repaired, what you left as an accepted limitation *and why*, any
    `viz_fidelity` row you believe is a false claim (route it back, never silently fix), and new
-   `limitations_encountered` entries (`stage: "report_build"`).
+   `limitations_encountered` entries (`stage: "report_build"`); then run `python scripts/validate_spec.py <migration-spec.json>`.
 
 **If a page must be built from scratch** (no rebuilt equivalent - rare), fall back to the full
 authoring chain: `powerbi-report-planning` -> `powerbi-report-design` -> **empty layout skeleton,

--- a/.github/agents/pbi-semantic-builder.agent.md
+++ b/.github/agents/pbi-semantic-builder.agent.md
@@ -177,7 +177,7 @@ enrich it, and hand it over refreshed.
    what Desktop's own Save does. Edit → refresh → save, in that order.
 9. **Report back**: model location, what you authored vs. what the engine did, every table-calc
    decision (visual calc vs measure, and why), anything you routed rather than fixed, and new
-   `limitations_encountered` entries (`stage: "model_build"`).
+   `limitations_encountered` entries (`stage: "semantic_build"`); then run `python scripts/validate_spec.py <migration-spec.json>`.
 
 ## Prep the model for AI (Copilot readiness) — final build phase
 

--- a/.github/agents/tableau-migrator.agent.md
+++ b/.github/agents/tableau-migrator.agent.md
@@ -231,8 +231,9 @@ it must show up in `limitations_encountered`, not be silently dropped.
      happen before any report work begins. Do not run report and model fixes concurrently against one
      bundle.
 9. **Delegate to `pbi-report-builder`** — only AFTER step 8's landing re-run has finished, because
-   that re-run recreates the `.Report` folder and would destroy its work. **Gate the handover:**
-   `python scripts/check_migration_progress.py --bundle <bundle> --handoff` must exit 0. Exit 1 means
+   that re-run recreates the `.Report` folder and would destroy its work. **Spec+handoff gates (both
+   exit 0):** `python scripts/validate_spec.py <spec>`;
+   `python scripts/check_migration_progress.py --bundle <bundle> --handoff`. Exit 1 means
    a model has no `cache.abf`, or one **older** than its TMDL — the report builder would open an
    EMPTY model and trigger its own refresh (minutes, plus a credential prompt on a live source).
    Measured: a cache written at 22:22 against a Desktop opened at 22:19 did exactly that, and a stale
@@ -240,7 +241,8 @@ it must show up in `limitations_encountered`, not be silently dropped.
    Give it: the handover
    slice, the validator's classification from step 7, the model location, and the reference bundle.
    Its edits must land as re-runnable `_build/fix_*.py` scripts, not bundle-only edits.
-10. **Delegate to `pbi-migration-validator` again — full sign-off mode**, on a FRESH invocation. Name
+10. **Delegate to `pbi-migration-validator` again — full sign-off mode**, on a FRESH invocation. First
+   rerun `python scripts/validate_spec.py <spec>`; block on failure. Name
    the mode explicitly; it is a different job from step 7's triage. It sees the artifacts, the
    reference bundle and the triage classifications, but **not the builders' rationale** — and it is
    told the classifications are **claims to verify, not settled facts**, including the ones an earlier

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Tests
         run: uv run pytest -q
 
+      - name: Migration spec contract gate
+        run: uv run python scripts/validate_spec.py --all
+
       - name: Privacy gate - no absolute user paths in tracked files
         run: uv run python scripts/set_data_folder.py --check
 

--- a/docs/migration-spec.schema.json
+++ b/docs/migration-spec.schema.json
@@ -277,7 +277,8 @@
       "description": "Appended to by every pipeline stage (parser + subagents). Raw material for the capabilities & limitations writeup.",
       "items": {
         "type": "object",
-        "required": ["item", "issue", "severity"],
+        "required": ["item", "issue", "severity", "stage"],
+        "additionalProperties": false,
         "properties": {
           "item": { "type": "string", "description": "id of the affected worksheet/dashboard/field" },
           "issue": { "type": "string" },

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -64,6 +64,7 @@ personas already use. Deleting them would make every persona *longer* — see
 
 | Script | What it enforces |
 |---|---|
+| `validate_spec.py` | Re-validates `migration-spec.json` after agents append `limitations_encountered`; error paths name the offending entry/field so the append can be fixed in place. |
 | `check_m_syntax.py` | Power Query M syntax across generated models — catches breakage that TMDL deserialization does not. |
 | `sync_agent_conventions.py` | Regenerates the shared-conventions block into all four personas; `--check` fails on drift **and prints each persona's size against the 30,000-char cap**. All four currently sit at ~99%, so this is the budget alarm. |
 | `probe_desktop_credential.ps1` | Whether a Desktop credential is already cached (`CREDENTIAL_PRESENT`/`_MISSING`), so agents prompt only when needed. The 1-row data probe outranks it as the gate of record. |

--- a/scripts/parse_tableau.py
+++ b/scripts/parse_tableau.py
@@ -49,6 +49,18 @@ _SHELF_FIELD_RE = re.compile(r"\[([^\[\]]+)\]\.\[([^\[\]]+)\]")
 _TABLEAU_LB_SENTINEL_RE = re.compile(r"^\s*[\u00c6\u00a0]+\s*$")
 
 
+class MigrationSpecValidationError(ValueError):
+    """Raised when a migration spec violates docs/migration-spec.schema.json."""
+
+    def __init__(self, errors: list[str]) -> None:
+        self.errors = errors
+        super().__init__("migration-spec.json schema validation failed:\n" + "\n".join(f"- {err}" for err in errors))
+
+
+class MigrationSpecValidationUnavailable(RuntimeError):
+    """Raised when a strict caller cannot load the schema validator."""
+
+
 def slugify(text: str) -> str:
     """Lowercase, alnum + underscore slug used to build stable synthetic ids."""
     text = re.sub(r"[^a-zA-Z0-9]+", "_", text.strip().lower())
@@ -1471,16 +1483,175 @@ def parse_workbook(path: Path) -> dict[str, Any]:
     return spec
 
 
-def validate_spec(spec: dict[str, Any], schema_path: Path) -> None:
-    """Validate the spec against migration-spec.schema.json; skips gracefully if jsonschema isn't
-    installed, since schema validation is a safety net, not a hard runtime dependency."""
+def _json_path(path_parts: list[Any]) -> str:
+    """Return an agent-friendly JSON path such as limitations_encountered[3].severity."""
+    if not path_parts:
+        return "<root>"
+    path = ""
+    for part in path_parts:
+        if isinstance(part, int):
+            path += f"[{part}]"
+        elif path:
+            path += f".{part}"
+        else:
+            path = str(part)
+    return path
+
+
+def _limitation_context(spec: dict[str, Any], path_parts: list[Any]) -> str:
+    """Name the affected limitations_encountered entry when a schema error points inside one."""
+    if len(path_parts) < 2 or path_parts[0] != "limitations_encountered" or not isinstance(path_parts[1], int):
+        return ""
+    entries = spec.get("limitations_encountered")
+    if not isinstance(entries, list) or path_parts[1] >= len(entries):
+        return ""
+    entry = entries[path_parts[1]]
+    if not isinstance(entry, dict):
+        return ""
+    details = [f"{key}={entry[key]!r}" for key in ("item", "stage", "severity") if key in entry]
+    return f" ({', '.join(details)})" if details else ""
+
+
+def _expectation(error: Any) -> str:
+    """Add concise expected-value guidance to jsonschema's raw message."""
+    if error.validator == "enum":
+        allowed = ", ".join(str(value) for value in error.validator_value)
+        return f" expected one of: {allowed}"
+    if error.validator == "required":
+        missing = [field for field in error.validator_value if field not in error.instance]
+        return f" missing required field(s): {', '.join(missing)}"
+    if error.validator == "additionalProperties":
+        allowed = ", ".join(error.schema.get("properties", {}))
+        return f" expected only these fields: {allowed}"
+    if error.validator == "type":
+        return f" expected type: {error.validator_value}"
+    return ""
+
+
+_SPEC_CONTRACT_GOOD_CANARY: dict[str, Any] = {
+    "migration_spec_version": "1.0",
+    "source": {"file_name": "canary.twb"},
+    "data_sources": [],
+    "worksheets": [],
+    "dashboards": [],
+    "limitations_encountered": [
+        {"item": "worksheet:profit", "issue": "valid downstream note", "severity": "high", "stage": "semantic_build"}
+    ],
+}
+
+_SPEC_CONTRACT_BAD_CANARIES: tuple[tuple[str, dict[str, Any]], ...] = (
+    (
+        "bad limitation severity",
+        {
+            "migration_spec_version": "1.0",
+            "source": {"file_name": "canary.twb"},
+            "data_sources": [],
+            "worksheets": [],
+            "dashboards": [],
+            "limitations_encountered": [
+                {"item": "worksheet:profit", "issue": "bad severity", "severity": "critical", "stage": "semantic_build"}
+            ],
+        },
+    ),
+    (
+        "missing limitation stage",
+        {
+            "migration_spec_version": "1.0",
+            "source": {"file_name": "canary.twb"},
+            "data_sources": [],
+            "worksheets": [],
+            "dashboards": [],
+            "limitations_encountered": [{"item": "worksheet:profit", "issue": "missing stage", "severity": "high"}],
+        },
+    ),
+    (
+        "non-object limitation entry",
+        {
+            "migration_spec_version": "1.0",
+            "source": {"file_name": "canary.twb"},
+            "data_sources": [],
+            "worksheets": [],
+            "dashboards": [],
+            "limitations_encountered": ["not an object"],
+        },
+    ),
+    (
+        "typoed limitation key",
+        {
+            "migration_spec_version": "1.0",
+            "source": {"file_name": "canary.twb"},
+            "data_sources": [],
+            "worksheets": [],
+            "dashboards": [],
+            "limitations_encountered": [
+                {
+                    "item": "worksheet:profit",
+                    "issue": "typoed key",
+                    "severity": "high",
+                    "stage": "semantic_build",
+                    "severtiy": "critical",
+                }
+            ],
+        },
+    ),
+)
+
+
+def _schema_contract_errors(validator: Any) -> list[str]:
+    """Return canary failures proving the compiled validator is too weak or too strict."""
+    errors = []
+    good_errors = sorted(validator.iter_errors(_SPEC_CONTRACT_GOOD_CANARY), key=lambda err: list(err.absolute_path))
+    if good_errors:
+        errors.append(f"known-good canary was rejected: {good_errors[0].message}")
+    for name, canary in _SPEC_CONTRACT_BAD_CANARIES:
+        if not list(validator.iter_errors(canary)):
+            errors.append(f"known-bad canary was accepted: {name}")
+    return errors
+
+
+def _unavailable_schema_result(message: str, require_jsonschema: bool, cause: Exception | None = None) -> list[str]:
+    """Raise for strict gates, warn-and-skip for parse-time compatibility."""
+    if require_jsonschema:
+        raise MigrationSpecValidationUnavailable(message) from cause
+    logger.warning("%s - skipping validation", message)
+    return []
+
+
+def collect_spec_validation_errors(
+    spec: dict[str, Any], schema_path: Path, *, require_jsonschema: bool = False
+) -> list[str]:
+    """Return human-readable schema errors; an empty list means the spec is valid."""
     try:
         import jsonschema  # pylint: disable=import-outside-toplevel
-    except ImportError:
-        logger.warning("jsonschema not installed - skipping validation")
-        return
+    except ImportError as exc:
+        message = "jsonschema not installed - cannot validate migration-spec.json"
+        return _unavailable_schema_result(message, require_jsonschema, exc)
     schema = json.loads(schema_path.read_text(encoding="utf-8"))
-    jsonschema.validate(spec, schema)
+    try:
+        jsonschema.Draft7Validator.check_schema(schema)
+    except jsonschema.SchemaError as exc:
+        message = f"{schema_path} is not a valid Draft 7 JSON schema: {exc.message}"
+        return _unavailable_schema_result(message, require_jsonschema, exc)
+    validator = jsonschema.Draft7Validator(schema)
+    contract_errors = _schema_contract_errors(validator)
+    if contract_errors:
+        message = f"{schema_path} cannot validate the migration spec contract: {'; '.join(contract_errors)}"
+        return _unavailable_schema_result(message, require_jsonschema)
+    errors = []
+    for error in sorted(validator.iter_errors(spec), key=lambda err: list(err.absolute_path)):
+        path_parts = list(error.absolute_path)
+        location = _json_path(path_parts)
+        context = _limitation_context(spec, path_parts)
+        expectation = _expectation(error)
+        errors.append(f"{location}{context}: {error.message};{expectation}")
+    return errors
+
+
+def validate_spec(spec: dict[str, Any], schema_path: Path) -> None:
+    """Validate the spec against migration-spec.schema.json with actionable error paths."""
+    errors = collect_spec_validation_errors(spec, schema_path)
+    if errors:
+        raise MigrationSpecValidationError(errors)
     logger.info("migration-spec.json validated against schema")
 
 
@@ -1499,7 +1670,11 @@ def main() -> None:
 
     logger.info("Parsing %s", args.workbook)
     spec = parse_workbook(args.workbook)
-    validate_spec(spec, args.schema)
+    try:
+        validate_spec(spec, args.schema)
+    except MigrationSpecValidationError as exc:
+        logger.error("%s", exc)
+        sys.exit(1)
 
     args.output.parent.mkdir(parents=True, exist_ok=True)
     args.output.write_text(json.dumps(spec, indent=2, ensure_ascii=False), encoding="utf-8")

--- a/scripts/validate_spec.py
+++ b/scripts/validate_spec.py
@@ -1,0 +1,96 @@
+"""
+purpose: Re-validate migration-spec.json after agents append limitations_encountered entries.
+usage:   python scripts/validate_spec.py migrations/workbooks/<slug>/migration-spec.json
+         python scripts/validate_spec.py --all
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+
+from parse_tableau import MigrationSpecValidationUnavailable
+from parse_tableau import collect_spec_validation_errors as collect_in_memory_errors
+
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+LOGGER = logging.getLogger("validate_spec")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCHEMA_PATH = REPO_ROOT / "docs" / "migration-spec.schema.json"
+SPEC_TREES = ("examples", "migrations/workbooks", "migrations/datasources")
+
+
+def collect_spec_validation_errors(spec_path: Path) -> list[str]:
+    """Return actionable validation errors for one migration-spec.json file."""
+    try:
+        spec = json.loads(spec_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return [f"<root>: invalid JSON at line {exc.lineno}, column {exc.colno}: {exc.msg}"]
+    try:
+        return collect_in_memory_errors(spec, SCHEMA_PATH, require_jsonschema=True)
+    except MigrationSpecValidationUnavailable as exc:
+        return [f"<root>: validation unavailable: {exc}"]
+
+
+def discover_specs() -> list[Path]:
+    """Find committed-style migration specs in every migration tree."""
+    specs: list[Path] = []
+    for tree in SPEC_TREES:
+        root = REPO_ROOT / tree
+        if root.exists():
+            specs.extend(root.glob("*/migration-spec.json"))
+    return sorted(specs)
+
+
+def _targets(args: argparse.Namespace) -> list[Path]:
+    targets = [path.resolve() for path in args.spec]
+    if args.all:
+        targets.extend(discover_specs())
+    return targets
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("spec", nargs="*", type=Path, help="migration-spec.json path(s) to validate")
+    parser.add_argument("--all", action="store_true", help="validate every spec under examples/ and migrations/")
+    args = parser.parse_args(argv)
+
+    targets = _targets(args)
+    if not targets:
+        parser.error("give one or more specs, or pass --all")
+
+    invalid_count = 0
+    for spec_path in targets:
+        if not spec_path.exists():
+            LOGGER.error("MISSING  %s", spec_path)
+            invalid_count += 1
+            continue
+        errors = collect_spec_validation_errors(spec_path)
+        if not errors:
+            LOGGER.info("ok       %s", spec_path)
+            continue
+        invalid_count += 1
+        LOGGER.error("INVALID  %s", spec_path)
+        for error in errors[:10]:
+            LOGGER.error("         %s", error)
+        if len(errors) > 10:
+            LOGGER.error("         ... and %d more", len(errors) - 10)
+
+    if invalid_count:
+        LOGGER.error(
+            "%d of %d spec(s) violate docs/migration-spec.schema.json. Fix the offending append; "
+            "do not re-parse, because that discards downstream limitations.",
+            invalid_count,
+            len(targets),
+        )
+        return 1
+    LOGGER.info("%d spec(s) valid.", len(targets))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_spec_contract.py
+++ b/tests/test_spec_contract.py
@@ -1,0 +1,239 @@
+"""Regression tests for post-parse migration-spec.json validation."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+# ruff: noqa: E402  (the sys.path insert above must precede this import)
+from validate_spec import collect_spec_validation_errors
+
+FIXTURE_SPEC = REPO_ROOT / "examples" / "shipping-kpis" / "migration-spec.json"
+
+
+def _fixture_spec() -> dict:
+    return json.loads(FIXTURE_SPEC.read_text(encoding="utf-8"))
+
+
+def _run_cli_with_schema(spec_path: Path, schema_path: Path) -> subprocess.CompletedProcess:
+    script = """
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path.cwd() / "scripts"))
+import validate_spec
+validate_spec.SCHEMA_PATH = Path(sys.argv[2])
+raise SystemExit(validate_spec.main([sys.argv[1]]))
+"""
+    return subprocess.run(
+        [sys.executable, "-c", script, str(spec_path), str(schema_path)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+
+
+def test_malformed_appended_limitation_names_the_bad_field(tmp_path: Path) -> None:
+    """The observed failure was an appended severity outside the schema enum."""
+    spec = _fixture_spec()
+    spec["limitations_encountered"].append(
+        {"item": "worksheet:profit", "issue": "seeded bad append", "severity": "critical", "stage": "semantic_build"}
+    )
+    path = tmp_path / "migration-spec.json"
+    path.write_text(json.dumps(spec), encoding="utf-8")
+
+    errors = collect_spec_validation_errors(path)
+
+    assert any(
+        "limitations_encountered[" in error
+        and ".severity" in error
+        and "worksheet:profit" in error
+        and "critical" in error
+        and "expected one of: info, low, medium, high" in error
+        for error in errors
+    )
+
+
+def test_missing_appended_limitation_stage_is_rejected(tmp_path: Path) -> None:
+    """Every post-parse limitation must say which stage appended it."""
+    spec = _fixture_spec()
+    spec["limitations_encountered"].append(
+        {"item": "worksheet:profit", "issue": "seeded bad append", "severity": "high"}
+    )
+    path = tmp_path / "migration-spec.json"
+    path.write_text(json.dumps(spec), encoding="utf-8")
+
+    errors = collect_spec_validation_errors(path)
+
+    assert any(
+        "limitations_encountered[" in error
+        and "worksheet:profit" in error
+        and "missing required field(s): stage" in error
+        for error in errors
+    )
+
+
+def test_typoed_appended_limitation_key_is_rejected(tmp_path: Path) -> None:
+    """A misspelled key must not masquerade as an agent-readable limitation."""
+    spec = _fixture_spec()
+    spec["limitations_encountered"].append(
+        {
+            "item": "worksheet:profit",
+            "issue": "seeded typo append",
+            "severity": "high",
+            "stage": "semantic_build",
+            "severtiy": "critical",
+        }
+    )
+    path = tmp_path / "migration-spec.json"
+    path.write_text(json.dumps(spec), encoding="utf-8")
+
+    errors = collect_spec_validation_errors(path)
+
+    assert any("severtiy" in error and "expected only these fields" in error for error in errors)
+
+
+def test_cli_rejects_malformed_append_with_actionable_output(tmp_path: Path) -> None:
+    """The command agents run must fail, not just the imported helper."""
+    spec = _fixture_spec()
+    spec["limitations_encountered"].append(
+        {"item": "worksheet:profit", "issue": "seeded bad append", "severity": "critical", "stage": "semantic_build"}
+    )
+    path = tmp_path / "migration-spec.json"
+    path.write_text(json.dumps(spec), encoding="utf-8")
+
+    proc = subprocess.run(
+        [sys.executable, str(REPO_ROOT / "scripts" / "validate_spec.py"), str(path)],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+
+    output = proc.stderr + proc.stdout
+    assert proc.returncode == 1
+    assert "limitations_encountered[" in output
+    assert ".severity" in output
+    assert "critical" in output
+    assert "expected one of: info, low, medium, high" in output
+
+
+def test_cli_fails_closed_when_jsonschema_is_unavailable(tmp_path: Path) -> None:
+    """A contract gate that cannot run must not report a malformed spec as valid."""
+    spec = _fixture_spec()
+    spec["limitations_encountered"].append(
+        {"item": "worksheet:profit", "issue": "seeded bad append", "severity": "critical", "stage": "semantic_build"}
+    )
+    path = tmp_path / "migration-spec.json"
+    path.write_text(json.dumps(spec), encoding="utf-8")
+    script = """
+import builtins
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path.cwd() / "scripts"))
+import validate_spec
+original_import = builtins.__import__
+def blocked_import(name, *args, **kwargs):
+    if name == "jsonschema":
+        raise ImportError("blocked by regression test")
+    return original_import(name, *args, **kwargs)
+builtins.__import__ = blocked_import
+raise SystemExit(validate_spec.main([sys.argv[1]]))
+"""
+
+    proc = subprocess.run(
+        [sys.executable, "-c", script, str(path)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+
+    output = proc.stderr + proc.stdout
+    assert proc.returncode == 1
+    assert "validation unavailable" in output
+    assert "jsonschema not installed" in output
+
+
+@pytest.mark.parametrize(
+    "schema_mutation",
+    [
+        "invalid_enum_shape",
+        "empty_schema",
+        "irrelevant_schema",
+        "ref_accept_anything",
+    ],
+)
+def test_cli_fails_closed_when_schema_cannot_validate_the_contract(tmp_path: Path, schema_mutation: str) -> None:
+    """A corrupt or vacuous schema must not make malformed specs look valid."""
+    spec = _fixture_spec()
+    spec["limitations_encountered"].append(
+        {"item": "worksheet:profit", "issue": "seeded bad append", "severity": "critical", "stage": "semantic_build"}
+    )
+    spec_path = tmp_path / "migration-spec.json"
+    spec_path.write_text(json.dumps(spec), encoding="utf-8")
+
+    schema = json.loads((REPO_ROOT / "docs" / "migration-spec.schema.json").read_text(encoding="utf-8"))
+    if schema_mutation == "invalid_enum_shape":
+        schema["properties"]["limitations_encountered"]["items"]["properties"]["severity"]["enum"] = {
+            "critical": "wrong shape"
+        }
+    elif schema_mutation == "empty_schema":
+        schema = {}
+    elif schema_mutation == "irrelevant_schema":
+        schema = {"description": "valid JSON Schema, but not the migration-spec contract"}
+    elif schema_mutation == "ref_accept_anything":
+        schema["definitions"]["accept_anything"] = {}
+        schema["$ref"] = "#/definitions/accept_anything"
+    schema_path = tmp_path / f"{schema_mutation}.schema.json"
+    schema_path.write_text(json.dumps(schema), encoding="utf-8")
+
+    proc = _run_cli_with_schema(spec_path, schema_path)
+
+    output = proc.stderr + proc.stdout
+    assert proc.returncode == 1
+    assert "validation unavailable" in output
+    assert "cannot validate" in output or "not a valid Draft 7 JSON schema" in output
+
+
+def test_legitimate_appended_limitation_passes_and_is_not_rewritten(tmp_path: Path) -> None:
+    """A valid semantic-build append must not be blocked or normalized away."""
+    spec = _fixture_spec()
+    spec["limitations_encountered"].append(
+        {"item": "worksheet:profit", "issue": "valid downstream note", "severity": "high", "stage": "semantic_build"}
+    )
+    path = tmp_path / "migration-spec.json"
+    original = json.dumps(spec, indent=2)
+    path.write_text(original, encoding="utf-8")
+
+    proc = subprocess.run(
+        [sys.executable, str(REPO_ROOT / "scripts" / "validate_spec.py"), str(path)],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+
+    assert proc.returncode == 0, proc.stderr + proc.stdout
+    assert path.read_text(encoding="utf-8") == original
+
+
+def test_every_committed_spec_validates_against_the_schema() -> None:
+    """The example corpus carries real appended limitations and must stay valid."""
+    specs = sorted((REPO_ROOT / "examples").glob("*/migration-spec.json"))
+    assert specs
+    invalid = {path: collect_spec_validation_errors(path) for path in specs}
+    assert not {path: errors for path, errors in invalid.items() if errors}


### PR DESCRIPTION
## What was wrong

`migration-spec.json` was schema-validated only when `parse_tableau.py` first wrote it. Later agents append `limitations_encountered`, so a bad append such as `severity: "critical"`, a missing `stage`, or a typo key could silently become downstream input.

## What changed

- Added `scripts/validate_spec.py` for mid-migration re-validation of one spec or all committed specs.
- Reused the parser's schema validation path by extracting actionable error collection in `scripts/parse_tableau.py`; this avoids a second validator implementation.
- Made the standalone validator fail closed when validation cannot run: missing `jsonschema`, invalid Draft 7 schema (`check_schema`), or a schema whose compiled behavior fails inline contract canaries.
- Added inline canaries: one known-good spec must pass; bad severity, missing stage, non-object limitation, and typo-key limitation must fail. This tests behavior rather than schema shape.
- Improved errors to name the path and limitation entry context, e.g. `limitations_encountered[...].severity (item=..., stage=...): ... expected one of: info, low, medium, high`.
- Tightened `limitations_encountered` schema entries to require `stage` and reject unknown keys.
- Wired the gate into CI, the writer personas' final append/report action, and orchestrator gates before report-builder and sign-off delegation.
- Corrected the semantic-builder persona to use schema-valid `stage: "semantic_build"`.

## Tests

- Watched failing-first: `python -m pytest tests\test_spec_contract.py -q` failed before implementation with `ModuleNotFoundError: No module named 'validate_spec'`.
- Watched the `$ref` bypass test fail against the previous commit (`7588f4e`) before replacing shape checks with canaries.
- Added coverage:
  - `test_malformed_appended_limitation_names_the_bad_field`
  - `test_missing_appended_limitation_stage_is_rejected`
  - `test_typoed_appended_limitation_key_is_rejected`
  - `test_cli_rejects_malformed_append_with_actionable_output`
  - `test_cli_fails_closed_when_jsonschema_is_unavailable`
  - `test_cli_fails_closed_when_schema_cannot_validate_the_contract`
  - `test_legitimate_appended_limitation_passes_and_is_not_rewritten`
  - `test_every_committed_spec_validates_against_the_schema`

## Gates run

- `ruff format/check` on changed Python files
- `python -m pylint scripts` → 10.00/10
- `python -m pytest -q` → 540 passed, 4 skipped
- `python scripts/validate_spec.py --all` → 16 specs valid
- Corpus count rechecked: 16 specs, 794 limitation entries
- `python scripts/sync_agent_conventions.py --check` → OK; `tableau-migrator` 29,986 chars

## Deliberately not changed

- Did not merge/cherry-pick `feat/battle-test-hardening` wholesale.
- Did not add re-parse overwrite protection from the stale branch; this PR is scoped to post-append validation.
- Did not make every object in the whole schema `additionalProperties: false`; only the appended limitation entries are tightened to avoid rejecting legitimate existing spec shapes.
- Did not reject exact duplicate limitations. They are schema-valid today and 8 of 16 committed specs already contain duplicates, so that needs a separate contract/corpus cleanup decision.

## Weakest point

The gate is still instruction-driven for subagent writes rather than an atomic append-and-validate helper. It now runs in each writer persona and before downstream delegation, but a helper would be harder to forget.