### PR TITLE
Harvest azureMap basemap + Series-veto findings

### DIFF
--- a/.github/pbi.kb/visuals/azureMap.md
+++ b/.github/pbi.kb/visuals/azureMap.md
@@ -54,14 +54,19 @@ for ws in ET.parse(twb).getroot().iter("worksheet"):
     sources = [e.get("name") for e in ws.iter("mapsource")]
 ```
 
+**Extracting the Tableau side is exact and mechanical. Choosing the Azure Maps equivalent is a
+separate judgement, and none of the three target mappings has been render-compared yet:**
+
 | Tableau source style | Azure Maps `defaultStyle` | confidence | evidence |
 | --- | --- | --- | --- |
-| `mapsource='Tableau'`, no `map-style` override | `grayscale_light` | ✅ verified | `book_6-1-Maps`, 2026-08-09, Desktop MSIX 2.157.627.0: 6 worksheets share this config, 3 have reference thumbnails, all light grey |
+| `mapsource='Tableau'`, no `map-style` override | `grayscale_light` | ⚠️ inferred | **Source side ✅:** `book_6-1-Maps`, 6 worksheets share this config, 3 have reference thumbnails, all light grey. **Target side ⚠️:** a Power BI render at `grayscale_light` exists (the 🟢 POSITIVE entry below, 2026-08-09, Desktop MSIX 2.157.627.0) but was never placed beside a Tableau thumbnail and judged a match |
 | `map-style='tableau-z-black'` | `night` | ⚠️ inferred | source side read from the `.twb` (Dark Map); the Azure target is a name match, **no side-by-side render captured** |
-| `mapsource='Satellite'` | `satellite` | ⚠️ inferred | source side read from the `.twb` (Mapbox); Azure target not render-compared. Note this file's §"MS Learn best practice" still lists `satellite`/`night` behaviour as structurally verified only |
+| `mapsource='Satellite'` | `satellite` | ⚠️ inferred | source side read from the `.twb` (Mapbox); Azure target not render-compared. The `powerbi-report-gotchas` skill (§7, Desktop verification mechanics) likewise records `satellite`/`night` behaviour as structural only |
 
-To promote a ⚠️ row to ✅, capture the Tableau reference render and the Power BI render of the same
-worksheet and compare them, then record date, Desktop/CLI version and worksheet here.
+To promote a row to ✅, capture the Tableau reference render and the Power BI render of the **same
+worksheet**, compare them, and record the worksheet, date and Desktop/CLI version here. Note what
+that bar excludes, because it is the trap this table already fell into once: confirming the *source*
+is light grey says nothing about whether Azure Maps' `grayscale_light` resembles it.
 
 **The method matters as much as the table** — it is how you convert an ⚠️ into a ✅ *on the source
 side*. Measured on `book_6-1-Maps`: **six** worksheets shared one identical config

--- a/.github/pbi.kb/visuals/azureMap.md
+++ b/.github/pbi.kb/visuals/azureMap.md
@@ -61,7 +61,7 @@ separate judgement, and none of the three target mappings has been render-compar
 | --- | --- | --- | --- |
 | `mapsource='Tableau'`, no `map-style` override | `grayscale_light` | ⚠️ inferred | **Source side ✅:** `book_6-1-Maps`, 6 worksheets share this config, 3 have reference thumbnails, all light grey. **Target side ⚠️:** a Power BI render at `grayscale_light` exists (the 🟢 POSITIVE entry below, 2026-08-09, Desktop MSIX 2.157.627.0) but was never placed beside a Tableau thumbnail and judged a match |
 | `map-style='tableau-z-black'` | `night` | ⚠️ inferred | source side read from the `.twb` (Dark Map); the Azure target is a name match, **no side-by-side render captured** |
-| `mapsource='Satellite'` | `satellite` | ⚠️ inferred | source side read from the `.twb` (Mapbox); Azure target not render-compared. The `powerbi-report-gotchas` skill (§7, Desktop verification mechanics) likewise records `satellite`/`night` behaviour as structural only |
+| `mapsource='Satellite'` | `satellite` | ⚠️ inferred | source side read from the `.twb` (Mapbox); Azure target not render-compared. The `powerbi-report-gotchas` skill (§5, Maps) likewise records `satellite`/`night` behaviour as structural only |
 
 To promote a row to ✅, capture the Tableau reference render and the Power BI render of the **same
 worksheet**, compare them, and record the worksheet, date and Desktop/CLI version here. Note what

--- a/.github/pbi.kb/visuals/azureMap.md
+++ b/.github/pbi.kb/visuals/azureMap.md
@@ -37,6 +37,37 @@ Installed formatting objects include `bubbleLayer`, `filledMap`, `heatMapLayer`,
 | Density/heatmap | Use `azureMap` heat map layer with Latitude/Longitude or valid locations; tune radius, units, transparency, intensity, gradient, min/max zoom, and optionally `Size` as weight. | 🟨 yellow structural | Learn says heat maps are for density/hot spots and perform better than many overlapping symbols for large point datasets. Source: https://learn.microsoft.com/en-us/azure/azure-maps/power-bi-visual-add-heat-map-layer, ms.date 2025-01-17. Needs a render-verified PBIR exemplar. |
 | Custom-territory map (non-standard regions) | Use `azureMap` data-bound `referenceLayer` with simplified GeoJSON/KML/WKT/SHP/CSV boundaries and a stable territory key in Location; style polygons with conditional formatting. Avoid legacy `shapeMap` unless a human has captured an exact unsupported requirement. | ✅ green for reference-layer choropleth; 🟥 red for Shape Map parity | Learn supports data-bound reference layers and custom styling; installed catalog shows `shapeMap` exists but `map`/`filledMap` are deprecated to `azureMap`. Source: https://learn.microsoft.com/en-us/azure/azure-maps/power-bi-visual-add-reference-layer, ms.date 2025-01-17; installed catalog 2026-07-19. |
 
+## Basemap: read it from the `.twb`, don't infer it from a thumbnail
+
+Azure Maps `mapControls.defaultStyle` is the basemap. Getting it from a 192 px reference thumbnail
+is guesswork (and impossible when no thumbnail exists), but the source workbook states it outright —
+so this is one of the few migration questions with an exact, mechanical answer.
+
+Per worksheet, the `.twb` carries a `<style-rule element='map'>` and a `<mapsource>`:
+
+```python
+for ws in ET.parse(twb).getroot().iter("worksheet"):
+    styles = [(f.get("attr"), f.get("value"))
+              for sr in ws.iter("style-rule") if sr.get("element") == "map"
+              for f in sr.iter("format")]
+    sources = [e.get("name") for e in ws.iter("mapsource")]
+```
+
+| Tableau | Azure Maps `defaultStyle` |
+| --- | --- |
+| `mapsource='Tableau'`, no `map-style` override | `grayscale_light`  ← Tableau's default light basemap |
+| `map-style='tableau-z-black'` | `night` |
+| `mapsource='Satellite'` | `satellite` |
+
+**The method matters as much as the table** — it is how you convert an ⚠️ inferred into a ✅
+verified. Measured on `book_6-1-Maps`: **six** worksheets shared one identical config
+(`mapsource='Tableau'`, no override), and **three** of those six had reference thumbnails, all light
+grey. Same configuration + a rendered exemplar of that configuration = evidence for the other three,
+including two that had no thumbnail at all and had been flagged "confirm before changing".
+
+Generalise it: when a reference render is missing, look for a **sibling that shares the identical
+source configuration and does have one**, rather than guessing or leaving the item unresolved.
+
 ## MS Learn best practice (as of 2026-07-19)
 
 Web access was available through `web_fetch`; several old Power BI `/power-bi/visuals/...azure-maps...` URLs now 404, while the current Microsoft Learn Azure Maps URLs below resolved.
@@ -75,6 +106,55 @@ a true dark basemap, `'road'` the standard one. So the encoding in "Known-good e
 
 **The entitlement caveat below is still true** — it is about an *unauthenticated* session, not about
 the encoding. Both states look identical to `validate`.
+
+## 🔴 Render-verified DEFECT: a `Series`/Legend well VETOES a data-bound `referenceLayer.polygonFillColor`
+
+**Verified 2026-08-09, Desktop MSIX 2.157.627.0, `book_6-1-Maps` (`Combined Map`), entitled
+signed-in session.** This is the caveat to the 🟢 POSITIVE entry directly above: the choropleth
+recipe works **only while the visual has no legend**. Add a `Series` projection and the ramp dies
+silently — `validate` reports 0 errors, the `linearGradient3` stays in `visual.json`, and the map
+still draws.
+
+**Symptom.** `referenceLayer[1].polygonFillColor` declares a `linearGradient3` over
+`Sum(Orders.Profit)`, yet the polygons render as one flat wash. Texas (`SUM(Profit)` = **−25,729**,
+the most negative value in the model) sampled **byte-identical RGB (156,177,200)** to mildly-positive
+states, and a single colour covered 33% of the landmass.
+
+**Why it is easy to misdiagnose.** The visual also had a multi-field Location well (the defect
+below), so "the choropleth is broken" looks like it should resolve once the Location is fixed. It
+does not — the two defects are independent.
+
+**The experiment that isolates the mechanism** (re-runnable; this is the part worth copying):
+
+1. Find a category that is *unique to one region*. In Superstore, **North Dakota sells ONLY Office
+   Supplies** (`SUM(Profit)` = +230.15) and **Wyoming ONLY Furniture** — verify with
+   `EVALUATE SUMMARIZECOLUMNS('Orders'[State], 'Orders'[Category], "p", SUM('Orders'[Profit]))`.
+2. Note the polygon colour of that region. Baseline: North Dakota rendered **reddish (226,100,103)**,
+   matching *neither* gradient stop — the anomaly that looks inexplicable until you know the cause.
+3. Change **only the category palette** (here: the `dataPoint` fix swapping Office Supplies from red
+   to orange). Change nothing about `referenceLayer`.
+4. North Dakota's polygon flips **red → orange**, and Montana follows its own dominant category.
+
+The polygons are being painted by the **Legend**, not by the FillRule. A region whose rows are
+100% one category takes that category's colour outright, which is exactly why single-category states
+read as "wrong colour" rather than "wrong shade".
+
+**Control.** `Filled Map`, in the same report, same `referenceLayer` encoding shape, **no `Series`
+well** → renders a true ramp. So the encoding is correct and the Legend is the differentiator.
+
+**Consequence for migrations.** Tableau's dual-axis map (`rows = Latitude + Latitude`) is genuinely
+two-or-more mark layers — `Combined Map`'s `.twb` has `pane[0] mark=Pie`, `pane[1] mark=Pie`,
+`pane[2] mark=Multipolygon`. An azureMap has **one Location well and one Legend well**, so it cannot
+carry two LODs with two colour encodings. Do not promise both. Choose:
+
+| keep | how | give up |
+|---|---|---|
+| the category pies (usually the point of the worksheet) | `Series` + city-grain Location; make `referenceLayer` a **static** boundary overlay (`unmappedObjectVisibility: true`, neutral fill, drop the inert FillRule) | the measure choropleth |
+| the measure choropleth | drop `Series`, Location = the polygon key | per-category marks |
+| both | two stacked visuals — **unproven**, azureMap has no transparent canvas, and it breaks the no-overlap space audit | — |
+
+A model-side lat/long column does **not** rescue this: the Legend veto applies regardless of how the
+Location is expressed.
 
 ## 🔴 Render-verified DEFECT: a multi-field Location well collapses every mark to ONE
 
@@ -132,6 +212,49 @@ is 604, and both 1 and 531 render without complaint.
 `Column` projection** is suspect. It is legal, it validates, and it is almost never what the Tableau
 source meant.
 
+## 🔴 Render-verified DEFECT: a visual-level MEASURE filter silently drops azureMap marks
+
+**Symptom.** An azureMap whose `filterConfig` carries an `Advanced` comparison against a **measure**
+plots far fewer marks than the identical DAX predicate returns. Measured on `Pie Chart Map`
+(2026-08-09): the filter `[Sales (w/o Category)] >= 24711.0D` should keep **10** cities; the map drew
+**5-6**. The missing ones were not the marginal ones — **New York City, the single largest value in
+the workbook (256,368)**, plus San Francisco, Philadelphia, San Diego and Jacksonville, were absent.
+
+**It is validation-invisible and render-plausible.** `validate` returns 0 errors, `preview-filters`
+shows one clean Visual-scoped filter, and the map draws a perfectly convincing set of pies. Nothing
+announces that half the marks are gone. **Only counting marks against a DAX ground truth finds it.**
+
+**Isolating experiment (re-runnable).** Four hypotheses eliminated in order, each with its own control:
+
+| hypothesis | test | result |
+|---|---|---|
+| render race / partial draw | recapture after a 25 s dwell | frame **byte-identical** → not timing |
+| geocoding fails for those cities | `Combined Map` — same `Orders[City, State]` Location, **no filter** | 110 blobs, **10 east of x=72%**, 2nd-largest at x=78.8% = NYC → geocoding is fine |
+| the measure is wrong at visual grain | DAX at the visual's true `(City,State) x Category` grain | returns the **city total on every category row** (Akron = 2729.986 x3) → correct |
+| the filter payload is malformed | read `filterConfig` | single clean `ComparisonKind: 2` (`>=`) vs `24711.0D` → well-formed |
+| **the filter itself** | **delete `filterConfig`, reload, recount** | **5 blobs -> 82 blobs.** Confirmed. |
+
+That last row is the whole experiment: one field removed, one reload, a 16x change in mark count.
+
+**Mechanism (inferred).** Same family as the gotcha "*a measure used as a visual-level filter at a
+finer grain than it evaluates silently zeroes the visual*" — but the **partial** form, which is far
+more dangerous than the total one. A visual that renders *empty* gets investigated; a visual that
+renders *most* of its marks gets signed off.
+
+**Remedies, in order of preference.**
+
+1. **Filter on a COLUMN, not a measure** — ask the semantic-model owner for a boolean/flag calculated
+   column evaluated at the filter's own grain (e.g. `Orders[City Is Top Sales]`). A column filter is
+   evaluated in the query's group-by, not re-evaluated per mark, and does not exhibit this. **This is
+   a model change — route it, don't make it from the report layer.**
+2. **Top-N filter** (`filterConfig` `type: "TopN"`) when the source intent really was "top N by
+   measure" rather than a threshold.
+3. **Leave the measure filter and document it** — only acceptable if you have counted the marks and
+   the count is right.
+
+**Standing rule this produces:** whenever an azureMap (or any high-cardinality visual) carries a
+**measure** filter, the mark count is not optional — get the DAX cardinality and count the rendered
+marks. `validate` cannot see this class of bug and neither can a glance at the render.
 ## 🟢 Render-verified NEGATIVE: azureMap draws NOTHING without the tenant entitlement
 
 **Verified 2026-07-19, Desktop MSIX 2.157.627.0, `book_6-1-Maps` maps migration.** Cost most of a

--- a/.github/pbi.kb/visuals/azureMap.md
+++ b/.github/pbi.kb/visuals/azureMap.md
@@ -37,11 +37,12 @@ Installed formatting objects include `bubbleLayer`, `filledMap`, `heatMapLayer`,
 | Density/heatmap | Use `azureMap` heat map layer with Latitude/Longitude or valid locations; tune radius, units, transparency, intensity, gradient, min/max zoom, and optionally `Size` as weight. | 🟨 yellow structural | Learn says heat maps are for density/hot spots and perform better than many overlapping symbols for large point datasets. Source: https://learn.microsoft.com/en-us/azure/azure-maps/power-bi-visual-add-heat-map-layer, ms.date 2025-01-17. Needs a render-verified PBIR exemplar. |
 | Custom-territory map (non-standard regions) | Use `azureMap` data-bound `referenceLayer` with simplified GeoJSON/KML/WKT/SHP/CSV boundaries and a stable territory key in Location; style polygons with conditional formatting. Avoid legacy `shapeMap` unless a human has captured an exact unsupported requirement. | ✅ green for reference-layer choropleth; 🟥 red for Shape Map parity | Learn supports data-bound reference layers and custom styling; installed catalog shows `shapeMap` exists but `map`/`filledMap` are deprecated to `azureMap`. Source: https://learn.microsoft.com/en-us/azure/azure-maps/power-bi-visual-add-reference-layer, ms.date 2025-01-17; installed catalog 2026-07-19. |
 
-## Basemap: read it from the `.twb`, don't infer it from a thumbnail
+## Basemap: read the SOURCE style from the `.twb`; the target mapping is a separate judgement
 
 Azure Maps `mapControls.defaultStyle` is the basemap. Getting it from a 192 px reference thumbnail
-is guesswork (and impossible when no thumbnail exists), but the source workbook states it outright —
-so this is one of the few migration questions with an exact, mechanical answer.
+is guesswork (and impossible when no thumbnail exists), but the source workbook states its own style
+outright — so **extracting the Tableau side is exact and mechanical.** Choosing the Azure Maps
+equivalent is a separate step, and is *not* verified by the extraction.
 
 Per worksheet, the `.twb` carries a `<style-rule element='map'>` and a `<mapsource>`:
 
@@ -53,14 +54,17 @@ for ws in ET.parse(twb).getroot().iter("worksheet"):
     sources = [e.get("name") for e in ws.iter("mapsource")]
 ```
 
-| Tableau | Azure Maps `defaultStyle` |
-| --- | --- |
-| `mapsource='Tableau'`, no `map-style` override | `grayscale_light`  ← Tableau's default light basemap |
-| `map-style='tableau-z-black'` | `night` |
-| `mapsource='Satellite'` | `satellite` |
+| Tableau source style | Azure Maps `defaultStyle` | confidence | evidence |
+| --- | --- | --- | --- |
+| `mapsource='Tableau'`, no `map-style` override | `grayscale_light` | ✅ verified | `book_6-1-Maps`, 2026-08-09, Desktop MSIX 2.157.627.0: 6 worksheets share this config, 3 have reference thumbnails, all light grey |
+| `map-style='tableau-z-black'` | `night` | ⚠️ inferred | source side read from the `.twb` (Dark Map); the Azure target is a name match, **no side-by-side render captured** |
+| `mapsource='Satellite'` | `satellite` | ⚠️ inferred | source side read from the `.twb` (Mapbox); Azure target not render-compared. Note this file's §"MS Learn best practice" still lists `satellite`/`night` behaviour as structurally verified only |
 
-**The method matters as much as the table** — it is how you convert an ⚠️ inferred into a ✅
-verified. Measured on `book_6-1-Maps`: **six** worksheets shared one identical config
+To promote a ⚠️ row to ✅, capture the Tableau reference render and the Power BI render of the same
+worksheet and compare them, then record date, Desktop/CLI version and worksheet here.
+
+**The method matters as much as the table** — it is how you convert an ⚠️ into a ✅ *on the source
+side*. Measured on `book_6-1-Maps`: **six** worksheets shared one identical config
 (`mapsource='Tableau'`, no override), and **three** of those six had reference thumbnails, all light
 grey. Same configuration + a rendered exemplar of that configuration = evidence for the other three,
 including two that had no thumbnail at all and had been flagged "confirm before changing".
@@ -116,9 +120,11 @@ silently — `validate` reports 0 errors, the `linearGradient3` stays in `visual
 still draws.
 
 **Symptom.** `referenceLayer[1].polygonFillColor` declares a `linearGradient3` over
-`Sum(Orders.Profit)`, yet the polygons render as one flat wash. Texas (`SUM(Profit)` = **−25,729**,
-the most negative value in the model) sampled **byte-identical RGB (156,177,200)** to mildly-positive
-states, and a single colour covered 33% of the landmass.
+`Sum(Orders.Profit)`, yet **the measure ramp is not applied** — polygons take categorical `Series`
+colours instead, so large same-category areas read as a flat wash. Texas (`SUM(Profit)` =
+**−25,729**, the most negative value in the model) sampled **byte-identical RGB (156,177,200)** to
+mildly-positive states, and a single colour covered 33% of the landmass. The map is not
+single-coloured overall — the point is that colour no longer encodes the measure.
 
 **Why it is easy to misdiagnose.** The visual also had a multi-field Location well (the defect
 below), so "the choropleth is broken" looks like it should resolve once the Location is fixed. It
@@ -214,11 +220,14 @@ source meant.
 
 ## 🔴 Render-verified DEFECT: a visual-level MEASURE filter silently drops azureMap marks
 
+**Verified 2026-08-09, Desktop MSIX 2.157.627.0, `book_6-1-Maps` (`Pie Chart Map`), entitled
+signed-in session** — same session and build as the two defects above.
+
 **Symptom.** An azureMap whose `filterConfig` carries an `Advanced` comparison against a **measure**
-plots far fewer marks than the identical DAX predicate returns. Measured on `Pie Chart Map`
-(2026-08-09): the filter `[Sales (w/o Category)] >= 24711.0D` should keep **10** cities; the map drew
-**5-6**. The missing ones were not the marginal ones — **New York City, the single largest value in
-the workbook (256,368)**, plus San Francisco, Philadelphia, San Diego and Jacksonville, were absent.
+plots far fewer marks than the identical DAX predicate returns. The filter
+`[Sales (w/o Category)] >= 24711.0D` should keep **10** cities; the map drew **5-6**. The missing
+ones were not the marginal ones — **New York City, the single largest value in the workbook
+(256,368)**, plus San Francisco, Philadelphia, San Diego and Jacksonville, were absent.
 
 **It is validation-invisible and render-plausible.** `validate` returns 0 errors, `preview-filters`
 shows one clean Visual-scoped filter, and the map draws a perfectly convincing set of pies. Nothing
@@ -235,6 +244,10 @@ announces that half the marks are gone. **Only counting marks against a DAX grou
 | **the filter itself** | **delete `filterConfig`, reload, recount** | **5 blobs -> 82 blobs.** Confirmed. |
 
 That last row is the whole experiment: one field removed, one reload, a 16x change in mark count.
+**Read it precisely, though** — on its own it proves the filter is what reduces the marks, not that
+it reduces them *wrongly*. The wrongness comes from the third row: DAX at the visual's own grain
+says the predicate keeps **10** cities, and the map drew **5-6**. Filter-is-the-cause (row 5) plus
+correct-count-is-10 (row 3) is what makes this a defect rather than a filter doing its job.
 
 **Mechanism (inferred).** Same family as the gotcha "*a measure used as a visual-level filter at a
 finer grain than it evaluates silently zeroes the visual*" — but the **partial** form, which is far
@@ -245,8 +258,10 @@ renders *most* of its marks gets signed off.
 
 1. **Filter on a COLUMN, not a measure** — ask the semantic-model owner for a boolean/flag calculated
    column evaluated at the filter's own grain (e.g. `Orders[City Is Top Sales]`). A column filter is
-   evaluated in the query's group-by, not re-evaluated per mark, and does not exhibit this. **This is
-   a model change — route it, don't make it from the report layer.**
+   evaluated in the query's group-by rather than re-evaluated per mark, so it should not exhibit
+   this — ⚠️ **inferred, not tested here:** no A/B control was run against a column filter on this
+   visual. Run that control before relying on it. **This is a model change — route it, don't make it
+   from the report layer.**
 2. **Top-N filter** (`filterConfig` `type: "TopN"`) when the source intent really was "top N by
    measure" rather than a threshold.
 3. **Leave the measure filter and document it** — only acceptable if you have counted the marks and

--- a/.github/skills/powerbi-report-gotchas/SKILL.md
+++ b/.github/skills/powerbi-report-gotchas/SKILL.md
@@ -343,13 +343,18 @@ A "dimension-on-rows dot strip" → scatter with `Category` = the dimension (Det
   - **`sleep(n)` then `screenshot` does NOT fix it either**, and is the trap most likely to catch
     you: the sleep elapses while sitting on the *previous* page, then the screenshot verb navigates
     and captures almost immediately, so the page you actually want gets **no settle at all**.
-  - **What works: capture repeatedly until two consecutive frames are byte-identical.** This is a
-    *heuristic*, not a readiness signal (bridge CLI 0.1.2 exposes none): one equal pair certifies a
-    **plateau**, not completion, so a partial plateau longer than `--stable-seconds` can still pass
-    — raise the dwell for cold or high-risk maps. It still beats a fixed timeout, because it
-    self-tunes to a cold or warm Desktop and is faster than a conservative sleep (measured: 108 s vs
-    209 s for 10 pages). Use
-    `python scripts/capture_powerbi_pages.py <report.Report> <out-dir> --pid <pid>`.
+  - **What works: recapture until ONE digest stays unchanged for a dwell — not merely until two
+    frames match.** Two consecutive equal frames only prove the render paused; the rule the
+    implementation actually enforces is that the digest is unchanged across the whole
+    `--stable-seconds` window, and that **time spent inside a blocking screenshot call does not
+    count toward the dwell** (an early version counted it, so slow captures banked "stable" time
+    they had not earned). Even then it is a *heuristic*, not a readiness signal — bridge CLI 0.1.2
+    exposes none — so a partial plateau longer than the dwell still passes: raise it for cold or
+    high-risk maps. It beats a fixed timeout in both directions, because one long sleep is
+    simultaneously too slow for warm pages and too short for cold ones (measured: 108 s vs 209 s
+    for 10 pages). Repo-local implementation:
+    `python scripts/capture_powerbi_pages.py <report.Report> <out-dir> --pid <pid>` — that script
+    lives in the host repo, not in this bundle, so outside it implement the rule above directly.
   - Corollary: **after any `reload`, treat the first captures as suspect** — the earliest pages in a
     batch are the ones that race.
 - **The `powerbi-desktop` bridge has NO refresh verb.** Verbs as of bridge CLI 0.1.2: `status`,

--- a/.github/skills/powerbi-report-gotchas/SKILL.md
+++ b/.github/skills/powerbi-report-gotchas/SKILL.md
@@ -329,17 +329,36 @@ A "dimension-on-rows dot strip" → scatter with `Category` = the dimension (Det
 
 ## 7. Desktop verification mechanics
 
+- **A screenshot can be PARTIALLY drawn, and that is more dangerous than a blank one.** 🟢
+  Render-verified 2026-08-09, bridge CLI 0.1.2. Visuals that fetch remote resources — above all
+  `azureMap`, which chains model query → basemap tiles → remote reference-layer GeoJSON → marks —
+  draw **progressively**. Capture too early and you get a plausible, finished-looking map that is
+  silently missing marks. Measured on one page (604 city pies), same report, same warm Desktop:
+  **411** distinct canvas colours captured immediately after navigating (pies only in the
+  western/central US) vs **41,185** once settled (pies nationwide). Both look like real maps; only
+  the second is. This defeats mark-counting and any "does it render" check.
+  - **`screenshot-all --settle <ms>` does NOT fix it.** The flag exists but delays only before the
+    **first** capture. Measured: `--settle 5000` over 10 pages cost **38 s**, not the ~76 s a
+    per-page delay would cost. Use it to cover the post-`reload` cold start — nothing more.
+  - **`sleep(n)` then `screenshot` does NOT fix it either**, and is the trap most likely to catch
+    you: the sleep elapses while sitting on the *previous* page, then the screenshot verb navigates
+    and captures almost immediately, so the page you actually want gets **no settle at all**.
+  - **What works: capture repeatedly until two consecutive frames are byte-identical.** This is a
+    *heuristic*, not a readiness signal (bridge CLI 0.1.2 exposes none): one equal pair certifies a
+    **plateau**, not completion, so a partial plateau longer than `--stable-seconds` can still pass
+    — raise the dwell for cold or high-risk maps. It still beats a fixed timeout, because it
+    self-tunes to a cold or warm Desktop and is faster than a conservative sleep (measured: 108 s vs
+    209 s for 10 pages). Use
+    `python scripts/capture_powerbi_pages.py <report.Report> <out-dir> --pid <pid>`.
+  - Corollary: **after any `reload`, treat the first captures as suspect** — the earliest pages in a
+    batch are the ones that race.
 - **The `powerbi-desktop` bridge has NO refresh verb.** Verbs as of bridge CLI 0.1.2: `status`,
   `manifest`, `open`, `reload`, `screenshot`, `screenshot-all` (underlying methods
   `application.state.get` / `report.snapshot.capture` / `file.reload`). PBIP stores no data cache, so a
   freshly-opened import report renders **empty** ("tables have incomplete or no data"). **A clean
   screenshot with empty visuals is an unrefreshed-model artifact, not a binding defect.**
-- **A blank or sparse screenshot is not evidence of a blank or sparse page.** `azureMap` and other
-  remote/progressive visuals can look plausible while still missing marks; re-capture with
-  `python scripts/capture_powerbi_pages.py <report.Report> <out-dir> --pid <pid>` and require
-  a byte-identical stability dwell before trusting the image. This is a heuristic, not a readiness
-  signal: a partial plateau longer than `--stable-seconds` can still pass, so raise the dwell for cold
-  or high-risk maps.
+- **A blank or sparse screenshot is not evidence of a blank or sparse page** — see the
+  partial-render entry above; re-capture with a stability dwell before trusting any image.
 - **First check whether you even need to refresh.** A model handed over already refreshed AND saved
   persists to `<Name>.SemanticModel/.pbi/cache.abf` and survives reopening. Run
   `python scripts/refresh_pbip_model.py --pid <pid> --verify-only` — `DATA_OK` means you are done. On


### PR DESCRIPTION
Two render-verified findings from the `book_6-1-Maps` migration that were not in #71, plus a de-duplication.

## Findings

**Basemap is readable from the `.twb`.** Azure Maps `mapControls.defaultStyle` can be derived mechanically from `<style-rule element='map'>` / `<mapsource>` instead of guessed from a 192px thumbnail (impossible when no thumbnail exists). Measured on `book_6-1-Maps`: six worksheets shared one identical config, three had thumbnails - which is evidence for the other three, including two that had none.

**A `Series`/Legend well VETOES a data-bound `referenceLayer.polygonFillColor`.** The choropleth recipe works only while the visual has no legend. Texas (`SUM(Profit)` = -25,729, the most negative in the model) sampled byte-identical RGB (156,177,200) to mildly-positive states. `validate` reported 0 errors and the `linearGradient3` stayed in `visual.json` - another validation-invisible defect.

## De-duplication

This work predated #71's review and carried the draft claiming the consecutive-frame capture check *'measures convergence'*. #71's review corrected that: one equal pair certifies a **plateau**, not completion. Both copies had landed. Kept the corrected wording, folded in the measurements the short version lacked (411 vs 41,185 colours; `--settle` delays only the first capture; the sleep-then-screenshot trap), and reduced the duplicate to a cross-reference.

Docs only - no script changes. `tests/test_skills.py`: 23 passed.