### PR TITLE
Fail loudly when a migration produces a model that opens and loads zero rows (refs #95)

### DIFF
--- a/.github/agents/tableau-migrator.agent.md
+++ b/.github/agents/tableau-migrator.agent.md
@@ -168,12 +168,14 @@ in the active contract's limitations/worklist instead of silently dropping it.
    credentials** — a Tableau user must supply a PAT. Without server access, fall back to step 4.
 2. **Run the deterministic tier — it builds, you consume.** `python scripts/run_estate.py --input
    <folder> --output <bundle>` runs the engine over one workbook or a whole folder, then supplies the
-   three things its own output contract does not: a **real exit code** (the engine prints
+   four things its own output contract does not: a **real exit code** (the engine prints
    `[FAIL] Definition of done` and returns 0 anyway), an **`--approved-dax` collision check** (that
    map is estate-global and name-keyed, so one approval for a calc named `Calculation2` lands in
-   *every* model that reuses the name), and **per-workbook handover slices** so the raw estate report
-   never enters a subagent's context. Exit 3 = `DOD_FAILED`, exit 4 = collision — resolve both before
-   delegating anything. Each subagent gets `handover/<workbook>.json`, never the whole `report.json`.
+   *every* model that reuses the name), an **empty-model gate** (`check_empty_model.py`, offline —
+   an Import partition over a flat file that never landed opens, validates, binds and holds **zero
+   rows**), and **per-workbook handover slices** so the raw estate report never enters a subagent's
+   context. Exit 3 = `DOD_FAILED`, 4 = collision, 5 = non-canonical engine, 6 = `EMPTY_MODEL` —
+   resolve before delegating anything. Each subagent gets `handover/<workbook>.json`, never the whole `report.json`.
    **Concurrency:** workbooks fan out in parallel *after* step 7's barrier; Power BI Desktop is not a
    lock (instances are `--pid`-scoped), but each costs ~1.3 GB, so cap at ~4.
 3. **Pick the canonical contract; never invent a parallel spec.** If the parser path already has

--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -333,12 +333,13 @@ answer.
 
 | exit | constant | meaning | what to do |
 |---|---|---|---|
-| `0` | `EXIT_OK` | `ESTATE: READY` — DoD not failed, no approval collisions | proceed |
+| `0` | `EXIT_OK` | `ESTATE: READY` — DoD not failed, no approval collisions, no empty models | proceed |
 | `1` | `EXIT_ENGINE_FAILED` | the engine itself exited non-zero | read the last 2000 chars it printed (the wrapper prints them to stderr) |
 | `2` | *(argparse/usage)* | `--input` missing and `--slice-only` not given | fix the command |
 | `3` | `EXIT_DOD_FAILED` | engine's definition of done is `failed` | **§3 decision point** — do not deploy |
 | `4` | `EXIT_COLLISION` | two models claim the same calc name with different formulas | resolve before approving DAX |
 | `5` | `EXIT_ENGINE_SOURCE` | *(pending branch only)* non-canonical engine | see §1.2 |
+| `6` | `EXIT_EMPTY_MODEL` | *(pending branch only)* a model would open and load **zero rows** — an Import partition over a flat file that never landed | read `<bundle>/empty-model-check.json`; land the file and repoint the partition, or make the table live. Never deploy it: it looks finished and shows nothing |
 
 Note `warn` is **deliberately allowed through** — it is the normal state of a real migration
 (deferred visuals, stubbed calcs), and blocking on it would make the wrapper useless ✅ verified

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -72,6 +72,7 @@ personas already use. Deleting them would make every persona *longer* — see
 |---|---|
 | `validate_spec.py` | Re-validates `migration-spec.json` after agents append `limitations_encountered`; error paths name the offending entry/field so the append can be fixed in place. |
 | `check_datamodel.py` | Dependency-free semantic-model gate: Power Query M syntax plus low-noise TMDL structural checks that catch Desktop load failures earlier. |
+| `check_empty_model.py` | Offline gate against a model that opens and loads **zero rows**: classifies every emitted TMDL partition and blocks (`run_estate.py` exit 6, `EXIT_EMPTY_MODEL`) on an Import over a flat file that is missing, foreign-path, or empty. Never judges live/DirectQuery, remote imports, calculated tables, or needs-review stubs. |
 | `check_m_syntax.py` | Compatibility shim for the pre-rename model gate; forwards to `check_datamodel.py` until external callers and old migration briefs have moved. |
 | `sync_agent_conventions.py` | Regenerates the shared-conventions block into all four personas; `--check` fails on drift **and prints each persona's size against the 30,000-char cap**. All four currently sit at ~99%, so this is the budget alarm. |
 | `probe_desktop_credential.ps1` | Whether a Desktop credential is already cached (`CREDENTIAL_PRESENT`/`_MISSING`), so agents prompt only when needed. The 1-row data probe outranks it as the gate of record. |

--- a/scripts/check_empty_model.py
+++ b/scripts/check_empty_model.py
@@ -1,0 +1,589 @@
+"""
+purpose: fail loudly when a migration produces a semantic model that OPENS BUT LOADS NO ROWS -
+         an Import partition whose flat-file source was never landed, or landed with no data.
+usage:   python scripts/check_empty_model.py <bundle-or-model-dir> [...]
+                                             [--json <file>] [--quiet] [--warn-only]
+
+Why this exists
+---------------
+Every other failure in an estate run is LOUD. The engine names what is missing, `run_estate.py`
+turns `definition_of_done: failed` into a non-zero exit, and the bundle is refused downstream.
+
+This one is not. Measured on a 38-workbook estate (2026-08-12, engine 2.126.0), `global_superstores_db`
+came back `definition_of_done: warn`, `report_bound: true`, `pbip_status: built` - a complete,
+openable, deployable PBIP whose single Import partition reads:
+
+    Source = Excel.Workbook(File.Contents("/Users/<someone>/.../Global Superstore.xlsx"), null, true)
+
+That absolute path belongs to the machine the Tableau workbook was authored on. On the migration host
+it does not exist, so the model opens, reports success, and loads **zero rows**. Nothing downstream
+distinguishes "migrated" from "migrated and empty"; the failure surfaces in front of the customer.
+The engine does say so in a `pbip_warnings` string - *"is flat-file but its data was not landed to an
+absolute path -- the model opens but loads no rows"* - but a warning string among hundreds is not a
+gate, and on the same estate that same warning was attached to a workbook (`RESTAPISample`) that
+produced no model at all while the workbook that DID produce an empty one was only `warn`.
+
+Hence the rule this module implements: **attribute from the artifact you inspect, never from a field
+you copy forward.** Every finding names the `.SemanticModel` folder, the table, the partition and the
+literal path that was read out of the TMDL on disk. No engine warning is trusted, parsed or echoed.
+
+Why here and not in `probe_bundle.py` / `check_datamodel.py`
+------------------------------------------------------------
+* `probe_bundle.py` answers "can a LIVE source be reached", and needs Power BI Desktop, a refresh and
+  usually a credential. It cannot run on a laptop with no tenant, which is exactly when this class of
+  defect ships.
+* `check_datamodel.py` answers "is the M/TMDL well-formed". The M here is perfectly well-formed. That
+  is the whole point: this is the repo's *"structural validation is necessary, not sufficient"* gap
+  made concrete - a clean parse proves shape, not that a single row will land.
+
+So this check is deliberately OFFLINE: no Fabric, no Desktop, no credential. It reads TMDL and stats
+files. That is also its limit - see "What it will NOT tell you" below.
+
+What counts as EMPTY (the only three shapes that block)
+-------------------------------------------------------
+An Import-mode partition whose data comes from a **local file**, where that file cannot yield rows on
+this host. The path is resolved first, because the engine routinely writes it as
+`#"SourceFolder" & "\\public_Extract.csv"` rather than as a literal - measured on that estate, 22 of
+34 file-backed partitions were parameterised, so a check that only understood literals would have
+left two thirds of its own subject matter unjudged:
+
+1. `missing_file`  - the resolved path does not exist.
+2. `foreign_path`  - the resolved path is written for a different operating system than this host
+                     (a POSIX `/Users/...` path on Windows, a `C:\\...` path on Linux). This is the
+                     shape a Tableau workbook authored on a Mac produces, and it is called out
+                     separately because `Path.exists()` alone can silently REMAP it - on Windows,
+                     `/Users/bob/x` is probed against the current drive, so a same-named local folder
+                     would answer "present" for a file the model can never read.
+3. `empty_file`    - the file exists but carries no data rows: zero bytes, or a delimited text file
+                     with nothing after its header.
+
+What is NEVER flagged (the false-positive posture, stated on purpose)
+---------------------------------------------------------------------
+| skipped as      | why it legitimately has no local rows                                          |
+|-----------------|--------------------------------------------------------------------------------|
+| `live`          | `mode: directQuery` / `dual` - rows come from the warehouse at query time       |
+| `remote_import` | Import over a database connector (Snowflake, Sql, PostgreSQL, Databricks...)    |
+| `calculated`    | `= calculated` partitions are DAX over other tables                            |
+| `dynamic_path`  | the path expression is not resolvable offline (a computed or undeclared        |
+|                 | parameter) - unknowable is never the same as empty                            |
+| `stub`          | `#table(type table [], {})` - the engine ALREADY reports these loudly as       |
+|                 | "N table(s) landed as a needs-review partition stub"; double-counting them     |
+|                 | here would make the new gate fire on workbooks that are already blocked        |
+| `inline`        | `#table(...)` carrying literal rows                                            |
+| `unrecognized`  | no data source this module recognises - an honest "cannot tell"                |
+
+A false alarm here blocks a customer estate, so the rule is: **anything this module cannot prove
+empty from the artifact is not empty.** Every category is counted and printed on every run, pass or
+fail, so the posture is auditable rather than assumed.
+
+What it will NOT tell you
+-------------------------
+* Whether a reachable database actually returns rows - that needs `probe_bundle.py` and a credential.
+* Whether the rows that DO land are correct. Row presence is not fidelity.
+* Anything about a bundle produced on another machine: a Windows-authored bundle inspected from Linux
+  is all `foreign_path`. Run this on the host that produced the bundle (as `run_estate.py` does).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+# `partition <name> = <kind>` - the head line. TMDL is indentation-scoped, so the body is every
+# following line indented deeper than the head; `_partition_blocks` walks that rather than guessing
+# a terminator, which is what makes it robust to new child keywords appearing upstream.
+_PARTITION_HEAD = re.compile(r"^(?P<indent>[ \t]*)partition\s+(?P<name>.+?)\s*=\s*(?P<kind>[A-Za-z]\w*)\s*$")
+_MODE = re.compile(r"^[ \t]*mode:\s*(?P<mode>\w+)\s*$", re.MULTILINE)
+
+# A Power Query string literal: M has no backslash escape, only a doubled quote for a literal `"`.
+# That is why paths appear verbatim (`"C:\data\x.csv"`) and why unescaping is a single replace.
+_M_STRING = r'"(?P<path>(?:[^"]|"")*)"'
+# Functions whose FIRST argument names a local file or folder.
+_FILE_FUNCTIONS = ("File.Contents", "Folder.Files", "Folder.Contents")
+# `expression SourceFolder = "C:\...\X.Data" meta [IsParameterQuery=true, ...]` in expressions.tmdl.
+# The engine emits exactly this for a landed flat-file model, so a partition's path is routinely
+# `#"SourceFolder" & "\public_Extract.csv"` rather than a literal. Measured on a 38-workbook estate:
+# 22 of 34 file-backed partitions were parameterised this way. Not resolving them would leave two
+# thirds of the file-backed surface unjudged - i.e. the gate would mostly not run.
+_M_PARAM_DEF = re.compile(r"""(?m)^\s*expression\s+(?:'([^']+)'|#"([^"]+)"|([^\s=]+))\s*=\s*(?P<value>[^\r\n]*)""")
+_M_PARAM_META = re.compile(r"\s+meta\s*\[.*$")
+_M_PARAM_REF = re.compile(r'^(?:#"(?P<quoted>[^"]+)"|(?P<bare>[A-Za-z_]\w*))$')
+
+# An empty-schema, empty-rows placeholder the engine lands when it cannot resolve a connector.
+_EMPTY_TABLE_STUB = re.compile(r"#table\s*\(\s*type\s+table\s*\[\s*\]\s*,\s*\{\s*\}\s*\)")
+_INLINE_TABLE = re.compile(r"#table\s*\(")
+
+# Import-mode partitions whose rows come from a SERVER. Offline row presence is unknowable for these
+# and claiming otherwise would be the false alarm this module exists to avoid.
+_REMOTE_CONNECTOR = re.compile(
+    r"\b(?:Sql|Snowflake|Databricks|Oracle|MySQL|PostgreSQL|AmazonRedshift|Odbc|GoogleBigQuery"
+    r"|Teradata|AnalysisServices|PowerBI|Web|SharePoint|AzureStorage|DataLake|Lakehouse|Fabric)"
+    r"\.[A-Za-z]+\s*\("
+)
+
+_POSIX_ABSOLUTE = re.compile(r"^/(?!/)")
+_WINDOWS_ABSOLUTE = re.compile(r"^(?:[A-Za-z]:[\\/]|\\\\|//)")
+
+# Delimited text whose data rows can be counted without a parser. Anything else (xlsx, parquet, json,
+# hyper) is judged on size alone - a partial answer is better than a wrong one.
+_DELIMITED_SUFFIXES = frozenset({".csv", ".tsv", ".txt", ".psv", ".tab"})
+
+CATEGORY_FILE_OK = "file_ok"
+# Blocking categories - the three shapes of "opens but loads no rows".
+CATEGORY_MISSING = "missing_file"
+CATEGORY_FOREIGN = "foreign_path"
+CATEGORY_EMPTY = "empty_file"
+BLOCKING_CATEGORIES = (CATEGORY_MISSING, CATEGORY_FOREIGN, CATEGORY_EMPTY)
+JUDGED_CATEGORIES = BLOCKING_CATEGORIES + (CATEGORY_FILE_OK,)
+
+EXIT_OK = 0
+EXIT_EMPTY_MODEL = 5
+EXIT_USAGE = 2
+
+# The host this check is running on, read ONCE into a module global so a test can exercise the other
+# host without a second CI runner. `os.name` is not read anywhere else in this module.
+HOST_OS = os.name
+
+REPORT_VERSION = 1
+REPORT_NAME = "empty-model-check.json"
+
+_REMEDIES = {
+    CATEGORY_MISSING: (
+        "land the data next to the bundle and repoint the partition "
+        "(scripts/extract_hyper_data.py materializes a packaged .hyper extract to CSV), "
+        "or convert the table to a live connection"
+    ),
+    CATEGORY_FOREIGN: (
+        "the Tableau workbook carried an absolute path from the machine it was authored on; "
+        "supply the file on this host and repoint the partition, or convert the table to a live connection"
+    ),
+    CATEGORY_EMPTY: (
+        "the source file landed with no data rows - re-materialize it "
+        "(scripts/extract_hyper_data.py reports a row_count per relation) before shipping the model"
+    ),
+}
+
+
+def _unescape_m_string(raw: str) -> str:
+    """Turn an M string literal's body into the path it denotes."""
+    return raw.replace('""', '"')
+
+
+def model_parameters(model_dir: Path) -> dict[str, str]:
+    """Text-valued M parameters (`expression Name = "..."`) declared by a model.
+
+    Only literal-valued parameters are collected. A parameter computed from anything else stays
+    unresolved on purpose, so a partition that depends on it is reported as `dynamic_path` rather
+    than judged against a guess.
+    """
+    params: dict[str, str] = {}
+    for tmdl in sorted((model_dir / "definition").glob("*.tmdl")):
+        for match in _M_PARAM_DEF.finditer(tmdl.read_text(encoding="utf-8-sig", errors="replace")):
+            name = match.group(1) or match.group(2) or match.group(3)
+            value = _M_PARAM_META.sub("", match.group("value")).strip()
+            if name and len(value) >= 2 and value.startswith('"') and value.endswith('"'):
+                params[name] = _unescape_m_string(value[1:-1])
+    return params
+
+
+def _first_call_arg(body: str, function: str) -> list[str]:
+    """The first argument of every `<function>(...)` call, as raw M text.
+
+    Scanned with a paren/quote depth counter rather than a regex because the argument is routinely a
+    concatenation containing its own calls and commas.
+    """
+    args: list[str] = []
+    for match in re.finditer(re.escape(function) + r"\s*\(", body):
+        depth, in_string, start = 1, False, match.end()
+        index = start
+        while index < len(body) and depth:
+            char = body[index]
+            if in_string:
+                in_string = not (char == '"' and body[index : index + 2] != '""')
+                index += 1 + (1 if char == '"' and body[index : index + 2] == '""' else 0)
+                continue
+            if char == '"':
+                in_string = True
+            elif char in "([{":
+                depth += 1
+            elif char in ")]}":
+                depth -= 1
+                if not depth:
+                    break
+            elif char == "," and depth == 1:
+                break
+            index += 1
+        args.append(body[start:index])
+    return args
+
+
+def _split_concat(expr: str) -> list[str]:
+    """Split an M expression on top-level `&`, leaving strings and nested calls intact."""
+    terms, depth, in_string, start = [], 0, False, 0
+    index = 0
+    while index < len(expr):
+        char = expr[index]
+        if in_string:
+            if char == '"':
+                if expr[index : index + 2] == '""':
+                    index += 2
+                    continue
+                in_string = False
+        elif char == '"':
+            in_string = True
+        elif char in "([{":
+            depth += 1
+        elif char in ")]}":
+            depth -= 1
+        elif char == "&" and not depth:
+            terms.append(expr[start:index])
+            start = index + 1
+        index += 1
+    terms.append(expr[start:])
+    return terms
+
+
+def eval_m_path(expr: str, params: dict[str, str]) -> str | None:
+    """Evaluate an M path expression to a literal, or None when it cannot be resolved offline.
+
+    Handles exactly what the engine emits - string literals and text parameters joined by `&`. Any
+    other shape (a function call, arithmetic, an undeclared parameter) returns None, which the caller
+    reports as `dynamic_path`: unknowable is never the same as empty.
+    """
+    resolved = []
+    for term in _split_concat(expr):
+        term = term.strip()
+        if len(term) >= 2 and term.startswith('"') and term.endswith('"') and '"' not in term[1:-1].replace('""', ""):
+            resolved.append(_unescape_m_string(term[1:-1]))
+            continue
+        ref = _M_PARAM_REF.match(term)
+        value = params.get(ref.group("quoted") or ref.group("bare")) if ref else None
+        if value is None:
+            return None
+        resolved.append(value)
+    return "".join(resolved)
+
+
+def _partition_blocks(text: str) -> list[dict]:
+    """Every `partition ... = <kind>` block in a TMDL file, with its indentation-scoped body."""
+    lines = text.splitlines()
+    blocks: list[dict] = []
+    for index, line in enumerate(lines):
+        head = _PARTITION_HEAD.match(line)
+        if not head:
+            continue
+        depth = len(head.group("indent").expandtabs(4))
+        body: list[str] = []
+        for follower in lines[index + 1 :]:
+            if follower.strip() and len(follower[: len(follower) - len(follower.lstrip())].expandtabs(4)) <= depth:
+                break
+            body.append(follower)
+        blocks.append(
+            {
+                "partition": head.group("name").strip().strip("'"),
+                "kind": head.group("kind"),
+                "line": index + 1,
+                "body": "\n".join(body),
+            }
+        )
+    return blocks
+
+
+def _path_flavour(raw: str) -> str:
+    """Classify a literal path as `posix`, `windows` or `relative` WITHOUT touching the filesystem."""
+    if _WINDOWS_ABSOLUTE.match(raw):
+        return "windows"
+    if _POSIX_ABSOLUTE.match(raw):
+        return "posix"
+    return "relative"
+
+
+def _host_flavour() -> str:
+    """The path flavour this host can actually read."""
+    return "windows" if HOST_OS == "nt" else "posix"
+
+
+def _is_foreign(flavour: str) -> bool:
+    """Whether an absolute path is written for a different OS than the one running this check.
+
+    Deliberately decided BEFORE any `exists()` call: on Windows, `Path('/Users/bob/x').exists()` is
+    probed against the current drive, so a mac path can be answered by an unrelated local folder and
+    an unreadable model would pass silently.
+    """
+    if flavour == "relative":
+        return False
+    return flavour != _host_flavour()
+
+
+def _has_data_rows(path: Path) -> bool:
+    """Whether a landed source file carries at least one data row.
+
+    Delimited text is read incrementally and abandoned after the second non-blank line, so a
+    multi-gigabyte CSV costs one buffer. Every other format is judged on size alone - this module
+    refuses to guess at a binary it cannot parse offline.
+    """
+    if path.stat().st_size == 0:
+        return False
+    if path.suffix.lower() not in _DELIMITED_SUFFIXES:
+        return True
+    seen = 0
+    with path.open("r", encoding="utf-8", errors="replace") as handle:
+        for line in handle:
+            if line.strip():
+                seen += 1
+                if seen > 1:
+                    return True
+    return False
+
+
+def _folder_has_data(folder: Path) -> bool:
+    """Whether a folder referenced by `Folder.Files` holds at least one non-empty file."""
+    return any(child.is_file() and child.stat().st_size > 0 for child in folder.rglob("*"))
+
+
+def _classify_file_source(raw: str, model_dir: Path, expect_folder: bool = False) -> tuple[str, str, str]:
+    """Judge one resolved path. Returns (category, resolved path, detail)."""
+    flavour = _path_flavour(raw)
+    if _is_foreign(flavour):
+        return CATEGORY_FOREIGN, raw, f"{flavour} absolute path cannot be read from this {_host_flavour()} host"
+
+    candidate = Path(raw) if flavour != "relative" else (model_dir / raw)
+    noun = "folder" if expect_folder else "file"
+    if not (candidate.is_dir() if expect_folder else candidate.is_file()):
+        return CATEGORY_MISSING, str(candidate), f"no {noun} at this path"
+    if not (_folder_has_data(candidate) if expect_folder else _has_data_rows(candidate)):
+        return CATEGORY_EMPTY, str(candidate), f"{noun} is present but has no data rows"
+    return CATEGORY_FILE_OK, str(candidate), f"{noun} is present and carries data rows"
+
+
+def _judge_file_sources(body: str, model_dir: Path, params: dict[str, str]) -> dict | None:
+    """Judge every local-file reference in a partition body, or None when there is none.
+
+    A partition can hold several. The first BLOCKING one decides, because a model with one unloadable
+    table is already the failure this gate exists to stop; an unresolvable path never overrides a
+    blocking one, and never becomes one.
+    """
+    unresolved = False
+    healthy: dict | None = None
+    for function in _FILE_FUNCTIONS:
+        for arg in _first_call_arg(body, function):
+            resolved = eval_m_path(arg, params)
+            if resolved is None:
+                unresolved = True
+                continue
+            category, path, detail = _classify_file_source(resolved, model_dir, function.startswith("Folder."))
+            if category in BLOCKING_CATEGORIES:
+                return {"category": category, "detail": detail, "path": resolved, "resolved_path": path}
+            healthy = {"category": CATEGORY_FILE_OK, "detail": detail, "path": resolved, "resolved_path": path}
+    if unresolved:
+        return {"category": "dynamic_path", "detail": "path is not resolvable offline (non-literal M expression)"}
+    return healthy
+
+
+def _classify_shape(block: dict, body: str, mode: str) -> dict | None:
+    """Verdicts decided by the partition's declared SHAPE, before any path is looked at.
+
+    These three run first and that ordering is load-bearing: a `directQuery` partition whose M
+    happens to name a file connector is still a live source, and judging it on the file would turn a
+    correct migration into a false alarm.
+    """
+    if block["kind"].lower() != "m":
+        return {"category": "calculated", "detail": f"`= {block['kind']}` partition, not a data load"}
+    if mode.lower() in {"directquery", "dual"}:
+        return {"category": "live", "detail": f"mode: {mode} - rows come from the source at query time"}
+    if _EMPTY_TABLE_STUB.search(body):
+        return {"category": "stub", "detail": "needs-review partition stub, already reported by the engine"}
+    return None
+
+
+def _classify_non_file(body: str) -> dict:
+    """Everything left once no local file is involved. None of it is ever blocking."""
+    if _REMOTE_CONNECTOR.search(body):
+        return {"category": "remote_import", "detail": "Import over a remote connector - not knowable offline"}
+    if _INLINE_TABLE.search(body):
+        return {"category": "inline", "detail": "#table literal carrying its own rows"}
+    return {"category": "unrecognized", "detail": "no recognizable data source - not judged"}
+
+
+def classify_partition(block: dict, model_dir: Path, params: dict[str, str] | None = None) -> dict:
+    """Decide whether one partition would load rows, and record WHY that verdict was reached."""
+    body = block["body"]
+    mode_match = _MODE.search(body)
+    mode = mode_match.group("mode") if mode_match else ""
+    verdict = dict(block)
+    verdict.pop("body")
+    verdict["mode"] = mode
+
+    decided = (
+        _classify_shape(block, body, mode)
+        or _judge_file_sources(body, model_dir, params or {})
+        or _classify_non_file(body)
+    )
+    return {**verdict, **decided}
+
+
+def scan_model(model_dir: Path, root: Path) -> dict:
+    """Classify every partition of one `.SemanticModel` folder."""
+    params = model_parameters(model_dir)
+    partitions = []
+    for tmdl in sorted((model_dir / "definition" / "tables").glob("*.tmdl")):
+        text = tmdl.read_text(encoding="utf-8-sig", errors="replace")
+        table = tmdl.stem
+        for block in _partition_blocks(text):
+            verdict = classify_partition(block, model_dir, params)
+            verdict["table"] = table
+            verdict["tmdl"] = tmdl.relative_to(root).as_posix() if tmdl.is_relative_to(root) else str(tmdl)
+            partitions.append(verdict)
+
+    findings = [p for p in partitions if p["category"] in BLOCKING_CATEGORIES]
+    return {
+        "model": model_dir.name,
+        "model_path": model_dir.relative_to(root).as_posix() if model_dir.is_relative_to(root) else str(model_dir),
+        "owner": _owner(model_dir, root),
+        "partitions_total": len(partitions),
+        "categories": _counts(partitions),
+        "findings": findings,
+        "status": "EMPTY" if findings else "OK",
+    }
+
+
+def _owner(model_dir: Path, root: Path) -> str:
+    """Which workbook this model belongs to, derived from where the artifact SITS.
+
+    The engine emits `pbip/<workbook>/<Model>.SemanticModel` for a workbook-owned model and
+    `semantic_models/<Model>.SemanticModel` for one that lands on its own. Reading the owner off the
+    path is what keeps attribution honest: the same engine warning string was measured attached to
+    the wrong workbook, so no reported field is copied forward.
+    """
+    if not model_dir.is_relative_to(root):
+        return model_dir.parent.name
+    parts = model_dir.relative_to(root).parts
+    if len(parts) >= 2 and parts[0] == "pbip":
+        return parts[1]
+    if len(parts) >= 1 and parts[0] == "semantic_models":
+        return "(standalone datasource model)"
+    return parts[0] if len(parts) > 1 else "(bundle root)"
+
+
+def _counts(partitions: list[dict]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for part in partitions:
+        counts[part["category"]] = counts.get(part["category"], 0) + 1
+    return dict(sorted(counts.items()))
+
+
+def find_models(root: Path) -> list[Path]:
+    """Every `.SemanticModel` folder under a bundle, or the folder itself if one was named."""
+    if root.name.endswith(".SemanticModel"):
+        return [root]
+    return sorted(p for p in root.rglob("*.SemanticModel") if p.is_dir())
+
+
+def scan(root: Path) -> dict:
+    """Scan a bundle (or a single model) and return the machine-readable report."""
+    models = [scan_model(model, root) for model in find_models(root)]
+    empty = [m for m in models if m["status"] == "EMPTY"]
+    return {
+        "version": REPORT_VERSION,
+        "root": str(root),
+        "host": "windows" if HOST_OS == "nt" else "posix",
+        "models_scanned": len(models),
+        "models_empty": len(empty),
+        "status": "EMPTY_MODELS" if empty else "OK",
+        "models": models,
+    }
+
+
+def _totals_line(prefix: str, totals: dict[str, int]) -> str:
+    """One `k=v, k=v` line, or an explicit `(none)` so a zero is never mistaken for a missing check."""
+    return prefix + (", ".join(f"{k}={v}" for k, v in totals.items()) or "(none)")
+
+
+def category_totals(report: dict, categories: tuple[str, ...], invert: bool = False) -> dict[str, int]:
+    """Estate-wide partition counts for (or excluding) a set of categories."""
+    totals: dict[str, int] = {}
+    for model in report["models"]:
+        for category, count in model["categories"].items():
+            if (category in categories) is not invert:
+                totals[category] = totals.get(category, 0) + count
+    return dict(sorted(totals.items()))
+
+
+def render(report: dict) -> str:
+    """Human-readable verdict: what is empty, which artifact says so, and what to do about it."""
+    lines = [f"EMPTY-MODEL CHECK: {report['models_scanned']} model(s) under {report['root']}"]
+    if not report["models_scanned"]:
+        lines.append("  no .SemanticModel folders found - nothing to judge")
+        return "\n".join(lines)
+
+    # Both lines print on every run, pass or fail: a gate whose false-positive posture is invisible is
+    # a gate nobody can audit. If `live` ever collapses to zero on an estate that plainly has
+    # warehouses in it, that is the signal the classifier has drifted.
+    lines.append(_totals_line("  judged (local file sources) : ", category_totals(report, JUDGED_CATEGORIES)))
+    lines.append(
+        _totals_line("  not judged (no local rows expected): ", category_totals(report, JUDGED_CATEGORIES, invert=True))
+    )
+
+    if report["status"] == "OK":
+        lines.append("  OK - every file-backed Import partition resolves to a file with data rows.")
+        return "\n".join(lines)
+
+    lines.append(f"\nEMPTY_MODEL: {report['models_empty']} model(s) would open and load NO ROWS")
+    for model in report["models"]:
+        if model["status"] != "EMPTY":
+            continue
+        lines.append(f"  {model['owner']} -> {model['model']}  ({model['model_path']})")
+        for finding in model["findings"]:
+            lines.append(f"      table '{finding['table']}' partition '{finding['partition']}': {finding['detail']}")
+            if finding.get("path"):
+                lines.append(f"        path: {finding['path']}")
+            lines.append(f"        fix : {_REMEDIES[finding['category']]}")
+    lines.append(
+        "\n  These models are STRUCTURALLY VALID - they parse, they validate, they open in Desktop and\n"
+        "  they report success. They contain no data. Do not deploy them: a report that looks finished\n"
+        "  and shows nothing fails in front of the customer instead of in front of us."
+    )
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description="Fail when a migrated semantic model would open but load no rows (offline check).",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("targets", nargs="+", type=Path, help="bundle dir(s) or .SemanticModel folder(s)")
+    parser.add_argument("--json", type=Path, help="also write the machine-readable report here")
+    parser.add_argument("--quiet", action="store_true", help="print only the verdict line")
+    parser.add_argument(
+        "--warn-only",
+        action="store_true",
+        help="report findings but always exit 0 (for an explicitly accepted snapshot)",
+    )
+    args = parser.parse_args(argv)
+
+    missing = [str(t) for t in args.targets if not t.is_dir()]
+    if missing:
+        print(f"ERROR: not a directory: {', '.join(missing)}", file=sys.stderr)
+        return EXIT_USAGE
+
+    reports = [scan(target.resolve()) for target in args.targets]
+    for report in reports:
+        print(render(report) if not args.quiet else f"{report['status']}: {report['root']}")
+
+    if args.json:
+        args.json.parent.mkdir(parents=True, exist_ok=True)
+        payload = reports[0] if len(reports) == 1 else {"version": REPORT_VERSION, "roots": reports}
+        args.json.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+    if args.warn_only:
+        return EXIT_OK
+    return EXIT_EMPTY_MODEL if any(r["status"] == "EMPTY_MODELS" for r in reports) else EXIT_OK
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_empty_model.py
+++ b/scripts/check_empty_model.py
@@ -52,7 +52,7 @@ left two thirds of its own subject matter unjudged:
                      (a POSIX `/Users/...` path on Windows, a `C:\\...` path on Linux). This is the
                      shape a Tableau workbook authored on a Mac produces, and it is called out
                      separately because `Path.exists()` alone can silently REMAP it - on Windows,
-                     `/Users/bob/x` is probed against the current drive, so a same-named local folder
+                     `/Users/<name>/x` is probed against the current drive, so a same-named local folder
                      would answer "present" for a file the model can never read.
 3. `empty_file`    - the file exists but carries no data rows: zero bytes, or a delimited text file
                      with nothing after its header.
@@ -310,7 +310,7 @@ def _host_flavour() -> str:
 def _is_foreign(flavour: str) -> bool:
     """Whether an absolute path is written for a different OS than the one running this check.
 
-    Deliberately decided BEFORE any `exists()` call: on Windows, `Path('/Users/bob/x').exists()` is
+    Deliberately decided BEFORE any `exists()` call: on Windows, `Path('/Users/<name>/x').exists()` is
     probed against the current drive, so a mac path can be answered by an unrelated local folder and
     an unreadable model would pass silently.
     """

--- a/scripts/run_estate.py
+++ b/scripts/run_estate.py
@@ -34,6 +34,13 @@ things a conversation cannot be trusted to remember every time:
 3. **`report.json` is ~14 KB per workbook** (83.4 KB measured for 6). At estate scale that is
    hundreds of KB of mostly-irrelevant context if handed whole to a per-workbook agent.
 
+4. **A model can pass every check above and still contain ZERO ROWS.** An Import partition over a
+   flat file that was never landed opens, validates, binds its report and reports success; the
+   engine notes it in a `pbip_warnings` string and moves on. Measured on a 38-workbook estate, one
+   such workbook came back `definition_of_done: warn` - it would have passed this coordinator's own
+   gate. `check_empty_model.py` is the offline artifact scan that catches it, wired in below as
+   `EXIT_EMPTY_MODEL`.
+
 Deliberately NOT here
 ---------------------
 No migration logic. This never writes TMDL, never writes PBIR, never opens Power BI Desktop. It runs
@@ -67,6 +74,9 @@ from collections import defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
 
+from check_empty_model import REPORT_NAME as EMPTY_MODEL_REPORT
+from check_empty_model import render as render_empty_model
+from check_empty_model import scan as scan_for_empty_models
 from engine_source import EngineNotFoundError, NonCanonicalEngineError, engine_provenance, resolve_engine
 from migration_bundle import sha256_file, write_engine_receipt
 
@@ -82,6 +92,7 @@ EXIT_ENGINE_FAILED = 1
 EXIT_DOD_FAILED = 3
 EXIT_COLLISION = 4
 EXIT_ENGINE_SOURCE = 5
+EXIT_EMPTY_MODEL = 6
 GENERATED_ARTIFACTS_KEY = "generated_artifacts"
 VOLATILE_GENERATED_DIRS = {".pbi"}
 SCRATCH_DIRS = frozenset({"scratch", "_work", "_build", "_probe", "tmp", "temp", "_shots"})
@@ -358,6 +369,24 @@ def record_engine_output(out_dir: Path, report: dict | None, phases: list[dict],
     write_receipt_phase(out_dir, phases, engine)
 
 
+def check_empty_models(out_dir: Path) -> dict:
+    """Scan the emitted models for the one failure the engine reports but nothing gates on.
+
+    THE SECOND reason this script exists, and the quieter one. `check_definition_of_done` catches a
+    migration that failed *visibly*. This catches one that succeeded visibly and produced nothing:
+    an Import partition over a flat file that was never landed opens fine, validates fine, deploys
+    fine, and shows a customer an empty report. Measured on a 38-workbook estate: one such model was
+    `definition_of_done: warn`, i.e. it would have passed every gate this coordinator had.
+
+    Offline by construction - no Fabric, no Desktop, no credential - so it runs on every estate, not
+    only the ones where a tenant happens to be reachable. The verdict is also written to
+    ``<bundle>/empty-model-check.json`` so a later deploy step can re-read it without re-deriving it.
+    """
+    report = scan_for_empty_models(out_dir)
+    (out_dir / EMPTY_MODEL_REPORT).write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    return report
+
+
 def build_parser() -> argparse.ArgumentParser:
     """The CLI surface, kept out of ``main`` so the run logic stays readable."""
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -432,8 +461,14 @@ def run_engine_phase(args: argparse.Namespace, engine: Path | None, phases: list
     return EXIT_OK
 
 
-def final_verdict(collisions: list, dod_ok: bool, dod_detail: str) -> int:
-    """The verdict the engine's own exit code cannot give us."""
+def final_verdict(collisions: list, dod_ok: bool, dod_detail: str, empty_models: dict, out_dir: Path) -> int:
+    """The verdict the engine's own exit code cannot give us.
+
+    Precedence is collision > definition of done > empty model. All three refuse the bundle and the
+    earlier ones are the broader signal, so they are what a reader should act on first. Only the
+    exit code is exclusive: the empty-model *text* is printed by the caller before this runs, so a
+    quiet defect is never hidden behind a loud one.
+    """
     if collisions:
         print_collisions(collisions)
         return EXIT_COLLISION
@@ -445,7 +480,16 @@ def final_verdict(collisions: list, dod_ok: bool, dod_detail: str) -> int:
             "  bundle downstream until the failing workbook(s) are resolved or explicitly accepted."
         )
         return EXIT_DOD_FAILED
-    print("\nESTATE: READY - definition of done is not failed, no approval collisions.")
+    if empty_models["status"] != "OK":
+        print(
+            f"\nESTATE: EMPTY_MODEL - {empty_models['models_empty']} of {empty_models['models_scanned']} "
+            "model(s) would open and load NO ROWS\n"
+            "  These passed the definition of done: they built, they bound, they validate. They have\n"
+            "  no data. Nothing else in this pipeline can tell 'migrated' from 'migrated and empty',\n"
+            f"  so this is the exit code that does. Details: {out_dir / EMPTY_MODEL_REPORT}"
+        )
+        return EXIT_EMPTY_MODEL
+    print("\nESTATE: READY - definition of done is not failed, no approval collisions, no empty models.")
     return EXIT_OK
 
 
@@ -496,6 +540,7 @@ def main(argv: list[str] | None = None) -> int:
     started = time.monotonic()
     dod_ok, dod_detail = check_definition_of_done(report)
     collisions = find_approval_collisions(report)
+    empty_models = check_empty_models(args.output)
     phases.append({"phase": "adjudicate", "elapsed_sec": round(time.monotonic() - started, 1)})
 
     # --- phase 3: slice -----------------------------------------------------------------------
@@ -510,7 +555,12 @@ def main(argv: list[str] | None = None) -> int:
     # --- report -------------------------------------------------------------------------------
     print_summary(report, args.output, slices, timings, dod_detail)
 
-    return final_verdict(collisions, dod_ok, dod_detail)
+    # Printed BEFORE the verdict, and on a pass as well as a fail: an empty model that ships
+    # alongside a `failed` definition of done is the one most likely to be missed, because the reader
+    # stops at the first blocking verdict.
+    print("\n" + render_empty_model(empty_models))
+
+    return final_verdict(collisions, dod_ok, dod_detail, empty_models, args.output)
 
 
 if __name__ == "__main__":

--- a/tests/test_check_empty_model.py
+++ b/tests/test_check_empty_model.py
@@ -34,7 +34,7 @@ import check_empty_model as cem  # noqa: E402  # pylint: disable=wrong-import-po
 
 # The shape that ships empty: an absolute path belonging to the machine the Tableau workbook was
 # authored on. Kept POSIX so it is foreign on the Windows CI/dev host and vice versa.
-MAC_AUTHOR_PATH = "/Users/tableau-author/Datasets/Global Superstore.xlsx"
+MAC_AUTHOR_PATH = "/Users/<author>/Datasets/Global Superstore.xlsx"
 WINDOWS_AUTHOR_PATH = r"D:\Datasets\Global Superstore.xlsx"
 
 
@@ -133,12 +133,18 @@ def _categories(model_dir: Path, root: Path | None = None) -> dict[str, int]:
 # ---------------------------------------------------------------------------
 
 
-def test_an_unlanded_flat_file_import_is_reported_as_empty(tmp_path: Path) -> None:
+def test_an_unlanded_flat_file_import_is_reported_as_empty(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """The measured silent success: builds, binds, validates, deploys, contains zero rows.
 
     This is the whole point of the gate. If this test can pass while the check is disabled, the gate
     is decorative.
+
+    The host is pinned because the *reason* is host-dependent and the verdict must not be: on the
+    Windows host that produced the measured estate this path is `foreign_path`; on the Linux CI
+    runner the same path is simply `missing_file`. Both block. Pinning keeps the assertion about the
+    behaviour rather than about which runner happened to execute it.
     """
+    monkeypatch.setattr(cem, "HOST_OS", "nt")
     bundle = tmp_path / "bundle"
     _model(bundle / "pbip" / "global_superstores_db", tables={"Orders": _excel_partition(MAC_AUTHOR_PATH)})
 
@@ -149,6 +155,18 @@ def test_an_unlanded_flat_file_import_is_reported_as_empty(tmp_path: Path) -> No
     finding = report["models"][0]["findings"][0]
     assert finding["category"] == cem.CATEGORY_FOREIGN
     assert finding["path"] == MAC_AUTHOR_PATH
+
+
+def test_the_unlanded_flat_file_blocks_on_either_host(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The category differs by host; the VERDICT must not. Same fixture, both hosts, both blocked."""
+    monkeypatch.setattr(cem, "HOST_OS", "posix")
+    bundle = tmp_path / "bundle"
+    _model(bundle / "pbip" / "wb", tables={"Orders": _excel_partition(MAC_AUTHOR_PATH)})
+
+    report = cem.scan(bundle)
+
+    assert report["status"] == "EMPTY_MODELS"
+    assert report["models"][0]["findings"][0]["category"] == cem.CATEGORY_MISSING
 
 
 def test_a_missing_native_path_is_reported_as_empty(tmp_path: Path) -> None:
@@ -276,7 +294,12 @@ def test_an_unresolvable_path_expression_is_not_judged(tmp_path: Path) -> None:
 
 def test_a_mixed_model_blocks_on_the_broken_table_only(tmp_path: Path) -> None:
     """One unloadable table among healthy ones is still a silent-success failure - the report shows
-    partial data, which is worse than none because it looks plausible."""
+    partial data, which is worse than none because it looks plausible.
+
+    Host is deliberately NOT pinned here: the healthy table points at a real file under `tmp_path`,
+    whose flavour is whatever the runner uses. So the assertion is on the SHAPE of the verdict -
+    exactly one blocking finding, on the right table - not on which blocking category it lands in.
+    """
     bundle = tmp_path / "bundle"
     landed = _landed_csv(bundle / "data" / "Extract.csv")
     _model(
@@ -293,12 +316,10 @@ def test_a_mixed_model_blocks_on_the_broken_table_only(tmp_path: Path) -> None:
 
     assert model["status"] == "EMPTY"
     assert [f["table"] for f in model["findings"]] == ["Orders"]
-    assert model["categories"] == {
-        cem.CATEGORY_FILE_OK: 1,
-        cem.CATEGORY_FOREIGN: 1,
-        "calculated": 1,
-        "live": 1,
-    }
+    assert model["findings"][0]["category"] in cem.BLOCKING_CATEGORIES
+    assert model["categories"][cem.CATEGORY_FILE_OK] == 1
+    assert model["categories"]["calculated"] == 1
+    assert model["categories"]["live"] == 1
 
 
 # ---------------------------------------------------------------------------
@@ -428,7 +449,7 @@ def test_a_standalone_datasource_model_is_labelled_as_one(tmp_path: Path) -> Non
 
 
 def test_a_posix_path_is_foreign_on_windows(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """On Windows `Path('/Users/x/y').exists()` is probed against the CURRENT DRIVE, so a same-named
+    """On Windows `Path('/Users/<name>/y').exists()` is probed against the CURRENT DRIVE, so a same-named
     local folder can answer "present" for a file the model can never read. The flavour check runs
     first precisely so that remap cannot produce a false pass."""
     monkeypatch.setattr(cem, "HOST_OS", "nt")
@@ -447,16 +468,23 @@ def test_a_windows_path_is_foreign_on_posix(monkeypatch: pytest.MonkeyPatch, tmp
     assert cem.scan(bundle)["models"][0]["findings"][0]["category"] == cem.CATEGORY_FOREIGN
 
 
-def test_a_native_path_is_never_called_foreign(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """The false-positive guard on the host check itself: every landed bundle path is native."""
-    monkeypatch.setattr(cem, "HOST_OS", "posix")
+@pytest.mark.parametrize(("host", "native_path"), [("nt", r"D:\Datasets\Orders.csv"), ("posix", "/data/Orders.csv")])
+def test_a_native_path_is_never_called_foreign(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, host: str, native_path: str
+) -> None:
+    """The false-positive guard on the host check itself.
+
+    Every path the engine lands is native to the host that produced the bundle, so `foreign_path`
+    must be reachable ONLY by a genuinely cross-OS path. A missing native file is still reported -
+    as `missing_file`, which names the right remedy - but it is never blamed on the wrong OS.
+    """
+    monkeypatch.setattr(cem, "HOST_OS", host)
     bundle = tmp_path / "bundle"
-    landed = _landed_csv(bundle / "data" / "Extract.csv")
-    _model(bundle / "pbip" / "wb", tables={"Extract": _csv_partition(f'"/{landed.as_posix().lstrip("/")}"')})
+    _model(bundle / "pbip" / "wb", tables={"Extract": _csv_partition(f'"{native_path}"')})
 
-    categories = cem.scan(bundle)["models"][0]["categories"]
+    findings = cem.scan(bundle)["models"][0]["findings"]
 
-    assert cem.CATEGORY_FOREIGN not in categories
+    assert [f["category"] for f in findings] == [cem.CATEGORY_MISSING]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_check_empty_model.py
+++ b/tests/test_check_empty_model.py
@@ -1,0 +1,567 @@
+r"""Tests for scripts/check_empty_model.py - the gate against a model that opens and loads no rows.
+
+Every fixture here is written from a REAL emitted artifact, not invented. The shapes come from a
+38-workbook estate run (2026-08-12, engine 2.126.0):
+
+* the failing one - `Excel.Workbook(File.Contents("<absolute path from the authoring Mac>"))`,
+  `mode: import`, in a model whose workbook came back `definition_of_done: warn` and `report_bound:
+  true`. It builds, it binds, it validates, it deploys, and it contains nothing.
+* the healthy landed one - `Csv.Document(File.Contents("<bundle>/data/.../Extract_Extract.csv"))`.
+* the healthy PARAMETERISED one - `Csv.Document(File.Contents(#"SourceFolder" & "\public_Extract.csv"))`
+  with `expression SourceFolder = "..."` in expressions.tmdl. 22 of that estate's 34 file-backed
+  partitions were this shape, so a checker that only understood literals would have judged a third of
+  its own subject matter and silently skipped the rest.
+* the live one - `mode: directQuery` over `Snowflake.Databases(...)`. 58 partitions in that estate.
+  A false alarm on these would have blocked a correct migration of a real customer estate, so the
+  tests that prove they are NOT flagged carry as much weight as the one that proves detection.
+* the needs-review stub - `#table(type table [], {})`. Already reported loudly by the engine as
+  "N table(s) landed as a needs-review partition stub"; flagging it here would double-count.
+
+The paths in these fixtures are synthetic. The repo is public.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import check_empty_model as cem  # noqa: E402  # pylint: disable=wrong-import-position
+
+# The shape that ships empty: an absolute path belonging to the machine the Tableau workbook was
+# authored on. Kept POSIX so it is foreign on the Windows CI/dev host and vice versa.
+MAC_AUTHOR_PATH = "/Users/tableau-author/Datasets/Global Superstore.xlsx"
+WINDOWS_AUTHOR_PATH = r"D:\Datasets\Global Superstore.xlsx"
+
+
+def _model(
+    root: Path,
+    name: str = "Orders (Global Superstore).SemanticModel",
+    tables: dict[str, str] | None = None,
+    expressions: str = "",
+) -> Path:
+    """Write a minimal but structurally real `.SemanticModel` folder."""
+    model = root / name
+    definition = model / "definition"
+    (definition / "tables").mkdir(parents=True, exist_ok=True)
+    if expressions:
+        (definition / "expressions.tmdl").write_text(expressions, encoding="utf-8")
+    for table, tmdl in (tables or {}).items():
+        (definition / "tables" / f"{table}.tmdl").write_text(tmdl, encoding="utf-8")
+    return model
+
+
+def _excel_partition(path: str, mode: str = "import") -> str:
+    return (
+        "table Orders\n\n"
+        "\tpartition 'Orders$' = m\n"
+        f"\t\tmode: {mode}\n"
+        "\t\tsource =\n"
+        "\t\t\tlet\n"
+        f'\t\t\t\tSource = Excel.Workbook(File.Contents("{path}"), null, true),\n'
+        '\t\t\t\tNavigation = Source{[Item="Orders", Kind="Sheet"]}[Data]\n'
+        "\t\t\tin\n"
+        "\t\t\t\tNavigation\n"
+    )
+
+
+def _csv_partition(expression: str, mode: str = "import", table: str = "Extract") -> str:
+    return (
+        f"table {table}\n\n"
+        f"\tpartition {table} = m\n"
+        f"\t\tmode: {mode}\n"
+        "\t\tsource =\n"
+        "\t\t\tlet\n"
+        f'\t\t\t\tSource = Csv.Document(File.Contents({expression}), [Delimiter=",", Encoding=1252]),\n'
+        "\t\t\t\tPromoted = Table.PromoteHeaders(Source, [PromoteAllScalars=true])\n"
+        "\t\t\tin\n"
+        "\t\t\t\tPromoted\n"
+    )
+
+
+SNOWFLAKE_DIRECTQUERY = (
+    "table FACT_ORDERS\n\n"
+    "\tpartition FACT_ORDERS = m\n"
+    "\t\tmode: directQuery\n"
+    "\t\tsource =\n"
+    "\t\t\tlet\n"
+    '\t\t\t\tSource = Snowflake.Databases(#"Server", #"Warehouse"),\n'
+    '\t\t\t\tDb = Source{[Name="MERIDIAN", Kind="Database"]}[Data]\n'
+    "\t\t\tin\n"
+    "\t\t\t\tDb\n"
+)
+
+SNOWFLAKE_IMPORT = SNOWFLAKE_DIRECTQUERY.replace("mode: directQuery", "mode: import")
+
+CALCULATED_DATE = (
+    "table Date\n\n"
+    "\tpartition Date = calculated\n"
+    "\t\tmode: import\n"
+    "\t\tsource = CALENDAR(DATE(2020, 1, 1), DATE(2026, 12, 31))\n"
+)
+
+NEEDS_REVIEW_STUB = (
+    "table 'sqlproxy (Groups)'\n\n"
+    "\tpartition sqlproxy = m\n"
+    "\t\tmode: import\n"
+    "\t\tsource =\n"
+    "\t\t\tlet\n"
+    "\t\t\t\t// TODO: complete the M partition for connector class 'csv' using Csv.Document\n"
+    "\t\t\t\tSource = #table(type table [], {})\n"
+    "\t\t\tin\n"
+    "\t\t\t\tSource\n"
+)
+
+
+def _landed_csv(path: Path, rows: int = 2) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    body = "\n".join(f"a{i},b{i}" for i in range(rows))
+    path.write_text("col_a,col_b\n" + (body + "\n" if rows else ""), encoding="utf-8")
+    return path
+
+
+def _categories(model_dir: Path, root: Path | None = None) -> dict[str, int]:
+    return cem.scan_model(model_dir, root or model_dir.parent)["categories"]
+
+
+# ---------------------------------------------------------------------------
+# The failure this module exists for
+# ---------------------------------------------------------------------------
+
+
+def test_an_unlanded_flat_file_import_is_reported_as_empty(tmp_path: Path) -> None:
+    """The measured silent success: builds, binds, validates, deploys, contains zero rows.
+
+    This is the whole point of the gate. If this test can pass while the check is disabled, the gate
+    is decorative.
+    """
+    bundle = tmp_path / "bundle"
+    _model(bundle / "pbip" / "global_superstores_db", tables={"Orders": _excel_partition(MAC_AUTHOR_PATH)})
+
+    report = cem.scan(bundle)
+
+    assert report["status"] == "EMPTY_MODELS"
+    assert report["models_empty"] == 1
+    finding = report["models"][0]["findings"][0]
+    assert finding["category"] == cem.CATEGORY_FOREIGN
+    assert finding["path"] == MAC_AUTHOR_PATH
+
+
+def test_a_missing_native_path_is_reported_as_empty(tmp_path: Path) -> None:
+    """Same shape, same host: the file simply is not there. Nothing about it errors at build time."""
+    bundle = tmp_path / "bundle"
+    absent = tmp_path / "never-landed" / "Orders.csv"
+    _model(bundle / "pbip" / "wb", tables={"Extract": _csv_partition(f'"{absent.as_posix()}"')})
+
+    findings = cem.scan(bundle)["models"][0]["findings"]
+
+    assert [f["category"] for f in findings] == [cem.CATEGORY_MISSING]
+
+
+def test_a_header_only_csv_is_reported_as_empty(tmp_path: Path) -> None:
+    """A landed file is not the same as landed DATA - a materializer can emit a header and no rows."""
+    bundle = tmp_path / "bundle"
+    landed = _landed_csv(bundle / "data" / "Extract.csv", rows=0)
+    _model(bundle / "pbip" / "wb", tables={"Extract": _csv_partition(f'"{landed.as_posix()}"')})
+
+    findings = cem.scan(bundle)["models"][0]["findings"]
+
+    assert [f["category"] for f in findings] == [cem.CATEGORY_EMPTY]
+
+
+def test_a_zero_byte_binary_source_is_reported_as_empty(tmp_path: Path) -> None:
+    """xlsx/parquet cannot be counted offline, but a zero-byte one is unambiguous."""
+    bundle = tmp_path / "bundle"
+    landed = bundle / "data" / "Sales.xlsx"
+    landed.parent.mkdir(parents=True)
+    landed.write_bytes(b"")
+    _model(bundle / "pbip" / "wb", tables={"Orders": _excel_partition(landed.as_posix())})
+
+    assert [f["category"] for f in cem.scan(bundle)["models"][0]["findings"]] == [cem.CATEGORY_EMPTY]
+
+
+def test_a_landed_csv_with_rows_is_not_flagged(tmp_path: Path) -> None:
+    """The control for every test above."""
+    bundle = tmp_path / "bundle"
+    landed = _landed_csv(bundle / "data" / "Extract.csv")
+    _model(bundle / "pbip" / "wb", tables={"Extract": _csv_partition(f'"{landed.as_posix()}"')})
+
+    report = cem.scan(bundle)
+
+    assert report["status"] == "OK"
+    assert report["models"][0]["categories"] == {cem.CATEGORY_FILE_OK: 1}
+
+
+# ---------------------------------------------------------------------------
+# False-positive posture: a blocked customer estate is a real cost
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("mode", ["directQuery", "dual"])
+def test_a_live_partition_is_never_flagged(tmp_path: Path, mode: str) -> None:
+    """A live source legitimately has no local rows. Flagging it turns a correct migration into an
+    outage report. 58 of the measured estate's partitions were `directQuery`."""
+    bundle = tmp_path / "bundle"
+    tmdl = SNOWFLAKE_DIRECTQUERY.replace("mode: directQuery", f"mode: {mode}")
+    _model(bundle / "pbip" / "Meridian_Revenue_by_Region", tables={"FACT_ORDERS": tmdl})
+
+    report = cem.scan(bundle)
+
+    assert report["status"] == "OK"
+    assert report["models"][0]["categories"] == {"live": 1}
+
+
+def test_a_live_partition_over_a_FILE_connector_is_still_live(tmp_path: Path) -> None:
+    """Mode is decided BEFORE source shape.
+
+    A `directQuery` partition whose M happens to mention a file must not be judged on the file, or
+    the ordering of the classifier silently becomes the gate's correctness condition.
+    """
+    bundle = tmp_path / "bundle"
+    _model(bundle / "pbip" / "wb", tables={"Orders": _excel_partition(MAC_AUTHOR_PATH, mode="directQuery")})
+
+    assert cem.scan(bundle)["status"] == "OK"
+
+
+def test_an_import_over_a_remote_connector_is_not_judged(tmp_path: Path) -> None:
+    """Import over Snowflake has rows or not depending on a server. Offline that is unknowable, and
+    unknowable must never be reported as empty."""
+    bundle = tmp_path / "bundle"
+    _model(bundle / "pbip" / "wb", tables={"FACT_ORDERS": SNOWFLAKE_IMPORT})
+
+    report = cem.scan(bundle)
+
+    assert report["status"] == "OK"
+    assert report["models"][0]["categories"] == {"remote_import": 1}
+
+
+def test_a_calculated_partition_is_not_judged(tmp_path: Path) -> None:
+    """`= calculated` is DAX over other tables - it has no source file by design."""
+    bundle = tmp_path / "bundle"
+    _model(bundle / "pbip" / "wb", tables={"Date": CALCULATED_DATE})
+
+    assert cem.scan(bundle)["models"][0]["categories"] == {"calculated": 1}
+
+
+def test_a_needs_review_stub_is_counted_but_does_not_block(tmp_path: Path) -> None:
+    """Deliberate non-escalation.
+
+    The engine ALREADY says "N table(s) landed as a needs-review partition stub" in the definition of
+    done. Blocking here too would make this gate fire on workbooks that are already reported, which
+    is how a new check earns a reputation for noise and gets switched off.
+    """
+    bundle = tmp_path / "bundle"
+    _model(bundle / "pbip" / "Admin_Insights_Starter", tables={"sqlproxy (Groups)": NEEDS_REVIEW_STUB})
+
+    report = cem.scan(bundle)
+
+    assert report["status"] == "OK"
+    assert report["models"][0]["categories"] == {"stub": 1}
+
+
+def test_an_unresolvable_path_expression_is_not_judged(tmp_path: Path) -> None:
+    """`unknowable` is not `empty`. A computed path is reported, never blocked on."""
+    bundle = tmp_path / "bundle"
+    _model(bundle / "pbip" / "wb", tables={"Extract": _csv_partition('Text.From(DateTime.LocalNow()) & ".csv"')})
+
+    report = cem.scan(bundle)
+
+    assert report["status"] == "OK"
+    assert report["models"][0]["categories"] == {"dynamic_path": 1}
+
+
+def test_a_mixed_model_blocks_on_the_broken_table_only(tmp_path: Path) -> None:
+    """One unloadable table among healthy ones is still a silent-success failure - the report shows
+    partial data, which is worse than none because it looks plausible."""
+    bundle = tmp_path / "bundle"
+    landed = _landed_csv(bundle / "data" / "Extract.csv")
+    _model(
+        bundle / "pbip" / "wb",
+        tables={
+            "Extract": _csv_partition(f'"{landed.as_posix()}"'),
+            "Orders": _excel_partition(MAC_AUTHOR_PATH),
+            "Date": CALCULATED_DATE,
+            "FACT_ORDERS": SNOWFLAKE_DIRECTQUERY,
+        },
+    )
+
+    model = cem.scan(bundle)["models"][0]
+
+    assert model["status"] == "EMPTY"
+    assert [f["table"] for f in model["findings"]] == ["Orders"]
+    assert model["categories"] == {
+        cem.CATEGORY_FILE_OK: 1,
+        cem.CATEGORY_FOREIGN: 1,
+        "calculated": 1,
+        "live": 1,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Parameterised paths - two thirds of the measured file-backed surface
+# ---------------------------------------------------------------------------
+
+
+def test_a_parameterised_path_that_landed_is_resolved_and_passes(tmp_path: Path) -> None:
+    """`#"SourceFolder" & "\\public_Extract.csv"` is what the engine actually emits for landed data."""
+    bundle = tmp_path / "bundle"
+    data = bundle / "pbip" / "Groups" / "Groups.Data"
+    _landed_csv(data / "public_Extract.csv")
+    _model(
+        bundle / "pbip" / "Groups",
+        name="Groups.SemanticModel",
+        tables={"Extract": _csv_partition('#"SourceFolder" & "/public_Extract.csv"')},
+        expressions=f'expression SourceFolder = "{data.as_posix()}" meta [IsParameterQuery=true, Type="Text"]\n',
+    )
+
+    report = cem.scan(bundle)
+
+    assert report["status"] == "OK"
+    assert report["models"][0]["categories"] == {cem.CATEGORY_FILE_OK: 1}
+
+
+def test_a_parameterised_path_whose_folder_never_landed_is_reported_as_empty(tmp_path: Path) -> None:
+    """The mutation that matters: if parameter resolution is dropped, this becomes `dynamic_path` and
+    the finding disappears - silently, on the majority shape."""
+    bundle = tmp_path / "bundle"
+    data = bundle / "pbip" / "Groups" / "Groups.Data"  # never created
+    _model(
+        bundle / "pbip" / "Groups",
+        name="Groups.SemanticModel",
+        tables={"Extract": _csv_partition('#"SourceFolder" & "/public_Extract.csv"')},
+        expressions=f'expression SourceFolder = "{data.as_posix()}" meta [IsParameterQuery=true, Type="Text"]\n',
+    )
+
+    findings = cem.scan(bundle)["models"][0]["findings"]
+
+    assert [f["category"] for f in findings] == [cem.CATEGORY_MISSING]
+    assert "public_Extract.csv" in findings[0]["path"]
+
+
+def test_an_undeclared_parameter_is_unresolvable_not_empty(tmp_path: Path) -> None:
+    """No `expression SourceFolder` anywhere - so the path is unknown, not absent."""
+    bundle = tmp_path / "bundle"
+    _model(bundle / "pbip" / "wb", tables={"Extract": _csv_partition('#"SourceFolder" & "/x.csv"')})
+
+    assert cem.scan(bundle)["models"][0]["categories"] == {"dynamic_path": 1}
+
+
+@pytest.mark.parametrize(
+    ("expression", "expected"),
+    [
+        ('"C:/data/x.csv"', "C:/data/x.csv"),
+        ('#"Folder" & "/x.csv"', "/base/x.csv"),
+        ('Folder & "/x.csv"', "/base/x.csv"),
+        ('#"Folder" & "/sub" & "/x.csv"', "/base/sub/x.csv"),
+        ('#"Missing" & "/x.csv"', None),
+        ('Text.From(1) & "/x.csv"', None),
+    ],
+)
+def test_m_path_evaluation(expression: str, expected: str | None) -> None:
+    """The concatenation evaluator, in isolation - including the two shapes it must REFUSE."""
+    assert cem.eval_m_path(expression, {"Folder": "/base"}) == expected
+
+
+def test_model_parameters_ignores_a_non_literal_parameter(tmp_path: Path) -> None:
+    """A computed parameter must not be half-resolved into a plausible-looking wrong path."""
+    model = _model(
+        tmp_path,
+        expressions=(
+            'expression Good = "C:/data" meta [IsParameterQuery=true]\n'
+            "expression Computed = Text.From(DateTime.LocalNow())\n"
+        ),
+    )
+    assert cem.model_parameters(model) == {"Good": "C:/data"}
+
+
+# ---------------------------------------------------------------------------
+# Attribution: from the artifact, never from a field copied forward
+# ---------------------------------------------------------------------------
+
+
+def test_the_finding_names_the_workbook_the_model_the_table_and_the_path(tmp_path: Path) -> None:
+    """The engine's own warning for this failure was measured attached to the WRONG workbook on the
+    same estate, so every identifier in a finding is read off the artifact being inspected."""
+    bundle = tmp_path / "bundle"
+    _model(bundle / "pbip" / "global_superstores_db", tables={"Orders": _excel_partition(MAC_AUTHOR_PATH)})
+
+    rendered = cem.render(cem.scan(bundle))
+
+    assert "global_superstores_db" in rendered
+    assert "Orders (Global Superstore).SemanticModel" in rendered
+    assert "table 'Orders'" in rendered
+    assert MAC_AUTHOR_PATH in rendered
+
+
+def test_no_engine_report_is_read_at_all(tmp_path: Path) -> None:
+    """A `report.json` blaming a different datasource must not change the verdict - because it is
+    never opened. The bundle here contains a deliberately misleading one."""
+    bundle = tmp_path / "bundle"
+    (bundle).mkdir()
+    (bundle / "report.json").write_text(
+        json.dumps({"workbooks": [{"name": "RESTAPISample", "pbip_warnings": ["blames 'World Indicators'"]}]}),
+        encoding="utf-8",
+    )
+    _model(bundle / "pbip" / "global_superstores_db", tables={"Orders": _excel_partition(MAC_AUTHOR_PATH)})
+
+    rendered = cem.render(cem.scan(bundle))
+
+    assert "World Indicators" not in rendered
+    assert "RESTAPISample" not in rendered
+
+
+def test_a_standalone_datasource_model_is_labelled_as_one(tmp_path: Path) -> None:
+    """`semantic_models/<X>.SemanticModel` belongs to no workbook; claiming one would be a guess."""
+    bundle = tmp_path / "bundle"
+    _model(bundle / "semantic_models", tables={"Orders": _excel_partition(MAC_AUTHOR_PATH)})
+
+    assert cem.scan(bundle)["models"][0]["owner"] == "(standalone datasource model)"
+
+
+# ---------------------------------------------------------------------------
+# Host awareness - the remap hazard that makes `exists()` alone unsafe
+# ---------------------------------------------------------------------------
+
+
+def test_a_posix_path_is_foreign_on_windows(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """On Windows `Path('/Users/x/y').exists()` is probed against the CURRENT DRIVE, so a same-named
+    local folder can answer "present" for a file the model can never read. The flavour check runs
+    first precisely so that remap cannot produce a false pass."""
+    monkeypatch.setattr(cem, "HOST_OS", "nt")
+    bundle = tmp_path / "bundle"
+    _model(bundle / "pbip" / "wb", tables={"Orders": _excel_partition(MAC_AUTHOR_PATH)})
+
+    assert cem.scan(bundle)["models"][0]["findings"][0]["category"] == cem.CATEGORY_FOREIGN
+
+
+def test_a_windows_path_is_foreign_on_posix(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The mirror image, so the check behaves the same on a Linux CI runner as on a Windows laptop."""
+    monkeypatch.setattr(cem, "HOST_OS", "posix")
+    bundle = tmp_path / "bundle"
+    _model(bundle / "pbip" / "wb", tables={"Orders": _excel_partition(WINDOWS_AUTHOR_PATH)})
+
+    assert cem.scan(bundle)["models"][0]["findings"][0]["category"] == cem.CATEGORY_FOREIGN
+
+
+def test_a_native_path_is_never_called_foreign(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The false-positive guard on the host check itself: every landed bundle path is native."""
+    monkeypatch.setattr(cem, "HOST_OS", "posix")
+    bundle = tmp_path / "bundle"
+    landed = _landed_csv(bundle / "data" / "Extract.csv")
+    _model(bundle / "pbip" / "wb", tables={"Extract": _csv_partition(f'"/{landed.as_posix().lstrip("/")}"')})
+
+    categories = cem.scan(bundle)["models"][0]["categories"]
+
+    assert cem.CATEGORY_FOREIGN not in categories
+
+
+# ---------------------------------------------------------------------------
+# TMDL parsing - the partition block walker
+# ---------------------------------------------------------------------------
+
+
+def test_partition_bodies_do_not_bleed_into_the_next_partition(tmp_path: Path) -> None:
+    """Two partitions in one table file: a body that over-reads would inherit the neighbour's source
+    and judge the wrong thing. `Sales` is broken, `Archive` is fine."""
+    bundle = tmp_path / "bundle"
+    landed = _landed_csv(bundle / "data" / "Archive.csv")
+    tmdl = (
+        "table Orders\n\n"
+        "\tpartition Sales = m\n"
+        "\t\tmode: import\n"
+        "\t\tsource =\n"
+        "\t\t\tlet\n"
+        f'\t\t\t\tSource = Csv.Document(File.Contents("{(tmp_path / "gone.csv").as_posix()}"))\n'
+        "\t\t\tin\n"
+        "\t\t\t\tSource\n\n"
+        "\tpartition Archive = m\n"
+        "\t\tmode: import\n"
+        "\t\tsource =\n"
+        "\t\t\tlet\n"
+        f'\t\t\t\tSource = Csv.Document(File.Contents("{landed.as_posix()}"))\n'
+        "\t\t\tin\n"
+        "\t\t\t\tSource\n\n"
+        "\tannotation PBI_Id = Orders\n"
+    )
+    _model(bundle / "pbip" / "wb", tables={"Orders": tmdl})
+
+    model = cem.scan(bundle)["models"][0]
+
+    assert model["categories"] == {cem.CATEGORY_MISSING: 1, cem.CATEGORY_FILE_OK: 1}
+    assert [f["partition"] for f in model["findings"]] == ["Sales"]
+
+
+def test_a_quoted_partition_name_is_unquoted(tmp_path: Path) -> None:
+    """`partition 'Orders$' = m` - the engine quotes names containing `$`, and the finding must read
+    back as the name a human sees in Desktop."""
+    bundle = tmp_path / "bundle"
+    _model(bundle / "pbip" / "wb", tables={"Orders": _excel_partition(MAC_AUTHOR_PATH)})
+
+    assert cem.scan(bundle)["models"][0]["findings"][0]["partition"] == "Orders$"
+
+
+def test_a_model_with_no_tables_folder_is_not_a_finding(tmp_path: Path) -> None:
+    """An empty scan target must produce OK, not a crash and not a false alarm."""
+    bundle = tmp_path / "bundle"
+    (bundle / "pbip" / "wb" / "Empty.SemanticModel" / "definition").mkdir(parents=True)
+
+    report = cem.scan(bundle)
+
+    assert report["models_scanned"] == 1
+    assert report["status"] == "OK"
+
+
+# ---------------------------------------------------------------------------
+# CLI contract
+# ---------------------------------------------------------------------------
+
+
+def test_cli_exits_five_on_an_empty_model_and_writes_the_json(tmp_path: Path, capsys) -> None:
+    """The exit code IS the gate; a message alone is what the engine already has."""
+    bundle = tmp_path / "bundle"
+    _model(bundle / "pbip" / "wb", tables={"Orders": _excel_partition(MAC_AUTHOR_PATH)})
+    out = tmp_path / "out" / "empty.json"
+
+    code = cem.main([str(bundle), "--json", str(out)])
+
+    assert code == cem.EXIT_EMPTY_MODEL
+    assert json.loads(out.read_text(encoding="utf-8"))["models_empty"] == 1
+    assert "EMPTY_MODEL" in capsys.readouterr().out
+
+
+def test_cli_exits_zero_on_a_healthy_bundle(tmp_path: Path) -> None:
+    bundle = tmp_path / "bundle"
+    landed = _landed_csv(bundle / "data" / "Extract.csv")
+    _model(bundle / "pbip" / "wb", tables={"Extract": _csv_partition(f'"{landed.as_posix()}"')})
+
+    assert cem.main([str(bundle)]) == cem.EXIT_OK
+
+
+def test_cli_warn_only_reports_but_does_not_block(tmp_path: Path, capsys) -> None:
+    """An explicitly accepted snapshot still has to SAY it is empty."""
+    bundle = tmp_path / "bundle"
+    _model(bundle / "pbip" / "wb", tables={"Orders": _excel_partition(MAC_AUTHOR_PATH)})
+
+    assert cem.main([str(bundle), "--warn-only"]) == cem.EXIT_OK
+    assert "EMPTY_MODEL" in capsys.readouterr().out
+
+
+def test_cli_rejects_a_path_that_is_not_a_directory(tmp_path: Path) -> None:
+    missing = tmp_path / "nope"
+    assert cem.main([str(missing)]) == cem.EXIT_USAGE
+
+
+def test_the_posture_is_printed_even_when_everything_passes(tmp_path: Path) -> None:
+    """A gate whose skip categories are invisible cannot be audited. If `live` ever collapses to zero
+    on an estate full of warehouses, the printed line is what makes that noticeable."""
+    bundle = tmp_path / "bundle"
+    _model(bundle / "pbip" / "wb", tables={"FACT_ORDERS": SNOWFLAKE_DIRECTQUERY})
+
+    rendered = cem.render(cem.scan(bundle))
+
+    assert "not judged" in rendered
+    assert "live=1" in rendered

--- a/tests/test_run_estate.py
+++ b/tests/test_run_estate.py
@@ -302,6 +302,110 @@ def test_slice_only_needs_no_engine_at_all(tmp_path: Path, monkeypatch) -> None:
 
 
 # ---------------------------------------------------------------------------
+# The empty-model gate: a bundle that passes everything above and holds no data
+# ---------------------------------------------------------------------------
+
+
+def _unlanded_model(out: Path, workbook: str = "global_superstores_db") -> None:
+    """An Import partition over a flat file that was never landed - the measured silent success.
+
+    The path is absolute and belongs to the machine the Tableau workbook was authored on. On the
+    Windows host that produced the measured estate the detector calls that `foreign_path`; on a Linux
+    CI runner the same path is simply `missing_file`. Both block, which is the point: these
+    assertions are about the coordinator's verdict, not about which runner executed them.
+    """
+    tables = out / "pbip" / workbook / "Orders.SemanticModel" / "definition" / "tables"
+    tables.mkdir(parents=True, exist_ok=True)
+    _write(
+        tables / "Orders.tmdl",
+        "table Orders\n\n"
+        "\tpartition Orders = m\n"
+        "\t\tmode: import\n"
+        "\t\tsource =\n"
+        "\t\t\tlet\n"
+        '\t\t\t\tSource = Excel.Workbook(File.Contents("/Users/<author>/Datasets/Orders.xlsx"), null, true)\n'
+        "\t\t\tin\n"
+        "\t\t\t\tSource\n",
+    )
+
+
+def _slice_only_argv(out: Path) -> list[str]:
+    return ["--output", str(out), "--slice-only"]
+
+
+def test_an_empty_model_blocks_a_bundle_that_the_definition_of_done_let_through(tmp_path: Path, capsys) -> None:
+    """The exact measured case: `definition_of_done: warn`, report bound, model contains nothing.
+
+    ``warn`` is deliberately allowed through (see the DoD tests above), so before this gate existed
+    this bundle reached the deployer and then a customer. The verdict has to live in the exit code -
+    a printed warning is what the engine already produced, and it was not enough.
+    """
+    out = tmp_path / "bundle"
+    _write(out / "report.json", json.dumps(_report(dod_status="warn")))
+    _unlanded_model(out)
+
+    code = run_estate.main(_slice_only_argv(out))
+
+    assert code == run_estate.EXIT_EMPTY_MODEL
+    printed = capsys.readouterr().out
+    assert "global_superstores_db" in printed
+    assert "Orders.xlsx" in printed
+
+
+def test_a_healthy_bundle_still_exits_zero(tmp_path: Path) -> None:
+    """The false-positive control at coordinator level: a landed CSV must not block the estate."""
+    out = tmp_path / "bundle"
+    _write(out / "report.json", json.dumps(_report(dod_status="warn")))
+    landed = _write(out / "data" / "Orders" / "Extract.csv", "a,b\n1,2\n")
+    tables = out / "pbip" / "wb" / "Orders.SemanticModel" / "definition" / "tables"
+    _write(
+        tables / "Orders.tmdl",
+        "table Orders\n\n"
+        "\tpartition Orders = m\n"
+        "\t\tmode: import\n"
+        "\t\tsource =\n"
+        "\t\t\tlet\n"
+        f'\t\t\t\tSource = Csv.Document(File.Contents("{landed.as_posix()}"))\n'
+        "\t\t\tin\n"
+        "\t\t\t\tSource\n",
+    )
+
+    assert run_estate.main(_slice_only_argv(out)) == run_estate.EXIT_OK
+
+
+def test_the_empty_model_verdict_is_printed_even_when_the_definition_of_done_already_failed(
+    tmp_path: Path, capsys
+) -> None:
+    """Precedence is DoD-first, but the READER must still be told about both.
+
+    A failed DoD returns before the empty-model branch, so if the render were emitted there the
+    quieter defect would be invisible on exactly the runs that have more than one problem. Measured
+    on the 38-workbook estate, that was the actual situation.
+    """
+    out = tmp_path / "bundle"
+    _write(out / "report.json", json.dumps(_report(dod_status="failed")))
+    _unlanded_model(out)
+
+    code = run_estate.main(_slice_only_argv(out))
+
+    assert code == run_estate.EXIT_DOD_FAILED
+    assert "EMPTY_MODEL" in capsys.readouterr().out
+
+
+def test_the_empty_model_verdict_is_persisted_for_later_steps(tmp_path: Path) -> None:
+    """The deployer runs in a different process and must not have to re-derive this."""
+    out = tmp_path / "bundle"
+    _write(out / "report.json", json.dumps(_report(dod_status="warn")))
+    _unlanded_model(out)
+
+    run_estate.main(_slice_only_argv(out))
+
+    verdict = json.loads((out / "empty-model-check.json").read_text(encoding="utf-8"))
+    assert verdict["status"] == "EMPTY_MODELS"
+    assert verdict["models"][0]["owner"] == "global_superstores_db"
+
+
+# ---------------------------------------------------------------------------
 # Slicing: the estate report must never enter a per-workbook agent's context
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Which half of #95 this is

**References #95, does not close it.** Issue #95 covers two failure shapes; this PR implements only the second.

| half | status |
|---|---|
| `needs-storage-decision` cohort (14 workbooks) | **not this PR** - root-caused to a Tableau UNION the deterministic engine does not resolve, filed upstream as `Yarbrdab000/tableau-fabric-skills#124`. An engine fix, not ours. |
| **silent success: "the model opens but loads no rows"** | **this PR** |

Leave #95 open until the upstream half lands.

## Why the quiet one needed a gate at all

The other failures are already loud, and that is working correctly: the engine names what is missing and `run_estate.py` exits 3 and refuses to hand the bundle downstream.

This one produces a model that **deploys, opens, binds its report, validates, and contains zero rows**. Nothing in the pipeline distinguished *migrated* from *migrated and empty*, so it surfaces in front of the customer rather than in front of us.

Measured on the 38-workbook estate run (engine 2.126.0), `global_superstores_db`:

```
definition_of_done : warn      <- allowed through on purpose
report_bound       : true
pbip_status        : built
partition Orders   : mode: import
  Source = Excel.Workbook(File.Contents("/Users/<author>/.../Global Superstore.xlsx"), null, true)
```

That absolute path belongs to the Mac the Tableau workbook was authored on. On the migration host it does not exist. `warn` is deliberately allowed through by the existing DoD gate, so before this PR that bundle reached the deployer.

This is the repo's own *"structural validation is necessary, not sufficient"* principle made concrete: the M is perfectly well-formed, and `check_datamodel.py` is right to pass it.

## What changed

**`scripts/check_empty_model.py`** (new) - classifies every emitted TMDL partition **offline**: no Fabric, no Power BI Desktop, no credential. A check that needs a tenant is a check nobody runs.

Blocks on the only three shapes it can *prove* empty:

| category | meaning |
|---|---|
| `missing_file` | the resolved path does not exist |
| `foreign_path` | the path is written for a different OS than this host (POSIX `/Users/...` on Windows, `C:\...` on Linux) |
| `empty_file` | zero bytes, or a delimited file with nothing after its header |

`foreign_path` is separate from `missing_file` on purpose: on Windows, `Path("/Users/<name>/x").exists()` is probed against the **current drive**, so a same-named local folder can answer "present" for a file the model can never read. Flavour is therefore decided by the path's own shape *before* any filesystem call.

Paths are resolved through **M parameters** first - the engine routinely emits `#"SourceFolder" & "\public_Extract.csv"` with the folder declared in `expressions.tmdl`. 22 of that estate's 34 file-backed partitions were this shape, so a literal-only check would have silently left two thirds of its own subject matter unjudged.

**`scripts/run_estate.py`** - wires it in as `EXIT_EMPTY_MODEL = 6`, next to the existing `EXIT_DOD_FAILED (3)` / `EXIT_COLLISION (4)` / `EXIT_ENGINE_SOURCE (5)`, and persists the verdict to `<bundle>/empty-model-check.json` so a later deploy step re-reads it instead of re-deriving it. (Originally written as 5; renumbered to 6 on rebase because #109 landed `EXIT_ENGINE_SOURCE = 5` on master first.)

Precedence is **collision > DoD > empty** (all three refuse the bundle; the earlier ones are the broader signal), but the empty-model **text** is printed before every early return, so the quiet defect is never hidden behind a louder one - on the real estate, that was the actual situation.

## False-positive posture (stated on purpose, and tested)

A false alarm blocks a customer estate, so: **anything this module cannot prove empty from the artifact is not empty.**

Never flagged: `live` (`directQuery`/`dual`), `remote_import` (Import over Snowflake/Sql/PostgreSQL/Databricks/...), `calculated`, `dynamic_path` (path not resolvable offline), `stub`, `inline`, `unrecognized`.

Two of those deserve their reasoning spelled out:

- **`live`** - mode is checked *before* source shape, so a `directQuery` partition whose M happens to name a file connector is still live. There is a test for exactly that ordering.
- **`stub`** (`#table(type table [], {})`) - the engine **already** reports these as *"N table(s) landed as a needs-review partition stub"*. Blocking here too would fire the new gate on workbooks that are already blocked, which is how a new check earns a reputation for noise and gets switched off.

Every category is counted and printed on **every** run, pass or fail, so the posture is auditable rather than assumed.

## Attribution is read off the artifact, never copied forward

On that same estate the engine attached this exact "flat-file ... loads no rows" warning to `RESTAPISample` - a workbook that produced **no model at all** - while the workbook that actually produced an empty model was only `warn`. So `check_empty_model.py` **never opens `report.json`**. Owner, model, table, partition and path all come from the `.SemanticModel` folder being inspected. There is a test that plants a deliberately misleading `report.json` in the bundle and asserts none of it reaches the output.

## Evidence

Against the real 38-workbook bundle (`--slice-only`, unmodified copy):

```
EMPTY-MODEL CHECK: 55 model(s)
  judged (local file sources)        : file_ok=33, foreign_path=1
  not judged (no local rows expected): calculated=121, live=58, stub=13

EMPTY_MODEL: 1 model(s) would open and load NO ROWS
  global_superstores_db -> Orders (Global Superstore).SemanticModel
      table 'Orders' partition 'Orders$': posix absolute path cannot be read from this windows host
        path: /Users/<author>/.../Global Superstore.xlsx
        fix : ... supply the file on this host and repoint the partition, or convert the table to a live connection
```

Three runs over that bundle, showing the gate is the *only* thing that changed the verdict:

| bundle state | `run_estate.py --slice-only` |
|---|---|
| as produced (15 DoD failures) | **3** `DOD_FAILED` - and the empty-model block still prints above it |
| DoD forced green, empty model present | **6** `EMPTY_MODEL` |
| DoD forced green, `global_superstores_db` removed (54 models) | **0** `READY` |

- **Catches** the one genuinely silent model.
- **Does not fire** on the other 54 models, including all **58 DirectQuery partitions** across the live Snowflake/Databricks models.
- Counts reconcile exactly against the estate: 34 file-backed = 19 `Csv.Document` + 15 `Excel.Workbook`; 168 Import partitions = 121 calculated + 34 file-backed + 13 stubs.

CI runs on `ubuntu-latest`, and path flavour is host-dependent by design, so the two new suites were also run under real Linux (WSL, CPython 3.12): **60/60 passing**.

## Mutation testing - 12/12 caught

A test that cannot fail is worse than none, so each mutation below was applied to this branch's code and the two suites (63 tests) re-run. Every one turned the suite red:

| # | mutation | tests failed |
|---|---|---|
| M1 | live/DirectQuery short-circuit removed | 5 - the **false-positive** direction |
| M2 | missing file treated as OK | 6 |
| M3 | `_is_foreign` never fires | 3 |
| M4 | empty file treated as OK | 2 |
| M5 | needs-review stub no longer recognised | 1 - the **double-count** direction |
| M6 | remote connector judged as a local file | 1 - the other false-positive direction |
| M7 | blocking set emptied | 19 |
| M8 | M-parameter resolution disabled | 25 |
| M9 | row counting disabled (header-only file looks full) | 1 |
| M10 | detector's own exit code downgraded to 0 | 1 |
| M11 | coordinator downgrades the verdict to a pass | 1 |
| M12 | coordinator never runs the check (gate wired out) | 7 |

Both directions are covered: mutations that would make the gate miss a real empty model (M2, M3, M4, M7, M8, M9, M10, M11, M12), and mutations that would make it fire on a healthy one (M1, M5, M6).

## Known limits (in the module docstring, not hidden here)

- It cannot say whether a *reachable database* returns rows - that is `probe_bundle.py` plus a credential.
- Row presence is not fidelity. This says "not empty", never "correct".
- It must run on the host that produced the bundle. A Windows-produced bundle inspected from Linux is all `foreign_path`. `run_estate.py` satisfies this by construction.
- A **relocated** bundle will legitimately trip `missing_file`, because the engine writes absolute paths. That is treated as correct behaviour, not a false positive: a moved bundle really would load nothing.
- **Deliberately not implemented:** blocking a model whose data-bearing tables are *all* needs-review stubs. The engine already names those in the definition of done, and escalating them here would double-report. Open to argument.

## Checks

Rebased onto master (post #105 / #109 / #110). `ruff format --check scripts tests`, `ruff check scripts tests`, `pylint scripts` (exit 0, 10.00/10), `pytest -q` (**971 passed, 4 skipped**), `check_datamodel.py --all`, `set_data_folder.py --check` and `sync_agent_conventions.py --check` all green locally.

Do not merge without review.
