### PR TITLE
Make pbip-model-refresh persist safely, bind to the right instance, and gate on real data

### DIFF
--- a/.github/skills/pbip-model-refresh/SKILL.md
+++ b/.github/skills/pbip-model-refresh/SKILL.md
@@ -192,8 +192,11 @@ data can only have come from the cache.
 Two traps:
 
 - The AMO client raises **"The server sent an unrecognizable response"** *while writing the file
-  correctly*. Judge success by the FILE (exists, non-empty, mtime advanced), never by the absence of
-  an exception.
+  correctly*. Judge success by the FILE, never by the absence of an exception — but "the file" means a
+  **complete** ABF: only that specific benign response is tolerated, and the staged `cache.abf.tmp` is
+  swapped in only after it is validated as a real Analysis Services backup (CFBF/OLE2 magic + a full
+  header), so a truncated or disk-full write is rejected instead of replacing a good cache. Any other
+  exception propagates and the compatibility-level alignment is rolled back.
 - `database_operations ExportToTmdlFolder` persists model *definition* changes but carries no rows.
   It cannot substitute for this.
 
@@ -215,22 +218,29 @@ queries that same wrong port.
 So, before refreshing, querying or saving anything, two guards run. First, **if you pass `--port` it
 must EQUAL the port derived from `--pid`** — a mismatch aborts, so `--port` can never bypass PID-based
 discovery to point the read (and the `ImageSave` write) at another instance. Second, `same_model()`
-compares the connected model's tables against the TMDL that owns the destination cache and requires an
-**EXACT table-for-table match**; a mismatch — or an identity it cannot establish at all (no model
-folder resolved, or no TMDL tables to fingerprint) — aborts with `WRONG_MODEL`, **failing closed**
-rather than assuming it is fine. A superset schema (all your tables plus more) is a mismatch, not a
-"confirmed". File metadata fundamentally cannot tell you whose rows are in a blob, only the model's
-own contents can. When a project folder holds several `.SemanticModel` directories the destination is
-resolved from the `.pbip` → report → `definition.pbir` `byPath` **binding**, never an arbitrary first
-match. In a parallel batch **always pass `--pid`** (`powerbi-desktop status` maps pid to open file);
-with several instances open the scripts refuse to guess.
+compares the connected model against the TMDL that owns the destination cache and requires an **exact
+match of tables, columns AND measures** — table names alone are too coarse (a bound sibling with the
+same table names but different columns or measures would pass), so the fingerprint descends into each
+table's columns and the model's measures, filtering only the auto-generated noise that never appears in
+TMDL (RowNumber system columns, `LocalDateTable_*` / `DateTableTemplate_*` auto-date tables). A
+mismatch — or an identity it cannot establish at all (no model folder resolved, or no TMDL to
+fingerprint) — aborts with `WRONG_MODEL`, **failing closed** rather than assuming it is fine. A superset
+schema (all your tables plus more) is a mismatch, not a "confirmed". File metadata fundamentally cannot
+tell you whose rows are in a blob, only the model's own contents can. When a project folder holds
+several `.SemanticModel` directories the destination is resolved from the `.pbip` → report →
+`definition.pbir` `byPath` **binding first**; only if no binding resolves does a single same-named
+sibling act as a last-resort fallback — the binding is authoritative and the name heuristic can never
+short-circuit it. In a parallel batch **always pass `--pid`** (`powerbi-desktop status` maps pid to open
+file); with several instances open the scripts refuse to guess.
 
 **Sweep for orphans before you build, not just siblings while you build.** Measured 2026-08-01: a
 Desktop instance was already running on the *exact `.pbip` path* about to be generated, left over from
-an earlier, since-deleted attempt. `same_model()` would not have caught it — its TMDL tables matched —
-but `INFO.MEASURES()` showed measures the new build never defines, i.e. a **different model held in
-memory on your path**, one Save away from overwriting the files you are generating. So at the start of
-a build, list `Get-Process PBIDesktop`, read each one's command line
+an earlier, since-deleted attempt. The tables-only fingerprint then in force would not have caught it —
+its TMDL tables matched — though the columns+measures fingerprint now would, because `INFO.MEASURES()`
+showed measures the new build never defines. But do not lean on that: an orphan whose schema is
+byte-for-byte your model (the common re-open case) is **identical** to `same_model()`, one Save away
+from overwriting the files you are generating. So at the start of a build, list `Get-Process
+PBIDesktop`, read each one's command line
 (`Get-CimInstance Win32_Process -Filter "ProcessId=<pid>"`), and force-close any instance already bound
 to your own `.pbip` before writing to it. Identify by `MainWindowTitle` + command line, never by "the
 one instance that is running".

--- a/.github/skills/pbip-model-refresh/SKILL.md
+++ b/.github/skills/pbip-model-refresh/SKILL.md
@@ -40,7 +40,7 @@ A migrated model hands over as *TMDL plus a promise*. Two things go wrong:
 ## Run it
 
 ```
-python scripts/refresh_pbip_model.py [--pid <pbidesktop-pid>] [--tables "A" "B"]
+python scripts/refresh_pbip_model.py [--pid <pbidesktop-pid>] [--canaries "A" "B"] [--tables "A" "B"]
                                      [--no-save] [--verify-only] [--ui-save]
 ```
 
@@ -112,22 +112,32 @@ stay byte-identical.
 Read-only preflight (proves credentials + source reachability without changing anything):
 
 ```
-python scripts/probe_desktop_query.py [--pid <pbidesktop-pid>] [--tables "A" "B"]
+python scripts/probe_desktop_query.py [--pid <pbidesktop-pid>] [--canaries "A" "B"]
 ```
 
-**Name one canary table per distinct live source** with `--tables`. A model-level `DATA_OK` is only
+**Name one canary table per distinct live source** with `--canaries`. A model-level `DATA_OK` is only
 emitted when *every* named canary returns rows; with **no** table named, only the first queryable
 table is probed and the verdict is **downgraded** to `TABLE_OK '<table>'` — a static parameter/CSV
 table can return rows while a live source never loaded, so one arbitrary table can never certify the
 whole model. This mirrors the `powerbi-semantic-model-gotchas` rule: *prove a REAL read per live
-source*. `refresh_pbip_model.py` applies the same rule to its own data check (its `--tables` is both
-the refresh scope and the canary set).
+source*.
 
-Both print a machine-readable last line: `REFRESH: DATA_OK + PERSISTED` / `TABLE_OK '<table>'` /
-`NO_DATA` / `NOT_PERSISTED` / `WRONG_MODEL` / `ERROR <msg>`, and `PREFLIGHT: DATA_OK` /
-`TABLE_OK '<table>'` / `NO_DATA` / `ERROR`. Exit 0 is the good outcome — but it covers **both** a
-model verdict (`DATA_OK`) and a single-table verdict (`TABLE_OK`), so a gate that needs model-level
-certainty must require the literal `DATA_OK` (i.e. pass explicit canaries), not merely exit 0.
+⚠️ **`--canaries` verifies; `--tables` narrows the refresh. They are different knobs, on purpose.**
+They used to be one, and that built a trap: the only documented way to earn `DATA_OK` was to name
+tables in `--tables`, which simultaneously refreshed **only** those tables — certifying a *model*-level
+verdict over a *partially* refreshed model, i.e. the "next agent gets an empty model" failure this
+bundle exists to prevent, wearing a green badge. So `refresh_pbip_model.py` now emits
+`TABLES_OK '<a>', '<b>'` — never `DATA_OK` — whenever `--tables` narrowed the refresh, and
+`--canaries` verifies without narrowing anything. `--tables` alone still supplies the canary set (old
+callers keep a probe), it just can no longer certify the whole model. `probe_desktop_query.py` never
+refreshes, so there `--tables`/`--table` remain plain aliases for `--canaries`.
+
+Both print a machine-readable last line: `REFRESH: DATA_OK + PERSISTED` / `TABLES_OK '<a>', '<b>'` /
+`TABLE_OK '<table>'` / `NO_DATA` / `NOT_PERSISTED` / `WRONG_MODEL` / `ERROR <msg>`, and
+`PREFLIGHT: DATA_OK` / `TABLE_OK '<table>'` / `NO_DATA` / `ERROR`. Exit 0 is the good outcome — but it
+covers a model verdict (`DATA_OK`), a scoped verdict (`TABLES_OK`) **and** a single-table verdict
+(`TABLE_OK`), so a gate that needs model-level certainty must require the literal `DATA_OK` — which
+means running a **whole-model** refresh with explicit `--canaries`, not merely exit 0.
 
 ## Order matters, do not refresh before you finish editing
 
@@ -170,7 +180,7 @@ number you read back.
 
 | Path | What it is | Status |
 |---|---|---|
-| **AMO `Server.ImageSave(databaseId, Stream)`** | Writes `cache.abf` directly from the engine. No UI, works headless; staged to `cache.abf.tmp` and swapped in atomically, so a failed/partial write can't destroy an existing good cache. | **Default (opt out with `--no-save`)** |
+| **AMO `Server.ImageSave(databaseId, Stream)`** | Writes `cache.abf` directly from the engine. No UI, works headless; staged to a per-run private file and swapped in atomically, so a failed/partial write (or a concurrent second run) can't destroy an existing good cache. | **Default (opt out with `--no-save`)** |
 | **UI Automation (`InvokePattern` on the "Save" element)** | Drives Desktop's own Save through the Windows *accessibility* tree. | Fallback / `--ui-save` |
 
 ⚠️ **Read the `--no-save` warning above before using either.** Both write the same `cache.abf`. A
@@ -193,11 +203,18 @@ Two traps:
 
 - The AMO client raises **"The server sent an unrecognizable response"** *while writing the file
   correctly*. Judge success by the FILE, never by the absence of an exception — but "the file" means a
-  **complete** ABF: only that specific benign response is tolerated, and the staged `cache.abf.tmp` is
-  swapped in only after its CFBF/OLE2 header **structure** validates against MS-CFB — the fixed header
-  fields, a whole-sector file length, and every referenced sector sitting inside the file, not merely
-  the 8-byte magic — so a truncated, sector-aligned or disk-full write is rejected instead of replacing
-  a good cache, and the check **fails closed** on any uncertainty. Any other exception propagates and
+  **complete** ABF: only that specific benign response is tolerated, and the staged file is swapped in
+  only after its **block chain** walks cleanly to EOF. A `cache.abf` is an Analysis Services backup,
+  **not** a Compound File / OLE2 container — an earlier round asserted CFBF and its check therefore
+  rejected 100% of real caches, silently disabling persist-by-default on every run. Measured across 13
+  real caches (17 KB → 60 MB, written by Desktop *and* by `ImageSave`): a 100-byte UTF-16LE
+  `"This backup was created using XPress9 compression."` preamble, a 2-byte pad, then blocks of
+  `uint32 uncompressed, uint32 lengthFromTheMagic, 4-byte magic 2A D7 86 4E, payload`, where the next
+  header sits at `offset + 8 + length` and the chain ends **exactly** at EOF. A truncated write leaves a
+  block claiming bytes past EOF; a write that stopped on a chunk boundary leaves a full-2 MiB *final*
+  block (every measured final block is smaller), so both are rejected instead of replacing a good cache.
+  The check **fails closed** on any uncertainty and **prints the reason** it refused — a predicate that
+  can only say "no" is how the CFBF mistake survived a whole review round. Any other exception propagates and
   the provisional compatibility-level alignment is rolled back; if that rollback cannot itself be
   completed the run **stops fatally** rather than falling through to the UI Save, because
   `database.tmdl` would otherwise ship declaring a level no cache was ever written at.

--- a/.github/skills/pbip-model-refresh/SKILL.md
+++ b/.github/skills/pbip-model-refresh/SKILL.md
@@ -194,9 +194,13 @@ Two traps:
 - The AMO client raises **"The server sent an unrecognizable response"** *while writing the file
   correctly*. Judge success by the FILE, never by the absence of an exception — but "the file" means a
   **complete** ABF: only that specific benign response is tolerated, and the staged `cache.abf.tmp` is
-  swapped in only after it is validated as a real Analysis Services backup (CFBF/OLE2 magic + a full
-  header), so a truncated or disk-full write is rejected instead of replacing a good cache. Any other
-  exception propagates and the compatibility-level alignment is rolled back.
+  swapped in only after its CFBF/OLE2 header **structure** validates against MS-CFB — the fixed header
+  fields, a whole-sector file length, and every referenced sector sitting inside the file, not merely
+  the 8-byte magic — so a truncated, sector-aligned or disk-full write is rejected instead of replacing
+  a good cache, and the check **fails closed** on any uncertainty. Any other exception propagates and
+  the provisional compatibility-level alignment is rolled back; if that rollback cannot itself be
+  completed the run **stops fatally** rather than falling through to the UI Save, because
+  `database.tmdl` would otherwise ship declaring a level no cache was ever written at.
 - `database_operations ExportToTmdlFolder` persists model *definition* changes but carries no rows.
   It cannot substitute for this.
 

--- a/.github/skills/pbip-model-refresh/SKILL.md
+++ b/.github/skills/pbip-model-refresh/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pbip-model-refresh
-description: Refresh a local PBIP/TMDL semantic model open in Power BI Desktop, and OPTIONALLY persist the result to .pbi/cache.abf (headlessly via AMO Server.ImageSave, UI-Automation fallback). Persisting is opt-in - `--save` - because a persisted cache can make the PBIP unopenable. Use after finishing TMDL edits, before handing a model to report authoring, or whenever Desktop reopens a migrated model empty. Source-tool agnostic - the model is already Power BI, so this applies equally to Tableau, Qlik and Cognos migrations.
+description: Refresh a local PBIP/TMDL semantic model open in Power BI Desktop, and persist the result to .pbi/cache.abf (headlessly via AMO Server.ImageSave, UI-Automation fallback). Persisting is the DEFAULT - opt OUT with `--no-save` for read-only or validate-then-deploy work; saving aligns database.tmdl's declared compatibilityLevel so the cache stays loadable, and the cache write is staged and swapped atomically. Use after finishing TMDL edits, before handing a model to report authoring, or whenever Desktop reopens a migrated model empty. Source-tool agnostic - the model is already Power BI, so this applies equally to Tableau, Qlik and Cognos migrations.
 ---
 
 # Refresh a local PBIP model, and make the data survive a close
@@ -19,6 +19,10 @@ and AMO client libraries under `~/.nuget/packages`, and `npx` for
 - [**`scripts/probe_desktop_query.py`**](scripts/probe_desktop_query.py) - read-only preflight: port
   discovery, ADOMD loading, table listing, and the one-row DAX probe. `refresh_pbip_model.py`
   imports from this file and from nothing else.
+- [**`scripts/probe_desktop_credential.ps1`**](scripts/probe_desktop_credential.ps1) - the arbiter a
+  refresh TIMEOUT names: a UI-Automation check for a data-source sign-in modal, so "slow" and
+  "blocked" are told apart by evidence, not guessed. Ships **inside** the bundle, so the instruction
+  the script prints at runtime resolves to a file that is actually here.
 - [**`tests/`**](tests) - the regression suite for both, runnable from this folder
   (`pytest tests`). It is what makes the portability claim below checkable rather than aspirational.
 
@@ -95,7 +99,8 @@ stay byte-identical.
 > and it was wrong: measured 2026-08-04 it fired on 2 of 5 Desktop instances opened on the *same*
 > bundle that refreshed cleanly on the other 3 (38.8 s on a good run, >87 s on a slow one, against a
 > 90 s ceiling — a ~3 s margin). It now reports `REFRESH: TIMEOUT` with the cause **UNKNOWN** and
-> names the arbiter (`scripts/probe_desktop_credential.ps1`).
+> names the arbiter (`scripts/probe_desktop_credential.ps1`, which **ships in this bundle** — the
+> script prints its absolute path at runtime so the instruction always points at a file that is here).
 >
 > **The ceiling is 300 s and is deliberately NOT agent-tunable — there is no flag.** A knob here is
 > an attractive nuisance: an agent that hits a timeout reaches for a bigger number, and the one case
@@ -107,12 +112,22 @@ stay byte-identical.
 Read-only preflight (proves credentials + source reachability without changing anything):
 
 ```
-python scripts/probe_desktop_query.py [--pid <pbidesktop-pid>] [--table "<table>"]
+python scripts/probe_desktop_query.py [--pid <pbidesktop-pid>] [--tables "A" "B"]
 ```
 
-Both print a machine-readable last line: `REFRESH: DATA_OK + PERSISTED` / `NO_DATA` /
-`NOT_PERSISTED` / `WRONG_MODEL` / `ERROR <msg>`, and `PREFLIGHT: DATA_OK` / `NO_DATA` / `ERROR`.
-Exit 0 only on the good outcome, so these are usable as gates.
+**Name one canary table per distinct live source** with `--tables`. A model-level `DATA_OK` is only
+emitted when *every* named canary returns rows; with **no** table named, only the first queryable
+table is probed and the verdict is **downgraded** to `TABLE_OK '<table>'` — a static parameter/CSV
+table can return rows while a live source never loaded, so one arbitrary table can never certify the
+whole model. This mirrors the `powerbi-semantic-model-gotchas` rule: *prove a REAL read per live
+source*. `refresh_pbip_model.py` applies the same rule to its own data check (its `--tables` is both
+the refresh scope and the canary set).
+
+Both print a machine-readable last line: `REFRESH: DATA_OK + PERSISTED` / `TABLE_OK '<table>'` /
+`NO_DATA` / `NOT_PERSISTED` / `WRONG_MODEL` / `ERROR <msg>`, and `PREFLIGHT: DATA_OK` /
+`TABLE_OK '<table>'` / `NO_DATA` / `ERROR`. Exit 0 is the good outcome — but it covers **both** a
+model verdict (`DATA_OK`) and a single-table verdict (`TABLE_OK`), so a gate that needs model-level
+certainty must require the literal `DATA_OK` (i.e. pass explicit canaries), not merely exit 0.
 
 ## Order matters, do not refresh before you finish editing
 
@@ -133,12 +148,15 @@ Re-localizing, reopening, refreshing and saving again produced a cache that **di
 `Stop-Process -Force` + reopen (`PREFLIGHT: DATA_OK`, no refresh). So "refresh last, after sanitize"
 does not rescue the cache: Desktop keys the cache to the definition it was built from.
 
-> **Hand-off rule:** leave the model **localized + refreshed**, and tell whoever commits to run the
-> sanitize step. ⚠️ **Revised 2026-08-04 — this used to say "+ persisted".** That was wrong, and it
-> was the more expensive of the two errors: persisting is what makes the PBIP unopenable (see the
-> `--save` warning above), so the guidance to always persist actively broke the hand-off it was
-> written to protect. Persist only with `--save`, only when the next step needs data to survive a
-> restart, and verify the PBIP still opens afterwards.
+> **Hand-off rule:** leave the model **localized + refreshed**. Persisting is the default and safe —
+> the compatibility alignment above keeps the cache loadable — but a persisted cache only *survives*
+> a hand-off when nothing rewrites the TMDL afterwards, and the committer still has to run the
+> sanitize step, which invalidates it. So either persist and tell whoever commits to re-run this
+> script after sanitizing, or hand off refreshed-but-not-persisted with `--no-save` and have them
+> refresh once more post-sanitize. ⚠️ **Revised 2026-08-04, corrected 2026-08-07:** an earlier note
+> here blamed *persisting* for making the PBIP unopenable and told you to persist only with a flag;
+> root-caused, that was a compatibility-level mismatch `image_save` now aligns away, not persistence
+> itself, so persisting is the safe default again.
 
 **`powerbi-desktop reload` does NOT re-read edited TMDL.** Measured 2026-08-01: after editing two
 measures on disk, `reload` returned `{"success": true}` and `INFO.MEASURES()` still showed the **old**
@@ -152,12 +170,14 @@ number you read back.
 
 | Path | What it is | Status |
 |---|---|---|
-| **AMO `Server.ImageSave(databaseId, Stream)`** | Writes `cache.abf` directly from the engine. No UI, works headless. | **Opt-in (`--save`)** |
+| **AMO `Server.ImageSave(databaseId, Stream)`** | Writes `cache.abf` directly from the engine. No UI, works headless; staged to `cache.abf.tmp` and swapped in atomically, so a failed/partial write can't destroy an existing good cache. | **Default (opt out with `--no-save`)** |
 | **UI Automation (`InvokePattern` on the "Save" element)** | Drives Desktop's own Save through the Windows *accessibility* tree. | Fallback / `--ui-save` |
 
-⚠️ **Read the `--save` warning above before using either.** Both write the same `cache.abf`, and a
-present cache was measured to make the PBIP unopenable. The mechanism below is sound and worth
-keeping - the error was making it the default, not building it.
+⚠️ **Read the `--no-save` warning above before using either.** Both write the same `cache.abf`. A
+present cache was once believed to make the PBIP unopenable; root-caused 2026-08-07, that was a
+compatibility-level **mismatch**, which `image_save` now prevents by aligning `database.tmdl` (and
+rolling that alignment back if the write fails). With the hazard gone, persisting is the DEFAULT and
+matches this script's stated purpose; `--no-save` opts out for read-only or validate-then-deploy work.
 
 **Why ImageSave exists at all**, because the obvious answer says it should not: the guidance is that
 writing model state back to `.pbip`/`cache.abf` "is a separate Save action that only the Desktop UI
@@ -192,11 +212,18 @@ machine") this writes *another migration's model into your own correct-looking `
 downstream signal still agrees: the file exists, is non-empty, is newly written, and the row count
 queries that same wrong port.
 
-So, before refreshing, querying or saving anything, `same_model()` compares the connected model's
-tables against the TMDL that owns the destination cache; a mismatch aborts with `WRONG_MODEL`. File
-metadata fundamentally cannot tell you whose rows are in a blob, only the model's own contents can. In
-a parallel batch **always pass `--pid`** (`powerbi-desktop status` maps pid to open file); with
-several instances open the scripts refuse to guess.
+So, before refreshing, querying or saving anything, two guards run. First, **if you pass `--port` it
+must EQUAL the port derived from `--pid`** — a mismatch aborts, so `--port` can never bypass PID-based
+discovery to point the read (and the `ImageSave` write) at another instance. Second, `same_model()`
+compares the connected model's tables against the TMDL that owns the destination cache and requires an
+**EXACT table-for-table match**; a mismatch — or an identity it cannot establish at all (no model
+folder resolved, or no TMDL tables to fingerprint) — aborts with `WRONG_MODEL`, **failing closed**
+rather than assuming it is fine. A superset schema (all your tables plus more) is a mismatch, not a
+"confirmed". File metadata fundamentally cannot tell you whose rows are in a blob, only the model's
+own contents can. When a project folder holds several `.SemanticModel` directories the destination is
+resolved from the `.pbip` → report → `definition.pbir` `byPath` **binding**, never an arbitrary first
+match. In a parallel batch **always pass `--pid`** (`powerbi-desktop status` maps pid to open file);
+with several instances open the scripts refuse to guess.
 
 **Sweep for orphans before you build, not just siblings while you build.** Measured 2026-08-01: a
 Desktop instance was already running on the *exact `.pbip` path* about to be generated, left over from
@@ -211,10 +238,12 @@ one instance that is running".
 ## Reusing this in another migration repo
 
 Nothing here is Tableau-specific, the input is already a Power BI model. **Copy this folder.**
-`SKILL.md`, the two scripts it runs and the tests that gate them are one unit: the scripts import
-only each other, and `tests/conftest.py` resolves them at `../scripts`, so the suite runs from
-wherever the folder lands. Drop it in the target repo's skill location (`.github/skills/`) or promote
-it to a global one such as `~/.copilot/skills/`, then prove the copy on the spot:
+`SKILL.md`, the two Python scripts it runs, the `probe_desktop_credential.ps1` arbiter they name at
+runtime, and the tests that gate them are one unit: the scripts import only each other, name the
+arbiter by their own bundled path, and `tests/conftest.py` resolves them at `../scripts`, so the
+suite — and every runtime instruction the scripts print — runs from wherever the folder lands. Drop
+it in the target repo's skill location (`.github/skills/`) or promote it to a global one such as
+`~/.copilot/skills/`, then prove the copy on the spot:
 
 ```
 pytest tests

--- a/.github/skills/pbip-model-refresh/scripts/_abf.py
+++ b/.github/skills/pbip-model-refresh/scripts/_abf.py
@@ -1,12 +1,13 @@
 """Cache-file integrity and atomic staged writes for ``refresh_pbip_model``.
 
-A persisted ``<Name>.SemanticModel/.pbi/cache.abf`` is an Analysis Services backup, i.e. a Microsoft
-Compound File Binary (OLE2/CFBF) container. This module holds the self-contained primitives that make
-persisting one SAFE (issue #113): proving a staged file is a COMPLETE CFBF container before it may
-replace a good cache, swapping it in atomically, and restoring a provisional compatibility alignment
-when the write does not land. ``refresh_pbip_model._persist_image`` orchestrates these with the
-compat/manifest policy layer, and every public name here is re-exported from ``refresh_pbip_model`` so
-callers and tests reach them through that module.
+A persisted ``<Name>.SemanticModel/.pbi/cache.abf`` is an Analysis Services backup: a UTF-16LE
+preamble followed by a chain of XPress9-compressed blocks (see ``_abf_rejection_reason`` for the
+measured layout). This module holds the self-contained primitives that make persisting one SAFE
+(issue #113): proving a staged file is a COMPLETE backup before it may replace a good cache, swapping
+it in atomically, and restoring a provisional compatibility alignment when the write does not land.
+``refresh_pbip_model._persist_image`` orchestrates these with the compat/manifest policy layer, and
+every public name here is re-exported from ``refresh_pbip_model`` so callers and tests reach them
+through that module.
 
 Extracted from ``refresh_pbip_model`` so that module stays under its line cap; nothing here depends on
 the rest of the bundle, only on ``os``/``struct``/``pathlib``.
@@ -16,95 +17,152 @@ from __future__ import annotations
 
 import os
 import struct
+import uuid
 from pathlib import Path
 
-# A persisted `cache.abf` is an Analysis Services backup = a Microsoft Compound File Binary
-# (OLE2/CFBF) container. `_is_complete_abf` validates the 512-byte CFBF header STRUCTURE (per MS-CFB),
-# not just the 8-byte magic: a torn write can keep the magic yet be rubble past it, and swapping that
-# over a good cache is the data loss #113 exists to prevent.
-_CFBF_MAGIC = b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1"
-_CFBF_HEADER_BYTES = 512
-_CFBF_BYTE_ORDER_LE = 0xFFFE  # header offset 28: little-endian mark; the only value CFBF permits
-_CFBF_MINI_SECTOR_SHIFT = 6  # header offset 32: fixed at 6 (64-byte mini sectors)
-# major version (offset 26) -> sector shift (offset 30): v3 = 512-byte sectors, v4 = 4096. No other pairing.
-_CFBF_VERSION_TO_SECTOR_SHIFT = {3: 9, 4: 12}
+# THE FORMAT, MEASURED - not assumed. An earlier round asserted a cache.abf was a Microsoft Compound
+# File Binary (OLE2/CFBF, magic `D0 CF 11 E0 ...`). It is NOT, and the cost of that guess was total:
+# `_is_complete_abf` returned False for every real cache, so the staged write NEVER swapped and
+# persist-by-default silently stopped working, falling back to the UI save on every single run.
+# Ground truth, from all 13 `cache.abf` files on this machine (17,478 B -> 60,688,851 B; 1 -> 47
+# blocks; written by Power BI Desktop AND by this script's own ImageSave):
+#
+#   0..99    UTF-16LE "This backup was created using XPress9 compression." (exactly 100 bytes)
+#   100..101 uint16 pad, 0 in all 13
+#   102..    block chain, each block: uint32 uncompressedBytes, uint32 blockBytes, 4-byte magic,
+#            then payload. `blockBytes` is measured FROM THE MAGIC, so the next block header starts
+#            at (headerOffset + 8 + blockBytes). The chain ends EXACTLY at EOF in all 13 files.
+_ABF_PREAMBLE = "This backup was created using XPress9 compression.".encode("utf-16-le")
+_ABF_FIRST_BLOCK_OFFSET = len(_ABF_PREAMBLE) + 2  # 100-byte preamble + the 2-byte pad
+_ABF_BLOCK_MAGIC = b"\x2a\xd7\x86\x4e"
+_ABF_BLOCK_HEADER_BYTES = 8 + len(_ABF_BLOCK_MAGIC)  # uint32 uncompressed + uint32 length + magic
+# Every one of the 60 NON-final blocks measured declares exactly 2 MiB uncompressed, and every one of
+# the 13 FINAL blocks declares less. So a file whose last block is a full 2 MiB is a write that
+# stopped on a block boundary with more to come - the one truncation a chain-walk alone cannot see.
+_ABF_MAX_BLOCK_BYTES = 2 * 1024 * 1024
 
 
-def _is_complete_abf(path: Path) -> bool:
-    """Is `path` a fully-written cache.abf, not a truncated or partial one?
+def _abf_rejection_reason(path: Path) -> str | None:
+    """Why `path` is not a complete cache.abf, or ``None`` when it is one.
 
-    A cache.abf is an Analysis Services backup, i.e. a Microsoft Compound File Binary (OLE2/CFBF)
-    container, so this validates the 512-byte CFBF header STRUCTURE against MS-CFB - not merely the
-    8-byte magic. A torn write keeps the magic and the first-written header fields yet loses the
-    sectors they point at, becoming rubble past the header; checking the fixed fields, whole-sector
-    length, and that every referenced sector is inside the file catches that (#113).
+    Walks the block chain described above and requires it to land EXACTLY on EOF. That is what makes
+    a partial write detectable: a torn write leaves a block header whose declared length runs past
+    the end of the file, and only a complete file consumes itself precisely.
+
+    Returns the reason rather than a bare bool so a rejection is DIAGNOSABLE. The CFBF bug above was
+    invisible for a whole round precisely because the predicate could only say "no"; a caller that
+    prints "preamble mismatch (got 54 00 68 00 ...)" names the defect in one run.
 
     **Fails CLOSED on any uncertainty:** rejecting a valid cache only routes the save to the slower
-    UI-Automation fallback, while accepting a truncated one destroys the existing cache.
+    UI-Automation fallback (and now says why), while accepting a truncated one destroys the existing
+    cache. The one known false reject that policy buys is an image whose uncompressed size is an exact
+    multiple of 2 MiB, whose final block would then be full-sized; none of the 13 measured files is
+    such a file, and the cost if one appears is the fallback, not data loss.
     """
     try:
         size = path.stat().st_size
         with path.open("rb") as handle:
-            header = handle.read(_CFBF_HEADER_BYTES)
-    except OSError:
-        return False
-    if size < _CFBF_HEADER_BYTES or len(header) < _CFBF_HEADER_BYTES or header[: len(_CFBF_MAGIC)] != _CFBF_MAGIC:
-        return False
-    try:
-        major = struct.unpack_from("<H", header, 26)[0]
-        byte_order = struct.unpack_from("<H", header, 28)[0]
-        sector_shift = struct.unpack_from("<H", header, 30)[0]
-        mini_shift = struct.unpack_from("<H", header, 32)[0]
-        num_fat = struct.unpack_from("<I", header, 44)[0]
-        first_dir = struct.unpack_from("<I", header, 48)[0]
-        difat = struct.unpack_from("<109I", header, 76)
-    except struct.error:
-        return False
-    if (
-        byte_order != _CFBF_BYTE_ORDER_LE
-        or mini_shift != _CFBF_MINI_SECTOR_SHIFT
-        or _CFBF_VERSION_TO_SECTOR_SHIFT.get(major) != sector_shift
-    ):
-        return False
-    sector_size = 1 << sector_shift
-    # A complete container is a whole number of sectors and holds at least the header plus one
-    # referenced sector; a non-aligned length or a header-only file is a torn write (rejects the
-    # 600-byte and sector-aligned truncations). Every referenced sector must sit inside the file -
-    # a truncation keeps these header indices but loses the sectors they name (now past EOF), and
-    # num_fat must be 1..109 (a cache.abf never needs the 0 or DIFAT-sector cases we do not walk).
-    if size % sector_size != 0 or size < 2 * sector_size:
-        return False
-    total_sectors = size // sector_size - 1
-    return (
-        1 <= num_fat <= len(difat)
-        and first_dir < total_sectors
-        and all(entry < total_sectors for entry in difat[:num_fat])
-    )
+            preamble = handle.read(len(_ABF_PREAMBLE))
+            if preamble != _ABF_PREAMBLE:
+                return f"not an AS backup preamble (first {len(preamble)} byte(s): {preamble[:16].hex(' ')})"
+            return _walk_abf_blocks(handle, size)
+    except OSError as exc:
+        return f"unreadable ({type(exc).__name__})"
 
 
-def _staged_image_write(cache_path: Path, write_image) -> bool:
+def _abf_block_header_problem(header: bytes, ordinal: int, offset: int, size: int) -> str | None:
+    """Why this block header is not well formed, or None. Split out to keep the chain walk flat."""
+    if len(header) < _ABF_BLOCK_HEADER_BYTES:
+        return f"truncated inside block {ordinal}'s header at offset {offset} (size {size})"
+    if header[8:] != _ABF_BLOCK_MAGIC:
+        return f"block {ordinal} at offset {offset} has magic {header[8:].hex(' ')}, not an AS block"
+    uncompressed, length = struct.unpack_from("<II", header, 0)
+    if not 0 < uncompressed <= _ABF_MAX_BLOCK_BYTES:
+        return f"block {ordinal} declares {uncompressed} uncompressed byte(s) (max {_ABF_MAX_BLOCK_BYTES})"
+    if length <= len(_ABF_BLOCK_MAGIC):
+        return f"block {ordinal} declares {length} byte(s), too short to hold any payload"
+    return None
+
+
+def _walk_abf_blocks(handle, size: int) -> str | None:
+    """Walk the XPress9 block chain from the first header; return a reason string, or None if intact."""
+    offset = _ABF_FIRST_BLOCK_OFFSET
+    blocks = 0
+    while True:
+        handle.seek(offset)
+        header = handle.read(_ABF_BLOCK_HEADER_BYTES)
+        problem = _abf_block_header_problem(header, blocks + 1, offset, size)
+        if problem is not None:
+            return problem
+        uncompressed, length = struct.unpack_from("<II", header, 0)
+        blocks += 1
+        end = offset + 8 + length
+        if end > size:
+            return f"block {blocks} needs {end} byte(s) but the file is {size} - truncated write"
+        if end < size:
+            offset = end
+            continue
+        if uncompressed == _ABF_MAX_BLOCK_BYTES:
+            return f"ends on a full {_ABF_MAX_BLOCK_BYTES}-byte block boundary after {blocks} block(s) - more was due"
+        return None
+
+
+def _is_complete_abf(path: Path) -> bool:
+    """Is `path` a fully-written cache.abf, not a truncated or partial one? See `_abf_rejection_reason`."""
+    return _abf_rejection_reason(path) is None
+
+
+def _staging_path(cache_path: Path) -> Path:
+    """A per-run staging filename, unique across concurrent runs against the SAME cache (issue #114).
+
+    Every run used to stage to one fixed ``cache.abf.tmp``. Two runs against a single model then
+    shared that path, and :func:`_staged_image_write`'s own ``if staging.exists(): unlink`` (below)
+    would delete the OTHER run's in-flight staging file. The victim run, seeing its staging gone,
+    concludes it did not commit and rolls its compatibility bump back UNDER the other run's freshly
+    written cache - leaving ``database.tmdl`` declaring a level no present cache matches, the #114
+    brick. Tagging the name with the PID and a random token makes each run's staging private, so no
+    run can disturb another's. That is necessary but NOT sufficient: the compatibility edit on
+    ``database.tmdl`` is also shared, so the whole transaction is additionally serialised by the
+    per-model lock in ``_lock``. Both defences are needed.
+    """
+    return cache_path.with_name(f"{cache_path.name}.{os.getpid()}-{uuid.uuid4().hex}.tmp")
+
+
+def _staged_image_write(cache_path: Path, write_image, staging: Path | None = None) -> bool:
     """Write the cache to a staging file and swap it in atomically. Returns True only on a COMPLETE write.
 
     `FileMode.Create` on the live `cache.abf` truncates a good cache the instant the write begins, so
     an ImageSave that then fails half way leaves the project WORSE than before -- no fresh cache and
-    no old one. Staging to `cache.abf.tmp` and only `os.replace`-ing it over the original once it is a
-    COMPLETE backup means a failed or partial write cannot destroy an existing good cache. Two rules
-    make "complete" mean what it says (#113): `write_image` is expected NOT to raise (`image_save`
-    absorbs the one benign AMO error and re-raises everything else), so any exception reaching here --
-    including from `os.replace` -- is a REAL failure that PROPAGATES after the staging file is removed,
-    letting the caller roll the compatibility bump back; and even on a clean return the staged file
-    must look like a backup (`_is_complete_abf`) before it is swapped in.
+    no old one. Staging to a PER-RUN file (`_staging_path`, unique per process so concurrent runs
+    cannot delete each other's -- issue #114) and only `os.replace`-ing it over the original once it
+    is a COMPLETE backup means a failed or partial write cannot destroy an existing good cache. Two
+    rules make "complete" mean what it says (#113): `write_image` is expected NOT to raise
+    (`image_save` absorbs the one benign AMO error and re-raises everything else), so any exception
+    reaching here -- including from `os.replace` -- is a REAL failure that PROPAGATES after the
+    staging file is removed, letting the caller roll the compatibility bump back; and even on a clean
+    return the staged file must look like a backup (`_is_complete_abf`) before it is swapped in.
+
+    `_persist_image` generates the unique `staging` once and passes it in, so the same path is used
+    for the write, the filesystem-based commit check, and cleanup; a direct caller may omit it and a
+    private one is generated.
+
+    A staged file that is REJECTED is announced, not swallowed. A silent "did not swap" is how a
+    wrong acceptance predicate hid for a whole review round while persist-by-default was dead.
     """
     cache_path.parent.mkdir(parents=True, exist_ok=True)
-    staging = cache_path.with_name(cache_path.name + ".tmp")
+    if staging is None:
+        staging = _staging_path(cache_path)
     if staging.exists():
         staging.unlink()
     swapped = False
     try:
         write_image(staging)
-        if _is_complete_abf(staging):
+        reason = _abf_rejection_reason(staging)
+        if reason is None:
             os.replace(staging, cache_path)
             swapped = True
+        else:
+            print(f"  save   : staged cache REJECTED - {reason}")
     finally:
         # Never leave a partial cache.abf.tmp behind. `finally` does not suppress the exception, so a
         # real write/replace error still propagates to _persist_image, which rolls the compat back.
@@ -153,14 +211,35 @@ def _cleanup_staging(staging: Path) -> None:
         pass
 
 
-def _restore_rollback_snapshot(snapshot: dict[Path, bytes | None]) -> list[Path]:
+def _snapshot_rollback_paths(paths: list[Path]) -> dict[Path, tuple[bytes, int, int] | None]:
+    """Capture each path's CONTENT **and TIMESTAMPS**, or ``None`` where the file does not exist yet.
+
+    The timestamps are not tidiness. Power BI Desktop discards a ``cache.abf`` that is OLDER than the
+    model definition beside it (SKILL.md: "NO_DATA despite a 113 KB cache sitting right there"). A
+    rollback that rewrites ``database.tmdl`` byte-for-byte but with a fresh mtime therefore leaves the
+    definition NEWER than the good cache the failed persist was supposed to protect - silently arming
+    the very cache-discard the bundle exists to prevent, while every byte-level check says "unchanged".
+    """
+    snapshot: dict[Path, tuple[bytes, int, int] | None] = {}
+    for path in paths:
+        try:
+            stat = path.stat()
+            snapshot[path] = (path.read_bytes(), stat.st_atime_ns, stat.st_mtime_ns)
+        except OSError:
+            snapshot[path] = None
+    return snapshot
+
+
+def _restore_rollback_snapshot(snapshot: dict[Path, tuple[bytes, int, int] | None]) -> list[Path]:
     """Restore each snapshotted path to its pre-alignment state ATOMICALLY. Returns the FAILED paths.
 
-    Three properties the round-2 version lacked (round-3 blocker 2): **atomic** (via a sibling
+    Four properties (round-3 blocker 2, plus round-4's mtime finding): **atomic** (via a sibling
     ``.rollback.tmp`` + ``os.replace``, so a crash mid-restore cannot itself tear ``database.tmdl``);
-    **all paths attempted** (the old loop raised on the first failure, leaving a subset reverted); and
+    **all paths attempted** (the old loop raised on the first failure, leaving a subset reverted);
     **failures reported, not swallowed** (the returned list lets the caller treat a residual failure
-    as FATAL rather than pretend success).
+    as FATAL rather than pretend success); and **timestamps restored too**, so "unchanged" means
+    unchanged to Desktop's cache-freshness comparison as well as to a byte diff
+    (see :func:`_snapshot_rollback_paths`).
     """
     failures: list[Path] = []
     for path, original in snapshot.items():
@@ -169,16 +248,17 @@ def _restore_rollback_snapshot(snapshot: dict[Path, bytes | None]) -> list[Path]
                 if path.exists():
                     path.unlink()
                 continue
-            if path.exists() and path.read_bytes() == original:
-                continue
-            tmp = path.with_name(path.name + ".rollback.tmp")
-            try:
-                tmp.write_bytes(original)
-                os.replace(tmp, path)
-            finally:
-                # A failed os.replace leaves the staging copy behind; never litter the model folder.
-                if tmp.exists():
-                    tmp.unlink()
+            content, atime_ns, mtime_ns = original
+            if not path.exists() or path.read_bytes() != content:
+                tmp = path.with_name(path.name + ".rollback.tmp")
+                try:
+                    tmp.write_bytes(content)
+                    os.replace(tmp, path)
+                finally:
+                    # A failed os.replace leaves the staging copy behind; never litter the model folder.
+                    if tmp.exists():
+                        tmp.unlink()
+            os.utime(path, ns=(atime_ns, mtime_ns))
         except OSError:
             failures.append(path)
     return failures

--- a/.github/skills/pbip-model-refresh/scripts/_abf.py
+++ b/.github/skills/pbip-model-refresh/scripts/_abf.py
@@ -1,0 +1,184 @@
+"""Cache-file integrity and atomic staged writes for ``refresh_pbip_model``.
+
+A persisted ``<Name>.SemanticModel/.pbi/cache.abf`` is an Analysis Services backup, i.e. a Microsoft
+Compound File Binary (OLE2/CFBF) container. This module holds the self-contained primitives that make
+persisting one SAFE (issue #113): proving a staged file is a COMPLETE CFBF container before it may
+replace a good cache, swapping it in atomically, and restoring a provisional compatibility alignment
+when the write does not land. ``refresh_pbip_model._persist_image`` orchestrates these with the
+compat/manifest policy layer, and every public name here is re-exported from ``refresh_pbip_model`` so
+callers and tests reach them through that module.
+
+Extracted from ``refresh_pbip_model`` so that module stays under its line cap; nothing here depends on
+the rest of the bundle, only on ``os``/``struct``/``pathlib``.
+"""
+
+from __future__ import annotations
+
+import os
+import struct
+from pathlib import Path
+
+# A persisted `cache.abf` is an Analysis Services backup = a Microsoft Compound File Binary
+# (OLE2/CFBF) container. `_is_complete_abf` validates the 512-byte CFBF header STRUCTURE (per MS-CFB),
+# not just the 8-byte magic: a torn write can keep the magic yet be rubble past it, and swapping that
+# over a good cache is the data loss #113 exists to prevent.
+_CFBF_MAGIC = b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1"
+_CFBF_HEADER_BYTES = 512
+_CFBF_BYTE_ORDER_LE = 0xFFFE  # header offset 28: little-endian mark; the only value CFBF permits
+_CFBF_MINI_SECTOR_SHIFT = 6  # header offset 32: fixed at 6 (64-byte mini sectors)
+# major version (offset 26) -> sector shift (offset 30): v3 = 512-byte sectors, v4 = 4096. No other pairing.
+_CFBF_VERSION_TO_SECTOR_SHIFT = {3: 9, 4: 12}
+
+
+def _is_complete_abf(path: Path) -> bool:
+    """Is `path` a fully-written cache.abf, not a truncated or partial one?
+
+    A cache.abf is an Analysis Services backup, i.e. a Microsoft Compound File Binary (OLE2/CFBF)
+    container, so this validates the 512-byte CFBF header STRUCTURE against MS-CFB - not merely the
+    8-byte magic. A torn write keeps the magic and the first-written header fields yet loses the
+    sectors they point at, becoming rubble past the header; checking the fixed fields, whole-sector
+    length, and that every referenced sector is inside the file catches that (#113).
+
+    **Fails CLOSED on any uncertainty:** rejecting a valid cache only routes the save to the slower
+    UI-Automation fallback, while accepting a truncated one destroys the existing cache.
+    """
+    try:
+        size = path.stat().st_size
+        with path.open("rb") as handle:
+            header = handle.read(_CFBF_HEADER_BYTES)
+    except OSError:
+        return False
+    if size < _CFBF_HEADER_BYTES or len(header) < _CFBF_HEADER_BYTES or header[: len(_CFBF_MAGIC)] != _CFBF_MAGIC:
+        return False
+    try:
+        major = struct.unpack_from("<H", header, 26)[0]
+        byte_order = struct.unpack_from("<H", header, 28)[0]
+        sector_shift = struct.unpack_from("<H", header, 30)[0]
+        mini_shift = struct.unpack_from("<H", header, 32)[0]
+        num_fat = struct.unpack_from("<I", header, 44)[0]
+        first_dir = struct.unpack_from("<I", header, 48)[0]
+        difat = struct.unpack_from("<109I", header, 76)
+    except struct.error:
+        return False
+    if (
+        byte_order != _CFBF_BYTE_ORDER_LE
+        or mini_shift != _CFBF_MINI_SECTOR_SHIFT
+        or _CFBF_VERSION_TO_SECTOR_SHIFT.get(major) != sector_shift
+    ):
+        return False
+    sector_size = 1 << sector_shift
+    # A complete container is a whole number of sectors and holds at least the header plus one
+    # referenced sector; a non-aligned length or a header-only file is a torn write (rejects the
+    # 600-byte and sector-aligned truncations). Every referenced sector must sit inside the file -
+    # a truncation keeps these header indices but loses the sectors they name (now past EOF), and
+    # num_fat must be 1..109 (a cache.abf never needs the 0 or DIFAT-sector cases we do not walk).
+    if size % sector_size != 0 or size < 2 * sector_size:
+        return False
+    total_sectors = size // sector_size - 1
+    return (
+        1 <= num_fat <= len(difat)
+        and first_dir < total_sectors
+        and all(entry < total_sectors for entry in difat[:num_fat])
+    )
+
+
+def _staged_image_write(cache_path: Path, write_image) -> bool:
+    """Write the cache to a staging file and swap it in atomically. Returns True only on a COMPLETE write.
+
+    `FileMode.Create` on the live `cache.abf` truncates a good cache the instant the write begins, so
+    an ImageSave that then fails half way leaves the project WORSE than before -- no fresh cache and
+    no old one. Staging to `cache.abf.tmp` and only `os.replace`-ing it over the original once it is a
+    COMPLETE backup means a failed or partial write cannot destroy an existing good cache. Two rules
+    make "complete" mean what it says (#113): `write_image` is expected NOT to raise (`image_save`
+    absorbs the one benign AMO error and re-raises everything else), so any exception reaching here --
+    including from `os.replace` -- is a REAL failure that PROPAGATES after the staging file is removed,
+    letting the caller roll the compatibility bump back; and even on a clean return the staged file
+    must look like a backup (`_is_complete_abf`) before it is swapped in.
+    """
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    staging = cache_path.with_name(cache_path.name + ".tmp")
+    if staging.exists():
+        staging.unlink()
+    swapped = False
+    try:
+        write_image(staging)
+        if _is_complete_abf(staging):
+            os.replace(staging, cache_path)
+            swapped = True
+    finally:
+        # Never leave a partial cache.abf.tmp behind. `finally` does not suppress the exception, so a
+        # real write/replace error still propagates to _persist_image, which rolls the compat back.
+        if not swapped and staging.exists():
+            staging.unlink()
+    return swapped
+
+
+class CompatRollbackError(RuntimeError):
+    """The cache write failed AND the provisional compatibility alignment could not be undone.
+
+    A FATAL, distinct condition (round-3 blocker 2): ``database.tmdl`` now declares a level no cache
+    was written at, so the caller MUST NOT fall through to the UI Save (which would persist the
+    mismatch) - it must stop and have the level restored from source control.
+    """
+
+
+def _cache_fingerprint(path: Path) -> tuple[int, int] | None:
+    """A cheap identity for a cache file - ``(size, mtime_ns)`` - or ``None`` if it does not exist."""
+    try:
+        stat = path.stat()
+    except OSError:
+        return None
+    return (stat.st_size, stat.st_mtime_ns)
+
+
+def _cache_committed(cache_path: Path, staging: Path, before: tuple[int, int] | None) -> bool:
+    """Did the staged write actually replace the cache? Judged by the FILESYSTEM, not a return flag.
+
+    ``os.replace`` is atomic, but a crash could move the file yet still surface an exception
+    ("commit-then-raise"). So commit is decided by OBSERVING the result: staging is gone, the cache is
+    now a complete ABF, and its fingerprint changed. Trusting only the writer's boolean return
+    misclassified that case and rolled compat back UNDER a freshly installed cache (round-3 blocker 2).
+    """
+    if staging.exists() or not _is_complete_abf(cache_path):
+        return False
+    return _cache_fingerprint(cache_path) != before
+
+
+def _cleanup_staging(staging: Path) -> None:
+    """Best-effort removal of the staging file; a leftover temp must never mask the real outcome."""
+    try:
+        if staging.exists():
+            staging.unlink()
+    except OSError:
+        pass
+
+
+def _restore_rollback_snapshot(snapshot: dict[Path, bytes | None]) -> list[Path]:
+    """Restore each snapshotted path to its pre-alignment state ATOMICALLY. Returns the FAILED paths.
+
+    Three properties the round-2 version lacked (round-3 blocker 2): **atomic** (via a sibling
+    ``.rollback.tmp`` + ``os.replace``, so a crash mid-restore cannot itself tear ``database.tmdl``);
+    **all paths attempted** (the old loop raised on the first failure, leaving a subset reverted); and
+    **failures reported, not swallowed** (the returned list lets the caller treat a residual failure
+    as FATAL rather than pretend success).
+    """
+    failures: list[Path] = []
+    for path, original in snapshot.items():
+        try:
+            if original is None:
+                if path.exists():
+                    path.unlink()
+                continue
+            if path.exists() and path.read_bytes() == original:
+                continue
+            tmp = path.with_name(path.name + ".rollback.tmp")
+            try:
+                tmp.write_bytes(original)
+                os.replace(tmp, path)
+            finally:
+                # A failed os.replace leaves the staging copy behind; never litter the model folder.
+                if tmp.exists():
+                    tmp.unlink()
+        except OSError:
+            failures.append(path)
+    return failures

--- a/.github/skills/pbip-model-refresh/scripts/_abf.py
+++ b/.github/skills/pbip-model-refresh/scripts/_abf.py
@@ -36,9 +36,9 @@ _ABF_PREAMBLE = "This backup was created using XPress9 compression.".encode("utf
 _ABF_FIRST_BLOCK_OFFSET = len(_ABF_PREAMBLE) + 2  # 100-byte preamble + the 2-byte pad
 _ABF_BLOCK_MAGIC = b"\x2a\xd7\x86\x4e"
 _ABF_BLOCK_HEADER_BYTES = 8 + len(_ABF_BLOCK_MAGIC)  # uint32 uncompressed + uint32 length + magic
-# Every one of the 60 NON-final blocks measured declares exactly 2 MiB uncompressed, and every one of
-# the 13 FINAL blocks declares less. So a file whose last block is a full 2 MiB is a write that
-# stopped on a block boundary with more to come - the one truncation a chain-walk alone cannot see.
+# Every non-final block measured declares exactly 2 MiB uncompressed, and every final block declares
+# less. That fixed interior size is load-bearing: without it, a write truncated exactly on a block
+# boundary can land cleanly on EOF and look complete.
 _ABF_MAX_BLOCK_BYTES = 2 * 1024 * 1024
 
 
@@ -100,6 +100,11 @@ def _walk_abf_blocks(handle, size: int) -> str | None:
         if end > size:
             return f"block {blocks} needs {end} byte(s) but the file is {size} - truncated write"
         if end < size:
+            if uncompressed != _ABF_MAX_BLOCK_BYTES:
+                return (
+                    f"block {blocks} is non-final but declares {uncompressed} uncompressed byte(s), "
+                    f"not the required {_ABF_MAX_BLOCK_BYTES}"
+                )
             offset = end
             continue
         if uncompressed == _ABF_MAX_BLOCK_BYTES:

--- a/.github/skills/pbip-model-refresh/scripts/_lock.py
+++ b/.github/skills/pbip-model-refresh/scripts/_lock.py
@@ -47,9 +47,8 @@ class ModelLockTimeout(RuntimeError):
     """The per-model persistence lock was held by a LIVE process past the acquisition timeout.
 
     Distinct from the dead-holder case (which is reclaimed, never raised): this means another run is
-    genuinely persisting the SAME model right now. The caller must NOT force past it - doing so is
-    exactly the #114 race - but back off, or fall back to a mechanism that does its own compatibility
-    alignment (Desktop's UI Save).
+    genuinely persisting the SAME model right now. The caller must NOT force past it or fall back to
+    an unlocked save - doing so is exactly the #114 race - but refuse to persist and ask for a retry.
     """
 
 

--- a/.github/skills/pbip-model-refresh/scripts/_lock.py
+++ b/.github/skills/pbip-model-refresh/scripts/_lock.py
@@ -1,0 +1,229 @@
+"""Per-model interprocess lock for ``refresh_pbip_model`` persistence (issue #114).
+
+Persisting a cache is a multi-step transaction: snapshot ``database.tmdl``, provisionally raise its
+``compatibilityLevel`` to the live level, write-and-swap ``cache.abf``, then commit or roll the bump
+back. Two runs against the SAME model share two mutable resources across that transaction - the
+staging file (which :func:`_abf._staging_path` now gives each run a private name) AND, the one unique
+names cannot fix, the compatibility edit on ``database.tmdl``. A hostile interleaving of the compat
+edit alone leaves the project declaring a level no present cache was written at - unopenable, with NO
+visible Desktop error (the "CompatibilityLevel downgrade" brick). So the WHOLE transaction has to be
+serialised, not merely the temp file.
+
+This module is the serialiser: a best-effort, cross-platform advisory lock built on an
+``O_CREAT | O_EXCL`` lock file, so it needs no third-party dependency and travels with the skill
+bundle. A lock held by a process that has since DIED is RECLAIMED - a dead holder must never wedge the
+tool forever - while a lock held by a LIVE process is waited for up to a timeout and then reported as
+:class:`ModelLockTimeout` rather than blocked on indefinitely. The safe direction on any uncertainty
+is to UNDER-reclaim (wait a little longer for a lock that is actually free) rather than OVER-reclaim
+(yank a lock from a live persist and re-open the #114 race).
+
+Self-contained: depends only on ``os``/``time``/``uuid``/``socket``/``contextlib`` (and ``ctypes`` on
+Windows, for process-liveness), so the bundle stays copyable with no external requirement.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import socket
+import time
+import uuid
+from pathlib import Path
+
+# A persist writes ~114 KB and takes seconds, so a live concurrent holder should clear well within
+# this; the timeout only bites a genuinely STUCK live holder (a dead one is reclaimed at once, never
+# waited for).
+_DEFAULT_TIMEOUT_SECONDS = 120.0
+_DEFAULT_POLL_SECONDS = 0.05
+# Fallback staleness for a lock we cannot pin to a live/dead PID (written by another host, or a torn
+# lock file): far longer than any real persist, so it never reclaims a lock a live local holder is
+# still using. Same-host liveness is checked first and takes precedence over this.
+_DEFAULT_STALE_AFTER_SECONDS = 600.0
+
+_HOSTNAME = socket.gethostname()
+
+
+class ModelLockTimeout(RuntimeError):
+    """The per-model persistence lock was held by a LIVE process past the acquisition timeout.
+
+    Distinct from the dead-holder case (which is reclaimed, never raised): this means another run is
+    genuinely persisting the SAME model right now. The caller must NOT force past it - doing so is
+    exactly the #114 race - but back off, or fall back to a mechanism that does its own compatibility
+    alignment (Desktop's UI Save).
+    """
+
+
+def _process_alive(pid: int) -> bool:
+    """Is a process with ``pid`` running on THIS host? Conservative: on any uncertainty, assume alive.
+
+    Stale-lock reclaim hinges on this, and the safe error is to UNDER-reclaim (wait longer for a lock
+    that is actually free) rather than OVER-reclaim (steal a lock from a live persist and re-open the
+    #114 race), so every ambiguous result returns True.
+    """
+    if pid <= 0:
+        return False
+    if os.name == "nt":
+        return _process_alive_windows(pid)
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True  # exists, owned by someone else
+    except OSError:
+        return True  # unknown -> assume alive
+    return True
+
+
+def _process_alive_windows(pid: int) -> bool:
+    """Windows process-liveness via ``OpenProcess``/``GetExitCodeProcess`` (no ``os.kill(pid, 0)``).
+
+    ``os.kill`` on Windows cannot probe with signal 0 - it would TERMINATE the process - so this uses
+    the Win32 API directly. A PID that no longer exists fails ``OpenProcess`` with
+    ``ERROR_INVALID_PARAMETER``; ``ERROR_ACCESS_DENIED`` means it exists but is not ours (alive). The
+    ``STILL_ACTIVE`` ambiguity (a process that genuinely exited with code 259) only ever makes a dead
+    holder look alive, i.e. errs toward UNDER-reclaim, which is the safe direction.
+    """
+    import ctypes  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
+    from ctypes import wintypes  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
+
+    process_query_limited_information = 0x1000
+    still_active = 259
+    error_invalid_parameter = 87
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    handle = kernel32.OpenProcess(process_query_limited_information, False, pid)
+    if not handle:
+        return ctypes.get_last_error() != error_invalid_parameter
+    try:
+        code = wintypes.DWORD()
+        if kernel32.GetExitCodeProcess(handle, ctypes.byref(code)):
+            return code.value == still_active
+        return True
+    finally:
+        kernel32.CloseHandle(handle)
+
+
+class _ModelLock:
+    """A non-reentrant, cross-process advisory lock backed by a single ``O_CREAT | O_EXCL`` lock file.
+
+    Non-reentrant on purpose: two persist transactions in one process (a nested/retried run) are two
+    logical writers and must still contend, so a second acquire against a held lock blocks and then
+    raises :class:`ModelLockTimeout` - it never silently re-enters.
+    """
+
+    def __init__(self, path: Path | os.PathLike | str, timeout: float, poll: float, stale_after: float) -> None:
+        self._path = Path(path)
+        self._timeout = float(timeout)
+        self._poll = float(poll)
+        self._stale_after = float(stale_after)
+        self._held = False
+
+    def __enter__(self) -> _ModelLock:
+        return self.acquire()
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        self.release()
+        return False
+
+    def acquire(self) -> _ModelLock:
+        """Take the lock, reclaiming it from a dead holder, or raise `ModelLockTimeout`."""
+        deadline = time.monotonic() + self._timeout
+        while True:
+            try:
+                fd = os.open(self._path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+            except FileExistsError:
+                if self._holder_gone():
+                    self._reclaim()
+                    continue
+                if time.monotonic() >= deadline:
+                    raise ModelLockTimeout(
+                        f"model persist lock {self._path} is held by {self._read_holder() or 'an unknown process'} "
+                        f"and did not release within {self._timeout:.0f}s"
+                    ) from None
+                time.sleep(self._poll)
+                continue
+            try:
+                os.write(fd, self._payload())
+            finally:
+                os.close(fd)
+            self._held = True
+            return self
+
+    def release(self) -> None:
+        """Drop the lock, but only if this process still owns it."""
+        if not self._held:
+            return
+        self._held = False
+        # Remove the lock only if it is still OURS: a peer that judged us stale may have reclaimed and
+        # re-created it, and deleting that would free a lock we no longer own.
+        with contextlib.suppress(OSError):
+            if self._read_pid() == os.getpid():
+                os.unlink(self._path)
+
+    def _payload(self) -> bytes:
+        return f"{os.getpid()}\n{_HOSTNAME}\n{time.time()}\n".encode()
+
+    def _read_lines(self) -> list[str]:
+        try:
+            return self._path.read_text(encoding="utf-8").splitlines()
+        except OSError:
+            return []
+
+    def _read_pid(self) -> int | None:
+        lines = self._read_lines()
+        try:
+            return int(lines[0].strip()) if lines else None
+        except ValueError:
+            return None
+
+    def _read_host(self) -> str | None:
+        lines = self._read_lines()
+        return lines[1].strip() if len(lines) > 1 else None
+
+    def _read_holder(self) -> str | None:
+        pid, host = self._read_pid(), self._read_host()
+        return f"pid {pid} on {host or '?'}" if pid is not None else None
+
+    def _holder_gone(self) -> bool:
+        """Is the current holder provably gone, so the lock may be reclaimed rather than waited on?"""
+        pid, host = self._read_pid(), self._read_host()
+        if pid is not None and host == _HOSTNAME:
+            return not _process_alive(pid)
+        # Cross-host or an unparseable/torn lock file: liveness is unknowable, so fall back to age -
+        # only a lock far older than any real persist is treated as abandoned.
+        try:
+            age = time.time() - self._path.stat().st_mtime
+        except OSError:
+            return False
+        return age > self._stale_after
+
+    def _reclaim(self) -> None:
+        """Atomically claim the right to delete a stale lock, then delete it. Racer-safe via rename.
+
+        ``os.rename`` of the single lock file succeeds for exactly one racer; every other racer's
+        rename fails (the source is already gone) and it simply retries the acquire loop, where it
+        will either create the lock afresh or find a live holder to wait on. This closes the classic
+        reclaim race where two processes both unlink-and-recreate and both believe they hold it.
+        """
+        claim = self._path.with_name(f"{self._path.name}.reclaim.{os.getpid()}.{uuid.uuid4().hex}")
+        try:
+            os.rename(self._path, claim)
+        except OSError:
+            return
+        with contextlib.suppress(OSError):
+            os.unlink(claim)
+
+
+def model_lock(
+    path: Path | os.PathLike | str,
+    timeout: float = _DEFAULT_TIMEOUT_SECONDS,
+    poll: float = _DEFAULT_POLL_SECONDS,
+    stale_after: float = _DEFAULT_STALE_AFTER_SECONDS,
+) -> _ModelLock:
+    """A per-model persistence lock as a context manager. See :class:`_ModelLock`.
+
+    Acquire it around the ENTIRE persist transaction (snapshot -> align -> write -> commit/rollback),
+    so a concurrent run cannot interleave with the shared compatibility edit.
+    """
+    return _ModelLock(path, timeout=timeout, poll=poll, stale_after=stale_after)

--- a/.github/skills/pbip-model-refresh/scripts/_verdict.py
+++ b/.github/skills/pbip-model-refresh/scripts/_verdict.py
@@ -1,0 +1,103 @@
+"""
+purpose: choose the canary set and print the machine-readable verdict for a refresh run
+usage:   imported by refresh_pbip_model.py (re-exported there; not a CLI of its own)
+
+Split out of `refresh_pbip_model.py` for the same reason as `_abf` and `_lock`: that module is at its
+line cap, and this is a self-contained layer - it decides WHICH tables get verified and turns the
+results into the one line a calling agent parses. It touches no engine and no filesystem beyond
+stat()ing the cache, so it is cheap to test directly.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def _canary_tables(args: argparse.Namespace) -> list[str] | None:
+    """The tables to VERIFY, which is deliberately NOT the same knob as the tables to REFRESH.
+
+    Coupling them (the round-3 behaviour: ``--tables`` was both) built a trap. The only documented way
+    to earn a model-level ``DATA_OK`` was to name canaries in ``--tables`` - which simultaneously
+    narrowed the refresh to just those tables, certifying a MODEL-level verdict over a PARTIALLY
+    refreshed model. An agent following the host-repo gate would have done exactly that, and the
+    "next agent gets an empty model" failure this bundle exists to prevent would have shipped wearing
+    a green verdict. ``--canaries`` verifies without narrowing; ``--tables`` still supplies the canary
+    set when it is the only flag given, so existing callers keep working - but see
+    :func:`_emit_data_verdict`, which no longer lets a narrowed refresh claim a model-level verdict.
+    """
+    if args.canaries:
+        return list(args.canaries)
+    return list(args.tables) if args.tables else None
+
+
+def _emit_data_verdict(
+    cache: Path | None,
+    before_stamp: float,
+    args: argparse.Namespace,
+    results: list[tuple[str, int]],
+    implicit: bool,
+) -> int:
+    """Print the data/cache lines and the machine-readable verdict; return the process exit code.
+
+    Split out of `main()` so the mutating path (identity gate + refresh + persist) and the reporting
+    path stay individually simple.
+    """
+    after_stamp = cache.stat().st_mtime if cache and cache.exists() else 0.0
+    persisted = cache is not None and after_stamp > before_stamp
+
+    for table, rows in results:
+        print(f"  data   : {rows} row(s) in '{table}'")
+    # Say what HAPPENED, not where a file would go. Printing the path alone reads as "written" -
+    # it misled a reader on 2026-08-05 into believing a probe run had persisted a 1-row cache.
+    # For a probe that distinction matters twice over: a persisted 1-row `cache.abf` is a trap, and
+    # a cache whose compatibility level disagrees with the project's makes the PBIP unopenable (see
+    # `--no-save`; `image_save` prevents that by aligning `database.tmdl`).
+    if persisted:
+        print(f"  cache  : PERSISTED -> {cache}")
+    elif cache is None:
+        print("  cache  : not persisted (no cache path resolved)")
+    elif args.no_save:
+        print("  cache  : not persisted (--no-save; the project is byte-identical)")
+    else:
+        # Persisting was requested (the default) and nothing landed. Naming the wrong reason here
+        # sent me looking in the wrong place for ten minutes; the real one is on the 'save' line.
+        print("  cache  : not persisted (the write did not land - see 'save' above)")
+
+    empty = [table for table, rows in results if rows <= 0]
+    if empty:
+        print(f"REFRESH: NO_DATA (empty: {', '.join(empty)} - check the source and credentials)")
+        return 1
+    wanted_save = not args.no_save and not args.verify_only
+    if wanted_save and not persisted:
+        print("REFRESH: NOT_PERSISTED (model has data in memory, but cache.abf did not update)")
+        return 1
+    suffix = " + PERSISTED" if wanted_save else ""
+    if implicit:
+        # No canaries were named, so only the first queryable table was probed. That is NOT a
+        # model-level guarantee (a static parameter/CSV table can pass while a live source never
+        # loaded), so the verdict names the single table actually probed instead of claiming DATA_OK.
+        only = results[0][0]
+        print(f"REFRESH: TABLE_OK '{only}'{suffix}")
+        print(
+            f"  note   : single-table probe of '{only}' only - NOT a model-level DATA_OK. A static "
+            "parameter/CSV table can return rows while a live source never loaded. Pass "
+            "--canaries <one per live source> to certify every source WITHOUT narrowing the refresh "
+            "(this mirrors the powerbi-semantic-model-gotchas rule: prove a REAL read per live source)."
+        )
+        return 0
+    if args.tables and not args.verify_only:
+        # Canaries all returned rows, but --tables narrowed the REFRESH, so the tables outside that
+        # list still hold whatever they held before (possibly nothing). A model-level DATA_OK over a
+        # partially refreshed model is exactly the false certificate #115 was filed about, so the
+        # verdict is scoped to what was actually refreshed and verified.
+        named = ", ".join(f"'{table}'" for table, _ in results)
+        print(f"REFRESH: TABLES_OK {named}{suffix}")
+        print(
+            "  note   : --tables narrowed the REFRESH, so this is NOT a model-level DATA_OK - tables "
+            "outside that list were not reloaded. Re-run without --tables (add --canaries <one per "
+            "live source>) to certify the whole model."
+        )
+        return 0
+    print(f"REFRESH: DATA_OK{suffix}")
+    return 0

--- a/.github/skills/pbip-model-refresh/scripts/probe_desktop_credential.ps1
+++ b/.github/skills/pbip-model-refresh/scripts/probe_desktop_credential.ps1
@@ -1,0 +1,99 @@
+<#
+.SYNOPSIS
+  Detect whether Power BI Desktop already has a cached credential for the live data source(s) in the
+  currently open model, WITHOUT the agent being able to type the credential itself.
+
+.DESCRIPTION
+  Live database sources (Databricks, SQL Server, Snowflake, ...) need a credential that is NOT in the
+  committed model files. In Power BI Desktop that credential is cached per-Windows-user (DPAPI) after
+  the user authenticates once in a modal dialog. The Desktop Bridge cannot fill that modal, so before
+  the agent's build/render/validate loop can work against live data, a human must sign in once.
+
+  This probe tells the two states apart so the migrator only prompts when needed. NOTE: for a
+  *serverless* source that cold-starts, the modal can appear only AFTER this probe's timeout, yielding a
+  false CREDENTIAL_PRESENT; treat the one-row data probe (DATA_OK vs NO_DATA) as the gate of record and
+  use this modal probe only to explain a NO_DATA. That probe ships inside the pbip-model-refresh skill:
+  .github/skills/pbip-model-refresh/scripts/probe_desktop_query.py (scripts/probe_desktop_query.py is a
+  forwarding shim kept for existing callers).
+    * If a credential modal is already open, or appears within -TimeoutSec of a refresh -> MISSING.
+    * If a refresh proceeds with no modal -> PRESENT (a credential is cached machine-wide; the loop
+      can run unattended) -- but re-confirm with the one-row data probe for serverless sources.
+
+  It triggers Refresh via UI Automation (the Bridge exposes no refresh verb) and watches every
+  top-level window of the target process for the connector credential dialog's signature text.
+
+  Windows-only by necessity (UI Automation / DPAPI). This is the sanctioned PowerShell exception to
+  the "committed scripts default to .py/.sh" rule, and it sits alongside scripts/preflight.ps1.
+
+.PARAMETER DesktopPid
+  The Power BI Desktop process id to drive (use the pid from `powerbi-desktop open`/`status`).
+
+.PARAMETER TimeoutSec
+  How long to wait for the credential modal after triggering refresh. Default 75s; use >=60s because a
+  serverless warehouse (e.g. Databricks) can cold-start before the prompt appears.
+
+.OUTPUTS
+  Final line `VERDICT: CREDENTIAL_MISSING` (exit 1) or `VERDICT: CREDENTIAL_PRESENT` (exit 0), or
+  `VERDICT: UNKNOWN` (exit 3) if the target window can't be found.
+
+.EXAMPLE
+  powershell -ExecutionPolicy Bypass -File scripts/probe_desktop_credential.ps1 -DesktopPid 42532
+#>
+param(
+  [Parameter(Mandatory = $true)][int]$DesktopPid,
+  [int]$TimeoutSec = 75
+)
+
+Add-Type -AssemblyName UIAutomationClient, UIAutomationTypes, WindowsBase
+
+$root = [System.Windows.Automation.AutomationElement]::RootElement
+$cond = New-Object System.Windows.Automation.PropertyCondition([System.Windows.Automation.AutomationElement]::ProcessIdProperty, $DesktopPid)
+
+# Connector credential-dialog signature text (covers Databricks / SQL / Snowflake / generic OAuth).
+$sig = 'You aren.t signed in|Personal Access Token|Databricks Client Credentials|specify how to connect|Account Key|Enter your credentials|Please specify how to connect'
+
+function Test-CredentialModal {
+  $cur = $root.FindFirst([System.Windows.Automation.TreeScope]::Children, $cond)
+  if (-not $cur) { return $null }
+  $desc = $cur.FindAll([System.Windows.Automation.TreeScope]::Descendants, [System.Windows.Automation.Condition]::TrueCondition)
+  foreach ($d in $desc) {
+    $n = $d.Current.Name
+    if ($n -and $n -match $sig) { return $n }
+  }
+  return $null
+}
+
+$win = $root.FindFirst([System.Windows.Automation.TreeScope]::Children, $cond)
+if (-not $win) { Write-Output "main window for pid $DesktopPid not found"; Write-Output "VERDICT: UNKNOWN"; exit 3 }
+
+# 1. If a credential modal is ALREADY open, the credential is missing - report immediately.
+$hit = Test-CredentialModal
+if ($hit) {
+  Write-Output ("credential modal already open: '{0}'" -f $hit.Substring(0, [Math]::Min(80, $hit.Length)))
+  Write-Output "VERDICT: CREDENTIAL_MISSING"
+  exit 1
+}
+
+# 2. Otherwise trigger a refresh and watch for the modal (generous timeout for warehouse cold-start).
+$all = $win.FindAll([System.Windows.Automation.TreeScope]::Descendants, [System.Windows.Automation.Condition]::TrueCondition)
+$invoked = $false
+foreach ($e in $all) {
+  if ($e.Current.Name -eq 'Refresh' -and (($e.GetSupportedPatterns() | ForEach-Object { $_.ProgrammaticName }) -match 'Invoke')) {
+    try { $e.GetCurrentPattern([System.Windows.Automation.InvokePattern]::Pattern).Invoke(); $invoked = $true; break } catch {}
+  }
+}
+Write-Output "refresh invoked: $invoked"
+
+$deadline = (Get-Date).AddSeconds($TimeoutSec)
+while ((Get-Date) -lt $deadline) {
+  Start-Sleep -Milliseconds 2000
+  $hit = Test-CredentialModal
+  if ($hit) {
+    Write-Output ("credential modal detected: '{0}'" -f $hit.Substring(0, [Math]::Min(80, $hit.Length)))
+    Write-Output "VERDICT: CREDENTIAL_MISSING"
+    exit 1
+  }
+}
+Write-Output "no credential modal within ${TimeoutSec}s (refresh proceeded)"
+Write-Output "VERDICT: CREDENTIAL_PRESENT"
+exit 0

--- a/.github/skills/pbip-model-refresh/scripts/probe_desktop_credential.ps1
+++ b/.github/skills/pbip-model-refresh/scripts/probe_desktop_credential.ps1
@@ -34,7 +34,9 @@
 
 .OUTPUTS
   Final line `VERDICT: CREDENTIAL_MISSING` (exit 1) or `VERDICT: CREDENTIAL_PRESENT` (exit 0), or
-  `VERDICT: UNKNOWN` (exit 3) if the target window can't be found.
+  `VERDICT: UNKNOWN` (exit 3) if no window for the pid can be found OR a Refresh control was never
+  invoked (with nothing invoked, "no modal appeared" proves nothing - reporting PRESENT then would be
+  a fail-open arbiter, worse than none).
 
 .EXAMPLE
   powershell -ExecutionPolicy Bypass -File scripts/probe_desktop_credential.ps1 -DesktopPid 42532
@@ -52,19 +54,26 @@ $cond = New-Object System.Windows.Automation.PropertyCondition([System.Windows.A
 # Connector credential-dialog signature text (covers Databricks / SQL / Snowflake / generic OAuth).
 $sig = 'You aren.t signed in|Personal Access Token|Databricks Client Credentials|specify how to connect|Account Key|Enter your credentials|Please specify how to connect'
 
+function Get-PidWindows {
+  # EVERY top-level window of the target process, not just the first. A credential modal is its own
+  # top-level window (a sibling of the main Desktop window, not a child), so scanning only the first
+  # would miss it - and the whole point of this arbiter is to catch that modal.
+  return $root.FindAll([System.Windows.Automation.TreeScope]::Children, $cond)
+}
+
 function Test-CredentialModal {
-  $cur = $root.FindFirst([System.Windows.Automation.TreeScope]::Children, $cond)
-  if (-not $cur) { return $null }
-  $desc = $cur.FindAll([System.Windows.Automation.TreeScope]::Descendants, [System.Windows.Automation.Condition]::TrueCondition)
-  foreach ($d in $desc) {
-    $n = $d.Current.Name
-    if ($n -and $n -match $sig) { return $n }
+  foreach ($w in Get-PidWindows) {
+    $desc = $w.FindAll([System.Windows.Automation.TreeScope]::Descendants, [System.Windows.Automation.Condition]::TrueCondition)
+    foreach ($d in $desc) {
+      $n = $d.Current.Name
+      if ($n -and $n -match $sig) { return $n }
+    }
   }
   return $null
 }
 
-$win = $root.FindFirst([System.Windows.Automation.TreeScope]::Children, $cond)
-if (-not $win) { Write-Output "main window for pid $DesktopPid not found"; Write-Output "VERDICT: UNKNOWN"; exit 3 }
+$windows = Get-PidWindows
+if (-not $windows -or $windows.Count -eq 0) { Write-Output "no window for pid $DesktopPid found"; Write-Output "VERDICT: UNKNOWN"; exit 3 }
 
 # 1. If a credential modal is ALREADY open, the credential is missing - report immediately.
 $hit = Test-CredentialModal
@@ -75,14 +84,26 @@ if ($hit) {
 }
 
 # 2. Otherwise trigger a refresh and watch for the modal (generous timeout for warehouse cold-start).
-$all = $win.FindAll([System.Windows.Automation.TreeScope]::Descendants, [System.Windows.Automation.Condition]::TrueCondition)
+# Search every top-level window for an invokable 'Refresh', not just the first.
 $invoked = $false
-foreach ($e in $all) {
-  if ($e.Current.Name -eq 'Refresh' -and (($e.GetSupportedPatterns() | ForEach-Object { $_.ProgrammaticName }) -match 'Invoke')) {
-    try { $e.GetCurrentPattern([System.Windows.Automation.InvokePattern]::Pattern).Invoke(); $invoked = $true; break } catch {}
+foreach ($w in $windows) {
+  $all = $w.FindAll([System.Windows.Automation.TreeScope]::Descendants, [System.Windows.Automation.Condition]::TrueCondition)
+  foreach ($e in $all) {
+    if ($e.Current.Name -eq 'Refresh' -and (($e.GetSupportedPatterns() | ForEach-Object { $_.ProgrammaticName }) -match 'Invoke')) {
+      try { $e.GetCurrentPattern([System.Windows.Automation.InvokePattern]::Pattern).Invoke(); $invoked = $true; break } catch {}
+    }
   }
+  if ($invoked) { break }
 }
 Write-Output "refresh invoked: $invoked"
+
+# If no Refresh was ever invoked, we did not actually test anything: "no modal appeared" is not
+# evidence a credential is cached. Report UNKNOWN rather than a fail-open CREDENTIAL_PRESENT.
+if (-not $invoked) {
+  Write-Output "no invokable Refresh control found for pid $DesktopPid - cannot probe the credential state"
+  Write-Output "VERDICT: UNKNOWN"
+  exit 3
+}
 
 $deadline = (Get-Date).AddSeconds($TimeoutSec)
 while ((Get-Date) -lt $deadline) {

--- a/.github/skills/pbip-model-refresh/scripts/probe_desktop_query.py
+++ b/.github/skills/pbip-model-refresh/scripts/probe_desktop_query.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import argparse
 import glob
 import os
+import re
 import subprocess
 import sys
 import time
@@ -49,7 +50,26 @@ PORT_DISCOVERY_INTERVAL_SECONDS = 2
 # Power BI's auto date/time scaffolding. Present in the engine, and serialized into a PBIP's
 # `definition/tables/` too when auto date/time is (or ever was) on - so a comparison of the two
 # sides has to strip it from BOTH, not just from the engine.
-AUTO_DATE_TABLE_PREFIXES = ("LocalDateTable", "DateTableTemplate")
+#
+# Matching is by the EXACT generated-name SHAPE, not a name prefix. Power BI always names these
+# tables `LocalDateTable_<GUID>` / `DateTableTemplate_<GUID>` with a canonical 8-4-4-4-12 hex GUID,
+# so requiring that whole shape is reliable. A prefix test (`startswith`) silently deleted a genuine
+# user table like `LocalDateTableSales` - columns and measures and all - from the identity
+# fingerprint, hiding real differences (round-3 blocker 4). Anything that is not the exact generated
+# shape is KEPT (fail closed toward comparing more, never less).
+_AUTO_DATE_TABLE_RE = re.compile(
+    r"^(?:LocalDateTable|DateTableTemplate)_[0-9A-Fa-f]{8}-(?:[0-9A-Fa-f]{4}-){3}[0-9A-Fa-f]{12}$"
+)
+
+
+def is_auto_date_table_name(name: str) -> bool:
+    """Is `name` Power BI's auto date/time scaffolding (`LocalDateTable_<GUID>`/`DateTableTemplate_<GUID>`)?
+
+    True ONLY for the exact generated shape - a canonical GUID suffix - so a user table that merely
+    starts with those words (e.g. `LocalDateTableSales`) is NOT mistaken for generated scaffolding and
+    stays in the fingerprint. Fails closed: unusual input keeps the table rather than dropping it.
+    """
+    return bool(_AUTO_DATE_TABLE_RE.match(name))
 
 
 def _load_adomd():
@@ -173,7 +193,7 @@ def table_names(conn, *, include_hidden: bool = False) -> list[str]:
             name = str(reader.GetValue(0))
             if not include_hidden and bool(reader.GetValue(1)):
                 continue
-            if not name.startswith(AUTO_DATE_TABLE_PREFIXES):
+            if not is_auto_date_table_name(name):
                 names.append(name)
     finally:
         reader.Close()
@@ -230,7 +250,7 @@ def column_names(conn) -> set[tuple[str, str]]:
             if int(reader.GetValue(3)) == _COLUMN_TYPE_ROWNUMBER:
                 continue
             table = id_to_name.get(str(reader.GetValue(0)))
-            if table is None or table.startswith(AUTO_DATE_TABLE_PREFIXES):
+            if table is None or is_auto_date_table_name(table):
                 continue
             explicit = reader.GetValue(1)
             name = str(explicit) if explicit not in (None, "") else str(reader.GetValue(2))
@@ -254,7 +274,7 @@ def measure_names(conn) -> set[tuple[str, str]]:
     try:
         while reader.Read():
             table = id_to_name.get(str(reader.GetValue(0)))
-            if table is None or table.startswith(AUTO_DATE_TABLE_PREFIXES):
+            if table is None or is_auto_date_table_name(table):
                 continue
             pairs.add((table, str(reader.GetValue(1))))
     finally:

--- a/.github/skills/pbip-model-refresh/scripts/probe_desktop_query.py
+++ b/.github/skills/pbip-model-refresh/scripts/probe_desktop_query.py
@@ -188,6 +188,80 @@ def first_table(conn) -> str:
     return names[0]
 
 
+# TMSCHEMA_COLUMNS.Type == 3 is the auto-generated per-table RowNumber (index) column. It is NEVER
+# serialized into TMDL, so an identity fingerprint that compared it would report every real model as
+# a stranger - it must be filtered from the live side, not compared. (1=Data, 2=Calculated,
+# 3=RowNumber, 4=CalculatedTableColumn.)
+_COLUMN_TYPE_ROWNUMBER = 3
+
+
+def _table_id_to_name(conn) -> dict[str, str]:
+    """Map each table's engine ID to its name, so column/measure rows can name their table."""
+    cmd = conn.CreateCommand()
+    cmd.CommandText = "SELECT [ID], [Name] FROM $SYSTEM.TMSCHEMA_TABLES"
+    reader = cmd.ExecuteReader()
+    mapping: dict[str, str] = {}
+    try:
+        while reader.Read():
+            mapping[str(reader.GetValue(0))] = str(reader.GetValue(1))
+    finally:
+        reader.Close()
+    return mapping
+
+
+def column_names(conn) -> set[tuple[str, str]]:
+    """`(table, column)` pairs from TMSCHEMA_COLUMNS, part of a model's identity fingerprint.
+
+    Two classes of AUTO-GENERATED column are filtered so the fingerprint compares only what the TMDL
+    actually declares (otherwise a legitimate model would fail its own identity gate):
+    * the per-table RowNumber index (`Type == _COLUMN_TYPE_ROWNUMBER`), which is never in TMDL; and
+    * every column of the `LocalDateTable_*` / `DateTableTemplate_*` auto date/time scaffolding, which
+      is filtered at TABLE level on the disk side too.
+    `ExplicitName` is the model name; `InferredName` is the fallback for a column whose name the
+    engine inferred. Comparison is case-folded by the caller.
+    """
+    id_to_name = _table_id_to_name(conn)
+    cmd = conn.CreateCommand()
+    cmd.CommandText = "SELECT [TableID], [ExplicitName], [InferredName], [Type] FROM $SYSTEM.TMSCHEMA_COLUMNS"
+    reader = cmd.ExecuteReader()
+    pairs: set[tuple[str, str]] = set()
+    try:
+        while reader.Read():
+            if int(reader.GetValue(3)) == _COLUMN_TYPE_ROWNUMBER:
+                continue
+            table = id_to_name.get(str(reader.GetValue(0)))
+            if table is None or table.startswith(AUTO_DATE_TABLE_PREFIXES):
+                continue
+            explicit = reader.GetValue(1)
+            name = str(explicit) if explicit not in (None, "") else str(reader.GetValue(2))
+            pairs.add((table, name))
+    finally:
+        reader.Close()
+    return pairs
+
+
+def measure_names(conn) -> set[tuple[str, str]]:
+    """`(table, measure)` pairs from TMSCHEMA_MEASURES, part of a model's identity fingerprint.
+
+    Measures on the auto date/time scaffolding are filtered for the same reason as its columns.
+    Comparison is case-folded by the caller.
+    """
+    id_to_name = _table_id_to_name(conn)
+    cmd = conn.CreateCommand()
+    cmd.CommandText = "SELECT [TableID], [Name] FROM $SYSTEM.TMSCHEMA_MEASURES"
+    reader = cmd.ExecuteReader()
+    pairs: set[tuple[str, str]] = set()
+    try:
+        while reader.Read():
+            table = id_to_name.get(str(reader.GetValue(0)))
+            if table is None or table.startswith(AUTO_DATE_TABLE_PREFIXES):
+                continue
+            pairs.add((table, str(reader.GetValue(1))))
+    finally:
+        reader.Close()
+    return pairs
+
+
 def _probe_one(port: int, conn, table: str) -> int:
     """Run EVALUATE TOPN(1, '<table>') for one table, print the evidence, and return the row count."""
     dax = f"EVALUATE TOPN(1, '{table}')"

--- a/.github/skills/pbip-model-refresh/scripts/probe_desktop_query.py
+++ b/.github/skills/pbip-model-refresh/scripts/probe_desktop_query.py
@@ -4,7 +4,7 @@ purpose: robust LOCAL data-source preflight for a migrated model open in Power B
          against the loaded model. A returned row proves, in one shot, that credentials are present, the
          source is reachable, and the M/partition is valid - the real gate before building the report.
 usage:   python .github/skills/pbip-model-refresh/scripts/probe_desktop_query.py
-             [--pid <pbidesktop-pid>] [--tables "A" "B"] [--port <n>]
+             [--pid <pbidesktop-pid>] [--canaries "A" "B"] [--port <n>]
          (ships inside the `pbip-model-refresh` skill; run it by its path from wherever the folder
           was copied. `scripts/probe_desktop_query.py` in this repo is a forwarding shim.)
 
@@ -13,11 +13,13 @@ Desktop pid. That scoping is STRICT: a named pid never falls back to another ins
 retries briefly (msmdsrv binds its port a moment after Desktop starts) and then fails. With no --pid
 the single running msmdsrv is used, and more than one is an error rather than a coin flip.
 
-Name one canary table per distinct live source with --tables: every named source is probed and an
+Name one canary table per distinct live source with --canaries: every named source is probed and an
 all-non-zero result earns the model-level PREFLIGHT: DATA_OK. If NO table is named, only the first
 queryable table is probed and the verdict is downgraded to PREFLIGHT: TABLE_OK '<table>' - a static
 parameter/CSV table can return rows while a live source never loaded, so one arbitrary table can
-never certify the model.
+never certify the model. (`--tables`/`--table` are accepted aliases; this script only READS, so
+naming canaries here never narrows anything. In `refresh_pbip_model` they are NOT interchangeable:
+there `--tables` narrows the refresh itself, which is why `--canaries` exists.)
 Emits a final line: PREFLIGHT: DATA_OK (all canaries returned rows) / PREFLIGHT: TABLE_OK '<table>'
 (implicit single-table probe only) / PREFLIGHT: NO_DATA / PREFLIGHT: ERROR <msg>.
 
@@ -306,7 +308,7 @@ def _probe_one(port: int, conn, table: str) -> int:
 def probe(port: int, tables: list[str] | None) -> int:
     """Probe each canary table with a 1-row read against localhost:<port>; return a process exit code.
 
-    With explicit `tables` (one canary per distinct live source) an all-non-zero result earns the
+    With an explicit canary set (one per distinct live source) an all-non-zero result earns the
     model-level ``PREFLIGHT: DATA_OK``. With NO table named, only the first queryable table is
     probed and the verdict is ``PREFLIGHT: TABLE_OK '<table>'`` - a single arbitrary table is not a
     model-level guarantee, because a static parameter/CSV table can return rows while a live source
@@ -331,8 +333,8 @@ def probe(port: int, tables: list[str] | None) -> int:
             print(f"PREFLIGHT: TABLE_OK '{only}'")
             print(
                 f"  note: single-table probe of '{only}' only - NOT a model-level DATA_OK. A static "
-                "parameter/CSV table can return rows while a live source never loaded. Pass --tables "
-                "<one canary per live source> to certify every source."
+                "parameter/CSV table can return rows while a live source never loaded. Pass --canaries "
+                "<one per live source> to certify every source."
             )
             return 0
         print("PREFLIGHT: DATA_OK")
@@ -350,9 +352,15 @@ def main(argv: list[str] | None = None) -> int:
         help="Power BI Desktop process id - required when several instances are open "
         "(`powerbi-desktop status` maps pid -> open file)",
     )
-    parser.add_argument("--table", help="Single canary table (legacy alias for --tables with one name)")
+    parser.add_argument("--table", help="Single canary table (legacy alias for --canaries with one name)")
     parser.add_argument(
         "--tables",
+        nargs="*",
+        help="Alias for --canaries. Kept for existing callers; this script never refreshes, so the "
+        "two mean the same thing HERE (they do not in refresh_pbip_model.py)",
+    )
+    parser.add_argument(
+        "--canaries",
         nargs="*",
         help="Canary tables to probe, one per distinct live source. With none, only the first "
         "queryable table is probed and the verdict is downgraded to name that single table",
@@ -360,8 +368,9 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--port", type=int, help="Local AS port (default: auto-discover)")
     args = parser.parse_args(argv)
 
-    # --tables (plural, the canary set) wins; --table stays as a one-name alias for old callers.
-    tables = list(args.tables) if args.tables else ([args.table] if args.table else None)
+    # Preference order: --canaries (the name that means the same thing in both scripts), then
+    # --tables (plural), then --table as a one-name alias for old callers.
+    tables = list(args.canaries or args.tables or ([args.table] if args.table else [])) or None
     port = args.port or discover_port(args.pid)
     try:
         return probe(port, tables)

--- a/.github/skills/pbip-model-refresh/scripts/probe_desktop_query.py
+++ b/.github/skills/pbip-model-refresh/scripts/probe_desktop_query.py
@@ -4,16 +4,22 @@ purpose: robust LOCAL data-source preflight for a migrated model open in Power B
          against the loaded model. A returned row proves, in one shot, that credentials are present, the
          source is reachable, and the M/partition is valid - the real gate before building the report.
 usage:   python .github/skills/pbip-model-refresh/scripts/probe_desktop_query.py
-             [--pid <pbidesktop-pid>] [--table "<table>"] [--port <n>]
+             [--pid <pbidesktop-pid>] [--tables "A" "B"] [--port <n>]
          (ships inside the `pbip-model-refresh` skill; run it by its path from wherever the folder
           was copied. `scripts/probe_desktop_query.py` in this repo is a forwarding shim.)
 
 If --port is omitted, the port is discovered from the msmdsrv process owned by (a child of) the given
 Desktop pid. That scoping is STRICT: a named pid never falls back to another instance's msmdsrv, it
 retries briefly (msmdsrv binds its port a moment after Desktop starts) and then fails. With no --pid
-the single running msmdsrv is used, and more than one is an error rather than a coin flip. If --table
-is omitted, the first non-hidden table is probed.
-Emits a final line: PREFLIGHT: DATA_OK (rows returned) / PREFLIGHT: NO_DATA / PREFLIGHT: ERROR <msg>.
+the single running msmdsrv is used, and more than one is an error rather than a coin flip.
+
+Name one canary table per distinct live source with --tables: every named source is probed and an
+all-non-zero result earns the model-level PREFLIGHT: DATA_OK. If NO table is named, only the first
+queryable table is probed and the verdict is downgraded to PREFLIGHT: TABLE_OK '<table>' - a static
+parameter/CSV table can return rows while a live source never loaded, so one arbitrary table can
+never certify the model.
+Emits a final line: PREFLIGHT: DATA_OK (all canaries returned rows) / PREFLIGHT: TABLE_OK '<table>'
+(implicit single-table probe only) / PREFLIGHT: NO_DATA / PREFLIGHT: ERROR <msg>.
 
 Windows-only: queries the Desktop's local AS via ADOMD.NET (pythonnet). This is the sanctioned
 Windows-API exception to the "committed scripts default to .py/.sh" rule.
@@ -182,33 +188,61 @@ def first_table(conn) -> str:
     return names[0]
 
 
-def probe(port: int, table: str | None) -> int:
-    """Run EVALUATE TOPN(1, <table>) against localhost:<port>; return process exit code."""
+def _probe_one(port: int, conn, table: str) -> int:
+    """Run EVALUATE TOPN(1, '<table>') for one table, print the evidence, and return the row count."""
+    dax = f"EVALUATE TOPN(1, '{table}')"
+    cmd = conn.CreateCommand()
+    cmd.CommandText = dax
+    reader = cmd.ExecuteReader()
+    cols = [reader.GetName(i) for i in range(reader.FieldCount)]
+    rows = 0
+    first_values: list[str] = []
+    while reader.Read():
+        rows += 1
+        if rows == 1:
+            first_values = [str(reader.GetValue(i)) for i in range(reader.FieldCount)]
+    reader.Close()
+    print(f"port={port}  table='{table}'  dax={dax}")
+    print(f"  columns ({len(cols)}): {cols[:8]}")
+    if rows:
+        print(f"  row: {first_values[:8]}")
+    return rows
+
+
+def probe(port: int, tables: list[str] | None) -> int:
+    """Probe each canary table with a 1-row read against localhost:<port>; return a process exit code.
+
+    With explicit `tables` (one canary per distinct live source) an all-non-zero result earns the
+    model-level ``PREFLIGHT: DATA_OK``. With NO table named, only the first queryable table is
+    probed and the verdict is ``PREFLIGHT: TABLE_OK '<table>'`` - a single arbitrary table is not a
+    model-level guarantee, because a static parameter/CSV table can return rows while a live source
+    never loaded (see the powerbi-semantic-model-gotchas rule: prove a REAL read per live source).
+    """
     adomd_connection = _load_adomd()
     conn = adomd_connection(f"Data Source=localhost:{port}")
     conn.Open()
     try:
-        target = table or first_table(conn)
-        dax = f"EVALUATE TOPN(1, '{target}')"
-        cmd = conn.CreateCommand()
-        cmd.CommandText = dax
-        reader = cmd.ExecuteReader()
-        cols = [reader.GetName(i) for i in range(reader.FieldCount)]
-        rows = 0
-        first_values: list[str] = []
-        while reader.Read():
-            rows += 1
-            if rows == 1:
-                first_values = [str(reader.GetValue(i)) for i in range(reader.FieldCount)]
-        reader.Close()
-        print(f"port={port}  table='{target}'  dax={dax}")
-        print(f"columns ({len(cols)}): {cols[:8]}")
-        if rows:
-            print(f"row: {first_values[:8]}")
-            print("PREFLIGHT: DATA_OK")
+        implicit = not tables
+        targets = list(tables) if tables else [first_table(conn)]
+        results = [(target, _probe_one(port, conn, target)) for target in targets]
+        empty = [target for target, rows in results if rows <= 0]
+        if empty:
+            print(
+                f"PREFLIGHT: NO_DATA (0 rows from: {', '.join(empty)} - source empty, "
+                "credential missing, or refresh failed)"
+            )
+            return 1
+        if implicit:
+            only = results[0][0]
+            print(f"PREFLIGHT: TABLE_OK '{only}'")
+            print(
+                f"  note: single-table probe of '{only}' only - NOT a model-level DATA_OK. A static "
+                "parameter/CSV table can return rows while a live source never loaded. Pass --tables "
+                "<one canary per live source> to certify every source."
+            )
             return 0
-        print("PREFLIGHT: NO_DATA (query ran but returned 0 rows - source empty or refresh failed)")
-        return 1
+        print("PREFLIGHT: DATA_OK")
+        return 0
     finally:
         conn.Close()
 
@@ -222,13 +256,21 @@ def main(argv: list[str] | None = None) -> int:
         help="Power BI Desktop process id - required when several instances are open "
         "(`powerbi-desktop status` maps pid -> open file)",
     )
-    parser.add_argument("--table", help="Table to probe (default: first queryable table)")
+    parser.add_argument("--table", help="Single canary table (legacy alias for --tables with one name)")
+    parser.add_argument(
+        "--tables",
+        nargs="*",
+        help="Canary tables to probe, one per distinct live source. With none, only the first "
+        "queryable table is probed and the verdict is downgraded to name that single table",
+    )
     parser.add_argument("--port", type=int, help="Local AS port (default: auto-discover)")
     args = parser.parse_args(argv)
 
+    # --tables (plural, the canary set) wins; --table stays as a one-name alias for old callers.
+    tables = list(args.tables) if args.tables else ([args.table] if args.table else None)
     port = args.port or discover_port(args.pid)
     try:
-        return probe(port, args.table)
+        return probe(port, tables)
     except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught
         print(f"PREFLIGHT: ERROR {type(exc).__name__}: {exc}")
         return 2

--- a/.github/skills/pbip-model-refresh/scripts/refresh_pbip_model.py
+++ b/.github/skills/pbip-model-refresh/scripts/refresh_pbip_model.py
@@ -139,8 +139,8 @@ SAVE_TIMEOUT_SECONDS = 120
 # How long a persist waits for a CONCURRENT persist of the same model to finish before giving up
 # (issue #114). A persist writes ~114 KB and takes seconds, so a live peer clears well within this;
 # the wait only bites a genuinely stuck LIVE holder (a dead holder's lock is reclaimed at once, never
-# waited on). On timeout `_persist_image` raises `ModelLockTimeout`, and `_refresh_and_save` degrades
-# to the UI Save - which does its own compatibility alignment - rather than forcing the #114 race.
+# waited on). On timeout `_persist_image` raises `ModelLockTimeout` and `_refresh_and_save` REFUSES to
+# persist (`NOT_PERSISTED`), naming the concurrent run.
 PERSIST_LOCK_TIMEOUT_SECONDS = 120.0
 # The XMLA refresh ceiling. NOT agent-tunable on purpose - there is no CLI flag for it.
 #
@@ -1035,34 +1035,39 @@ def _refresh_and_save(pid: int, port: int, cache: Path | None, args: argparse.Na
     #
     # `--no-save` is for read-only work (the validator is read-only BY CONTRACT and must pass it) and
     # for validate-then-deploy, where the project must stay byte-identical.
-    if args.no_save:
-        return None
-
-    # Preferred: a real API call. Falls back to driving the UI only if it fails, so a change in the
-    # engine can never leave the pipeline with no way to persist.
-    saved, save_message = (False, "no cache path resolved")
-    if cache is not None and not args.ui_save:
-        try:
-            saved, save_message = image_save(port, cache, model_dir=cache.parent.parent)
-        except CompatRollbackError as exc:
-            # FATAL: the cache write failed AND the compatibility alignment could not be rolled back,
-            # so database.tmdl declares a level that was never written to a cache. Driving the UI Save
-            # on top of that inconsistent state would persist the mismatch, so do NOT fall back to it.
-            print(f"  save   : {exc}")
-            print(
-                "REFRESH: ERROR compatibility rollback failed - database.tmdl left inconsistent; "
-                "do NOT save. Restore database.tmdl from source control before retrying."
-            )
-            return 2
-        except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught
-            saved, save_message = False, f"ImageSave unavailable ({type(exc).__name__}); falling back to UI"
-    if not saved:
+    if not args.no_save:
+        # Preferred: a real API call. Falls back to driving the UI only if it fails, so a change in the
+        # engine can never leave the pipeline with no way to persist.
+        saved, save_message = (False, "no cache path resolved")
+        if cache is not None and not args.ui_save:
+            try:
+                saved, save_message = image_save(port, cache, model_dir=cache.parent.parent)
+            except CompatRollbackError as exc:
+                # FATAL: the cache write failed AND the compatibility alignment could not be rolled back,
+                # so database.tmdl declares a level that was never written to a cache. Driving the UI Save
+                # on top of that inconsistent state would persist the mismatch, so do NOT fall back to it.
+                print(f"  save   : {exc}")
+                print(
+                    "REFRESH: ERROR compatibility rollback failed - database.tmdl left inconsistent; "
+                    "do NOT save. Restore database.tmdl from source control before retrying."
+                )
+                return 2
+            except ModelLockTimeout as exc:
+                print(f"  save   : {exc}")
+                print(
+                    "REFRESH: NOT_PERSISTED (a concurrent persist of this model holds the lock; "
+                    "data is in memory only). Wait for the other run to finish and retry."
+                )
+                return 1
+            except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught
+                saved, save_message = False, f"ImageSave unavailable ({type(exc).__name__}); falling back to UI"
+        if not saved:
+            print(f"  save   : {save_message}")
+            saved, save_message = save(pid)
         print(f"  save   : {save_message}")
-        saved, save_message = save(pid)
-    print(f"  save   : {save_message}")
-    if not saved:
-        print("REFRESH: NOT_PERSISTED (data is in memory only - the next open will be empty)")
-        return 1
+        if not saved:
+            print("REFRESH: NOT_PERSISTED (data is in memory only - the next open will be empty)")
+            return 1
     return None
 
 

--- a/.github/skills/pbip-model-refresh/scripts/refresh_pbip_model.py
+++ b/.github/skills/pbip-model-refresh/scripts/refresh_pbip_model.py
@@ -93,13 +93,27 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 # ruff: noqa: E402  (the sys.path insert above must precede this import)
 # pylint: disable=wrong-import-position
 from probe_desktop_query import (
-    AUTO_DATE_TABLE_PREFIXES,
     _load_adomd,
     column_names,
     discover_port,
     first_table,
+    is_auto_date_table_name,
     measure_names,
     table_names,
+)
+
+# Cache-file integrity + atomic staged-write/rollback primitives live in _abf so this module
+# stays under its line cap; re-exported here so callers and tests reach them via refresh_pbip_model.
+from _abf import (  # noqa: F401  # pylint: disable=unused-import
+    _CFBF_HEADER_BYTES,
+    _CFBF_MAGIC,
+    CompatRollbackError,
+    _cache_committed,
+    _cache_fingerprint,
+    _cleanup_staging,
+    _is_complete_abf,
+    _restore_rollback_snapshot,
+    _staged_image_write,
 )
 
 SAVE_SETTLE_SECONDS = 3
@@ -136,12 +150,6 @@ MEASURE_DECL_RE = re.compile(r"^\s*measure\s+(?:'([^']+)'|([^=\s]+))", re.MULTIL
 GENERATED_ARTIFACTS_KEY = "generated_artifacts"
 GENERATED_EDIT_DECLARATIONS = Path("_build") / "generated-edit-declarations.json"
 
-# A persisted `cache.abf` is an Analysis Services backup, which is a Microsoft Compound File Binary
-# (OLE2) container - it always begins with this 8-byte signature and is at least one 512-byte CFBF
-# header. Verifying that before swapping a staged file over a good cache is what stops a truncated or
-# interrupted write from being mistaken for a real one and destroying the existing cache (#113).
-_CFBF_MAGIC = b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1"
-_CFBF_HEADER_BYTES = 512
 
 # The credential arbiter that settles a refresh TIMEOUT (slow source vs. sign-in modal). Resolved
 # relative to THIS file so the runtime recovery instruction always points at the copy that ships
@@ -449,25 +457,6 @@ def _compat_rollback_paths(model_dir: Path | None) -> list[Path]:
     return paths
 
 
-def _is_complete_abf(path: Path) -> bool:
-    """Is `path` a fully-written cache.abf, not a truncated or partial one?
-
-    A cache.abf is an Analysis Services backup, i.e. a Microsoft Compound File Binary (OLE2)
-    container, so a complete one begins with `_CFBF_MAGIC` and is at least one CFBF header
-    (`_CFBF_HEADER_BYTES`). This is a NECESSARY, cheap check, not a full parse: paired with only
-    suppressing the one benign AMO exception (`_is_benign_imagesave_response_error`), it keeps a
-    disk-full or interrupted write from replacing a good cache with rubble (#113). It stays
-    conservative - rejecting a VALID cache would be worse than the bug - so it checks only the
-    signature and a minimum size, never an exact length or sector alignment.
-    """
-    try:
-        with path.open("rb") as handle:
-            head = handle.read(len(_CFBF_MAGIC))
-        return head == _CFBF_MAGIC and path.stat().st_size >= _CFBF_HEADER_BYTES
-    except OSError:
-        return False
-
-
 def _is_benign_imagesave_response_error(exc: BaseException) -> bool:
     """AMO's ImageSave raises even after a fully correct write - only THAT error is benign.
 
@@ -481,84 +470,52 @@ def _is_benign_imagesave_response_error(exc: BaseException) -> bool:
     return "unrecognizable response" in str(exc).lower()
 
 
-def _staged_image_write(cache_path: Path, write_image) -> bool:
-    """Write the cache to a staging file and swap it in atomically. Returns True only on a COMPLETE write.
-
-    `FileMode.Create` on the live `cache.abf` truncates a good cache the instant the write begins, so
-    an ImageSave that then fails half way leaves the project WORSE than before -- no fresh cache and
-    no old one. Staging to `cache.abf.tmp` and only `os.replace`-ing it over the original once it is a
-    COMPLETE backup means a failed or partial write cannot destroy an existing good cache. Two rules
-    make "complete" mean what it says (#113): `write_image` is expected NOT to raise (`image_save`
-    absorbs the one benign AMO error and re-raises everything else), so any exception reaching here --
-    including from `os.replace` -- is a REAL failure that PROPAGATES after the staging file is removed,
-    letting the caller roll the compatibility bump back; and even on a clean return the staged file
-    must look like a backup (`_is_complete_abf`) before it is swapped in.
-    """
-    cache_path.parent.mkdir(parents=True, exist_ok=True)
-    staging = cache_path.with_name(cache_path.name + ".tmp")
-    if staging.exists():
-        staging.unlink()
-    swapped = False
-    try:
-        write_image(staging)
-        if _is_complete_abf(staging):
-            os.replace(staging, cache_path)
-            swapped = True
-    finally:
-        # Never leave a partial cache.abf.tmp behind. `finally` does not suppress the exception, so a
-        # real write/replace error still propagates to _persist_image, which rolls the compat back.
-        if not swapped and staging.exists():
-            staging.unlink()
-    return swapped
-
-
-def _restore_rollback_snapshot(snapshot: dict[Path, bytes | None]) -> None:
-    """Restore each snapshotted path to exactly its pre-alignment state (bytes, or absence)."""
-    for path, original in snapshot.items():
-        if original is None:
-            if path.exists():
-                path.unlink()
-        elif not path.exists() or path.read_bytes() != original:
-            path.write_bytes(original)
-
-
 def _persist_image(cache_path: Path, model_dir: Path | None, live_level: int, write_image) -> tuple[bool, str]:
     """Align compat, stage the cache write, swap atomically, and roll compat back UNLESS it committed.
 
-    Pure-Python (no .NET), so the atomic-write and rollback guarantees are unit-testable without a
-    live Analysis Services instance. ``write_image(staging_path)`` performs the actual engine write.
-
-    The whole align -> write -> replace sequence is wrapped so the compatibility bump is provisional:
-    it is kept ONLY if the cache was definitively committed. The rollback therefore runs on the clean
-    "write did not land" return AND on any exception raised along the way -- a stale-temp unlink, a
-    ``stat()``, or a Windows ``os.replace`` that raises ``PermissionError`` because the cache is
-    locked. Before this was a ``finally`` the rollback ran only on the ``False`` return, so an
-    exception left ``database.tmdl`` bumped for a cache that was never written, and the caller carried
-    that state into the UI Save (#113, round-2 blocker 2).
+    Pure-Python (no .NET), so the guarantees are unit-testable without a live AS instance.
+    ``write_image(staging_path)`` performs the actual engine write. Commit is decided by the
+    FILESYSTEM (:func:`_cache_committed`), so an ``os.replace`` that moved the file yet still raised is
+    recognised as committed and the alignment KEPT - never rolled back under a freshly installed cache.
+    When the write did NOT land, the alignment is restored atomically from the snapshot, every path is
+    attempted, and a residual failure raises :class:`CompatRollbackError` (round-3 blocker 2).
     """
     rollback_paths = _compat_rollback_paths(model_dir)
     snapshot = {path: (path.read_bytes() if path.exists() else None) for path in rollback_paths}
-    committed = False
+    staging = cache_path.with_name(cache_path.name + ".tmp")
+    before = _cache_fingerprint(cache_path)
+    swapped = False
+    write_error: BaseException | None = None
     try:
         aligned = _align_compatibility(model_dir, live_level)
         if aligned:
             print(f"  save   : {aligned}")
+        swapped = _staged_image_write(cache_path, write_image)
+    except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught  # commit judged below by the filesystem
+        write_error = exc
 
-        committed = _staged_image_write(cache_path, write_image)
-        if committed:
-            # The cache is written and swapped in; a post-commit stat failure must NOT undo it, so the
-            # size note is best-effort and never flips `committed` back to False.
-            try:
-                size_note = f"{cache_path.stat().st_size / 1024:.1f} KB, "
-            except OSError:
-                size_note = ""
-            return True, f"persisted via AMO ImageSave ({size_note}compatibilityLevel {live_level})"
-        return False, "ImageSave did not produce a complete cache file (compatibility alignment rolled back)"
-    finally:
-        # Undo the (provisional) alignment unless the cache actually committed. A failed persist must
-        # never leave database.tmdl declaring a level that was never written to a cache.
-        if not committed:
-            _restore_rollback_snapshot(snapshot)
+    if swapped or _cache_committed(cache_path, staging, before):
+        _cleanup_staging(staging)
+        try:
+            size_note = f"{cache_path.stat().st_size / 1024:.1f} KB, "
+        except OSError:
+            size_note = ""
+        return True, f"persisted via AMO ImageSave ({size_note}compatibilityLevel {live_level})"
+
+    # The cache was NOT installed, so the provisional alignment must come back exactly.
+    _cleanup_staging(staging)
+    failures = _restore_rollback_snapshot(snapshot)
+    if failures:
+        raise CompatRollbackError(
+            "compatibility rollback FAILED for "
+            + ", ".join(str(path) for path in failures)
+            + " - database.tmdl no longer matches the cache; restore it from source control before retrying"
+        )
+    if write_error is not None:
+        # A real write/replace failure with a CLEAN rollback: the project is consistent, so re-raise
+        # and let the caller fall back to the UI save (an ordinary ImageSave failure).
+        raise write_error
+    return False, "ImageSave did not produce a complete cache file (compatibility alignment rolled back)"
 
 
 def image_save(port: int, cache_path: Path, model_dir: Path | None = None):
@@ -669,19 +626,37 @@ Write-Output 'NO_INVOKABLE_SAVE'; exit 1
     )
 
 
-def _model_from_pbip_binding(pbip: Path, models: list[Path]) -> Path | None:
-    """The `.SemanticModel` a `.pbip` actually binds to, read from the binding, not guessed.
+def _looks_like_semantic_model(path: Path) -> bool:
+    """A resolved `byPath` target that is really an on-disk `.SemanticModel` folder.
 
-    A `.pbip` names its report; the report's `definition.pbir` names the model by a relative
-    `datasetReference.byPath.path`. Following that chain identifies the owning model even when a
-    folder holds several `.SemanticModel` directories. Returns None when the binding cannot be read
-    unambiguously - the caller then fails closed rather than guessing `models[0]`.
+    Requires the `.SemanticModel` suffix AND an existing `definition/` dir, so a binding pointing at a
+    deleted/renamed model is rejected here and the caller then fails closed.
     """
-    report_dirs: list[Path] = []
+    return path.is_dir() and path.name.endswith(".SemanticModel") and (path / "definition").is_dir()
+
+
+def _resolve_pbip_binding(pbip: Path) -> tuple[str, Path | None]:
+    """Resolve the `.pbip` -> report -> `definition.pbir` `byPath` binding to a model, TRI-STATE.
+
+    Returns exactly one of:
+      ("resolved", model_dir) - one binding target that is a real `.SemanticModel` (possibly OUTSIDE
+                                this `.pbip`'s folder). Use it.
+      ("unresolvable", None)  - a binding EXISTS but names no single real model (missing/renamed, or
+                                several reports disagree). FAIL CLOSED.
+      ("absent", None)        - no `byPath` anywhere; a name/count heuristic MAY now apply.
+
+    "Absent" and "present-but-unresolvable" are deliberately DIFFERENT results: the first permits a
+    heuristic, the second forbids it. Collapsing them (round-2) let a dangling or outside-the-folder
+    binding fall through to `models[0]` - a wrong-project write reachable even with a single adjacent
+    model. The target is resolved DIRECTLY from `byPath`, NOT intersected with the pbip folder's
+    siblings, so an outside-the-folder binding still resolves and a lone decoy cannot shadow it
+    (round-3 mandate, points 2-3).
+    """
     try:
         pbip_data = json.loads(pbip.read_text(encoding="utf-8-sig"))
     except (OSError, json.JSONDecodeError):
         pbip_data = None
+    report_dirs: list[Path] = []
     if isinstance(pbip_data, dict):
         for artifact in pbip_data.get("artifacts", []) or []:
             report = artifact.get("report") if isinstance(artifact, dict) else None
@@ -691,8 +666,8 @@ def _model_from_pbip_binding(pbip: Path, models: list[Path]) -> Path | None:
     if not report_dirs:
         report_dirs = [pbir.parent for pbir in pbip.parent.glob("*.Report")]
 
-    matches: set[Path] = set()
-    model_by_resolved = {model.resolve(): model for model in models}
+    saw_binding = False
+    targets: set[Path] = set()
     for report_dir in report_dirs:
         pbir = report_dir / "definition.pbir"
         try:
@@ -702,52 +677,56 @@ def _model_from_pbip_binding(pbip: Path, models: list[Path]) -> Path | None:
         by_path = (((data.get("datasetReference") or {}).get("byPath")) or {}).get("path")
         if not by_path:
             continue
+        saw_binding = True
         target = (pbir.parent / by_path).resolve()
-        if target in model_by_resolved:
-            matches.add(target)
-    if len(matches) == 1:
-        return model_by_resolved[matches.pop()]
+        if _looks_like_semantic_model(target):
+            targets.add(target)
+    if not saw_binding:
+        return "absent", None
+    if len(targets) == 1:
+        return "resolved", next(iter(targets))
+    return "unresolvable", None
+
+
+def _cache_from_absent_binding(pbip: Path) -> Path | None:
+    """Name/count heuristic for the owning model - reached ONLY when no `byPath` binding exists.
+
+    Kept in its own function so no branch of it can precede the authoritative binding lookup in
+    :func:`cache_file` (the early-return shape that failed review twice). One model -> it; otherwise
+    the single sibling whose stem matches the `.pbip`; else None (ambiguous, fail closed).
+    """
+    models = sorted(pbip.parent.glob("*.SemanticModel"))
+    if not models:
+        return None
+    if len(models) == 1:
+        return models[0] / ".pbi" / "cache.abf"
+    stem = pbip.stem.lower()
+    by_name = [model for model in models if model.stem.lower() == stem]
+    if len(by_name) == 1:
+        return by_name[0] / ".pbi" / "cache.abf"
     return None
 
 
 def cache_file(pid: int) -> Path | None:
     """Where `<Name>.SemanticModel/.pbi/cache.abf` belongs for the model this instance has open.
 
-    Resolves the DESTINATION, not an existing file: on a first build there is no cache yet, and
-    globbing for one returned None and silently sent the save down the UI-Automation fallback.
-
-    When a folder holds several `.SemanticModel` directories the model is resolved from the PBIP
-    BINDING (the `.pbip` -> report -> `definition.pbir` `byPath` chain) FIRST, because that is the
-    authoritative statement of which model the `.pbip` opens. Only if the binding cannot be read is
-    an exact stem match used as a weaker fallback, and otherwise this returns None so the identity
-    gate fails closed. The order matters: consulting the name first let a same-named sibling shadow
-    the model the binding actually points at (#114, round-2 blocker 3a), and the old `models[0]`
-    fallback silently bound the run to an arbitrary sibling - the wrong-instance write this exists to
-    prevent.
+    Resolves the DESTINATION, not an existing file (on a first build there is no cache yet). There is
+    exactly ONE resolution order, with the authoritative binding consulted FIRST and UNCONDITIONALLY -
+    no early return can precede it. This failed review twice with the same shape (round-1 a stem
+    heuristic ran first; round-2 a `len(models)==1` shortcut), so the binding is now tri-state
+    (round-3 mandate): resolved -> use it (even OUTSIDE this folder); unresolvable -> None (fail
+    closed); absent -> and only then a name/count heuristic may run.
     """
     inst = _instance(pid)
     if inst is None or not inst.get("currentFilePath"):
         return None
     pbip = Path(inst["currentFilePath"])
-    models = sorted(pbip.parent.glob("*.SemanticModel"))
-    if not models:
-        return None
-    if len(models) == 1:
-        return models[0] / ".pbi" / "cache.abf"
-    # Authoritative: follow the .pbip -> report -> definition.pbir byPath binding.
-    bound = _model_from_pbip_binding(pbip, models)
-    if bound is not None:
+    state, bound = _resolve_pbip_binding(pbip)
+    if state == "resolved":
         return bound / ".pbi" / "cache.abf"
-    # Only when the binding is unreadable/absent: fall back to an exact stem match. This is a weaker
-    # heuristic and must NEVER run ahead of the binding, or a same-named sibling shadows the model
-    # the .pbip actually opens.
-    stem = pbip.stem.lower()
-    by_name = [model for model in models if model.stem.lower() == stem]
-    if len(by_name) == 1:
-        return by_name[0] / ".pbi" / "cache.abf"
-    # Ambiguous, and no binding resolved it: refuse to guess. Returning None makes the identity gate
-    # fail closed rather than persist into whichever sibling happened to sort first.
-    return None
+    if state == "unresolvable":
+        return None
+    return _cache_from_absent_binding(pbip)
 
 
 def tmdl_tables(model_dir: Path) -> set[str]:
@@ -765,7 +744,7 @@ def tmdl_tables(model_dir: Path) -> set[str]:
     for tmdl in sorted(definition.glob("tables/*.tmdl")):
         text = tmdl.read_text(encoding="utf-8-sig", errors="replace")
         names.update(quoted or bare for quoted, bare in TABLE_DECL_RE.findall(text))
-    return {name for name in names if not name.startswith(AUTO_DATE_TABLE_PREFIXES)}
+    return {name for name in names if not is_auto_date_table_name(name)}
 
 
 def _live_tables(port: int) -> set[str]:
@@ -796,7 +775,7 @@ def tmdl_columns_measures(model_dir: Path) -> tuple[set[tuple[str, str]], set[tu
         if not decl:
             continue
         table = decl.group(1) or decl.group(2)
-        if table.startswith(AUTO_DATE_TABLE_PREFIXES):
+        if is_auto_date_table_name(table):
             continue
         columns.update((table, quoted or bare) for quoted, bare in COLUMN_DECL_RE.findall(text))
         measures.update((table, quoted or bare) for quoted, bare in MEASURE_DECL_RE.findall(text))
@@ -1008,6 +987,16 @@ def _refresh_and_save(pid: int, port: int, cache: Path | None, args: argparse.Na
     if cache is not None and not args.ui_save:
         try:
             saved, save_message = image_save(port, cache, model_dir=cache.parent.parent)
+        except CompatRollbackError as exc:
+            # FATAL: the cache write failed AND the compatibility alignment could not be rolled back,
+            # so database.tmdl declares a level that was never written to a cache. Driving the UI Save
+            # on top of that inconsistent state would persist the mismatch, so do NOT fall back to it.
+            print(f"  save   : {exc}")
+            print(
+                "REFRESH: ERROR compatibility rollback failed - database.tmdl left inconsistent; "
+                "do NOT save. Restore database.tmdl from source control before retrying."
+            )
+            return 2
         except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught
             saved, save_message = False, f"ImageSave unavailable ({type(exc).__name__}); falling back to UI"
     if not saved:

--- a/.github/skills/pbip-model-refresh/scripts/refresh_pbip_model.py
+++ b/.github/skills/pbip-model-refresh/scripts/refresh_pbip_model.py
@@ -2,7 +2,7 @@
 purpose: Refresh a local PBIP model in Power BI Desktop and PERSIST the result, so the next agent
          (and the next Desktop open) sees real data instead of an empty model.
 usage:   python .github/skills/pbip-model-refresh/scripts/refresh_pbip_model.py
-             [--pid <pbidesktop-pid>] [--tables "A" "B"] [--no-save]
+             [--pid <pbidesktop-pid>] [--canaries "A" "B"] [--tables "A" "B"] [--no-save]
          (ships inside the `pbip-model-refresh` skill; run it by its path from wherever the folder
           was copied. `scripts/refresh_pbip_model.py` in this repo is a forwarding shim.)
 
@@ -105,19 +105,43 @@ from probe_desktop_query import (
 # Cache-file integrity + atomic staged-write/rollback primitives live in _abf so this module
 # stays under its line cap; re-exported here so callers and tests reach them via refresh_pbip_model.
 from _abf import (  # noqa: F401  # pylint: disable=unused-import
-    _CFBF_HEADER_BYTES,
-    _CFBF_MAGIC,
+    _ABF_BLOCK_MAGIC,
+    _ABF_MAX_BLOCK_BYTES,
+    _ABF_PREAMBLE,
     CompatRollbackError,
+    _abf_rejection_reason,
     _cache_committed,
     _cache_fingerprint,
     _cleanup_staging,
     _is_complete_abf,
     _restore_rollback_snapshot,
+    _snapshot_rollback_paths,
     _staged_image_write,
+    _staging_path,
+)
+
+# Per-model interprocess lock for the persist transaction, in its own module for the same reason;
+# re-exported so callers and tests reach it via refresh_pbip_model.
+from _lock import (  # noqa: F401  # pylint: disable=unused-import
+    ModelLockTimeout,
+    model_lock,
+)
+
+# The verdict/reporting layer lives in _verdict for the same line-cap reason as _abf and _lock;
+# re-exported here so callers and tests reach it via refresh_pbip_model.
+from _verdict import (  # noqa: F401  # pylint: disable=unused-import
+    _canary_tables,
+    _emit_data_verdict,
 )
 
 SAVE_SETTLE_SECONDS = 3
 SAVE_TIMEOUT_SECONDS = 120
+# How long a persist waits for a CONCURRENT persist of the same model to finish before giving up
+# (issue #114). A persist writes ~114 KB and takes seconds, so a live peer clears well within this;
+# the wait only bites a genuinely stuck LIVE holder (a dead holder's lock is reclaimed at once, never
+# waited on). On timeout `_persist_image` raises `ModelLockTimeout`, and `_refresh_and_save` degrades
+# to the UI Save - which does its own compatibility alignment - rather than forcing the #114 race.
+PERSIST_LOCK_TIMEOUT_SECONDS = 120.0
 # The XMLA refresh ceiling. NOT agent-tunable on purpose - there is no CLI flag for it.
 #
 # 300s is chosen from measurement, not intuition. A 246,236-row, 11-table refresh took 38.8s on a
@@ -470,7 +494,13 @@ def _is_benign_imagesave_response_error(exc: BaseException) -> bool:
     return "unrecognizable response" in str(exc).lower()
 
 
-def _persist_image(cache_path: Path, model_dir: Path | None, live_level: int, write_image) -> tuple[bool, str]:
+def _persist_image(
+    cache_path: Path,
+    model_dir: Path | None,
+    live_level: int,
+    write_image,
+    lock_timeout: float = PERSIST_LOCK_TIMEOUT_SECONDS,
+) -> tuple[bool, str]:
     """Align compat, stage the cache write, swap atomically, and roll compat back UNLESS it committed.
 
     Pure-Python (no .NET), so the guarantees are unit-testable without a live AS instance.
@@ -479,10 +509,35 @@ def _persist_image(cache_path: Path, model_dir: Path | None, live_level: int, wr
     recognised as committed and the alignment KEPT - never rolled back under a freshly installed cache.
     When the write did NOT land, the alignment is restored atomically from the snapshot, every path is
     attempted, and a residual failure raises :class:`CompatRollbackError` (round-3 blocker 2).
+
+    The ENTIRE transaction (snapshot -> align -> write -> commit-or-rollback) runs under a per-model
+    interprocess lock (issue #114). Two runs against one model share BOTH the staging file (now given
+    a private per-run name) AND the provisional compatibility edit on ``database.tmdl``; a hostile
+    interleaving of the compat edit alone leaves the project declaring a level no present cache
+    matches. The lock serialises the whole transaction so no interleaving is possible; a dead holder's
+    lock is reclaimed rather than blocking forever, and a live holder that overruns ``lock_timeout``
+    surfaces as :class:`ModelLockTimeout` rather than an unbounded wait.
+    """
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = cache_path.with_name(cache_path.name + ".lock")
+    with model_lock(lock_path, timeout=lock_timeout):
+        return _persist_image_locked(cache_path, model_dir, live_level, write_image)
+
+
+def _persist_image_locked(cache_path: Path, model_dir: Path | None, live_level: int, write_image) -> tuple[bool, str]:
+    """The persist transaction itself, run while the per-model lock is held (see :func:`_persist_image`).
+
+    ``KeyboardInterrupt`` handling is the subtle part (issue #113 route 2). The commit-detection and
+    rollback below MUST run even when the write is interrupted, or a Ctrl+C during alignment/ImageSave
+    leaves ``database.tmdl`` bumped for a cache that was never written - the same brick, different
+    route. So the write is guarded with ``except BaseException`` (``KeyboardInterrupt`` is NOT an
+    ``Exception``), the interrupt is stashed in ``write_error``, and it is re-raised only AFTER a clean
+    rollback. If the rollback itself fails, :class:`CompatRollbackError` is raised INSTEAD (chained
+    from the interrupt): a bricked project matters more than a tidy Ctrl+C.
     """
     rollback_paths = _compat_rollback_paths(model_dir)
-    snapshot = {path: (path.read_bytes() if path.exists() else None) for path in rollback_paths}
-    staging = cache_path.with_name(cache_path.name + ".tmp")
+    snapshot = _snapshot_rollback_paths(rollback_paths)
+    staging = _staging_path(cache_path)
     before = _cache_fingerprint(cache_path)
     swapped = False
     write_error: BaseException | None = None
@@ -490,8 +545,8 @@ def _persist_image(cache_path: Path, model_dir: Path | None, live_level: int, wr
         aligned = _align_compatibility(model_dir, live_level)
         if aligned:
             print(f"  save   : {aligned}")
-        swapped = _staged_image_write(cache_path, write_image)
-    except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught  # commit judged below by the filesystem
+        swapped = _staged_image_write(cache_path, write_image, staging)
+    except BaseException as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught  # KeyboardInterrupt must NOT bypass rollback; commit judged below by the filesystem
         write_error = exc
 
     if swapped or _cache_committed(cache_path, staging, before):
@@ -510,10 +565,11 @@ def _persist_image(cache_path: Path, model_dir: Path | None, live_level: int, wr
             "compatibility rollback FAILED for "
             + ", ".join(str(path) for path in failures)
             + " - database.tmdl no longer matches the cache; restore it from source control before retrying"
-        )
+        ) from write_error
     if write_error is not None:
-        # A real write/replace failure with a CLEAN rollback: the project is consistent, so re-raise
-        # and let the caller fall back to the UI save (an ordinary ImageSave failure).
+        # A real write/replace failure OR an interrupt, WITH a clean rollback: the project is
+        # consistent again, so re-raise. For an interrupt this honours the Ctrl+C; for an ordinary
+        # ImageSave failure the caller falls back to the UI save.
         raise write_error
     return False, "ImageSave did not produce a complete cache file (compatibility alignment rolled back)"
 
@@ -887,11 +943,12 @@ def row_counts(port: int, tables: list[str] | None) -> tuple[list[tuple[str, int
     """Row counts per canary table - the gate of record. Returns (results, implicit).
 
     A refresh that "succeeded" but returns no rows is not a refresh; only data proves the source was
-    reachable, the credential worked and the M was valid. With explicit `tables` (one canary per
-    distinct source), every source is asserted, so an all-non-zero result justifies a model-level
-    verdict. With no tables the first queryable table is probed and ``implicit`` is True - that is a
-    single-table probe, NOT a model-level guarantee: a static parameter/CSV table can return rows
-    while a live source never loaded. The caller downgrades the verdict wording accordingly.
+    reachable, the credential worked and the M was valid. With an explicit canary set (one per
+    distinct source), every source is asserted. With none, the first queryable table is probed and
+    ``implicit`` is True - that is a single-table probe, NOT a model-level guarantee: a static
+    parameter/CSV table can return rows while a live source never loaded. Whether an all-non-zero
+    result earns a MODEL-level verdict is not decided here: it also depends on whether the refresh
+    covered the whole database (see :func:`_emit_data_verdict`).
     """
     adomd_connection = _load_adomd()
     conn = adomd_connection(f"Data Source=localhost:{port}")
@@ -1060,9 +1117,16 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--tables",
         nargs="*",
-        help="Tables to refresh AND the canary set to verify (default: whole database). Name one "
-        "table per distinct live source to earn a model-level DATA_OK; with none, only the first "
-        "queryable table is probed and the verdict is downgraded to name that single table",
+        help="Tables to REFRESH (default: the whole database). This narrows the refresh, so it can "
+        "never earn a model-level DATA_OK - name canaries with --canaries instead",
+    )
+    parser.add_argument(
+        "--canaries",
+        nargs="*",
+        help="Tables to VERIFY after the refresh, one per distinct live source. A whole-database "
+        "refresh whose canaries all return rows earns the model-level DATA_OK. Defaults to --tables "
+        "when only that is given; with neither, the first queryable table is probed and the verdict "
+        "is downgraded to name that single table",
     )
     parser.add_argument(
         "--save",
@@ -1085,65 +1149,6 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         help="Force the legacy UI-Automation save instead of AMO ImageSave (fallback/diagnostic)",
     )
     return parser
-
-
-def _emit_data_verdict(
-    cache: Path | None,
-    before_stamp: float,
-    args: argparse.Namespace,
-    results: list[tuple[str, int]],
-    implicit: bool,
-) -> int:
-    """Print the data/cache lines and the machine-readable verdict; return the process exit code.
-
-    Split out of `main()` so the mutating path (identity gate + refresh + persist) and the reporting
-    path stay individually simple.
-    """
-    after_stamp = cache.stat().st_mtime if cache and cache.exists() else 0.0
-    persisted = cache is not None and after_stamp > before_stamp
-
-    for table, rows in results:
-        print(f"  data   : {rows} row(s) in '{table}'")
-    # Say what HAPPENED, not where a file would go. Printing the path alone reads as "written" -
-    # it misled a reader on 2026-08-05 into believing a probe run had persisted a 1-row cache.
-    # For a probe that distinction matters twice over: a persisted 1-row `cache.abf` is a trap, and
-    # a cache whose compatibility level disagrees with the project's makes the PBIP unopenable (see
-    # `--no-save`; `image_save` prevents that by aligning `database.tmdl`).
-    if persisted:
-        print(f"  cache  : PERSISTED -> {cache}")
-    elif cache is None:
-        print("  cache  : not persisted (no cache path resolved)")
-    elif args.no_save:
-        print("  cache  : not persisted (--no-save; the project is byte-identical)")
-    else:
-        # Persisting was requested (the default) and nothing landed. Naming the wrong reason here
-        # sent me looking in the wrong place for ten minutes; the real one is on the 'save' line.
-        print("  cache  : not persisted (the write did not land - see 'save' above)")
-
-    empty = [table for table, rows in results if rows <= 0]
-    if empty:
-        print(f"REFRESH: NO_DATA (empty: {', '.join(empty)} - check the source and credentials)")
-        return 1
-    wanted_save = not args.no_save and not args.verify_only
-    if wanted_save and not persisted:
-        print("REFRESH: NOT_PERSISTED (model has data in memory, but cache.abf did not update)")
-        return 1
-    suffix = " + PERSISTED" if wanted_save else ""
-    if implicit:
-        # No canaries were named, so only the first queryable table was probed. That is NOT a
-        # model-level guarantee (a static parameter/CSV table can pass while a live source never
-        # loaded), so the verdict names the single table actually probed instead of claiming DATA_OK.
-        only = results[0][0]
-        print(f"REFRESH: TABLE_OK '{only}'{suffix}")
-        print(
-            f"  note   : single-table probe of '{only}' only - NOT a model-level DATA_OK. A static "
-            "parameter/CSV table can return rows while a live source never loaded. Pass "
-            "--tables <one canary per live source> to certify every source (this mirrors the "
-            "powerbi-semantic-model-gotchas rule: prove a REAL read per live source)."
-        )
-        return 0
-    print(f"REFRESH: DATA_OK{suffix}")
-    return 0
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -1181,7 +1186,7 @@ def main(argv: list[str] | None = None) -> int:
         if outcome is not None:
             return outcome
 
-    results, implicit = row_counts(port, args.tables)
+    results, implicit = row_counts(port, _canary_tables(args))
     return _emit_data_verdict(cache, before_stamp, args, results, implicit)
 
 

--- a/.github/skills/pbip-model-refresh/scripts/refresh_pbip_model.py
+++ b/.github/skills/pbip-model-refresh/scripts/refresh_pbip_model.py
@@ -92,7 +92,15 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 # ruff: noqa: E402  (the sys.path insert above must precede this import)
 # pylint: disable=wrong-import-position
-from probe_desktop_query import AUTO_DATE_TABLE_PREFIXES, _load_adomd, discover_port, first_table, table_names
+from probe_desktop_query import (
+    AUTO_DATE_TABLE_PREFIXES,
+    _load_adomd,
+    column_names,
+    discover_port,
+    first_table,
+    measure_names,
+    table_names,
+)
 
 SAVE_SETTLE_SECONDS = 3
 SAVE_TIMEOUT_SECONDS = 120
@@ -120,8 +128,20 @@ REFRESH_WALL_CLOCK_GRACE_SECONDS = 30
 # A TMDL table declaration sits at column 0 of `definition/tables/<Name>.tmdl`; the name is quoted
 # only when it needs to be (spaces, punctuation), so both forms have to be accepted.
 TABLE_DECL_RE = re.compile(r"^table\s+(?:'([^']+)'|(\S+))", re.MULTILINE)
+# A column/measure declaration sits INDENTED under its table, and is quoted only when it must be.
+# The unquoted branch stops at whitespace OR `=`, so a calculated column/measure (`column 'X' = expr`
+# or `measure Total = SUM(...)`) yields just the name, never the expression that follows.
+COLUMN_DECL_RE = re.compile(r"^\s*column\s+(?:'([^']+)'|([^=\s]+))", re.MULTILINE)
+MEASURE_DECL_RE = re.compile(r"^\s*measure\s+(?:'([^']+)'|([^=\s]+))", re.MULTILINE)
 GENERATED_ARTIFACTS_KEY = "generated_artifacts"
 GENERATED_EDIT_DECLARATIONS = Path("_build") / "generated-edit-declarations.json"
+
+# A persisted `cache.abf` is an Analysis Services backup, which is a Microsoft Compound File Binary
+# (OLE2) container - it always begins with this 8-byte signature and is at least one 512-byte CFBF
+# header. Verifying that before swapping a staged file over a good cache is what stops a truncated or
+# interrupted write from being mistaken for a real one and destroying the existing cache (#113).
+_CFBF_MAGIC = b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1"
+_CFBF_HEADER_BYTES = 512
 
 # The credential arbiter that settles a refresh TIMEOUT (slow source vs. sign-in modal). Resolved
 # relative to THIS file so the runtime recovery instruction always points at the copy that ships
@@ -429,62 +449,116 @@ def _compat_rollback_paths(model_dir: Path | None) -> list[Path]:
     return paths
 
 
+def _is_complete_abf(path: Path) -> bool:
+    """Is `path` a fully-written cache.abf, not a truncated or partial one?
+
+    A cache.abf is an Analysis Services backup, i.e. a Microsoft Compound File Binary (OLE2)
+    container, so a complete one begins with `_CFBF_MAGIC` and is at least one CFBF header
+    (`_CFBF_HEADER_BYTES`). This is a NECESSARY, cheap check, not a full parse: paired with only
+    suppressing the one benign AMO exception (`_is_benign_imagesave_response_error`), it keeps a
+    disk-full or interrupted write from replacing a good cache with rubble (#113). It stays
+    conservative - rejecting a VALID cache would be worse than the bug - so it checks only the
+    signature and a minimum size, never an exact length or sector alignment.
+    """
+    try:
+        with path.open("rb") as handle:
+            head = handle.read(len(_CFBF_MAGIC))
+        return head == _CFBF_MAGIC and path.stat().st_size >= _CFBF_HEADER_BYTES
+    except OSError:
+        return False
+
+
+def _is_benign_imagesave_response_error(exc: BaseException) -> bool:
+    """AMO's ImageSave raises even after a fully correct write - only THAT error is benign.
+
+    Measured: the client throws "The server sent an unrecognizable response" while the backup is
+    written correctly, so a save cannot be judged by the absence of an exception. But every OTHER
+    failure (disk full, permission denied, the stream closing mid-write) MUST propagate, or a partial
+    write is mistaken for success and destroys the existing cache - the precise #113 defect. Matching
+    only the known message fails SAFE if the wording ever changes: a real write is treated as failed
+    (the pipeline falls back to the UI save), never a partial write treated as a success.
+    """
+    return "unrecognizable response" in str(exc).lower()
+
+
 def _staged_image_write(cache_path: Path, write_image) -> bool:
-    """Write the cache to a staging file and swap it in atomically. Returns True on a real write.
+    """Write the cache to a staging file and swap it in atomically. Returns True only on a COMPLETE write.
 
-    ``FileMode.Create`` on the live ``cache.abf`` truncates a good cache the instant the write
-    begins, so an ImageSave that then fails half way leaves the project WORSE than before -- no
-    fresh cache and no old one either. Staging to ``cache.abf.tmp`` and only ``os.replace``-ing it
-    over the original once it exists and is non-empty means a failed or partial write cannot destroy
-    an existing good cache.
-
-    Success is judged by the staged FILE, never by the absence of an exception: the AMO client
-    raises "The server sent an unrecognizable response" *while writing correctly*, so ``write_image``
-    is allowed to raise, and a raise with a non-empty staging file still counts as a write.
+    `FileMode.Create` on the live `cache.abf` truncates a good cache the instant the write begins, so
+    an ImageSave that then fails half way leaves the project WORSE than before -- no fresh cache and
+    no old one. Staging to `cache.abf.tmp` and only `os.replace`-ing it over the original once it is a
+    COMPLETE backup means a failed or partial write cannot destroy an existing good cache. Two rules
+    make "complete" mean what it says (#113): `write_image` is expected NOT to raise (`image_save`
+    absorbs the one benign AMO error and re-raises everything else), so any exception reaching here --
+    including from `os.replace` -- is a REAL failure that PROPAGATES after the staging file is removed,
+    letting the caller roll the compatibility bump back; and even on a clean return the staged file
+    must look like a backup (`_is_complete_abf`) before it is swapped in.
     """
     cache_path.parent.mkdir(parents=True, exist_ok=True)
     staging = cache_path.with_name(cache_path.name + ".tmp")
     if staging.exists():
         staging.unlink()
+    swapped = False
     try:
         write_image(staging)
-    except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught
-        # The write is judged by the file below, not by whether the call raised.
-        del exc
-    if staging.exists() and staging.stat().st_size > 0:
-        os.replace(staging, cache_path)
-        return True
-    if staging.exists():
-        staging.unlink()
-    return False
+        if _is_complete_abf(staging):
+            os.replace(staging, cache_path)
+            swapped = True
+    finally:
+        # Never leave a partial cache.abf.tmp behind. `finally` does not suppress the exception, so a
+        # real write/replace error still propagates to _persist_image, which rolls the compat back.
+        if not swapped and staging.exists():
+            staging.unlink()
+    return swapped
 
 
-def _persist_image(cache_path: Path, model_dir: Path | None, live_level: int, write_image) -> tuple[bool, str]:
-    """Align compat, stage the cache write, swap atomically, and roll compat back if the write fails.
-
-    Pure-Python (no .NET), so the atomic-write and rollback guarantees are unit-testable without a
-    live Analysis Services instance. ``write_image(staging_path)`` performs the actual engine write.
-    """
-    rollback_paths = _compat_rollback_paths(model_dir)
-    snapshot = {path: (path.read_bytes() if path.exists() else None) for path in rollback_paths}
-
-    aligned = _align_compatibility(model_dir, live_level)
-    if aligned:
-        print(f"  save   : {aligned}")
-
-    if _staged_image_write(cache_path, write_image):
-        size_kb = cache_path.stat().st_size / 1024
-        return True, f"persisted via AMO ImageSave ({size_kb:.1f} KB, compatibilityLevel {live_level})"
-
-    # The write did not land: undo the (provisional) compatibility alignment so a failed persist
-    # cannot leave database.tmdl declaring a level that was never actually written to a cache.
+def _restore_rollback_snapshot(snapshot: dict[Path, bytes | None]) -> None:
+    """Restore each snapshotted path to exactly its pre-alignment state (bytes, or absence)."""
     for path, original in snapshot.items():
         if original is None:
             if path.exists():
                 path.unlink()
-        elif path.read_bytes() != original:
+        elif not path.exists() or path.read_bytes() != original:
             path.write_bytes(original)
-    return False, "ImageSave did not produce a cache file (compatibility alignment rolled back)"
+
+
+def _persist_image(cache_path: Path, model_dir: Path | None, live_level: int, write_image) -> tuple[bool, str]:
+    """Align compat, stage the cache write, swap atomically, and roll compat back UNLESS it committed.
+
+    Pure-Python (no .NET), so the atomic-write and rollback guarantees are unit-testable without a
+    live Analysis Services instance. ``write_image(staging_path)`` performs the actual engine write.
+
+    The whole align -> write -> replace sequence is wrapped so the compatibility bump is provisional:
+    it is kept ONLY if the cache was definitively committed. The rollback therefore runs on the clean
+    "write did not land" return AND on any exception raised along the way -- a stale-temp unlink, a
+    ``stat()``, or a Windows ``os.replace`` that raises ``PermissionError`` because the cache is
+    locked. Before this was a ``finally`` the rollback ran only on the ``False`` return, so an
+    exception left ``database.tmdl`` bumped for a cache that was never written, and the caller carried
+    that state into the UI Save (#113, round-2 blocker 2).
+    """
+    rollback_paths = _compat_rollback_paths(model_dir)
+    snapshot = {path: (path.read_bytes() if path.exists() else None) for path in rollback_paths}
+    committed = False
+    try:
+        aligned = _align_compatibility(model_dir, live_level)
+        if aligned:
+            print(f"  save   : {aligned}")
+
+        committed = _staged_image_write(cache_path, write_image)
+        if committed:
+            # The cache is written and swapped in; a post-commit stat failure must NOT undo it, so the
+            # size note is best-effort and never flips `committed` back to False.
+            try:
+                size_note = f"{cache_path.stat().st_size / 1024:.1f} KB, "
+            except OSError:
+                size_note = ""
+            return True, f"persisted via AMO ImageSave ({size_note}compatibilityLevel {live_level})"
+        return False, "ImageSave did not produce a complete cache file (compatibility alignment rolled back)"
+    finally:
+        # Undo the (provisional) alignment unless the cache actually committed. A failed persist must
+        # never leave database.tmdl declaring a level that was never written to a cache.
+        if not committed:
+            _restore_rollback_snapshot(snapshot)
 
 
 def image_save(port: int, cache_path: Path, model_dir: Path | None = None):
@@ -524,9 +598,13 @@ def image_save(port: int, cache_path: Path, model_dir: Path | None = None):
             try:
                 server.ImageSave(database.ID, stream)
             except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught
-                # Expected: the response parser trips even on a successful write. The staged-file
-                # check in _staged_image_write is the real evidence.
-                del exc
+                # AMO's response parser trips even on a fully correct write, so ONLY that specific
+                # error is swallowed; the staged-file check in _staged_image_write is the real
+                # evidence. Every other failure (disk full, permission, the stream dying mid-write)
+                # is re-raised so a partial write cannot be mistaken for a success and overwrite the
+                # existing good cache (#113).
+                if not _is_benign_imagesave_response_error(exc):
+                    raise
             finally:
                 stream.Close()
 
@@ -639,10 +717,13 @@ def cache_file(pid: int) -> Path | None:
     globbing for one returned None and silently sent the save down the UI-Automation fallback.
 
     When a folder holds several `.SemanticModel` directories the model is resolved from the PBIP
-    BINDING (the `.pbip` -> report -> `definition.pbir` `byPath` chain), then by an exact name match,
-    and otherwise this returns None so the identity gate fails closed. The old `models[0]` fallback
-    silently bound the run to an arbitrary sibling model - exactly the wrong-instance write this
-    skill exists to prevent.
+    BINDING (the `.pbip` -> report -> `definition.pbir` `byPath` chain) FIRST, because that is the
+    authoritative statement of which model the `.pbip` opens. Only if the binding cannot be read is
+    an exact stem match used as a weaker fallback, and otherwise this returns None so the identity
+    gate fails closed. The order matters: consulting the name first let a same-named sibling shadow
+    the model the binding actually points at (#114, round-2 blocker 3a), and the old `models[0]`
+    fallback silently bound the run to an arbitrary sibling - the wrong-instance write this exists to
+    prevent.
     """
     inst = _instance(pid)
     if inst is None or not inst.get("currentFilePath"):
@@ -653,13 +734,17 @@ def cache_file(pid: int) -> Path | None:
         return None
     if len(models) == 1:
         return models[0] / ".pbi" / "cache.abf"
+    # Authoritative: follow the .pbip -> report -> definition.pbir byPath binding.
+    bound = _model_from_pbip_binding(pbip, models)
+    if bound is not None:
+        return bound / ".pbi" / "cache.abf"
+    # Only when the binding is unreadable/absent: fall back to an exact stem match. This is a weaker
+    # heuristic and must NEVER run ahead of the binding, or a same-named sibling shadows the model
+    # the .pbip actually opens.
     stem = pbip.stem.lower()
     by_name = [model for model in models if model.stem.lower() == stem]
     if len(by_name) == 1:
         return by_name[0] / ".pbi" / "cache.abf"
-    bound = _model_from_pbip_binding(pbip, models)
-    if bound is not None:
-        return bound / ".pbi" / "cache.abf"
     # Ambiguous, and no binding resolved it: refuse to guess. Returning None makes the identity gate
     # fail closed rather than persist into whichever sibling happened to sort first.
     return None
@@ -694,6 +779,81 @@ def _live_tables(port: int) -> set[str]:
         conn.Close()
 
 
+def tmdl_columns_measures(model_dir: Path) -> tuple[set[tuple[str, str]], set[tuple[str, str]]]:
+    """`(table, column)` and `(table, measure)` pairs declared by the TMDL on disk.
+
+    The finer half of the identity fingerprint: two models can share table names but differ in their
+    columns or measures, and a table-only match would confirm the wrong one (#114, round-2 blocker
+    3). Each `tables/<Name>.tmdl` declares exactly one table, so its name scopes every column/measure
+    in the file; auto date-table files are skipped to mirror the live-side filter.
+    """
+    definition = model_dir / "definition"
+    columns: set[tuple[str, str]] = set()
+    measures: set[tuple[str, str]] = set()
+    for tmdl in sorted(definition.glob("tables/*.tmdl")):
+        text = tmdl.read_text(encoding="utf-8-sig", errors="replace")
+        decl = TABLE_DECL_RE.search(text)
+        if not decl:
+            continue
+        table = decl.group(1) or decl.group(2)
+        if table.startswith(AUTO_DATE_TABLE_PREFIXES):
+            continue
+        columns.update((table, quoted or bare) for quoted, bare in COLUMN_DECL_RE.findall(text))
+        measures.update((table, quoted or bare) for quoted, bare in MEASURE_DECL_RE.findall(text))
+    return columns, measures
+
+
+def _live_columns_measures(port: int) -> tuple[set[tuple[str, str]], set[tuple[str, str]]]:
+    """`(table, column)` and `(table, measure)` pairs in the model currently served on `port`.
+
+    Auto-generated columns (RowNumber, and the auto date/time scaffolding) are filtered inside
+    `column_names`/`measure_names` so the live side compares like-for-like with the TMDL on disk.
+    """
+    adomd_connection = _load_adomd()
+    conn = adomd_connection(f"Data Source=localhost:{port}")
+    conn.Open()
+    try:
+        return column_names(conn), measure_names(conn)
+    finally:
+        conn.Close()
+
+
+def _first_schema_difference(kind: str, on_disk: set[tuple[str, str]], live: set[tuple[str, str]]) -> str | None:
+    """Compare two `(table, name)` sets case-insensitively; return a message if they differ, else None.
+
+    Pure and .NET-free so the exact-match rule is unit-testable. Names are compared case-folded (the
+    engine and TMDL can disagree only on case), and the message names a few offenders from each side
+    so a refusal is diagnosable rather than a bare mismatch.
+    """
+    disk_fold = {(table.casefold(), name.casefold()) for table, name in on_disk}
+    live_fold = {(table.casefold(), name.casefold()) for table, name in live}
+    missing = sorted(
+        f"{table}[{name}]" for table, name in on_disk if (table.casefold(), name.casefold()) not in live_fold
+    )
+    extra = sorted(f"{table}[{name}]" for table, name in live if (table.casefold(), name.casefold()) not in disk_fold)
+    if not missing and not extra:
+        return None
+    return (
+        f"{len(missing)} TMDL {kind}(s) absent from the connected model (e.g. {missing[:3]}), "
+        f"{len(extra)} connected {kind}(s) not in the TMDL (e.g. {extra[:3]})"
+    )
+
+
+def _first_table_difference(on_disk: set[str], live: set[str]) -> str | None:
+    """Compare table-name sets case-insensitively; return the WRONG_MODEL reason, or None if equal."""
+    disk_fold = {name.casefold() for name in on_disk}
+    live_fold = {name.casefold() for name in live}
+    missing = sorted(name for name in on_disk if name.casefold() not in live_fold)
+    extra = sorted(name for name in live if name.casefold() not in disk_fold)
+    if not missing and not extra:
+        return None
+    return (
+        f"{len(missing)} TMDL table(s) absent from the connected model (e.g. {missing[:3]}), "
+        f"{len(extra)} connected table(s) not in the TMDL (e.g. {extra[:3]}) - "
+        "an exact table-for-table match is required"
+    )
+
+
 def same_model(port: int, cache_path: Path | None) -> tuple[bool, str]:
     """Is the model served on `port` the one that owns `cache_path`? Returns (ok, message).
 
@@ -708,13 +868,15 @@ def same_model(port: int, cache_path: Path | None) -> tuple[bool, str]:
     not the same answer, and this gate guards a write into another migration's project. It used to
     return True ("unverified") in both cases and let the write through.
 
-    **The fingerprint is EXACT, not a subset.** The connected model's tables must equal the TMDL's,
-    table-for-table. The previous check only required the TMDL tables to be PRESENT in the engine,
-    so a sibling with a SUPERSET schema (all your tables plus more) passed and was reported
-    "confirmed" - the precise hole this closes. Concurrent Desktop instances are supported, so that
-    sibling is reachable, not theoretical. Extra live tables now abort with WRONG_MODEL: a properly
-    exported model (finish TMDL edits, then refresh, then save) has no engine-only tables once the
-    auto date-table scaffolding is filtered from both sides.
+    **The fingerprint is EXACT, not a subset, and reaches columns and measures.** The connected
+    model's tables must equal the TMDL's table-for-table, AND its columns and measures must match too.
+    A table-only check confirmed a sibling that shared table names but differed in columns or measures
+    - and once `cache_file`'s binding is authoritative (round-2 blocker 3a) that sibling is reachable
+    on a widened/wrong port, so tables alone are not enough (round-2 blocker 3). Auto-generated
+    columns (the RowNumber index, the auto date/time scaffolding) are FILTERED, not compared, so a
+    legitimate model never fails its own gate over engine-only artifacts. The previous check also only
+    required the TMDL tables to be PRESENT in the engine, so a SUPERSET sibling passed; an exact match
+    now refuses it.
     """
     if cache_path is None:
         return False, "identity UNVERIFIED (no model folder resolved for this pid) - refusing (fail closed)"
@@ -724,19 +886,22 @@ def same_model(port: int, cache_path: Path | None) -> tuple[bool, str]:
         return False, (
             f"identity UNVERIFIED (no TMDL tables under {model_dir / 'definition'}) - refusing (fail closed)"
         )
-    live_names = _live_tables(port)
-    live = {name.casefold() for name in live_names}
-    on_disk_fold = {name.casefold() for name in on_disk}
-    missing = sorted(name for name in on_disk if name.casefold() not in live)
-    extra = sorted(name for name in live_names if name.casefold() not in on_disk_fold)
-    if missing or extra:
-        return False, (
-            f"port {port} does NOT serve {model_dir.name}: "
-            f"{len(missing)} TMDL table(s) absent from the connected model (e.g. {missing[:3]}), "
-            f"{len(extra)} connected table(s) not in the TMDL (e.g. {extra[:3]}) - "
-            "an exact table-for-table match is required"
-        )
-    return True, f"{model_dir.name} confirmed on port {port} ({len(on_disk)} table(s), exact match)"
+    table_diff = _first_table_difference(on_disk, _live_tables(port))
+    if table_diff is not None:
+        return False, f"port {port} does NOT serve {model_dir.name}: {table_diff}"
+    disk_columns, disk_measures = tmdl_columns_measures(model_dir)
+    live_columns, live_measures = _live_columns_measures(port)
+    for kind, on_disk_set, live_set in (
+        ("column", disk_columns, live_columns),
+        ("measure", disk_measures, live_measures),
+    ):
+        difference = _first_schema_difference(kind, on_disk_set, live_set)
+        if difference is not None:
+            return False, f"port {port} does NOT serve {model_dir.name}: {difference} - an exact match is required"
+    return True, (
+        f"{model_dir.name} confirmed on port {port} "
+        f"({len(on_disk)} table(s), {len(disk_columns)} column(s), {len(disk_measures)} measure(s), exact match)"
+    )
 
 
 def row_counts(port: int, tables: list[str] | None) -> tuple[list[tuple[str, int]], bool]:
@@ -807,7 +972,7 @@ def _refresh_and_save(pid: int, port: int, cache: Path | None, args: argparse.Na
                 "    (b) BLOCKED: Desktop is showing a data-source sign-in modal no automation\n"
                 "        can fill. Retrying cannot dismiss it; a human must sign in once.\n"
                 "  SETTLE IT - run the arbiter that ships beside this script, do not guess:\n"
-                f"    powershell -File {CREDENTIAL_PROBE} -DesktopPid {pid}\n"
+                f'    powershell -File "{CREDENTIAL_PROBE}" -DesktopPid {pid}\n'
                 "  A one-row probe bundle narrows this, but does NOT settle it: a probe limited to a\n"
                 "  single row is fast once the source is WARM, yet measured 2026-08-05 a 1-row probe\n"
                 "  against a SUSPENDED Snowflake warehouse took 167 s (vs 21 s against an already\n"

--- a/.github/skills/pbip-model-refresh/scripts/refresh_pbip_model.py
+++ b/.github/skills/pbip-model-refresh/scripts/refresh_pbip_model.py
@@ -2,7 +2,7 @@
 purpose: Refresh a local PBIP model in Power BI Desktop and PERSIST the result, so the next agent
          (and the next Desktop open) sees real data instead of an empty model.
 usage:   python .github/skills/pbip-model-refresh/scripts/refresh_pbip_model.py
-             [--pid <pbidesktop-pid>] [--tables "A" "B"] [--save]
+             [--pid <pbidesktop-pid>] [--tables "A" "B"] [--no-save]
          (ships inside the `pbip-model-refresh` skill; run it by its path from wherever the folder
           was copied. `scripts/refresh_pbip_model.py` in this repo is a forwarding shim.)
 
@@ -63,13 +63,15 @@ then save. Anything that rewrites TMDL afterwards - including the host repo's sa
 Binding to the right instance (parallel batches)
 ------------------------------------------------
 The destination is resolved from the pid (`cache_file`), but the DATA comes from whatever Analysis
-Services instance answers on `port`. If those two ever disagree - one bad `--port`, or a widened
-port lookup - this writes a **sibling migration's model into your own correct `cache.abf`**, and
-nothing catches it: `image_save` can only check that the file exists, is non-empty and is newly
-written, and `row_count` queries that same wrong port, so both signals agree and both are wrong.
-Hence `same_model()` runs FIRST, before the refresh: it compares the connected model's tables with
-the TMDL that owns the destination cache, and a mismatch aborts with `REFRESH: WRONG_MODEL`. File
-metadata fundamentally cannot tell you whose rows are in the blob; only the model's own contents can.
+Services instance answers on `port`. If those two ever disagree - a widened port lookup, or a
+`--port` pointed at another instance - this would write a **sibling migration's model into your own
+correct `cache.abf`**, and file metadata could not catch it: `image_save` can only check that the
+file exists, is non-empty and is newly written, and `row_counts` queries that same wrong port, so
+both signals agree and both are wrong. Two defences run BEFORE the refresh: `--port`, if given, must
+equal the port derived from the pid (a mismatch aborts, so it can never bypass pid-based discovery),
+and `same_model()` compares the connected model's tables with the TMDL that owns the destination
+cache and aborts on any difference with `REFRESH: WRONG_MODEL`. File metadata fundamentally cannot
+tell you whose rows are in the blob; only the model's own contents can.
 """
 
 from __future__ import annotations
@@ -120,6 +122,11 @@ REFRESH_WALL_CLOCK_GRACE_SECONDS = 30
 TABLE_DECL_RE = re.compile(r"^table\s+(?:'([^']+)'|(\S+))", re.MULTILINE)
 GENERATED_ARTIFACTS_KEY = "generated_artifacts"
 GENERATED_EDIT_DECLARATIONS = Path("_build") / "generated-edit-declarations.json"
+
+# The credential arbiter that settles a refresh TIMEOUT (slow source vs. sign-in modal). Resolved
+# relative to THIS file so the runtime recovery instruction always points at the copy that ships
+# INSIDE the bundle - it must not name a path that only exists in the host repo (issue #118).
+CREDENTIAL_PROBE = Path(__file__).resolve().parent / "probe_desktop_credential.ps1"
 
 
 def _catalog_id(conn) -> str:
@@ -370,7 +377,7 @@ def align_declared_compatibility(path: Path, level: int) -> None:
     path.write_text(new_text, encoding="utf-8", newline="")
 
 
-def _align_compatibility(database, model_dir: Path | None) -> str | None:
+def _align_compatibility(model_dir: Path | None, live_level: int) -> str | None:
     """Make ``database.tmdl`` declare the level the live database is actually running at.
 
     Returns a note describing the change, or ``None`` when nothing needed doing.
@@ -381,10 +388,13 @@ def _align_compatibility(database, model_dir: Path | None) -> str | None:
     (measured: `1604 -> 1606` written at the same timestamp as `cache.abf`). An earlier version made
     it opt-in behind `--align-compat`; that was ceremony rather than safety, since the only response
     to the refusal is to re-run with the flag.
+
+    The edit is written eagerly, but the caller (:func:`_persist_image`) treats it as **provisional**:
+    it snapshots the files this can touch first and rolls them back if the ImageSave that follows
+    fails, so a mid-failure never leaves ``database.tmdl`` bumped for a cache that was not written.
     """
     if model_dir is None:
         return None
-    live_level = int(database.CompatibilityLevel)
     declared, declared_path = read_declared_compatibility(model_dir)
     if declared is None or declared == live_level:
         return None
@@ -403,6 +413,80 @@ def _align_compatibility(database, model_dir: Path | None) -> str | None:
     return f"aligned {declared_path.name} {declared} -> {live_level} (Desktop runs the model at {live_level})"
 
 
+def _compat_rollback_paths(model_dir: Path | None) -> list[Path]:
+    """The files an alignment can touch, so a failed persist can restore them exactly.
+
+    Two files: ``database.tmdl`` (its declared level) and the generated-edit declaration ledger
+    (``_build/generated-edit-declarations.json``). Rolling the level back without also dropping the
+    declaration would leave a record of a change that did not stick.
+    """
+    if model_dir is None:
+        return []
+    paths = [model_dir / "definition" / "database.tmdl"]
+    bundle = _bundle_root_for(model_dir)
+    if bundle is not None:
+        paths.append(bundle / GENERATED_EDIT_DECLARATIONS)
+    return paths
+
+
+def _staged_image_write(cache_path: Path, write_image) -> bool:
+    """Write the cache to a staging file and swap it in atomically. Returns True on a real write.
+
+    ``FileMode.Create`` on the live ``cache.abf`` truncates a good cache the instant the write
+    begins, so an ImageSave that then fails half way leaves the project WORSE than before -- no
+    fresh cache and no old one either. Staging to ``cache.abf.tmp`` and only ``os.replace``-ing it
+    over the original once it exists and is non-empty means a failed or partial write cannot destroy
+    an existing good cache.
+
+    Success is judged by the staged FILE, never by the absence of an exception: the AMO client
+    raises "The server sent an unrecognizable response" *while writing correctly*, so ``write_image``
+    is allowed to raise, and a raise with a non-empty staging file still counts as a write.
+    """
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    staging = cache_path.with_name(cache_path.name + ".tmp")
+    if staging.exists():
+        staging.unlink()
+    try:
+        write_image(staging)
+    except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught
+        # The write is judged by the file below, not by whether the call raised.
+        del exc
+    if staging.exists() and staging.stat().st_size > 0:
+        os.replace(staging, cache_path)
+        return True
+    if staging.exists():
+        staging.unlink()
+    return False
+
+
+def _persist_image(cache_path: Path, model_dir: Path | None, live_level: int, write_image) -> tuple[bool, str]:
+    """Align compat, stage the cache write, swap atomically, and roll compat back if the write fails.
+
+    Pure-Python (no .NET), so the atomic-write and rollback guarantees are unit-testable without a
+    live Analysis Services instance. ``write_image(staging_path)`` performs the actual engine write.
+    """
+    rollback_paths = _compat_rollback_paths(model_dir)
+    snapshot = {path: (path.read_bytes() if path.exists() else None) for path in rollback_paths}
+
+    aligned = _align_compatibility(model_dir, live_level)
+    if aligned:
+        print(f"  save   : {aligned}")
+
+    if _staged_image_write(cache_path, write_image):
+        size_kb = cache_path.stat().st_size / 1024
+        return True, f"persisted via AMO ImageSave ({size_kb:.1f} KB, compatibilityLevel {live_level})"
+
+    # The write did not land: undo the (provisional) compatibility alignment so a failed persist
+    # cannot leave database.tmdl declaring a level that was never actually written to a cache.
+    for path, original in snapshot.items():
+        if original is None:
+            if path.exists():
+                path.unlink()
+        elif path.read_bytes() != original:
+            path.write_bytes(original)
+    return False, "ImageSave did not produce a cache file (compatibility alignment rolled back)"
+
+
 def image_save(port: int, cache_path: Path, model_dir: Path | None = None):
     """Persist the in-memory model to ``<Name>.SemanticModel/.pbi/cache.abf`` via AMO ``ImageSave``.
 
@@ -417,44 +501,38 @@ def image_save(port: int, cache_path: Path, model_dir: Path | None = None):
 
     ⚠️ **Saving therefore EDITS the deployable artifact.** ``database.tmdl`` is part of what gets
     deployed, and this raises its declared level. If a downstream target cannot accept the higher
-    level, do not pass ``--save`` -- the default (refresh in memory, persist nothing) exists exactly
-    for the validate-then-deploy path, and leaves the project byte-identical.
+    level, pass ``--no-save`` -- refresh-in-memory-persist-nothing exists exactly for the
+    validate-then-deploy path, and leaves the project byte-identical.
 
-    Note the client throws "The server sent an unrecognizable response" while writing correctly, so
-    success is judged by the FILE (exists, non-empty, newly written), never by the absence of an
-    exception.
+    The write is **staged and swapped atomically** and the compatibility alignment is **rolled back
+    on failure** (see :func:`_persist_image` / :func:`_staged_image_write`), so a mid-failure can
+    neither destroy an existing good cache nor leave ``database.tmdl`` bumped for a cache that was
+    never written. Note the client throws "The server sent an unrecognizable response" while writing
+    correctly, so success is judged by the FILE, never by the absence of an exception.
     """
     server_type = _load_amo()
     from System.IO import FileAccess, FileMode, FileStream  # noqa: PLC0415  # pylint: disable=import-outside-toplevel,import-error
-
-    cache_path.parent.mkdir(parents=True, exist_ok=True)
-    before = cache_path.stat().st_mtime if cache_path.exists() else 0.0
 
     server = server_type()
     server.Connect(f"Data Source=localhost:{port}")
     try:
         database = server.Databases[0]
         live_level = int(database.CompatibilityLevel)
-        aligned = _align_compatibility(database, model_dir)
-        if aligned:
-            print(f"  save   : {aligned}")
 
-        stream = FileStream(str(cache_path), FileMode.Create, FileAccess.Write)
-        try:
-            server.ImageSave(database.ID, stream)
-        except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught
-            # Expected: the response parser trips even on a successful write. Fall through to the
-            # file check, which is the real evidence.
-            del exc
-        finally:
-            stream.Close()
+        def write_image(staging: Path) -> None:
+            stream = FileStream(str(staging), FileMode.Create, FileAccess.Write)
+            try:
+                server.ImageSave(database.ID, stream)
+            except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught
+                # Expected: the response parser trips even on a successful write. The staged-file
+                # check in _staged_image_write is the real evidence.
+                del exc
+            finally:
+                stream.Close()
+
+        return _persist_image(cache_path, model_dir, live_level, write_image)
     finally:
         server.Disconnect()
-
-    if cache_path.exists() and cache_path.stat().st_size > 0 and cache_path.stat().st_mtime > before:
-        size_kb = cache_path.stat().st_size / 1024
-        return True, f"persisted via AMO ImageSave ({size_kb:.1f} KB, compatibilityLevel {live_level})"
-    return False, "ImageSave did not produce a cache file"
 
 
 def save(pid: int) -> tuple[bool, str]:
@@ -513,11 +591,58 @@ Write-Output 'NO_INVOKABLE_SAVE'; exit 1
     )
 
 
+def _model_from_pbip_binding(pbip: Path, models: list[Path]) -> Path | None:
+    """The `.SemanticModel` a `.pbip` actually binds to, read from the binding, not guessed.
+
+    A `.pbip` names its report; the report's `definition.pbir` names the model by a relative
+    `datasetReference.byPath.path`. Following that chain identifies the owning model even when a
+    folder holds several `.SemanticModel` directories. Returns None when the binding cannot be read
+    unambiguously - the caller then fails closed rather than guessing `models[0]`.
+    """
+    report_dirs: list[Path] = []
+    try:
+        pbip_data = json.loads(pbip.read_text(encoding="utf-8-sig"))
+    except (OSError, json.JSONDecodeError):
+        pbip_data = None
+    if isinstance(pbip_data, dict):
+        for artifact in pbip_data.get("artifacts", []) or []:
+            report = artifact.get("report") if isinstance(artifact, dict) else None
+            rel = report.get("path") if isinstance(report, dict) else None
+            if rel:
+                report_dirs.append(pbip.parent / rel)
+    if not report_dirs:
+        report_dirs = [pbir.parent for pbir in pbip.parent.glob("*.Report")]
+
+    matches: set[Path] = set()
+    model_by_resolved = {model.resolve(): model for model in models}
+    for report_dir in report_dirs:
+        pbir = report_dir / "definition.pbir"
+        try:
+            data = json.loads(pbir.read_text(encoding="utf-8-sig"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        by_path = (((data.get("datasetReference") or {}).get("byPath")) or {}).get("path")
+        if not by_path:
+            continue
+        target = (pbir.parent / by_path).resolve()
+        if target in model_by_resolved:
+            matches.add(target)
+    if len(matches) == 1:
+        return model_by_resolved[matches.pop()]
+    return None
+
+
 def cache_file(pid: int) -> Path | None:
     """Where `<Name>.SemanticModel/.pbi/cache.abf` belongs for the model this instance has open.
 
     Resolves the DESTINATION, not an existing file: on a first build there is no cache yet, and
     globbing for one returned None and silently sent the save down the UI-Automation fallback.
+
+    When a folder holds several `.SemanticModel` directories the model is resolved from the PBIP
+    BINDING (the `.pbip` -> report -> `definition.pbir` `byPath` chain), then by an exact name match,
+    and otherwise this returns None so the identity gate fails closed. The old `models[0]` fallback
+    silently bound the run to an arbitrary sibling model - exactly the wrong-instance write this
+    skill exists to prevent.
     """
     inst = _instance(pid)
     if inst is None or not inst.get("currentFilePath"):
@@ -526,10 +651,18 @@ def cache_file(pid: int) -> Path | None:
     models = sorted(pbip.parent.glob("*.SemanticModel"))
     if not models:
         return None
-    # Prefer the model matching the .pbip name when a folder holds several.
+    if len(models) == 1:
+        return models[0] / ".pbi" / "cache.abf"
     stem = pbip.stem.lower()
-    chosen = next((m for m in models if m.stem.lower() == stem), models[0])
-    return chosen / ".pbi" / "cache.abf"
+    by_name = [model for model in models if model.stem.lower() == stem]
+    if len(by_name) == 1:
+        return by_name[0] / ".pbi" / "cache.abf"
+    bound = _model_from_pbip_binding(pbip, models)
+    if bound is not None:
+        return bound / ".pbi" / "cache.abf"
+    # Ambiguous, and no binding resolved it: refuse to guess. Returning None makes the identity gate
+    # fail closed rather than persist into whichever sibling happened to sort first.
+    return None
 
 
 def tmdl_tables(model_dir: Path) -> set[str]:
@@ -537,8 +670,8 @@ def tmdl_tables(model_dir: Path) -> set[str]:
 
     `utf-8-sig` and the auto date-table filter both matter to the *gate*, not just to tidiness:
     Desktop writes TMDL with a BOM, and a BOM immediately followed by the declaration would make
-    `^table` miss every file - leaving an empty fingerprint, which `same_model` reports as
-    "unverified" and lets through. Auto date tables are serialized into `tables/` when auto
+    `^table` miss every file - leaving an empty fingerprint, which `same_model` treats as
+    unverifiable and (now) REFUSES. Auto date tables are serialized into `tables/` when auto
     date/time is (or ever was) on, and they are filtered out of the live side, so leaving them here
     would make every such model look like a stranger.
     """
@@ -570,50 +703,70 @@ def same_model(port: int, cache_path: Path | None) -> tuple[bool, str]:
     (file exists, non-empty, mtime advanced, row count) agrees with it, because they all read the
     same wrong source. Comparing the model's own tables is what breaks that self-consistency.
 
-    Extra tables in the engine are fine (a field parameter added in-memory, or anything the caller
-    has not exported yet) and are only reported, since TMDL that lags the engine is worth knowing
-    about. A TMDL table MISSING from the engine is not: either this is a different model, or the
-    definition on disk changed after Desktop opened it - and Desktop discards a cache that is older
-    than the definition, so persisting then would be pointless anyway.
+    **Fails CLOSED.** Whenever identity cannot be established - no model folder resolved, or no TMDL
+    tables to fingerprint - this returns False, because "I could not verify" and "it is fine" are
+    not the same answer, and this gate guards a write into another migration's project. It used to
+    return True ("unverified") in both cases and let the write through.
+
+    **The fingerprint is EXACT, not a subset.** The connected model's tables must equal the TMDL's,
+    table-for-table. The previous check only required the TMDL tables to be PRESENT in the engine,
+    so a sibling with a SUPERSET schema (all your tables plus more) passed and was reported
+    "confirmed" - the precise hole this closes. Concurrent Desktop instances are supported, so that
+    sibling is reachable, not theoretical. Extra live tables now abort with WRONG_MODEL: a properly
+    exported model (finish TMDL edits, then refresh, then save) has no engine-only tables once the
+    auto date-table scaffolding is filtered from both sides.
     """
     if cache_path is None:
-        return True, "identity unverified (no model folder resolved for this pid)"
+        return False, "identity UNVERIFIED (no model folder resolved for this pid) - refusing (fail closed)"
     model_dir = cache_path.parent.parent
     on_disk = tmdl_tables(model_dir)
     if not on_disk:
-        return True, f"identity unverified (no TMDL tables under {model_dir / 'definition'})"
-    live = {name.casefold() for name in _live_tables(port)}
-    missing = sorted(name for name in on_disk if name.casefold() not in live)
-    if missing:
         return False, (
-            f"port {port} does NOT serve {model_dir.name}: {len(missing)}/{len(on_disk)} of its TMDL "
-            f"tables are absent from the connected model (e.g. {missing[:3]})"
+            f"identity UNVERIFIED (no TMDL tables under {model_dir / 'definition'}) - refusing (fail closed)"
         )
-    extra = len(live) - len(on_disk)
-    note = f", engine has {extra} more not in TMDL" if extra > 0 else ""
-    return True, f"{model_dir.name} confirmed on port {port} ({len(on_disk)} TMDL table(s) present{note})"
+    live_names = _live_tables(port)
+    live = {name.casefold() for name in live_names}
+    on_disk_fold = {name.casefold() for name in on_disk}
+    missing = sorted(name for name in on_disk if name.casefold() not in live)
+    extra = sorted(name for name in live_names if name.casefold() not in on_disk_fold)
+    if missing or extra:
+        return False, (
+            f"port {port} does NOT serve {model_dir.name}: "
+            f"{len(missing)} TMDL table(s) absent from the connected model (e.g. {missing[:3]}), "
+            f"{len(extra)} connected table(s) not in the TMDL (e.g. {extra[:3]}) - "
+            "an exact table-for-table match is required"
+        )
+    return True, f"{model_dir.name} confirmed on port {port} ({len(on_disk)} table(s), exact match)"
 
 
-def row_count(port: int) -> tuple[int, str]:
-    """Rows in the first queryable table - the gate of record.
+def row_counts(port: int, tables: list[str] | None) -> tuple[list[tuple[str, int]], bool]:
+    """Row counts per canary table - the gate of record. Returns (results, implicit).
 
     A refresh that "succeeded" but returns no rows is not a refresh; only data proves the source was
-    reachable, the credential worked and the M was valid.
+    reachable, the credential worked and the M was valid. With explicit `tables` (one canary per
+    distinct source), every source is asserted, so an all-non-zero result justifies a model-level
+    verdict. With no tables the first queryable table is probed and ``implicit`` is True - that is a
+    single-table probe, NOT a model-level guarantee: a static parameter/CSV table can return rows
+    while a live source never loaded. The caller downgrades the verdict wording accordingly.
     """
     adomd_connection = _load_adomd()
     conn = adomd_connection(f"Data Source=localhost:{port}")
     conn.Open()
     try:
-        table = first_table(conn)
-        cmd = conn.CreateCommand()
-        cmd.CommandText = f"EVALUATE ROW(\"n\", COUNTROWS('{table}'))"
-        reader = cmd.ExecuteReader()
-        rows = 0
-        while reader.Read():
-            value = reader.GetValue(0)
-            rows = int(value) if value is not None else 0
-        reader.Close()
-        return rows, table
+        implicit = not tables
+        targets = list(tables) if tables else [first_table(conn)]
+        results: list[tuple[str, int]] = []
+        for table in targets:
+            cmd = conn.CreateCommand()
+            cmd.CommandText = f"EVALUATE ROW(\"n\", COUNTROWS('{table}'))"
+            reader = cmd.ExecuteReader()
+            rows = 0
+            while reader.Read():
+                value = reader.GetValue(0)
+                rows = int(value) if value is not None else 0
+            reader.Close()
+            results.append((table, rows))
+        return results, implicit
     finally:
         conn.Close()
 
@@ -653,8 +806,8 @@ def _refresh_and_save(pid: int, port: int, cache: Path | None, args: argparse.Na
                 "        do NOT simply wait longer.\n"
                 "    (b) BLOCKED: Desktop is showing a data-source sign-in modal no automation\n"
                 "        can fill. Retrying cannot dismiss it; a human must sign in once.\n"
-                "  SETTLE IT - run the arbiter, do not guess:\n"
-                f"    powershell -File scripts/probe_desktop_credential.ps1 -DesktopPid {pid}\n"
+                "  SETTLE IT - run the arbiter that ships beside this script, do not guess:\n"
+                f"    powershell -File {CREDENTIAL_PROBE} -DesktopPid {pid}\n"
                 "  A one-row probe bundle narrows this, but does NOT settle it: a probe limited to a\n"
                 "  single row is fast once the source is WARM, yet measured 2026-08-05 a 1-row probe\n"
                 "  against a SUSPENDED Snowflake warehouse took 167 s (vs 21 s against an already\n"
@@ -735,8 +888,8 @@ def _identity_gate(port: int, cache_path: Path | None) -> bool:
     return ok
 
 
-def main(argv: list[str] | None = None) -> int:
-    """CLI entry point: refresh, save, and prove data is really there."""
+def _build_arg_parser() -> argparse.ArgumentParser:
+    """The CLI parser, built in one place so a test can assert the documented default matches it."""
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument(
         "--pid",
@@ -744,8 +897,19 @@ def main(argv: list[str] | None = None) -> int:
         help="Power BI Desktop process id - required when several instances are open "
         "(`powerbi-desktop status` maps pid -> open file)",
     )
-    parser.add_argument("--port", type=int, help="Local AS port (default: auto-discover)")
-    parser.add_argument("--tables", nargs="*", help="Tables to refresh (default: whole database)")
+    parser.add_argument(
+        "--port",
+        type=int,
+        help="Local AS port. Derived from --pid; if given it MUST equal the pid-discovered port "
+        "(a mismatch aborts - it cannot silently point the write at another instance)",
+    )
+    parser.add_argument(
+        "--tables",
+        nargs="*",
+        help="Tables to refresh AND the canary set to verify (default: whole database). Name one "
+        "table per distinct live source to earn a model-level DATA_OK; with none, only the first "
+        "queryable table is probed and the verdict is downgraded to name that single table",
+    )
     parser.add_argument(
         "--save",
         action="store_true",
@@ -766,34 +930,26 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Force the legacy UI-Automation save instead of AMO ImageSave (fallback/diagnostic)",
     )
-    args = parser.parse_args(argv)
+    return parser
 
-    pid = _resolve_pid(args.pid)
-    if pid is None:
-        return 2
 
-    port = args.port or discover_port(pid)
-    # Resolved ONCE: the path that gets verified must be the path that gets written, and every
-    # re-derivation is another Desktop Bridge round trip that can come back empty.
-    cache = cache_file(pid)
-    before_stamp = cache.stat().st_mtime if cache and cache.exists() else 0.0
+def _emit_data_verdict(
+    cache: Path | None,
+    before_stamp: float,
+    args: argparse.Namespace,
+    results: list[tuple[str, int]],
+    implicit: bool,
+) -> int:
+    """Print the data/cache lines and the machine-readable verdict; return the process exit code.
 
-    # Gate everything on identity: refreshing, row-counting or persisting a sibling's model is a
-    # fully self-consistent false positive, so it has to be caught BEFORE any of the three.
-    if not _identity_gate(port, cache):
-        return 2
-
-    if not args.verify_only:
-        outcome = _refresh_and_save(pid, port, cache, args)
-        if outcome is not None:
-            return outcome
-
-    rows, table = row_count(port)
-
+    Split out of `main()` so the mutating path (identity gate + refresh + persist) and the reporting
+    path stay individually simple.
+    """
     after_stamp = cache.stat().st_mtime if cache and cache.exists() else 0.0
     persisted = cache is not None and after_stamp > before_stamp
 
-    print(f"  data   : {rows} row(s) in '{table}'")
+    for table, rows in results:
+        print(f"  data   : {rows} row(s) in '{table}'")
     # Say what HAPPENED, not where a file would go. Printing the path alone reads as "written" -
     # it misled a reader on 2026-08-05 into believing a probe run had persisted a 1-row cache.
     # For a probe that distinction matters twice over: a persisted 1-row `cache.abf` is a trap, and
@@ -810,15 +966,69 @@ def main(argv: list[str] | None = None) -> int:
         # sent me looking in the wrong place for ten minutes; the real one is on the 'save' line.
         print("  cache  : not persisted (the write did not land - see 'save' above)")
 
-    if rows <= 0:
-        print("REFRESH: NO_DATA (refresh ran but the table is empty - check the source and credentials)")
+    empty = [table for table, rows in results if rows <= 0]
+    if empty:
+        print(f"REFRESH: NO_DATA (empty: {', '.join(empty)} - check the source and credentials)")
         return 1
     wanted_save = not args.no_save and not args.verify_only
     if wanted_save and not persisted:
         print("REFRESH: NOT_PERSISTED (model has data in memory, but cache.abf did not update)")
         return 1
-    print("REFRESH: DATA_OK" + (" + PERSISTED" if wanted_save else ""))
+    suffix = " + PERSISTED" if wanted_save else ""
+    if implicit:
+        # No canaries were named, so only the first queryable table was probed. That is NOT a
+        # model-level guarantee (a static parameter/CSV table can pass while a live source never
+        # loaded), so the verdict names the single table actually probed instead of claiming DATA_OK.
+        only = results[0][0]
+        print(f"REFRESH: TABLE_OK '{only}'{suffix}")
+        print(
+            f"  note   : single-table probe of '{only}' only - NOT a model-level DATA_OK. A static "
+            "parameter/CSV table can return rows while a live source never loaded. Pass "
+            "--tables <one canary per live source> to certify every source (this mirrors the "
+            "powerbi-semantic-model-gotchas rule: prove a REAL read per live source)."
+        )
+        return 0
+    print(f"REFRESH: DATA_OK{suffix}")
     return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point: refresh, save, and prove data is really there."""
+    args = _build_arg_parser().parse_args(argv)
+
+    pid = _resolve_pid(args.pid)
+    if pid is None:
+        return 2
+
+    # The port is DERIVED from the pid. A stray --port must never bypass that on this mutating path:
+    # the destination cache is resolved from the pid, so a --port pointing at another instance would
+    # read (and, via ImageSave, persist) a sibling's model into this project's own correct cache.abf.
+    discovered = discover_port(pid)
+    if args.port is not None and args.port != discovered:
+        print(
+            f"REFRESH: ERROR --port {args.port} does not match the port {discovered} discovered from "
+            f"pid {pid} - refusing to read or write across instances (drop --port; it is derived from --pid)"
+        )
+        return 2
+    port = discovered
+
+    # Resolved ONCE: the path that gets verified must be the path that gets written, and every
+    # re-derivation is another Desktop Bridge round trip that can come back empty.
+    cache = cache_file(pid)
+    before_stamp = cache.stat().st_mtime if cache and cache.exists() else 0.0
+
+    # Gate everything on identity: refreshing, row-counting or persisting a sibling's model is a
+    # fully self-consistent false positive, so it has to be caught BEFORE any of the three.
+    if not _identity_gate(port, cache):
+        return 2
+
+    if not args.verify_only:
+        outcome = _refresh_and_save(pid, port, cache, args)
+        if outcome is not None:
+            return outcome
+
+    results, implicit = row_counts(port, args.tables)
+    return _emit_data_verdict(cache, before_stamp, args, results, implicit)
 
 
 if __name__ == "__main__":

--- a/.github/skills/pbip-model-refresh/tests/test_canary_data_gate.py
+++ b/.github/skills/pbip-model-refresh/tests/test_canary_data_gate.py
@@ -196,3 +196,68 @@ def test_row_counts_falls_back_to_first_table_and_flags_implicit(monkeypatch) ->
     results, implicit = refresh_pbip_model.row_counts(52001, None)
     assert results == [("Parameters", 1)]
     assert implicit is True
+
+
+# --- the verdict matrix: --tables is SCOPE, --canaries is VERIFICATION (round-4 finding 5) --------
+
+
+def _verdict(argv: list[str], results: list[tuple[str, int]], implicit: bool, capsys) -> str:
+    args = refresh_pbip_model._build_arg_parser().parse_args(argv)
+    refresh_pbip_model._emit_data_verdict(None, 0.0, args, results, implicit)
+    return capsys.readouterr().out
+
+
+def test_canaries_flag_wins_over_the_tables_flag() -> None:
+    """When both are given, the VERIFICATION set is `--canaries`; `--tables` stays the refresh scope."""
+    args = refresh_pbip_model._build_arg_parser().parse_args(
+        ["--pid", "1", "--tables", "Orders", "--canaries", "Live", "Other"]
+    )
+    assert refresh_pbip_model._canary_tables(args) == ["Live", "Other"]
+
+
+def test_tables_still_supplies_canaries_when_it_is_the_only_flag() -> None:
+    """Existing callers keep a probe set - they just no longer get a model-level verdict from it."""
+    args = refresh_pbip_model._build_arg_parser().parse_args(["--pid", "1", "--tables", "Orders"])
+    assert refresh_pbip_model._canary_tables(args) == ["Orders"]
+
+
+def test_neither_flag_means_no_canaries_so_the_probe_downgrades() -> None:
+    args = refresh_pbip_model._build_arg_parser().parse_args(["--pid", "1"])
+    assert refresh_pbip_model._canary_tables(args) is None
+
+
+def test_verdict_for_a_narrowed_refresh_is_tables_ok(capsys) -> None:
+    """The blocker: a refresh narrowed by `--tables` may not print DATA_OK, however green the rows."""
+    out = _verdict(["--pid", "1", "--tables", "Orders", "--no-save"], [("Orders", 5)], False, capsys)
+    assert "REFRESH: TABLES_OK 'Orders'" in out
+    assert "REFRESH: DATA_OK" not in out
+    assert "--canaries" in out, "the verdict must name the way to earn a model-level result"
+
+
+def test_verdict_for_named_canaries_is_data_ok(capsys) -> None:
+    out = _verdict(["--pid", "1", "--canaries", "Orders", "--no-save"], [("Orders", 5)], False, capsys)
+    assert "REFRESH: DATA_OK" in out
+
+
+def test_canaries_do_not_rescue_a_narrowed_refresh(capsys) -> None:
+    """Naming canaries alongside `--tables` still leaves every OTHER table unrefreshed."""
+    out = _verdict(
+        ["--pid", "1", "--tables", "Orders", "--canaries", "Orders", "--no-save"], [("Orders", 5)], False, capsys
+    )
+    assert "REFRESH: TABLES_OK 'Orders'" in out
+    assert "REFRESH: DATA_OK" not in out
+
+
+def test_verify_only_with_tables_is_still_data_ok(capsys) -> None:
+    """`--verify-only` never refreshes, so `--tables` narrowed nothing and the model verdict stands."""
+    out = _verdict(["--pid", "1", "--tables", "Orders", "--verify-only"], [("Orders", 5)], False, capsys)
+    assert "REFRESH: DATA_OK" in out
+
+
+def test_an_empty_canary_still_beats_every_other_verdict(capsys) -> None:
+    """NO_DATA outranks the scope downgrade: an empty table is the loudest fact in the run."""
+    out = _verdict(
+        ["--pid", "1", "--tables", "Orders", "Live", "--no-save"], [("Orders", 5), ("Live", 0)], False, capsys
+    )
+    assert "REFRESH: NO_DATA" in out
+    assert "Live" in out

--- a/.github/skills/pbip-model-refresh/tests/test_canary_data_gate.py
+++ b/.github/skills/pbip-model-refresh/tests/test_canary_data_gate.py
@@ -1,0 +1,198 @@
+"""The data gate must never certify a whole model from one arbitrary table (#115).
+
+`DATA_OK` says "every live source loaded". Emitting it from an IMPLICIT first-table probe is a false
+positive: a static parameter/CSV table can return rows while every live source failed to load, and
+"first non-hidden table" is often exactly such a table. So:
+
+- with explicit canaries (one per distinct live source) an all-non-zero result earns `DATA_OK`;
+- with none, only the first queryable table is probed and the verdict is downgraded to
+  `TABLE_OK '<table>'`, naming the single table actually read;
+- any empty table is `NO_DATA`, naming it.
+
+These tests drive both surfaces that emit the verdict: `probe_desktop_query.probe` (the read-only
+preflight) and `refresh_pbip_model.row_counts` (the refresh's own data check).
+"""
+
+from __future__ import annotations
+
+import re
+
+# `conftest.py` next to this file puts the skill's own `scripts/` on `sys.path`.
+# ruff: noqa: E402  (the conftest-provided path must be in place before these imports)
+import probe_desktop_query
+import refresh_pbip_model
+
+
+class _Reader:
+    """A minimal ADOMD data reader (PascalCase because the real one is .NET)."""
+
+    def __init__(self, columns: list[str], rows: list[list]) -> None:
+        self._columns = columns
+        self._rows = list(rows)
+        self._cur: list | None = None
+
+    @property
+    def FieldCount(self) -> int:  # noqa: N802
+        return len(self._columns)
+
+    def GetName(self, index: int) -> str:  # noqa: N802
+        return self._columns[index]
+
+    def Read(self) -> bool:  # noqa: N802
+        if not self._rows:
+            return False
+        self._cur = self._rows.pop(0)
+        return True
+
+    def GetValue(self, index: int):  # noqa: N802
+        return self._cur[index]
+
+    def Close(self) -> None:  # noqa: N802
+        self._cur = None
+
+
+class _Command:  # pylint: disable=too-few-public-methods
+    def __init__(self, conn: _Conn) -> None:
+        self._conn = conn
+        self.CommandText = ""  # noqa: N815
+
+    def ExecuteReader(self) -> _Reader:  # noqa: N802
+        return self._conn.reader_for(self.CommandText)
+
+
+class _Conn:
+    """A fake connection that answers the three DAX/DMV shapes these functions send."""
+
+    def __init__(self, tables: list[tuple[str, bool]], counts: dict[str, int]) -> None:
+        self._tables = tables
+        self._counts = counts
+
+    def Open(self) -> None:  # noqa: N802
+        pass
+
+    def Close(self) -> None:  # noqa: N802
+        pass
+
+    def CreateCommand(self) -> _Command:  # noqa: N802
+        return _Command(self)
+
+    def reader_for(self, text: str) -> _Reader:
+        if "TMSCHEMA_TABLES" in text:
+            return _Reader(["Name", "IsHidden"], [[name, hidden] for name, hidden in self._tables])
+        topn = re.search(r"TOPN\(1, '([^']+)'\)", text)
+        if topn:
+            has_rows = self._counts.get(topn.group(1), 0) > 0
+            return _Reader(["Sales Amount"], [["value"]] if has_rows else [])
+        countrows = re.search(r"COUNTROWS\('([^']+)'\)", text)
+        if countrows:
+            return _Reader(["n"], [[self._counts.get(countrows.group(1), 0)]])
+        raise AssertionError(f"unexpected DAX/DMV: {text}")
+
+
+def _wire(monkeypatch, module, conn: _Conn) -> None:
+    monkeypatch.setattr(module, "_load_adomd", lambda: lambda _dsn: conn)
+
+
+# --- probe_desktop_query.probe: the read-only preflight verdict ---------------------------------
+
+
+def test_probe_with_no_canary_is_table_ok_not_data_ok(monkeypatch, capsys) -> None:
+    """The #115 defect: an implicit probe of the first table 'Parameters' must NOT claim DATA_OK."""
+    conn = _Conn([("Parameters", False), ("Orders", False)], {"Parameters": 1, "Orders": 5})
+    _wire(monkeypatch, probe_desktop_query, conn)
+
+    exit_code = probe_desktop_query.probe(52001, None)
+    out = capsys.readouterr().out
+    assert exit_code == 0
+    assert "PREFLIGHT: TABLE_OK 'Parameters'" in out
+    assert "PREFLIGHT: DATA_OK" not in out, "an implicit single-table probe must not certify the model"
+
+
+def test_probe_with_explicit_canaries_is_data_ok(monkeypatch, capsys) -> None:
+    """One canary per live source, all non-zero, is the case that legitimately earns DATA_OK."""
+    conn = _Conn([("Orders", False)], {"Orders": 5, "Customers": 3})
+    _wire(monkeypatch, probe_desktop_query, conn)
+
+    exit_code = probe_desktop_query.probe(52001, ["Orders", "Customers"])
+    out = capsys.readouterr().out
+    assert exit_code == 0
+    assert "PREFLIGHT: DATA_OK" in out
+
+
+def test_probe_reports_no_data_when_a_canary_is_empty(monkeypatch, capsys) -> None:
+    """A named live source returning 0 rows is NO_DATA, and must be named - not hidden by a sibling."""
+    conn = _Conn([("Orders", False)], {"Orders": 5, "Live": 0})
+    _wire(monkeypatch, probe_desktop_query, conn)
+
+    exit_code = probe_desktop_query.probe(52001, ["Orders", "Live"])
+    out = capsys.readouterr().out
+    assert exit_code == 1
+    assert "PREFLIGHT: NO_DATA" in out
+    assert "Live" in out
+
+
+def test_probe_single_explicit_table_earns_data_ok(monkeypatch, capsys) -> None:
+    """An EXPLICIT single canary is the caller's own choice, so it still earns a model verdict.
+
+    Only the IMPLICIT arbitrary first-table pick is downgraded; naming a table is opting in to
+    certifying on it, which is exactly what #115 asks callers to do.
+    """
+    conn = _Conn([("Orders", False)], {"Orders": 9})
+    _wire(monkeypatch, probe_desktop_query, conn)
+
+    exit_code = probe_desktop_query.probe(52001, ["Orders"])
+    out = capsys.readouterr().out
+    assert exit_code == 0
+    assert "PREFLIGHT: DATA_OK" in out
+    assert "TABLE_OK" not in out
+
+
+def test_main_maps_the_tables_flag_to_the_canary_list(monkeypatch) -> None:
+    """`--tables A B` reaches `probe` as ["A", "B"]; the port is the discovered one."""
+    seen: dict[str, object] = {}
+    monkeypatch.setattr(probe_desktop_query, "discover_port", lambda pid: 52001)
+    monkeypatch.setattr(probe_desktop_query, "probe", lambda port, tables: seen.update(port=port, tables=tables) or 0)
+    assert probe_desktop_query.main(["--pid", "111", "--tables", "A", "B"]) == 0
+    assert seen == {"port": 52001, "tables": ["A", "B"]}
+
+
+def test_main_maps_the_legacy_single_table_flag(monkeypatch) -> None:
+    """`--table X` (legacy) becomes a one-name canary list, so old callers keep a model verdict."""
+    seen: dict[str, object] = {}
+    monkeypatch.setattr(probe_desktop_query, "discover_port", lambda pid: 52001)
+    monkeypatch.setattr(probe_desktop_query, "probe", lambda port, tables: seen.update(tables=tables) or 0)
+    assert probe_desktop_query.main(["--pid", "111", "--table", "Orders"]) == 0
+    assert seen["tables"] == ["Orders"]
+
+
+def test_main_maps_no_table_to_none_so_the_probe_downgrades(monkeypatch) -> None:
+    """With neither flag, `probe` receives None and is responsible for the TABLE_OK downgrade."""
+    seen: dict[str, object] = {}
+    monkeypatch.setattr(probe_desktop_query, "discover_port", lambda pid: 52001)
+    monkeypatch.setattr(probe_desktop_query, "probe", lambda port, tables: seen.update(tables=tables) or 0)
+    assert probe_desktop_query.main(["--pid", "111"]) == 0
+    assert seen["tables"] is None
+
+
+# --- refresh_pbip_model.row_counts: the refresh's own data check --------------------------------
+
+
+def test_row_counts_probes_each_named_canary(monkeypatch) -> None:
+    """Explicit canaries: one COUNTROWS per table, in order, and `implicit` is False."""
+    conn = _Conn([("Orders", False)], {"Orders": 5, "Customers": 3})
+    _wire(monkeypatch, refresh_pbip_model, conn)
+
+    results, implicit = refresh_pbip_model.row_counts(52001, ["Orders", "Customers"])
+    assert results == [("Orders", 5), ("Customers", 3)]
+    assert implicit is False
+
+
+def test_row_counts_falls_back_to_first_table_and_flags_implicit(monkeypatch) -> None:
+    """No canaries: probe the first queryable table only, and flag it implicit so the caller
+    downgrades the verdict to TABLE_OK rather than DATA_OK."""
+    conn = _Conn([("Parameters", False), ("Orders", False)], {"Parameters": 1})
+    _wire(monkeypatch, refresh_pbip_model, conn)
+
+    results, implicit = refresh_pbip_model.row_counts(52001, None)
+    assert results == [("Parameters", 1)]
+    assert implicit is True

--- a/.github/skills/pbip-model-refresh/tests/test_desktop_instance_binding.py
+++ b/.github/skills/pbip-model-refresh/tests/test_desktop_instance_binding.py
@@ -34,6 +34,13 @@ SKILL_ROOT = Path(__file__).resolve().parents[1]
 CREDENTIAL_PROBE_PS1 = SKILL_ROOT / "scripts" / "probe_desktop_credential.ps1"
 REF_TABLE_RE = re.compile(r"^ref table\s+(?:'([^']+)'|(\S+))", re.MULTILINE)
 
+# Real Power BI auto date/time tables ALWAYS carry a canonical 8-4-4-4-12 GUID suffix, and the
+# identity fingerprint now filters them by that exact shape rather than a name prefix (round-3
+# blocker 4). Fixtures that stand in for the scaffolding must therefore use the real generated shape;
+# a short stub like `LocalDateTable_abc` is (correctly) treated as a genuine user table now.
+AUTO_DATE_LOCAL = "LocalDateTable_9f2c1e4a-1111-2222-3333-444455556666"
+AUTO_DATE_TEMPLATE = "DateTableTemplate_0a1b2c3d-4e5f-6789-abcd-ef0123456789"
+
 
 def _example_models() -> list[Path]:
     """This repo's committed `examples/` corpus, if the host repo has one.
@@ -186,7 +193,7 @@ class _FakeConnection:
 
 def test_table_names_filters_the_auto_date_scaffolding_but_can_keep_hidden_tables() -> None:
     """A hidden table is part of a model's fingerprint; `LocalDateTable_*` never is (not in TMDL)."""
-    rows = [("Sales", False), ("Bridge", True), ("LocalDateTable_abc", True), ("DateTableTemplate_x", True)]
+    rows = [("Sales", False), ("Bridge", True), (AUTO_DATE_LOCAL, True), (AUTO_DATE_TEMPLATE, True)]
     assert table_names(_FakeConnection(rows)) == ["Sales"]
     assert table_names(_FakeConnection(rows), include_hidden=True) == ["Sales", "Bridge"]
 
@@ -261,11 +268,35 @@ def test_auto_date_tables_on_disk_do_not_look_like_a_stranger(monkeypatch, tmp_p
     The live side already strips them, so leaving them in the disk side would report them as
     "missing from the connected model" and abort every such migration with WRONG_MODEL.
     """
-    cache = _model_folder(tmp_path, "MyMigration", ["Orders", "LocalDateTable_9f2c", "DateTableTemplate_1a"])
+    cache = _model_folder(tmp_path, "MyMigration", ["Orders", AUTO_DATE_LOCAL, AUTO_DATE_TEMPLATE])
     assert tmdl_tables(cache.parent.parent) == {"Orders"}
     _stub_live_to_match_disk(monkeypatch, cache)
     ok, message = same_model(52001, cache)
     assert ok, message
+
+
+def test_a_user_table_named_like_the_auto_date_prefix_stays_in_the_disk_fingerprint(tmp_path: Path) -> None:
+    """A GENUINE user table like `LocalDateTableSales` must NOT be mistaken for auto date/time scaffolding.
+
+    The round-2 filter matched anything starting with `LocalDateTable`/`DateTableTemplate`, so a real
+    user table with that prefix vanished from the fingerprint entirely - columns, measures and all -
+    hiding real differences between two models (round-3 blocker 4). Only the exact GUID-suffixed shape
+    is scaffolding; everything else is compared.
+    """
+    cache = _model_folder(tmp_path, "MyMigration", ["Orders", "LocalDateTableSales", "DateTableTemplateArchive"])
+    assert tmdl_tables(cache.parent.parent) == {"Orders", "LocalDateTableSales", "DateTableTemplateArchive"}
+
+
+def test_is_auto_date_table_name_matches_only_the_generated_guid_shape() -> None:
+    """The scaffolding predicate is exact: a canonical GUID suffix is required, a prefix is not enough."""
+    assert probe_desktop_query.is_auto_date_table_name(AUTO_DATE_LOCAL)
+    assert probe_desktop_query.is_auto_date_table_name(AUTO_DATE_TEMPLATE)
+    # Genuine user tables that merely start with the words are NOT scaffolding.
+    assert not probe_desktop_query.is_auto_date_table_name("LocalDateTableSales")
+    assert not probe_desktop_query.is_auto_date_table_name("DateTableTemplateArchive")
+    # A short/truncated suffix is not the generated shape either, so it is kept (fail closed).
+    assert not probe_desktop_query.is_auto_date_table_name("LocalDateTable_abc")
+    assert not probe_desktop_query.is_auto_date_table_name("LocalDateTable_9f2c1e4a-1111-2222-3333")
 
 
 def test_same_model_accepts_an_exact_case_insensitive_match(monkeypatch, tmp_path: Path) -> None:
@@ -395,12 +426,28 @@ def test_tmdl_columns_measures_skips_auto_date_tables(tmp_path: Path) -> None:
     tables_dir = tmp_path / "M.SemanticModel" / "definition" / "tables"
     tables_dir.mkdir(parents=True)
     (tables_dir / "Sales.tmdl").write_text("table Sales\n\n\tcolumn Amount\n", encoding="utf-8")
-    (tables_dir / "LocalDateTable_x.tmdl").write_text(
-        "table LocalDateTable_x\n\n\tcolumn Year\n\tmeasure M = 1\n", encoding="utf-8"
+    (tables_dir / f"{AUTO_DATE_LOCAL}.tmdl").write_text(
+        f"table {AUTO_DATE_LOCAL}\n\n\tcolumn Year\n\tmeasure M = 1\n", encoding="utf-8"
     )
     columns, measures = refresh_pbip_model.tmdl_columns_measures(tmp_path / "M.SemanticModel")
     assert columns == {("Sales", "Amount")}
     assert measures == set()
+
+
+def test_tmdl_columns_measures_keeps_a_user_table_named_like_the_auto_date_prefix(tmp_path: Path) -> None:
+    """A user table `LocalDateTableSales` keeps its columns and measures in the fingerprint (round-3 B4).
+
+    The prefix filter dropped this whole table, so two models differing only inside it looked
+    identical - the exact defence `same_model` exists to provide. The GUID-shape filter keeps it.
+    """
+    tables_dir = tmp_path / "M.SemanticModel" / "definition" / "tables"
+    tables_dir.mkdir(parents=True)
+    (tables_dir / "LocalDateTableSales.tmdl").write_text(
+        "table LocalDateTableSales\n\n\tcolumn Region\n\tmeasure Revenue = 1\n", encoding="utf-8"
+    )
+    columns, measures = refresh_pbip_model.tmdl_columns_measures(tmp_path / "M.SemanticModel")
+    assert columns == {("LocalDateTableSales", "Region")}
+    assert measures == {("LocalDateTableSales", "Revenue")}
 
 
 class _FingerprintReader:  # pylint: disable=too-few-public-methods
@@ -461,7 +508,7 @@ def test_column_names_filters_rownumber_and_auto_date_columns() -> None:
     preferring the explicit model name over the engine's inferred one.
     """
     conn = _FingerprintConn(
-        tables={"t1": "Orders", "t2": "LocalDateTable_abc"},
+        tables={"t1": "Orders", "t2": AUTO_DATE_LOCAL},
         columns=[
             ("t1", "Amount", "Amount", 1),  # data column -> kept
             ("t1", "", "Qty", 2),  # calculated, no explicit name -> InferredName
@@ -473,10 +520,23 @@ def test_column_names_filters_rownumber_and_auto_date_columns() -> None:
     assert probe_desktop_query.column_names(conn) == {("Orders", "Amount"), ("Orders", "Qty")}
 
 
+def test_column_names_keeps_a_user_table_named_like_the_auto_date_prefix() -> None:
+    """The live column fingerprint keeps a genuine `LocalDateTableSales`, only the GUID shape is dropped."""
+    conn = _FingerprintConn(
+        tables={"t1": "LocalDateTableSales", "t2": AUTO_DATE_LOCAL},
+        columns=[
+            ("t1", "Region", "Region", 1),  # user table that merely starts with the prefix -> kept
+            ("t2", "Date", "Date", 1),  # real auto date-table column -> filtered
+        ],
+        measures=[],
+    )
+    assert probe_desktop_query.column_names(conn) == {("LocalDateTableSales", "Region")}
+
+
 def test_measure_names_filters_auto_date_measures() -> None:
     """Measures on the auto date/time tables are filtered too, mirroring the disk side."""
     conn = _FingerprintConn(
-        tables={"t1": "Sales", "t2": "DateTableTemplate_1"},
+        tables={"t1": "Sales", "t2": AUTO_DATE_TEMPLATE},
         columns=[],
         measures=[("t1", "Total Sales"), ("t2", "Some Auto Measure")],
     )
@@ -610,6 +670,35 @@ def test_persisting_is_the_default(monkeypatch, tmp_path: Path, capsys) -> None:
     out = capsys.readouterr().out
     assert "REFRESH: DATA_OK + PERSISTED" in out
     assert cache.exists(), "a default refresh must persist cache.abf"
+
+
+def test_a_compat_rollback_failure_is_fatal_and_does_not_fall_back_to_ui_save(monkeypatch, tmp_path, capsys):
+    """A `CompatRollbackError` from persist is FATAL - the run must NOT drive the UI Save on top of it.
+
+    When the cache write fails AND the compatibility alignment cannot be rolled back, database.tmdl
+    declares a level no cache was written at. Saving over that inconsistent state would persist the
+    mismatch, so `main` must exit with an error and never reach the UI-save fallback (round-3 blocker
+    2). Round-2 converted every ImageSave exception into a UI-save fallback, so this case saved anyway.
+    """
+    cache = _model_folder(tmp_path, "MyMigration", ["Orders"])
+    _stub_bridge(monkeypatch, [{"pid": 111, "currentFilePath": str(tmp_path / "MyMigration.pbip")}])
+    monkeypatch.setattr(refresh_pbip_model, "discover_port", lambda pid: 52001)
+    _stub_live_to_match_disk(monkeypatch, cache)
+    monkeypatch.setattr(refresh_pbip_model, "refresh", lambda port, tables, timeout: (True, "refreshed"))
+    monkeypatch.setattr(refresh_pbip_model, "row_counts", lambda port, tables: ([("Orders", 42)], False))
+
+    def raise_rollback_error(port: int, cache_path: Path, model_dir=None):
+        del port, cache_path, model_dir
+        raise refresh_pbip_model.CompatRollbackError("compatibility rollback FAILED for database.tmdl")
+
+    monkeypatch.setattr(refresh_pbip_model, "image_save", raise_rollback_error)
+    monkeypatch.setattr(refresh_pbip_model, "save", _explode("the UI fallback must not run after a rollback failure"))
+
+    exit_code = refresh_pbip_model.main(["--pid", "111", "--tables", "Orders"])
+    out = capsys.readouterr().out
+    assert exit_code == 2
+    assert "compatibility rollback failed" in out.lower()
+    assert "do NOT save" in out
 
 
 def test_compatibility_alignment_declares_generated_edit(tmp_path: Path) -> None:
@@ -783,6 +872,70 @@ def test_cache_file_uses_the_stem_only_when_no_binding_resolves(monkeypatch, tmp
     assert resolved == tmp_path / "Proj.SemanticModel" / ".pbi" / "cache.abf"
 
 
+def _project_with_binding_outside_the_folder(root: Path, *, target_exists: bool) -> Path:
+    """A `.pbip` whose report binds to a model OUTSIDE its own folder, plus ONE adjacent decoy model.
+
+    Structure (returns the `.pbip`, stem `Proj`)::
+
+        root/proj/Proj.pbip                      -> artifacts: Proj.Report
+        root/proj/Proj.Report/definition.pbir    -> byPath: ../../elsewhere/Real.SemanticModel
+        root/proj/Decoy.SemanticModel/...         (the single adjacent sibling - a DECOY)
+        root/elsewhere/Real.SemanticModel/...     (the bound model, present only if target_exists)
+
+    This is the round-3 mandate case: with exactly ONE `.SemanticModel` beside the `.pbip`, the
+    round-2 `len(models)==1` shortcut returned that lone sibling BEFORE consulting the binding, so a
+    binding pointing outside the folder was ignored and the decoy was written into - a wrong-project
+    write reachable even with a single adjacent model.
+    """
+    proj = root / "proj"
+    decoy = proj / "Decoy.SemanticModel" / "definition" / "tables"
+    decoy.mkdir(parents=True)
+    (decoy / "T.tmdl").write_text("table 'T'\n\n\tcolumn X\n", encoding="utf-8")
+    if target_exists:
+        real = root / "elsewhere" / "Real.SemanticModel" / "definition" / "tables"
+        real.mkdir(parents=True)
+        (real / "T.tmdl").write_text("table 'T'\n\n\tcolumn X\n", encoding="utf-8")
+    report = proj / "Proj.Report"
+    report.mkdir(parents=True)
+    (report / "definition.pbir").write_text(
+        json.dumps({"version": "1.0", "datasetReference": {"byPath": {"path": "../../elsewhere/Real.SemanticModel"}}}),
+        encoding="utf-8",
+    )
+    pbip = proj / "Proj.pbip"
+    pbip.write_text(
+        json.dumps({"version": "1.0", "artifacts": [{"report": {"path": "Proj.Report"}}]}), encoding="utf-8"
+    )
+    return pbip
+
+
+def test_cache_file_follows_a_binding_that_points_outside_the_folder(monkeypatch, tmp_path: Path) -> None:
+    """A binding to a model OUTSIDE the `.pbip` folder wins over the lone adjacent decoy (round-3 mandate).
+
+    The authoritative binding is resolved DIRECTLY from the byPath, not intersected with the `.pbip`
+    folder's `*.SemanticModel` siblings, so it resolves the real owner even though it lives elsewhere -
+    and the single adjacent `Decoy` model never shadows it. Round-2 returned the decoy via the
+    `len(models)==1` shortcut that ran ahead of the binding.
+    """
+    pbip = _project_with_binding_outside_the_folder(tmp_path, target_exists=True)
+    _stub_bridge(monkeypatch, [{"pid": 111, "currentFilePath": str(pbip)}])
+    resolved = refresh_pbip_model.cache_file(111)
+    assert resolved == tmp_path / "elsewhere" / "Real.SemanticModel" / ".pbi" / "cache.abf"
+    assert resolved != tmp_path / "proj" / "Decoy.SemanticModel" / ".pbi" / "cache.abf"
+
+
+def test_cache_file_fails_closed_when_the_binding_points_at_a_missing_model(monkeypatch, tmp_path: Path) -> None:
+    """A binding present but UNRESOLVABLE (its target is gone) fails closed - it must NOT fall to the decoy.
+
+    "Binding absent" (heuristics may apply) and "binding present but unresolvable" (fail closed) are
+    different conditions and must not share a code path. Here the byPath names a model that does not
+    exist, so `cache_file` returns None rather than silently writing the lone adjacent `Decoy` - the
+    wrong-project write the round-3 mandate closes.
+    """
+    pbip = _project_with_binding_outside_the_folder(tmp_path, target_exists=False)
+    _stub_bridge(monkeypatch, [{"pid": 111, "currentFilePath": str(pbip)}])
+    assert refresh_pbip_model.cache_file(111) is None
+
+
 def test_a_mismatched_port_aborts_before_any_read_or_write(monkeypatch, tmp_path: Path, capsys) -> None:
     """`--port` must EQUAL the pid-derived port, or the run aborts before touching anything.
 
@@ -924,10 +1077,22 @@ def test_credential_arbiter_enumerates_all_windows_and_fails_closed() -> None:
     pinned structurally: it must enumerate all top-level windows (`Get-PidWindows`/`FindAll`, not the
     old single-window `FindFirst`), and when no Refresh control was ever invoked it must report
     UNKNOWN rather than asserting a credential is present.
+
+    The not-invoked verdict is checked INSIDE the `if (-not $invoked) { ... }` block, not anywhere in
+    the file: a bare `VERDICT: UNKNOWN` search passed even when that branch was mutated to emit
+    `CREDENTIAL_PRESENT`, because a second `VERDICT: UNKNOWN` (the no-window guard) still matched
+    (round-3 major 5). Scoping the assertions to the block is what makes the test able to fail.
     """
     text = CREDENTIAL_PROBE_PS1.read_text(encoding="utf-8")
     assert "Get-PidWindows" in text, "must enumerate windows via the all-windows helper"
     assert "FindAll" in text, "must use FindAll (every top-level window)"
     assert "FindFirst" not in text, "the single-window FindFirst scan was the fail-open enumeration bug"
-    assert re.search(r"-not\s+\$invoked", text), "must guard the case where no Refresh was invoked"
-    assert re.search(r"VERDICT:\s*UNKNOWN", text), "the not-invoked case must report UNKNOWN, not CREDENTIAL_PRESENT"
+
+    block_match = re.search(r"if \(-not \$invoked\)\s*\{(.*?)\}", text, re.DOTALL)
+    assert block_match, "must guard the case where no Refresh was invoked with an `if (-not $invoked)` block"
+    block = block_match.group(1)
+    assert re.search(r"VERDICT:\s*UNKNOWN", block), "the not-invoked branch itself must report UNKNOWN"
+    assert re.search(r"\bexit\s+3\b", block), "the not-invoked branch must exit 3 (the UNKNOWN code)"
+    assert "CREDENTIAL_PRESENT" not in block, (
+        "the not-invoked branch must NOT report CREDENTIAL_PRESENT - that is the fail-open arbiter bug"
+    )

--- a/.github/skills/pbip-model-refresh/tests/test_desktop_instance_binding.py
+++ b/.github/skills/pbip-model-refresh/tests/test_desktop_instance_binding.py
@@ -607,7 +607,7 @@ def test_main_still_refreshes_and_persists_the_right_instance(monkeypatch, tmp_p
 
     monkeypatch.setattr(refresh_pbip_model, "image_save", fake_image_save)
 
-    assert refresh_pbip_model.main(["--pid", "111", "--tables", "Orders", "--save"]) == 0
+    assert refresh_pbip_model.main(["--pid", "111", "--canaries", "Orders", "--save"]) == 0
     out = capsys.readouterr().out
     assert "REFRESH: DATA_OK + PERSISTED" in out
     assert cache.read_bytes() == b"cache"
@@ -635,7 +635,7 @@ def test_no_save_leaves_the_project_byte_identical(monkeypatch, tmp_path: Path, 
     monkeypatch.setattr(refresh_pbip_model, "image_save", _explode("image_save must not run"))
     monkeypatch.setattr(refresh_pbip_model, "save", _explode("save must not run"))
 
-    assert refresh_pbip_model.main(["--pid", "111", "--tables", "Orders", "--no-save"]) == 0
+    assert refresh_pbip_model.main(["--pid", "111", "--canaries", "Orders", "--no-save"]) == 0
     out = capsys.readouterr().out
     assert "REFRESH: DATA_OK" in out
     assert "PERSISTED" not in out
@@ -666,7 +666,7 @@ def test_persisting_is_the_default(monkeypatch, tmp_path: Path, capsys) -> None:
     monkeypatch.setattr(refresh_pbip_model, "image_save", fake_image_save)
     monkeypatch.setattr(refresh_pbip_model, "save", _explode("the UI fallback must not run"))
 
-    assert refresh_pbip_model.main(["--pid", "111", "--tables", "Orders"]) == 0
+    assert refresh_pbip_model.main(["--pid", "111", "--canaries", "Orders"]) == 0
     out = capsys.readouterr().out
     assert "REFRESH: DATA_OK + PERSISTED" in out
     assert cache.exists(), "a default refresh must persist cache.abf"
@@ -694,7 +694,7 @@ def test_a_compat_rollback_failure_is_fatal_and_does_not_fall_back_to_ui_save(mo
     monkeypatch.setattr(refresh_pbip_model, "image_save", raise_rollback_error)
     monkeypatch.setattr(refresh_pbip_model, "save", _explode("the UI fallback must not run after a rollback failure"))
 
-    exit_code = refresh_pbip_model.main(["--pid", "111", "--tables", "Orders"])
+    exit_code = refresh_pbip_model.main(["--pid", "111", "--canaries", "Orders"])
     out = capsys.readouterr().out
     assert exit_code == 2
     assert "compatibility rollback failed" in out.lower()
@@ -974,7 +974,7 @@ def test_a_matching_port_is_accepted(monkeypatch, tmp_path: Path, capsys) -> Non
 
     monkeypatch.setattr(refresh_pbip_model, "image_save", fake_image_save)
 
-    exit_code = refresh_pbip_model.main(["--pid", "111", "--tables", "Orders", "--port", "52001"])
+    exit_code = refresh_pbip_model.main(["--pid", "111", "--canaries", "Orders", "--port", "52001"])
     out = capsys.readouterr().out
     assert exit_code == 0
     assert "REFRESH: DATA_OK + PERSISTED" in out
@@ -1037,6 +1037,113 @@ def test_an_empty_canary_reports_no_data_naming_the_table(monkeypatch, tmp_path:
     assert exit_code == 1
     assert "REFRESH: NO_DATA" in out
     assert "Live" in out, "the empty canary must be named"
+
+
+def test_narrowing_the_refresh_cannot_earn_a_model_level_data_ok(monkeypatch, tmp_path: Path, capsys) -> None:
+    """`--tables` narrows the REFRESH, so it may never certify the whole model (round-4 finding 5).
+
+    Round 3 made `--tables` both the refresh scope AND the canary set, while the host repo's
+    `pbi-semantic-builder` gate mandates `DATA_OK + PERSISTED`. An agent chasing that verdict would
+    have added `--tables a b`, thereby refreshing ONLY those tables and certifying a model-level
+    result over a partially refreshed model - the exact "next agent gets an empty model" failure this
+    bundle exists to prevent. The scope flag now earns a scoped `TABLES_OK`; `--canaries` verifies
+    without narrowing, and is what earns `DATA_OK`.
+    """
+    cache = _model_folder(tmp_path, "MyMigration", ["Orders"])
+    _stub_bridge(monkeypatch, [{"pid": 111, "currentFilePath": str(tmp_path / "MyMigration.pbip")}])
+    monkeypatch.setattr(refresh_pbip_model, "discover_port", lambda pid: 52001)
+    _stub_live_to_match_disk(monkeypatch, cache)
+    seen: dict[str, object] = {}
+    monkeypatch.setattr(
+        refresh_pbip_model,
+        "refresh",
+        lambda port, tables, timeout: seen.update(refreshed=tables) or (True, "refreshed"),
+    )
+    monkeypatch.setattr(
+        refresh_pbip_model,
+        "row_counts",
+        lambda port, tables: (seen.update(probed=tables), ([("Orders", 42)], False))[1],
+    )
+
+    def fake_image_save(port: int, cache_path: Path, model_dir=None):
+        del port, model_dir
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_path.write_bytes(b"cache")
+        return True, "persisted"
+
+    monkeypatch.setattr(refresh_pbip_model, "image_save", fake_image_save)
+
+    assert refresh_pbip_model.main(["--pid", "111", "--tables", "Orders"]) == 0
+    out = capsys.readouterr().out
+    assert "REFRESH: TABLES_OK 'Orders' + PERSISTED" in out
+    assert "REFRESH: DATA_OK" not in out, "a narrowed refresh must not certify the whole model"
+    assert seen["refreshed"] == ["Orders"], "--tables must still scope the refresh"
+    assert seen["probed"] == ["Orders"], "--tables still supplies the canary set when it is the only flag"
+
+
+def test_canaries_verify_the_whole_model_without_narrowing_the_refresh(monkeypatch, tmp_path: Path, capsys) -> None:
+    """The way out of the trap: `--canaries` probes named tables while the refresh stays model-wide."""
+    cache = _model_folder(tmp_path, "MyMigration", ["Orders"])
+    _stub_bridge(monkeypatch, [{"pid": 111, "currentFilePath": str(tmp_path / "MyMigration.pbip")}])
+    monkeypatch.setattr(refresh_pbip_model, "discover_port", lambda pid: 52001)
+    _stub_live_to_match_disk(monkeypatch, cache)
+    seen: dict[str, object] = {}
+    monkeypatch.setattr(
+        refresh_pbip_model,
+        "refresh",
+        lambda port, tables, timeout: seen.update(refreshed=tables) or (True, "refreshed"),
+    )
+    monkeypatch.setattr(
+        refresh_pbip_model,
+        "row_counts",
+        lambda port, tables: (seen.update(probed=tables), ([("Orders", 42)], False))[1],
+    )
+
+    def fake_image_save(port: int, cache_path: Path, model_dir=None):
+        del port, model_dir
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_path.write_bytes(b"cache")
+        return True, "persisted"
+
+    monkeypatch.setattr(refresh_pbip_model, "image_save", fake_image_save)
+
+    assert refresh_pbip_model.main(["--pid", "111", "--canaries", "Orders"]) == 0
+    out = capsys.readouterr().out
+    assert "REFRESH: DATA_OK + PERSISTED" in out
+    assert seen["refreshed"] is None, "--canaries must NOT narrow the refresh"
+    assert seen["probed"] == ["Orders"], "--canaries must be the probed set"
+
+
+def test_the_bundled_credential_arbiter_never_fails_open() -> None:
+    """The arbiter must not answer CREDENTIAL_PRESENT when it never managed to invoke a Refresh.
+
+    "No modal appeared" is evidence only if something was actually triggered. The copy that shipped at
+    the repo root reported PRESENT in that case - a fail-open arbiter, which is worse than no arbiter,
+    because an agent trusts it and builds against a source it cannot read.
+    """
+    body = CREDENTIAL_PROBE_PS1.read_text(encoding="utf-8")
+    assert "if (-not $invoked)" in body, "the not-invoked branch is the fail-open guard"
+    guard = body.split("if (-not $invoked)", 1)[1].split("$deadline", 1)[0]
+    assert "VERDICT: UNKNOWN" in guard and "exit 3" in guard
+    assert "CREDENTIAL_PRESENT" not in guard
+
+
+def test_the_repo_root_credential_probe_is_a_forwarding_shim() -> None:
+    """One arbiter, not two. The root path is what the docs cite, so it must REACH this bundled copy.
+
+    Two same-named probes had silently diverged, and the one the documentation pointed at was the
+    fail-open one. HOST-repo fixture, so it skips where this bundle has been copied out.
+    """
+    for parent in SKILL_ROOT.parents:
+        root_probe = parent / "scripts" / "probe_desktop_credential.ps1"
+        if root_probe.exists():
+            body = root_probe.read_text(encoding="utf-8")
+            assert "@args" in body and "pbip-model-refresh" in body, (
+                "scripts/probe_desktop_credential.ps1 is a second arbiter again, not a forwarding shim"
+            )
+            assert "UIAutomationClient" not in body, "the shim must not carry its own UIA implementation"
+            return
+    pytest.skip("no host repo scripts/ folder next to this bundle")
 
 
 def _explode(name: str):

--- a/.github/skills/pbip-model-refresh/tests/test_desktop_instance_binding.py
+++ b/.github/skills/pbip-model-refresh/tests/test_desktop_instance_binding.py
@@ -31,6 +31,7 @@ from probe_desktop_query import discover_port, table_names
 from refresh_pbip_model import _instance, _resolve_pid, same_model, tmdl_tables
 
 SKILL_ROOT = Path(__file__).resolve().parents[1]
+CREDENTIAL_PROBE_PS1 = SKILL_ROOT / "scripts" / "probe_desktop_credential.ps1"
 REF_TABLE_RE = re.compile(r"^ref table\s+(?:'([^']+)'|(\S+))", re.MULTILINE)
 
 
@@ -215,6 +216,26 @@ def _model_folder(root: Path, name: str, tables: list[str], *, bom: bool = False
     return root / f"{name}.SemanticModel" / ".pbi" / "cache.abf"
 
 
+def _stub_live_to_match_disk(monkeypatch, cache: Path) -> None:
+    """Stub `same_model`'s live side to mirror the on-disk model exactly (a legitimate exact match).
+
+    `same_model` reads the connected model's tables, columns AND measures off the AS port; with no
+    Desktop in a unit test all three are faked. Deriving the fake from the SAME on-disk model via the
+    real parsers keeps both sides in lockstep, so a test that only cares about the main() flow gets a
+    clean identity pass without hand-copying a schema. `raising=False` on the columns/measures stub is
+    what lets the revert experiment run: round-1 has no `_live_columns_measures`, and there the stub is
+    simply set and never consulted.
+    """
+    model_dir = cache.parent.parent
+    monkeypatch.setattr(refresh_pbip_model, "_live_tables", lambda port: set(tmdl_tables(model_dir)))
+    monkeypatch.setattr(
+        refresh_pbip_model,
+        "_live_columns_measures",
+        lambda port: refresh_pbip_model.tmdl_columns_measures(model_dir),
+        raising=False,
+    )
+
+
 def test_tmdl_tables_reads_through_a_byte_order_mark(tmp_path: Path) -> None:
     """Desktop writes TMDL with a BOM, and a BOM before `table` would empty the whole fingerprint.
 
@@ -242,7 +263,7 @@ def test_auto_date_tables_on_disk_do_not_look_like_a_stranger(monkeypatch, tmp_p
     """
     cache = _model_folder(tmp_path, "MyMigration", ["Orders", "LocalDateTable_9f2c", "DateTableTemplate_1a"])
     assert tmdl_tables(cache.parent.parent) == {"Orders"}
-    monkeypatch.setattr(refresh_pbip_model, "_live_tables", lambda port: {"Orders"})
+    _stub_live_to_match_disk(monkeypatch, cache)
     ok, message = same_model(52001, cache)
     assert ok, message
 
@@ -255,6 +276,12 @@ def test_same_model_accepts_an_exact_case_insensitive_match(monkeypatch, tmp_pat
     """
     cache = _model_folder(tmp_path, "MyMigration", ["Orders", "Date Table"])
     monkeypatch.setattr(refresh_pbip_model, "_live_tables", lambda port: {"orders", "date table"})
+    monkeypatch.setattr(
+        refresh_pbip_model,
+        "_live_columns_measures",
+        lambda port: ({("orders", "X"), ("date table", "X")}, set()),
+        raising=False,
+    )
     ok, message = same_model(52001, cache)
     assert ok, message
     assert "exact match" in message
@@ -302,6 +329,158 @@ def test_same_model_fails_closed_when_it_cannot_verify(monkeypatch, tmp_path: Pa
     empty.parent.mkdir(parents=True)
     ok, message = same_model(52001, empty)
     assert not ok and "UNVERIFIED" in message.upper()
+
+
+def test_same_model_refuses_when_a_column_differs(monkeypatch, tmp_path: Path) -> None:
+    """Matching table NAMES but a different column is a different model - tables alone are not enough.
+
+    Once `cache_file`'s binding is authoritative (round-2 blocker 3a), a same-named sibling is
+    reachable on a widened/wrong port, so the table-only fingerprint stops being defence-in-depth and
+    becomes the ONLY control - and a sibling sharing table names but differing in columns passes it.
+    The fingerprint therefore reaches columns (#114, round-2 blocker 3): here the tables match exactly
+    but the connected model has `Orders[Y]` where the TMDL has `Orders[X]`, and it must be refused.
+    """
+    cache = _model_folder(tmp_path, "MyMigration", ["Orders"])  # disk column: Orders[X]
+    monkeypatch.setattr(refresh_pbip_model, "_live_tables", lambda port: {"Orders"})
+    monkeypatch.setattr(
+        refresh_pbip_model, "_live_columns_measures", lambda port: ({("Orders", "Y")}, set()), raising=False
+    )
+    ok, message = same_model(52001, cache)
+    assert not ok
+    assert "column" in message
+
+
+def test_same_model_refuses_when_a_measure_differs(monkeypatch, tmp_path: Path) -> None:
+    """Matching tables and columns but a different measure is still a different model.
+
+    The measure dimension is the second half of the finer fingerprint (#114, round-2 blocker 3): two
+    models can agree on every table and column yet differ in their measures. Here the connected model
+    carries a `Total Sales` measure the TMDL does not, so `same_model` must refuse.
+    """
+    cache = _model_folder(tmp_path, "MyMigration", ["Orders"])  # disk: Orders[X], no measures
+    monkeypatch.setattr(refresh_pbip_model, "_live_tables", lambda port: {"Orders"})
+    monkeypatch.setattr(
+        refresh_pbip_model,
+        "_live_columns_measures",
+        lambda port: ({("Orders", "X")}, {("Orders", "Total Sales")}),
+        raising=False,
+    )
+    ok, message = same_model(52001, cache)
+    assert not ok
+    assert "measure" in message
+
+
+def test_tmdl_columns_measures_parses_quoted_and_calculated_names(tmp_path: Path) -> None:
+    """The disk fingerprint reads column/measure NAMES only - quoted or not - never the expression."""
+    tables_dir = tmp_path / "M.SemanticModel" / "definition" / "tables"
+    tables_dir.mkdir(parents=True)
+    (tables_dir / "Sales.tmdl").write_text(
+        "table Sales\n"
+        "\n"
+        "\tcolumn 'Order Date'\n"
+        "\tcolumn Qty\n"
+        "\tcolumn Margin = [Revenue] - [Cost]\n"  # calculated column: name before '='
+        "\n"
+        "\tmeasure 'Total Sales' = SUM(Sales[Revenue])\n"
+        "\tmeasure Count = COUNTROWS(Sales)\n",
+        encoding="utf-8",
+    )
+    columns, measures = refresh_pbip_model.tmdl_columns_measures(tmp_path / "M.SemanticModel")
+    assert columns == {("Sales", "Order Date"), ("Sales", "Qty"), ("Sales", "Margin")}
+    assert measures == {("Sales", "Total Sales"), ("Sales", "Count")}
+
+
+def test_tmdl_columns_measures_skips_auto_date_tables(tmp_path: Path) -> None:
+    """Auto date/time scaffolding is filtered on the disk side, mirroring the live-side filter."""
+    tables_dir = tmp_path / "M.SemanticModel" / "definition" / "tables"
+    tables_dir.mkdir(parents=True)
+    (tables_dir / "Sales.tmdl").write_text("table Sales\n\n\tcolumn Amount\n", encoding="utf-8")
+    (tables_dir / "LocalDateTable_x.tmdl").write_text(
+        "table LocalDateTable_x\n\n\tcolumn Year\n\tmeasure M = 1\n", encoding="utf-8"
+    )
+    columns, measures = refresh_pbip_model.tmdl_columns_measures(tmp_path / "M.SemanticModel")
+    assert columns == {("Sales", "Amount")}
+    assert measures == set()
+
+
+class _FingerprintReader:  # pylint: disable=too-few-public-methods
+    """A minimal positional ADOMD reader (PascalCase mirrors the .NET one)."""
+
+    def __init__(self, rows: list[list]) -> None:
+        self._rows = [list(row) for row in rows]
+        self._cur: list | None = None
+
+    def Read(self) -> bool:  # noqa: N802
+        if not self._rows:
+            return False
+        self._cur = self._rows.pop(0)
+        return True
+
+    def GetValue(self, index: int):  # noqa: N802
+        return self._cur[index]
+
+    def Close(self) -> None:  # noqa: N802
+        self._cur = None
+
+
+class _FingerprintCommand:  # pylint: disable=too-few-public-methods
+    def __init__(self, conn: _FingerprintConn) -> None:
+        self._conn = conn
+        self.CommandText = ""  # noqa: N815
+
+    def ExecuteReader(self) -> _FingerprintReader:  # noqa: N802
+        return self._conn.reader_for(self.CommandText)
+
+
+class _FingerprintConn:  # pylint: disable=too-few-public-methods
+    """Answers the DMV queries `column_names`/`measure_names` send: table-id map, columns, measures."""
+
+    def __init__(self, *, tables: dict[str, str], columns: list[tuple], measures: list[tuple]) -> None:
+        self._tables = tables
+        self._columns = columns
+        self._measures = measures
+
+    def CreateCommand(self) -> _FingerprintCommand:  # noqa: N802
+        return _FingerprintCommand(self)
+
+    def reader_for(self, text: str) -> _FingerprintReader:
+        if "TMSCHEMA_TABLES" in text:
+            return _FingerprintReader([[tid, name] for tid, name in self._tables.items()])
+        if "TMSCHEMA_COLUMNS" in text:
+            return _FingerprintReader(self._columns)
+        if "TMSCHEMA_MEASURES" in text:
+            return _FingerprintReader(self._measures)
+        raise AssertionError(f"unexpected DMV: {text}")
+
+
+def test_column_names_filters_rownumber_and_auto_date_columns() -> None:
+    """The live column fingerprint drops the auto RowNumber index and the auto date/time scaffolding.
+
+    Those never appear in TMDL, so comparing them would make a legitimate model fail its own identity
+    gate - the false-negative the reviewer flagged (#114, round-2 blocker 3). Everything else is kept,
+    preferring the explicit model name over the engine's inferred one.
+    """
+    conn = _FingerprintConn(
+        tables={"t1": "Orders", "t2": "LocalDateTable_abc"},
+        columns=[
+            ("t1", "Amount", "Amount", 1),  # data column -> kept
+            ("t1", "", "Qty", 2),  # calculated, no explicit name -> InferredName
+            ("t1", "RowNumber-2b", "RowNumber", 3),  # RowNumber (Type 3) -> filtered
+            ("t2", "Date", "Date", 1),  # auto date-table column -> filtered
+        ],
+        measures=[],
+    )
+    assert probe_desktop_query.column_names(conn) == {("Orders", "Amount"), ("Orders", "Qty")}
+
+
+def test_measure_names_filters_auto_date_measures() -> None:
+    """Measures on the auto date/time tables are filtered too, mirroring the disk side."""
+    conn = _FingerprintConn(
+        tables={"t1": "Sales", "t2": "DateTableTemplate_1"},
+        columns=[],
+        measures=[("t1", "Total Sales"), ("t2", "Some Auto Measure")],
+    )
+    assert probe_desktop_query.measure_names(conn) == {("Sales", "Total Sales")}
 
 
 def _stub_bridge(monkeypatch, instances: list[dict]) -> None:
@@ -353,7 +532,7 @@ def test_main_still_refreshes_and_persists_the_right_instance(monkeypatch, tmp_p
     cache = _model_folder(tmp_path, "MyMigration", ["Orders"])
     _stub_bridge(monkeypatch, [{"pid": 111, "currentFilePath": str(tmp_path / "MyMigration.pbip")}])
     monkeypatch.setattr(refresh_pbip_model, "discover_port", lambda pid: 52001)
-    monkeypatch.setattr(refresh_pbip_model, "_live_tables", lambda port: {"Orders"})
+    _stub_live_to_match_disk(monkeypatch, cache)
     monkeypatch.setattr(refresh_pbip_model, "refresh", lambda port, tables, timeout: (True, "refreshed"))
     monkeypatch.setattr(refresh_pbip_model, "row_counts", lambda port, tables: ([("Orders", 42)], False))
 
@@ -390,7 +569,7 @@ def test_no_save_leaves_the_project_byte_identical(monkeypatch, tmp_path: Path, 
     cache = _model_folder(tmp_path, "MyMigration", ["Orders"])
     _stub_bridge(monkeypatch, [{"pid": 111, "currentFilePath": str(tmp_path / "MyMigration.pbip")}])
     monkeypatch.setattr(refresh_pbip_model, "discover_port", lambda pid: 52001)
-    monkeypatch.setattr(refresh_pbip_model, "_live_tables", lambda port: {"Orders"})
+    _stub_live_to_match_disk(monkeypatch, cache)
     monkeypatch.setattr(refresh_pbip_model, "refresh", lambda port, tables, timeout: (True, "refreshed"))
     monkeypatch.setattr(refresh_pbip_model, "row_counts", lambda port, tables: ([("Orders", 42)], False))
     monkeypatch.setattr(refresh_pbip_model, "image_save", _explode("image_save must not run"))
@@ -414,7 +593,7 @@ def test_persisting_is_the_default(monkeypatch, tmp_path: Path, capsys) -> None:
     cache = _model_folder(tmp_path, "MyMigration", ["Orders"])
     _stub_bridge(monkeypatch, [{"pid": 111, "currentFilePath": str(tmp_path / "MyMigration.pbip")}])
     monkeypatch.setattr(refresh_pbip_model, "discover_port", lambda pid: 52001)
-    monkeypatch.setattr(refresh_pbip_model, "_live_tables", lambda port: {"Orders"})
+    _stub_live_to_match_disk(monkeypatch, cache)
     monkeypatch.setattr(refresh_pbip_model, "refresh", lambda port, tables, timeout: (True, "refreshed"))
     monkeypatch.setattr(refresh_pbip_model, "row_counts", lambda port, tables: ([("Orders", 42)], False))
 
@@ -479,10 +658,10 @@ def test_a_timeout_does_not_assert_a_credential_modal(monkeypatch, tmp_path: Pat
     a permanent dead end. It fired on 2 of 5 Desktop instances opened on the SAME bundle that
     refreshed cleanly on the other 3 (38.8s good run, >87s slow run, 90s ceiling).
     """
-    _model_folder(tmp_path, "MyMigration", ["Orders"])
+    cache = _model_folder(tmp_path, "MyMigration", ["Orders"])
     _stub_bridge(monkeypatch, [{"pid": 111, "currentFilePath": str(tmp_path / "MyMigration.pbip")}])
     monkeypatch.setattr(refresh_pbip_model, "discover_port", lambda pid: 52001)
-    monkeypatch.setattr(refresh_pbip_model, "_live_tables", lambda port: {"Orders"})
+    _stub_live_to_match_disk(monkeypatch, cache)
     monkeypatch.setattr(refresh_pbip_model, "refresh", _explode("The XML for Analysis request timed out"))
 
     exit_code = refresh_pbip_model.main(["--pid", "111"])
@@ -537,13 +716,17 @@ def test_an_unresolved_destination_fails_closed_not_into_a_blind_write(monkeypat
     assert calls == [111], "cache_file must be resolved exactly once, not re-derived after the gate"
 
 
-def _project_with_two_models(root: Path, bypath: str | None) -> Path:
+def _project_with_two_models(root: Path, bypath: str | None, *, stem_decoy: bool) -> Path:
     """Two `.SemanticModel` folders, a `.pbip` and its report; `bypath` is the pbir binding (or None).
 
-    Returns the `.pbip` path. With `bypath` None the report carries no binding, so nothing resolves
-    the ambiguity and `cache_file` must refuse to guess rather than grab an arbitrary sibling.
+    Returns the `.pbip` path (stem `Proj`). The BOUND model is always `Zed`, which sorts LAST, so a
+    fixture that resolved to it cannot have done so by grabbing the first-sorted sibling. `stem_decoy`
+    controls the other folder: `Proj` (matching the `.pbip` stem) exposes the #114 round-2 blocker 3a
+    hole - the name heuristic must NOT short-circuit the binding - while `Alpha` (no stem match) is
+    the genuinely-ambiguous case where, absent a binding, `cache_file` must refuse to guess.
     """
-    for name in ("Bound", "Other"):
+    other = "Proj" if stem_decoy else "Alpha"
+    for name in (other, "Zed"):
         tables = root / f"{name}.SemanticModel" / "definition" / "tables"
         tables.mkdir(parents=True)
         (tables / "T.tmdl").write_text("table 'T'\n\n\tcolumn X\n", encoding="utf-8")
@@ -561,27 +744,43 @@ def _project_with_two_models(root: Path, bypath: str | None) -> Path:
 
 
 def test_cache_file_resolves_the_bound_model_when_several_exist(monkeypatch, tmp_path: Path) -> None:
-    """With several `.SemanticModel` folders, the destination comes from the `.pbip` BINDING.
+    """With several `.SemanticModel` folders, the destination comes from the `.pbip` BINDING - first.
 
-    The old code fell back to `models[0]` (first sorted), silently binding the run to an arbitrary
-    sibling - exactly the wrong-instance write this skill exists to prevent. The `.pbip` -> report ->
-    `definition.pbir` `byPath` chain names the real owner, and `cache_file` must follow it.
+    The bound model here is `Zed` while a same-named `Proj` sibling matches the `.pbip` stem. Round-1
+    consulted the name heuristic BEFORE the binding, so that `Proj` decoy short-circuited it and the
+    run bound to the wrong sibling (#114, round-2 blocker 3a). The binding names the real owner
+    (`Zed`), and `cache_file` must follow it even when a stem-matching decoy exists. `Zed` also sorts
+    last, so this cannot pass by the old `models[0]` accident either.
     """
-    pbip = _project_with_two_models(tmp_path, "../Bound.SemanticModel")
+    pbip = _project_with_two_models(tmp_path, "../Zed.SemanticModel", stem_decoy=True)
     _stub_bridge(monkeypatch, [{"pid": 111, "currentFilePath": str(pbip)}])
     resolved = refresh_pbip_model.cache_file(111)
-    assert resolved == tmp_path / "Bound.SemanticModel" / ".pbi" / "cache.abf"
+    assert resolved == tmp_path / "Zed.SemanticModel" / ".pbi" / "cache.abf"
 
 
 def test_cache_file_refuses_to_guess_when_the_binding_is_ambiguous(monkeypatch, tmp_path: Path) -> None:
     """No name match and no resolvable binding => None, so the identity gate fails closed.
 
-    `Bound` sorts before `Other`, so the old `models[0]` fallback would have returned `Bound` here
-    with no evidence it is the right one. Returning None is what makes the downstream gate refuse.
+    Neither `Alpha` nor `Zed` matches the `.pbip` stem `Proj`, and there is no binding, so nothing
+    names the owner. The old `models[0]` fallback would have grabbed `Alpha` (first sorted) with no
+    evidence; returning None is what makes the downstream gate refuse.
     """
-    pbip = _project_with_two_models(tmp_path, None)
+    pbip = _project_with_two_models(tmp_path, None, stem_decoy=False)
     _stub_bridge(monkeypatch, [{"pid": 111, "currentFilePath": str(pbip)}])
     assert refresh_pbip_model.cache_file(111) is None
+
+
+def test_cache_file_uses_the_stem_only_when_no_binding_resolves(monkeypatch, tmp_path: Path) -> None:
+    """The stem heuristic is a legitimate FALLBACK - it just must never run ahead of the binding.
+
+    With no binding but a single stem-matching sibling (`Proj`), naming it is the best available
+    evidence, so `cache_file` may return it. This pins that the round-2 reordering did not delete the
+    fallback, only demoted it below the authoritative binding.
+    """
+    pbip = _project_with_two_models(tmp_path, None, stem_decoy=True)
+    _stub_bridge(monkeypatch, [{"pid": 111, "currentFilePath": str(pbip)}])
+    resolved = refresh_pbip_model.cache_file(111)
+    assert resolved == tmp_path / "Proj.SemanticModel" / ".pbi" / "cache.abf"
 
 
 def test_a_mismatched_port_aborts_before_any_read_or_write(monkeypatch, tmp_path: Path, capsys) -> None:
@@ -607,10 +806,10 @@ def test_a_mismatched_port_aborts_before_any_read_or_write(monkeypatch, tmp_path
 
 def test_a_matching_port_is_accepted(monkeypatch, tmp_path: Path, capsys) -> None:
     """An explicit `--port` that EQUALS the pid-derived port is fine - the guard blocks only mismatch."""
-    _model_folder(tmp_path, "MyMigration", ["Orders"])
+    cache = _model_folder(tmp_path, "MyMigration", ["Orders"])
     _stub_bridge(monkeypatch, [{"pid": 111, "currentFilePath": str(tmp_path / "MyMigration.pbip")}])
     monkeypatch.setattr(refresh_pbip_model, "discover_port", lambda pid: 52001)
-    monkeypatch.setattr(refresh_pbip_model, "_live_tables", lambda port: {"Orders"})
+    _stub_live_to_match_disk(monkeypatch, cache)
     monkeypatch.setattr(refresh_pbip_model, "refresh", lambda port, tables, timeout: (True, "refreshed"))
     monkeypatch.setattr(refresh_pbip_model, "row_counts", lambda port, tables: ([("Orders", 5)], False))
 
@@ -639,7 +838,7 @@ def test_an_implicit_probe_downgrades_to_table_ok_but_still_persists(monkeypatch
     cache = _model_folder(tmp_path, "MyMigration", ["Orders"])
     _stub_bridge(monkeypatch, [{"pid": 111, "currentFilePath": str(tmp_path / "MyMigration.pbip")}])
     monkeypatch.setattr(refresh_pbip_model, "discover_port", lambda pid: 52001)
-    monkeypatch.setattr(refresh_pbip_model, "_live_tables", lambda port: {"Orders"})
+    _stub_live_to_match_disk(monkeypatch, cache)
     monkeypatch.setattr(refresh_pbip_model, "refresh", lambda port, tables, timeout: (True, "refreshed"))
     monkeypatch.setattr(refresh_pbip_model, "row_counts", lambda port, tables: ([("Parameters", 1)], True))
 
@@ -665,10 +864,10 @@ def test_an_empty_canary_reports_no_data_naming_the_table(monkeypatch, tmp_path:
     With explicit canaries, EVERY named source must return rows; one empty table (a live source whose
     credential failed) is the exact failure #115 wants surfaced, not averaged away by the others.
     """
-    _model_folder(tmp_path, "MyMigration", ["Orders"])
+    cache = _model_folder(tmp_path, "MyMigration", ["Orders"])
     _stub_bridge(monkeypatch, [{"pid": 111, "currentFilePath": str(tmp_path / "MyMigration.pbip")}])
     monkeypatch.setattr(refresh_pbip_model, "discover_port", lambda pid: 52001)
-    monkeypatch.setattr(refresh_pbip_model, "_live_tables", lambda port: {"Orders"})
+    _stub_live_to_match_disk(monkeypatch, cache)
     monkeypatch.setattr(refresh_pbip_model, "refresh", lambda port, tables, timeout: (True, "refreshed"))
     monkeypatch.setattr(refresh_pbip_model, "row_counts", lambda port, tables: ([("Orders", 42), ("Live", 0)], False))
 
@@ -692,3 +891,43 @@ def _explode(name: str):
         raise AssertionError(f"{name}() must not run once the identity check has failed")
 
     return boom
+
+
+def test_timeout_recovery_command_quotes_a_path_with_spaces(monkeypatch, tmp_path: Path, capsys) -> None:
+    """The printed recovery command must QUOTE the arbiter path, or a space breaks `powershell -File`.
+
+    Verified experimentally in the round-2 review: `powershell -File C:\\Program Files\\...` parses as
+    `-File 'C:\\Program'`. The arbiter is bundled and can sit under a spaced directory (a user profile
+    with a space is the common case), so the command must read `-File "<path>"` (#118, round-2 major 4).
+    """
+    cache = _model_folder(tmp_path, "MyMigration", ["Orders"])
+    spaced = tmp_path / "Program Files" / "probe_desktop_credential.ps1"
+    spaced.parent.mkdir(parents=True)
+    spaced.write_text("# stub arbiter\n", encoding="utf-8")
+    monkeypatch.setattr(refresh_pbip_model, "CREDENTIAL_PROBE", spaced)
+    _stub_bridge(monkeypatch, [{"pid": 111, "currentFilePath": str(tmp_path / "MyMigration.pbip")}])
+    monkeypatch.setattr(refresh_pbip_model, "discover_port", lambda pid: 52001)
+    _stub_live_to_match_disk(monkeypatch, cache)
+    monkeypatch.setattr(refresh_pbip_model, "refresh", _explode("The XML for Analysis request timed out"))
+
+    exit_code = refresh_pbip_model.main(["--pid", "111"])
+    out = capsys.readouterr().out
+    assert exit_code == 3
+    assert f'-File "{spaced}"' in out, "the arbiter path must be quoted for powershell -File"
+
+
+def test_credential_arbiter_enumerates_all_windows_and_fails_closed() -> None:
+    """The credential arbiter (#118) must not fail OPEN, and must inspect EVERY window for the pid.
+
+    It became "the arbiter" the timeout message points at, so a fail-open answer is worse than none
+    (round-2 major 5). The script needs live UIAutomation + Desktop to execute, so these two fixes are
+    pinned structurally: it must enumerate all top-level windows (`Get-PidWindows`/`FindAll`, not the
+    old single-window `FindFirst`), and when no Refresh control was ever invoked it must report
+    UNKNOWN rather than asserting a credential is present.
+    """
+    text = CREDENTIAL_PROBE_PS1.read_text(encoding="utf-8")
+    assert "Get-PidWindows" in text, "must enumerate windows via the all-windows helper"
+    assert "FindAll" in text, "must use FindAll (every top-level window)"
+    assert "FindFirst" not in text, "the single-window FindFirst scan was the fail-open enumeration bug"
+    assert re.search(r"-not\s+\$invoked", text), "must guard the case where no Refresh was invoked"
+    assert re.search(r"VERDICT:\s*UNKNOWN", text), "the not-invoked case must report UNKNOWN, not CREDENTIAL_PRESENT"

--- a/.github/skills/pbip-model-refresh/tests/test_desktop_instance_binding.py
+++ b/.github/skills/pbip-model-refresh/tests/test_desktop_instance_binding.py
@@ -7,7 +7,7 @@ silently widen to "any msmdsrv on the machine" whenever the pid-scoped lookup ca
 most likely because Desktop was up before its msmdsrv had bound a port - and then took the first
 result. That writes a SIBLING migration's model into this migration's own correct `cache.abf`, and
 every existing check still passes: `image_save` can only see that the file exists, is non-empty and
-was newly written, and `row_count` queries that same wrong port, so both signals agree and both are
+was newly written, and `row_counts` queries that same wrong port, so both signals agree and both are
 wrong. `cache.abf` is gitignored, so nothing downstream catches it either.
 
 So these tests lock in the two defences: never widen a named pid (and never pick between ambiguous
@@ -247,13 +247,34 @@ def test_auto_date_tables_on_disk_do_not_look_like_a_stranger(monkeypatch, tmp_p
     assert ok, message
 
 
-def test_same_model_accepts_the_model_that_owns_the_cache(monkeypatch, tmp_path: Path) -> None:
-    """Extra tables in the engine are normal (auto date tables, in-memory edits); missing ones are not."""
+def test_same_model_accepts_an_exact_case_insensitive_match(monkeypatch, tmp_path: Path) -> None:
+    """The model that OWNS the cache matches the TMDL table-for-table (case-insensitively).
+
+    An exactly-matching set - names differing only by case (`orders` vs `Orders`) - is the one thing
+    that earns "confirmed". This is the legitimate flow the fail-closed gate must NOT block.
+    """
+    cache = _model_folder(tmp_path, "MyMigration", ["Orders", "Date Table"])
+    monkeypatch.setattr(refresh_pbip_model, "_live_tables", lambda port: {"orders", "date table"})
+    ok, message = same_model(52001, cache)
+    assert ok, message
+    assert "exact match" in message
+
+
+def test_same_model_refuses_a_superset_schema(monkeypatch, tmp_path: Path) -> None:
+    """A sibling holding ALL your tables PLUS more is a different model, not a lagging TMDL.
+
+    This test used to assert the opposite (`test_same_model_accepts_the_model_that_owns_the_cache`
+    expected ok=True and "more not in TMDL"). That fail-open subset match is the exact #114 hole: the
+    check only required the TMDL tables to be PRESENT in the engine, so a richer sibling passed and
+    was reported "confirmed". Concurrent Desktop instances are supported, so that sibling is
+    reachable, not hypothetical - and once its model is confirmed, its rows get written into this
+    project's cache.abf. An exact match now refuses it.
+    """
     cache = _model_folder(tmp_path, "MyMigration", ["Orders", "Date Table"])
     monkeypatch.setattr(refresh_pbip_model, "_live_tables", lambda port: {"orders", "Date Table", "Extra"})
     ok, message = same_model(52001, cache)
-    assert ok, message
-    assert "more not in TMDL" in message, "TMDL that lags the engine is worth reporting, not refusing"
+    assert not ok
+    assert "Extra" in message, "the extra live table must be named as the reason for refusal"
 
 
 def test_same_model_refuses_a_siblings_model(monkeypatch, tmp_path: Path) -> None:
@@ -265,16 +286,22 @@ def test_same_model_refuses_a_siblings_model(monkeypatch, tmp_path: Path) -> Non
     assert "Orders" in message and "MyMigration.SemanticModel" in message
 
 
-def test_same_model_says_so_when_it_cannot_verify(monkeypatch, tmp_path: Path) -> None:
-    """No model folder / no TMDL is 'unknown', not 'wrong' - it must not block a legitimate save."""
+def test_same_model_fails_closed_when_it_cannot_verify(monkeypatch, tmp_path: Path) -> None:
+    """'Cannot verify' must FAIL CLOSED, because this gate guards a write into a project.
+
+    No model folder resolved, or no TMDL tables to fingerprint, is 'unknown' - and unknown is not
+    'fine'. This test used to assert the opposite (ok=True + "unverified"): a hiccup that left the
+    destination unresolved let the write straight through. That fail-open path is #114; both shapes
+    now return False.
+    """
     monkeypatch.setattr(refresh_pbip_model, "_live_tables", lambda port: {"Whatever"})
     ok, message = same_model(52001, None)
-    assert ok and "unverified" in message
+    assert not ok and "UNVERIFIED" in message.upper()
 
     empty = tmp_path / "Empty.SemanticModel" / ".pbi" / "cache.abf"
     empty.parent.mkdir(parents=True)
     ok, message = same_model(52001, empty)
-    assert ok and "unverified" in message
+    assert not ok and "UNVERIFIED" in message.upper()
 
 
 def _stub_bridge(monkeypatch, instances: list[dict]) -> None:
@@ -309,7 +336,7 @@ def test_main_aborts_before_refreshing_a_wrong_bound_instance(monkeypatch, tmp_p
     _stub_bridge(monkeypatch, [{"pid": 111, "currentFilePath": str(tmp_path / "MyMigration.pbip")}])
     monkeypatch.setattr(refresh_pbip_model, "discover_port", lambda pid: 52001)
     monkeypatch.setattr(refresh_pbip_model, "_live_tables", lambda port: {"Turbine"})
-    for never in ("refresh", "image_save", "save", "row_count"):
+    for never in ("refresh", "image_save", "save", "row_counts"):
         monkeypatch.setattr(refresh_pbip_model, never, _explode(never))
 
     assert refresh_pbip_model.main(["--pid", "111"]) == 2
@@ -319,28 +346,29 @@ def test_main_aborts_before_refreshing_a_wrong_bound_instance(monkeypatch, tmp_p
 def test_main_still_refreshes_and_persists_the_right_instance(monkeypatch, tmp_path: Path, capsys) -> None:
     """The gate must not cry wolf: the normal single-migration flow has to stay green.
 
-    Passes `--save` explicitly: persisting became opt-in on 2026-08-04 (a present `cache.abf` makes
-    the PBIP unopenable), so this exercises the save path deliberately rather than by default.
+    Passes explicit `--tables Orders` (both the refresh scope and the canary set, so an all-non-zero
+    result earns the model-level DATA_OK - #115) and a legacy `--save` (now an accepted no-op, since
+    persisting is the default - #113), proving both still work and still persist.
     """
     cache = _model_folder(tmp_path, "MyMigration", ["Orders"])
     _stub_bridge(monkeypatch, [{"pid": 111, "currentFilePath": str(tmp_path / "MyMigration.pbip")}])
     monkeypatch.setattr(refresh_pbip_model, "discover_port", lambda pid: 52001)
     monkeypatch.setattr(refresh_pbip_model, "_live_tables", lambda port: {"Orders"})
     monkeypatch.setattr(refresh_pbip_model, "refresh", lambda port, tables, timeout: (True, "refreshed"))
-    monkeypatch.setattr(refresh_pbip_model, "row_count", lambda port: (42, "Orders"))
+    monkeypatch.setattr(refresh_pbip_model, "row_counts", lambda port, tables: ([("Orders", 42)], False))
 
-    def fake_image_save(port: int, cache_path: Path, model_dir=None, align_compat: bool = False):
-        # Signature mirrors the real image_save, including the compatibility-level guard arguments
-        # added 2026-08-07. A stub that lags the real signature raises TypeError, which main()
-        # swallows into the UI-save fallback - so this test would go green against a broken call.
-        del port, model_dir, align_compat
+    def fake_image_save(port: int, cache_path: Path, model_dir=None):
+        # Signature mirrors the real image_save EXACTLY. A stub that lags it raises TypeError, which
+        # main() swallows into the UI-save fallback - so a drifted stub would go green against a
+        # broken call.
+        del port, model_dir
         cache_path.parent.mkdir(parents=True, exist_ok=True)
         cache_path.write_bytes(b"cache")
         return True, "persisted"
 
     monkeypatch.setattr(refresh_pbip_model, "image_save", fake_image_save)
 
-    assert refresh_pbip_model.main(["--pid", "111", "--save"]) == 0
+    assert refresh_pbip_model.main(["--pid", "111", "--tables", "Orders", "--save"]) == 0
     out = capsys.readouterr().out
     assert "REFRESH: DATA_OK + PERSISTED" in out
     assert cache.read_bytes() == b"cache"
@@ -364,11 +392,11 @@ def test_no_save_leaves_the_project_byte_identical(monkeypatch, tmp_path: Path, 
     monkeypatch.setattr(refresh_pbip_model, "discover_port", lambda pid: 52001)
     monkeypatch.setattr(refresh_pbip_model, "_live_tables", lambda port: {"Orders"})
     monkeypatch.setattr(refresh_pbip_model, "refresh", lambda port, tables, timeout: (True, "refreshed"))
-    monkeypatch.setattr(refresh_pbip_model, "row_count", lambda port: (42, "Orders"))
+    monkeypatch.setattr(refresh_pbip_model, "row_counts", lambda port, tables: ([("Orders", 42)], False))
     monkeypatch.setattr(refresh_pbip_model, "image_save", _explode("image_save must not run"))
     monkeypatch.setattr(refresh_pbip_model, "save", _explode("save must not run"))
 
-    assert refresh_pbip_model.main(["--pid", "111", "--no-save"]) == 0
+    assert refresh_pbip_model.main(["--pid", "111", "--tables", "Orders", "--no-save"]) == 0
     out = capsys.readouterr().out
     assert "REFRESH: DATA_OK" in out
     assert "PERSISTED" not in out
@@ -388,7 +416,7 @@ def test_persisting_is_the_default(monkeypatch, tmp_path: Path, capsys) -> None:
     monkeypatch.setattr(refresh_pbip_model, "discover_port", lambda pid: 52001)
     monkeypatch.setattr(refresh_pbip_model, "_live_tables", lambda port: {"Orders"})
     monkeypatch.setattr(refresh_pbip_model, "refresh", lambda port, tables, timeout: (True, "refreshed"))
-    monkeypatch.setattr(refresh_pbip_model, "row_count", lambda port: (42, "Orders"))
+    monkeypatch.setattr(refresh_pbip_model, "row_counts", lambda port, tables: ([("Orders", 42)], False))
 
     def fake_image_save(port: int, cache_path: Path, model_dir=None):
         del port, model_dir
@@ -399,7 +427,7 @@ def test_persisting_is_the_default(monkeypatch, tmp_path: Path, capsys) -> None:
     monkeypatch.setattr(refresh_pbip_model, "image_save", fake_image_save)
     monkeypatch.setattr(refresh_pbip_model, "save", _explode("the UI fallback must not run"))
 
-    assert refresh_pbip_model.main(["--pid", "111"]) == 0
+    assert refresh_pbip_model.main(["--pid", "111", "--tables", "Orders"]) == 0
     out = capsys.readouterr().out
     assert "REFRESH: DATA_OK + PERSISTED" in out
     assert cache.exists(), "a default refresh must persist cache.abf"
@@ -430,7 +458,7 @@ def test_compatibility_alignment_declares_generated_edit(tmp_path: Path) -> None
     class FakeDatabase:
         CompatibilityLevel = 1702
 
-    note = refresh_pbip_model._align_compatibility(FakeDatabase(), model_dir)
+    note = refresh_pbip_model._align_compatibility(model_dir, int(FakeDatabase.CompatibilityLevel))
 
     declarations = json.loads((tmp_path / "_build" / "generated-edit-declarations.json").read_text(encoding="utf-8"))
     declaration = declarations["declarations"][0]
@@ -464,35 +492,199 @@ def test_a_timeout_does_not_assert_a_credential_modal(monkeypatch, tmp_path: Pat
     assert "CAUSE UNKNOWN" in out
     assert "THIS NEEDS A HUMAN" not in out, "a timeout heuristic must not emit a stop-word instruction"
     assert "probe_desktop_credential" in out, "it must name the arbiter that settles the cause"
+    # #118: the arbiter it names must actually ship in the bundle, and the message must print its
+    # bundled absolute path - a runtime instruction to run a file that is not here breaks the
+    # bundle's self-containment claim.
+    arbiter = refresh_pbip_model.CREDENTIAL_PROBE
+    assert str(arbiter) in out, "the timeout must print the arbiter's absolute, bundled path"
+    assert arbiter.is_file(), "the named arbiter must actually ship in the bundle"
+    assert arbiter.parent == SKILL_ROOT / "scripts", "the arbiter must live inside this skill's scripts/"
 
 
-def test_persisting_uses_the_exact_cache_path_the_gate_verified(monkeypatch, tmp_path: Path, capsys) -> None:
-    """Re-deriving the destination after the gate means writing somewhere never verified.
+def test_an_unresolved_destination_fails_closed_not_into_a_blind_write(monkeypatch, tmp_path: Path, capsys) -> None:
+    """An unresolved destination must fail CLOSED at the gate, before any write - and be resolved once.
 
-    `cache_file` is a Desktop Bridge round trip, and `_bridge_status` returns `{}` on any non-JSON
-    output - so a hiccup at gate time (path `None`, "identity unverified", gate passes as a no-op)
-    followed by a successful call afterwards would have persisted an unchecked model. The write must
-    never reach a path the gate did not see.
+    `cache_file` is a Desktop Bridge round trip and returns None when the pid maps to no single model
+    (an ambiguous `.SemanticModel` folder, or a bridge hiccup). This test used to assert that the run
+    then proceeded to a `NOT_PERSISTED` exit 1 - i.e. the fail-OPEN gate let a None destination
+    through as "unverified -> fine". Under #114 the gate fails closed: None aborts with WRONG_MODEL
+    (exit 2) and refresh/save/image_save never run. `cache_file` is also resolved EXACTLY once -
+    re-deriving it after the gate would verify one path and write another.
     """
+    calls: list[int] = []
+
+    def fake_cache_file(pid: int) -> None:
+        calls.append(pid)
+        return None
+
     written: list[Path] = []
 
-    def _record(port: int, path: Path) -> tuple[bool, str]:
-        written.append(path)
+    def _record(port: int, cache_path: Path, model_dir=None) -> tuple[bool, str]:
+        written.append(cache_path)
         return True, "saved via ImageSave"
 
-    resolved = [None, _model_folder(tmp_path, "MyMigration", ["Orders"])]
-    monkeypatch.setattr(refresh_pbip_model, "cache_file", lambda pid: resolved.pop(0) if resolved else None)
+    monkeypatch.setattr(refresh_pbip_model, "cache_file", fake_cache_file)
     monkeypatch.setattr(refresh_pbip_model, "discover_port", lambda pid: 52001)
     monkeypatch.setattr(refresh_pbip_model, "_live_tables", lambda port: {"Turbine"})
-    monkeypatch.setattr(refresh_pbip_model, "refresh", lambda port, tables, timeout: (True, "refreshed"))
-    monkeypatch.setattr(refresh_pbip_model, "row_count", lambda port: (7, "Orders"))
-    monkeypatch.setattr(refresh_pbip_model, "save", lambda pid: (True, "saved via UI"))
+    monkeypatch.setattr(refresh_pbip_model, "refresh", _explode("refresh must not run on an unverified destination"))
+    monkeypatch.setattr(refresh_pbip_model, "save", _explode("save must not run"))
     monkeypatch.setattr(refresh_pbip_model, "image_save", _record)
 
-    exit_code = refresh_pbip_model.main(["--pid", "111", "--save"])
+    exit_code = refresh_pbip_model.main(["--pid", "111"])
+    assert exit_code == 2
+    assert "REFRESH: WRONG_MODEL" in capsys.readouterr().out
     assert written == []
+    assert calls == [111], "cache_file must be resolved exactly once, not re-derived after the gate"
+
+
+def _project_with_two_models(root: Path, bypath: str | None) -> Path:
+    """Two `.SemanticModel` folders, a `.pbip` and its report; `bypath` is the pbir binding (or None).
+
+    Returns the `.pbip` path. With `bypath` None the report carries no binding, so nothing resolves
+    the ambiguity and `cache_file` must refuse to guess rather than grab an arbitrary sibling.
+    """
+    for name in ("Bound", "Other"):
+        tables = root / f"{name}.SemanticModel" / "definition" / "tables"
+        tables.mkdir(parents=True)
+        (tables / "T.tmdl").write_text("table 'T'\n\n\tcolumn X\n", encoding="utf-8")
+    report = root / "Proj.Report"
+    report.mkdir(parents=True)
+    dataset_ref = {"byPath": {"path": bypath}} if bypath else {}
+    (report / "definition.pbir").write_text(
+        json.dumps({"version": "1.0", "datasetReference": dataset_ref}), encoding="utf-8"
+    )
+    pbip = root / "Proj.pbip"
+    pbip.write_text(
+        json.dumps({"version": "1.0", "artifacts": [{"report": {"path": "Proj.Report"}}]}), encoding="utf-8"
+    )
+    return pbip
+
+
+def test_cache_file_resolves_the_bound_model_when_several_exist(monkeypatch, tmp_path: Path) -> None:
+    """With several `.SemanticModel` folders, the destination comes from the `.pbip` BINDING.
+
+    The old code fell back to `models[0]` (first sorted), silently binding the run to an arbitrary
+    sibling - exactly the wrong-instance write this skill exists to prevent. The `.pbip` -> report ->
+    `definition.pbir` `byPath` chain names the real owner, and `cache_file` must follow it.
+    """
+    pbip = _project_with_two_models(tmp_path, "../Bound.SemanticModel")
+    _stub_bridge(monkeypatch, [{"pid": 111, "currentFilePath": str(pbip)}])
+    resolved = refresh_pbip_model.cache_file(111)
+    assert resolved == tmp_path / "Bound.SemanticModel" / ".pbi" / "cache.abf"
+
+
+def test_cache_file_refuses_to_guess_when_the_binding_is_ambiguous(monkeypatch, tmp_path: Path) -> None:
+    """No name match and no resolvable binding => None, so the identity gate fails closed.
+
+    `Bound` sorts before `Other`, so the old `models[0]` fallback would have returned `Bound` here
+    with no evidence it is the right one. Returning None is what makes the downstream gate refuse.
+    """
+    pbip = _project_with_two_models(tmp_path, None)
+    _stub_bridge(monkeypatch, [{"pid": 111, "currentFilePath": str(pbip)}])
+    assert refresh_pbip_model.cache_file(111) is None
+
+
+def test_a_mismatched_port_aborts_before_any_read_or_write(monkeypatch, tmp_path: Path, capsys) -> None:
+    """`--port` must EQUAL the pid-derived port, or the run aborts before touching anything.
+
+    A `--port` pointing at another instance is the wrong-instance write in one argument: the
+    destination is resolved from the pid, so a stray port reads (and, via ImageSave, persists) a
+    sibling's model into this project's own correct cache.abf. #114 closes it by refusing any
+    mismatch up front - the identity probe, refresh, row count and save must never run.
+    """
+    _model_folder(tmp_path, "MyMigration", ["Orders"])
+    _stub_bridge(monkeypatch, [{"pid": 111, "currentFilePath": str(tmp_path / "MyMigration.pbip")}])
+    monkeypatch.setattr(refresh_pbip_model, "discover_port", lambda pid: 52001)
+    for never in ("same_model", "refresh", "image_save", "save", "row_counts"):
+        monkeypatch.setattr(refresh_pbip_model, never, _explode(never))
+
+    exit_code = refresh_pbip_model.main(["--pid", "111", "--port", "59999"])
+    out = capsys.readouterr().out
+    assert exit_code == 2
+    assert "59999" in out and "52001" in out, "the error must name both the given and the discovered port"
+    assert "does not match" in out
+
+
+def test_a_matching_port_is_accepted(monkeypatch, tmp_path: Path, capsys) -> None:
+    """An explicit `--port` that EQUALS the pid-derived port is fine - the guard blocks only mismatch."""
+    _model_folder(tmp_path, "MyMigration", ["Orders"])
+    _stub_bridge(monkeypatch, [{"pid": 111, "currentFilePath": str(tmp_path / "MyMigration.pbip")}])
+    monkeypatch.setattr(refresh_pbip_model, "discover_port", lambda pid: 52001)
+    monkeypatch.setattr(refresh_pbip_model, "_live_tables", lambda port: {"Orders"})
+    monkeypatch.setattr(refresh_pbip_model, "refresh", lambda port, tables, timeout: (True, "refreshed"))
+    monkeypatch.setattr(refresh_pbip_model, "row_counts", lambda port, tables: ([("Orders", 5)], False))
+
+    def fake_image_save(port: int, cache_path: Path, model_dir=None):
+        del port, model_dir
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_path.write_bytes(b"cache")
+        return True, "persisted"
+
+    monkeypatch.setattr(refresh_pbip_model, "image_save", fake_image_save)
+
+    exit_code = refresh_pbip_model.main(["--pid", "111", "--tables", "Orders", "--port", "52001"])
+    out = capsys.readouterr().out
+    assert exit_code == 0
+    assert "REFRESH: DATA_OK + PERSISTED" in out
+
+
+def test_an_implicit_probe_downgrades_to_table_ok_but_still_persists(monkeypatch, tmp_path: Path, capsys) -> None:
+    """No `--tables`: only the first queryable table is probed, so the verdict names that one table.
+
+    A model-level `DATA_OK` from an implicit single-table probe is the #115 defect: a static
+    parameter/CSV table (here 'Parameters') can return rows while every live source failed to load.
+    The verdict must be `TABLE_OK 'Parameters'`, never `DATA_OK`. Persistence is a separate axis and
+    is unaffected.
+    """
+    cache = _model_folder(tmp_path, "MyMigration", ["Orders"])
+    _stub_bridge(monkeypatch, [{"pid": 111, "currentFilePath": str(tmp_path / "MyMigration.pbip")}])
+    monkeypatch.setattr(refresh_pbip_model, "discover_port", lambda pid: 52001)
+    monkeypatch.setattr(refresh_pbip_model, "_live_tables", lambda port: {"Orders"})
+    monkeypatch.setattr(refresh_pbip_model, "refresh", lambda port, tables, timeout: (True, "refreshed"))
+    monkeypatch.setattr(refresh_pbip_model, "row_counts", lambda port, tables: ([("Parameters", 1)], True))
+
+    def fake_image_save(port: int, cache_path: Path, model_dir=None):
+        del port, model_dir
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_path.write_bytes(b"cache")
+        return True, "persisted"
+
+    monkeypatch.setattr(refresh_pbip_model, "image_save", fake_image_save)
+
+    exit_code = refresh_pbip_model.main(["--pid", "111"])
+    out = capsys.readouterr().out
+    assert exit_code == 0
+    assert "REFRESH: TABLE_OK 'Parameters'" in out
+    assert "REFRESH: DATA_OK" not in out, "an implicit single-table probe must never claim a model-level DATA_OK"
+    assert cache.exists(), "the downgrade is about the VERDICT, not about suppressing persistence"
+
+
+def test_an_empty_canary_reports_no_data_naming_the_table(monkeypatch, tmp_path: Path, capsys) -> None:
+    """A named canary returning 0 rows is a source that never loaded - NO_DATA, naming the table.
+
+    With explicit canaries, EVERY named source must return rows; one empty table (a live source whose
+    credential failed) is the exact failure #115 wants surfaced, not averaged away by the others.
+    """
+    _model_folder(tmp_path, "MyMigration", ["Orders"])
+    _stub_bridge(monkeypatch, [{"pid": 111, "currentFilePath": str(tmp_path / "MyMigration.pbip")}])
+    monkeypatch.setattr(refresh_pbip_model, "discover_port", lambda pid: 52001)
+    monkeypatch.setattr(refresh_pbip_model, "_live_tables", lambda port: {"Orders"})
+    monkeypatch.setattr(refresh_pbip_model, "refresh", lambda port, tables, timeout: (True, "refreshed"))
+    monkeypatch.setattr(refresh_pbip_model, "row_counts", lambda port, tables: ([("Orders", 42), ("Live", 0)], False))
+
+    def fake_image_save(port: int, cache_path: Path, model_dir=None):
+        del port, model_dir
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_path.write_bytes(b"cache")
+        return True, "persisted"
+
+    monkeypatch.setattr(refresh_pbip_model, "image_save", fake_image_save)
+
+    exit_code = refresh_pbip_model.main(["--pid", "111", "--tables", "Orders", "Live"])
+    out = capsys.readouterr().out
     assert exit_code == 1
-    assert "NOT_PERSISTED" in capsys.readouterr().out
+    assert "REFRESH: NO_DATA" in out
+    assert "Live" in out, "the empty canary must be named"
 
 
 def _explode(name: str):

--- a/.github/skills/pbip-model-refresh/tests/test_persist_atomicity.py
+++ b/.github/skills/pbip-model-refresh/tests/test_persist_atomicity.py
@@ -1,0 +1,185 @@
+"""The persisted cache write must be atomic, and a failed persist must not leave the project bumped.
+
+Two guarantees this file pins, both from #113:
+
+1. **Atomic swap.** `ImageSave` opens `cache.abf` with `FileMode.Create`, which TRUNCATES a good
+   cache the instant the write begins - so a write that then fails half way leaves the project WORSE
+   than before (no fresh cache and no old one). `_staged_image_write` writes `cache.abf.tmp` and only
+   `os.replace`s it over the original once it exists and is non-empty, so a failed/partial write can
+   never destroy an existing good cache.
+2. **Compat rollback.** Saving raises `database.tmdl`'s declared compatibilityLevel to the live
+   level. That edit is written eagerly (so the serialized cache matches the project), but it is
+   PROVISIONAL: if the ImageSave that follows does not land, `_persist_image` restores
+   `database.tmdl` (and the generated-edit ledger) exactly, so a mid-failure never leaves the model
+   declaring a level that was never actually written to a cache.
+
+Plus a docs-vs-code guard: the SKILL.md frontmatter's persistence default must match the argparse
+default, so the two cannot silently drift again (the #113 doc bug: frontmatter said "opt-in" while
+the code persisted by default).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+# `conftest.py` next to this file puts the skill's own `scripts/` on `sys.path`.
+# ruff: noqa: E402  (the conftest-provided path must be in place before these imports)
+import refresh_pbip_model
+
+SKILL_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _model(root: Path, name: str = "MyMigration", compat: int | None = None) -> Path:
+    """A minimal `<Name>.SemanticModel` on disk; returns the `cache.abf` destination inside it."""
+    definition = root / f"{name}.SemanticModel" / "definition"
+    (definition / "tables").mkdir(parents=True)
+    (definition / "tables" / "Orders.tmdl").write_text("table 'Orders'\n\n\tcolumn X\n", encoding="utf-8")
+    if compat is not None:
+        (definition / "database.tmdl").write_text(f"database\n\tcompatibilityLevel: {compat}\n", encoding="utf-8")
+    return root / f"{name}.SemanticModel" / ".pbi" / "cache.abf"
+
+
+def test_a_failed_write_does_not_destroy_an_existing_good_cache(tmp_path: Path) -> None:
+    """FileMode.Create truncates on open; staging is what keeps a failed write from erasing the cache."""
+    cache = _model(tmp_path)
+    cache.parent.mkdir(parents=True)
+    cache.write_bytes(b"GOOD-EXISTING-CACHE")
+
+    def write_nothing(_staging: Path) -> None:
+        # A write that produces no file - e.g. the engine refused - must not touch the live cache.
+        return None
+
+    assert refresh_pbip_model._staged_image_write(cache, write_nothing) is False
+    assert cache.read_bytes() == b"GOOD-EXISTING-CACHE", "a failed write must leave the old cache intact"
+    assert not cache.with_name(cache.name + ".tmp").exists(), "no staging file may be left behind"
+
+
+def test_a_raising_write_with_no_output_leaves_the_cache_intact(tmp_path: Path) -> None:
+    """`write_image` is allowed to RAISE (the AMO client throws mid-write); judge by the file, not the
+    exception - and a raise that produced nothing must still not clobber the existing cache."""
+    cache = _model(tmp_path)
+    cache.parent.mkdir(parents=True)
+    cache.write_bytes(b"GOOD-EXISTING-CACHE")
+
+    def raise_without_writing(_staging: Path) -> None:
+        raise RuntimeError("The server sent an unrecognizable response")
+
+    assert refresh_pbip_model._staged_image_write(cache, raise_without_writing) is False
+    assert cache.read_bytes() == b"GOOD-EXISTING-CACHE"
+    assert not cache.with_name(cache.name + ".tmp").exists()
+
+
+def test_a_raising_write_that_still_produced_bytes_counts_as_a_write(tmp_path: Path) -> None:
+    """The real client raises WHILE writing correctly, so a non-empty staging file is a success even
+    though the call raised - success is the FILE, never the absence of an exception."""
+    cache = _model(tmp_path)
+
+    def raise_after_writing(staging: Path) -> None:
+        staging.parent.mkdir(parents=True, exist_ok=True)
+        staging.write_bytes(b"NEW-CACHE-BYTES")
+        raise RuntimeError("The server sent an unrecognizable response")
+
+    assert refresh_pbip_model._staged_image_write(cache, raise_after_writing) is True
+    assert cache.read_bytes() == b"NEW-CACHE-BYTES"
+    assert not cache.with_name(cache.name + ".tmp").exists(), "the staging file must be swapped, not left"
+
+
+def test_a_successful_write_swaps_the_new_cache_in(tmp_path: Path) -> None:
+    """The happy path: staging is written, then atomically replaces the destination."""
+    cache = _model(tmp_path)
+    cache.parent.mkdir(parents=True)
+    cache.write_bytes(b"OLD")
+
+    def write_new(staging: Path) -> None:
+        staging.write_bytes(b"NEW-CACHE-BYTES")
+
+    assert refresh_pbip_model._staged_image_write(cache, write_new) is True
+    assert cache.read_bytes() == b"NEW-CACHE-BYTES"
+
+
+def test_persist_rolls_back_the_compat_bump_when_the_write_fails(tmp_path: Path) -> None:
+    """A failed persist must undo the provisional compatibilityLevel alignment, byte-for-byte.
+
+    Otherwise database.tmdl - part of the deployable artifact - is left declaring a level that was
+    never actually written to a cache, and the generated-edit ledger records a change that did not
+    stick. An engine-run manifest is present so the alignment DOES append a ledger entry, letting us
+    prove that entry is rolled back too (not just database.tmdl).
+    """
+    cache = _model(tmp_path, compat=1604)
+    model_dir = cache.parent.parent
+    database_tmdl = model_dir / "definition" / "database.tmdl"
+    before = database_tmdl.read_bytes()
+    before_hash = refresh_pbip_model.sha256_file(database_tmdl)
+    (tmp_path / "input_manifest.json").write_text(
+        json.dumps(
+            {
+                "generated_artifacts": {
+                    "version": 1,
+                    "run_id": "engine-run",
+                    "recorded_at": "2026-08-10T08:00:00+00:00",
+                    "report_sha256": "report-hash",
+                    "files": {"MyMigration.SemanticModel/definition/database.tmdl": before_hash},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    def failing_write(_staging: Path) -> None:
+        return None
+
+    ok, message = refresh_pbip_model._persist_image(cache, model_dir, 1702, failing_write)
+    assert ok is False
+    assert "rolled back" in message
+    assert database_tmdl.read_bytes() == before, "a failed persist must restore database.tmdl exactly"
+    ledger = tmp_path / "_build" / "generated-edit-declarations.json"
+    assert not ledger.exists(), "the generated-edit ledger entry must be rolled back too"
+    assert not cache.exists()
+
+
+def test_persist_aligns_and_writes_on_success(tmp_path: Path) -> None:
+    """On a successful write the alignment STAYS: the cache is a 1702 image, so the project must
+    declare 1702 or the reopen hits the compatibility-downgrade crash."""
+    cache = _model(tmp_path, compat=1604)
+    model_dir = cache.parent.parent
+    database_tmdl = model_dir / "definition" / "database.tmdl"
+
+    def good_write(staging: Path) -> None:
+        staging.write_bytes(b"CACHE")
+
+    ok, message = refresh_pbip_model._persist_image(cache, model_dir, 1702, good_write)
+    assert ok is True
+    assert "1702" in message
+    assert "compatibilityLevel: 1702" in database_tmdl.read_text(encoding="utf-8")
+    assert cache.read_bytes() == b"CACHE"
+
+
+def _frontmatter(text: str) -> str:
+    """The YAML frontmatter block between the first pair of `---` fences."""
+    assert text.startswith("---"), "SKILL.md must open with a YAML frontmatter fence"
+    return text.split("---", 2)[1]
+
+
+def test_documented_persist_default_matches_the_argparse_default() -> None:
+    """The doc and the code cannot drift: the frontmatter's persistence default must equal argparse's.
+
+    This is the #113 bug pinned so it cannot recur - the frontmatter said persisting was "opt-in via
+    --save" while `main()` persisted by DEFAULT (`--no-save` opts out). The check is bidirectional:
+    whatever the parser actually does, the prose must say the same thing.
+    """
+    parser = refresh_pbip_model._build_arg_parser()
+    defaults = parser.parse_args([])
+    # Persisting is the default exactly when the opt-OUT flag defaults to False and there is no
+    # separate opt-IN gate (`--save` is an accepted no-op).
+    code_persists_by_default = defaults.no_save is False
+    assert code_persists_by_default, "guard assumption: the parser must persist by default"
+
+    frontmatter = _frontmatter((SKILL_ROOT / "SKILL.md").read_text(encoding="utf-8")).lower()
+    doc_says_opt_in = "opt-in" in frontmatter or "opt in" in frontmatter
+    doc_says_default = "default" in frontmatter
+    assert not doc_says_opt_in, "frontmatter must NOT describe persisting as opt-in - the code persists by default"
+    assert doc_says_default, "frontmatter must state that persisting is the default"
+    # Bidirectional: the prose's claim and the parser's behaviour must agree.
+    doc_persists_by_default = doc_says_default and not doc_says_opt_in
+    assert doc_persists_by_default == code_persists_by_default

--- a/.github/skills/pbip-model-refresh/tests/test_persist_atomicity.py
+++ b/.github/skills/pbip-model-refresh/tests/test_persist_atomicity.py
@@ -1,18 +1,33 @@
 """The persisted cache write must be atomic, and a failed persist must not leave the project bumped.
 
-Two guarantees this file pins, both from #113:
+Four guarantees this file pins:
 
-1. **Atomic swap.** `ImageSave` opens `cache.abf` with `FileMode.Create`, which TRUNCATES a good
-   cache the instant the write begins - so a write that then fails half way leaves the project WORSE
-   than before (no fresh cache and no old one). `_staged_image_write` writes `cache.abf.tmp` and only
-   `os.replace`s it over the original once it exists and is a COMPLETE ABF backup, so a failed or
-   partial write can never destroy an existing good cache. A raise, or a clean return that produced
-   only partial bytes, both preserve the existing cache (#113, round-2 blocker 1).
-2. **Compat rollback.** Saving raises `database.tmdl`'s declared compatibilityLevel to the live
+1. **Atomic swap (#113).** `ImageSave` opens `cache.abf` with `FileMode.Create`, which TRUNCATES a
+   good cache the instant the write begins - so a write that then fails half way leaves the project
+   WORSE than before (no fresh cache and no old one). `_staged_image_write` writes a per-run staging
+   file and only `os.replace`s it over the original once it exists and is a COMPLETE ABF backup, so a
+   failed or partial write can never destroy an existing good cache. A raise, or a clean return that
+   produced only partial bytes, both preserve the existing cache (#113, round-2 blocker 1).
+2. **Compat rollback (#113).** Saving raises `database.tmdl`'s declared compatibilityLevel to the live
    level. That edit is written eagerly (so the serialized cache matches the project), but it is
    PROVISIONAL: if the ImageSave that follows does not land, `_persist_image` restores
    `database.tmdl` (and the generated-edit ledger) exactly, so a mid-failure never leaves the model
    declaring a level that was never actually written to a cache.
+3. **Interrupt-safe rollback (#113 route 2).** The rollback in (2) must run when the write is
+   INTERRUPTED, not only when it fails with an ordinary exception. `KeyboardInterrupt` is a
+   `BaseException`, not an `Exception`, so a Ctrl+C during alignment or ImageSave used to propagate
+   straight past BOTH the commit check and the rollback, leaving `database.tmdl` bumped for a cache
+   that was never written - the same brick by a different route. `_persist_image` now catches
+   `BaseException`, rolls back, and re-raises the interrupt; or, if the rollback ITSELF fails, raises
+   `CompatRollbackError` in its place (a bricked project matters more than a tidy Ctrl+C).
+4. **Concurrency-safe persist (#114).** Two runs against one model must not corrupt each other. They
+   shared a single fixed `cache.abf.tmp` staging file AND the provisional compat edit on
+   `database.tmdl`; a hostile interleaving deleted one run's staging, made it roll compat back under
+   the other's freshly written cache, and left compat declaring a level no present cache matched.
+   Staging is now a per-run PRIVATE name (`_staging_path`), and the WHOLE transaction is serialised by
+   a per-model interprocess lock (`_lock.model_lock`) whose dead-holder locks are reclaimed rather
+   than wedging the tool forever. Both defences are needed - unique names alone leave the shared
+   compat edit unprotected.
 
 Plus a docs-vs-code guard: the SKILL.md frontmatter's persistence default must match the argparse
 default, so the two cannot silently drift again (the #113 doc bug: frontmatter said "opt-in" while
@@ -22,7 +37,12 @@ the code persisted by default).
 from __future__ import annotations
 
 import json
+import os
+import socket
 import struct
+import subprocess
+import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -44,33 +64,69 @@ def _model(root: Path, name: str = "MyMigration", compat: int | None = None) -> 
     return root / f"{name}.SemanticModel" / ".pbi" / "cache.abf"
 
 
-def _build_minimal_cfbf() -> bytes:
-    """A genuine, minimal 3-sector Microsoft Compound File Binary (v3, 512-byte sectors).
+# The REAL cache.abf format, restated here independently of the code under test.
+#
+# Round 3 asserted a cache.abf was a Microsoft Compound File Binary and THESE FIXTURES synthesised
+# CFBF containers - so the suite agreed with the code and both were wrong. `_is_complete_abf` accepted
+# 0 of the 13 real caches on the machine that produced them, `_staged_image_write` therefore never
+# swapped, and persist-by-default (the entire subject of #113) silently stopped working on every run
+# (round-4 blocker 1). The lesson is in where these constants come from: they are hard-coded from a
+# hex dump of real caches, NOT imported from `refresh_pbip_model`, because a fixture built out of the
+# predicate's own constants can only ever confirm the predicate - never contradict it.
+#
+#   0..99    UTF-16LE "This backup was created using XPress9 compression." (exactly 100 bytes)
+#   100..101 uint16 pad (0 in all 13 measured files)
+#   102..    block chain; each block is uint32 uncompressedBytes, uint32 lengthFromTheMagic,
+#            4-byte magic, payload. Next header = offset + 8 + length. The chain ends EXACTLY at EOF.
+_ABF_PREAMBLE = "This backup was created using XPress9 compression.".encode("utf-16-le")
+_ABF_BLOCK_MAGIC = b"\x2a\xd7\x86\x4e"
+_ABF_MAX_BLOCK_BYTES = 2 * 1024 * 1024
+# Bytes 100..113 of a REAL cache written by this toolkit's OWN ImageSave - `health-tracker`,
+# 116,237 B, the very artefact `refresh_pbip_model`'s docstring cites as its ImageSave proof. The
+# golden test below rebuilds those 14 bytes from the builder, so a builder that drifts from the real
+# format fails loudly instead of quietly re-inventing round 3's mistake.
+_REAL_ABF_HEADER_HEX = "000000c00b009fc501002ad7864e"
+_REAL_ABF_UNCOMPRESSED = 770_048
+_REAL_ABF_PAYLOAD_BYTES = 116_123
+_REAL_ABF_TOTAL_BYTES = 116_237
 
-    Layout: a 512-byte header + one FAT sector + one directory sector (1536 bytes total). This is a
-    REAL CFBF container - header fields set to their only legal values, the FAT self-referencing, and
-    a Root Entry directory record - not merely the magic bytes with zero padding. `_is_complete_abf`
-    validates the header STRUCTURE (round-3 blocker 1), so fixtures must be structurally valid, and
-    every truncation of THIS blob is a realistic torn write.
+
+def _abf_bytes(blocks: tuple[tuple[int, int], ...] = ((770_048, 500),), seed: int = 0x5A) -> bytes:
+    """A complete Analysis Services backup image: preamble, pad, then `(uncompressed, payload)` blocks.
+
+    `seed` varies the payload so two valid images can be told apart byte-for-byte.
+    """
+    blob = bytearray(_ABF_PREAMBLE)
+    blob += struct.pack("<H", 0)
+    for index, (uncompressed, payload_bytes) in enumerate(blocks):
+        blob += struct.pack("<II", uncompressed, len(_ABF_BLOCK_MAGIC) + payload_bytes)
+        blob += _ABF_BLOCK_MAGIC
+        blob += bytes(((seed + index + i) % 256 for i in range(payload_bytes)))
+    return bytes(blob)
+
+
+def _cfbf_bytes() -> bytes:
+    """A genuine, minimal 3-sector Microsoft Compound File Binary - kept ONLY as a negative control.
+
+    Round 3 believed this was what a cache.abf looks like. It is not, and a test that pins the
+    REJECTION of a structurally valid CFBF is what stops that belief coming back: any future predicate
+    that starts accepting compound files has re-acquired the round-3 defect.
     """
     sector = 512
     endofchain, freesect, fatsect, nostream = 0xFFFFFFFE, 0xFFFFFFFF, 0xFFFFFFFD, 0xFFFFFFFF
 
     header = bytearray(sector)
-    header[0:8] = refresh_pbip_model._CFBF_MAGIC
+    header[0:8] = b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1"
     struct.pack_into("<H", header, 24, 0x003E)  # minor version
     struct.pack_into("<H", header, 26, 3)  # major version 3 -> 512-byte sectors
     struct.pack_into("<H", header, 28, 0xFFFE)  # byte-order mark
     struct.pack_into("<H", header, 30, 9)  # sector shift (1<<9 == 512)
     struct.pack_into("<H", header, 32, 6)  # mini sector shift (fixed)
-    struct.pack_into("<I", header, 40, 0)  # num directory sectors (0 for v3)
     struct.pack_into("<I", header, 44, 1)  # num FAT sectors
     struct.pack_into("<I", header, 48, 1)  # first directory sector -> sector 1
     struct.pack_into("<I", header, 56, 4096)  # mini-stream cutoff
     struct.pack_into("<I", header, 60, endofchain)  # first mini-FAT sector
-    struct.pack_into("<I", header, 64, 0)  # num mini-FAT sectors
     struct.pack_into("<I", header, 68, endofchain)  # first DIFAT sector
-    struct.pack_into("<I", header, 72, 0)  # num DIFAT sectors
     for i in range(109):  # DIFAT: FAT lives at sector 0, the rest are free
         struct.pack_into("<I", header, 76 + i * 4, 0 if i == 0 else freesect)
 
@@ -90,74 +146,215 @@ def _build_minimal_cfbf() -> bytes:
     struct.pack_into("<I", directory, 72, nostream)  # right sibling
     struct.pack_into("<I", directory, 76, nostream)  # child
     struct.pack_into("<I", directory, 116, endofchain)  # mini-stream start sector
-    struct.pack_into("<Q", directory, 120, 0)  # stream size
-    for entry in range(1, 4):  # remaining directory records are unallocated
-        base = entry * 128
-        struct.pack_into("<I", directory, base + 68, nostream)
-        struct.pack_into("<I", directory, base + 72, nostream)
-        struct.pack_into("<I", directory, base + 76, nostream)
-
     return bytes(header) + bytes(fat) + bytes(directory)
 
 
-def _valid_abf_bytes() -> bytes:
-    """Bytes that pass `_is_complete_abf`: a genuine minimal CFBF container, not magic + zero padding.
+def _real_cache_abf_files() -> list[Path]:
+    """Real `cache.abf` files on this machine, smallest first - the ground-truth corpus, or [].
 
-    A real `cache.abf` is a Microsoft Compound File Binary, and the completeness check validates the
-    CFBF header structure (#113, round-3 blocker 1), so happy-path tests must write something that is
-    actually a container - the previous magic-plus-zeros blob no longer qualifies (its byte-order mark
-    was 0, not 0xFFFE), which is the whole point of the stricter check.
+    Real caches are gitignored (`.gitignore`: `**/.pbi/cache.abf`), so they are ground truth when
+    present and simply absent in a clean clone or when this bundle is copied elsewhere - hence the
+    tests that use them SKIP rather than fail, which is what keeps the bundle portable. Set
+    `PBIP_REFRESH_REAL_ABF` to a cache.abf (or a directory holding some) to point the corpus anywhere.
     """
-    return _build_minimal_cfbf()
+    override = os.environ.get("PBIP_REFRESH_REAL_ABF")
+    found: list[Path] = []
+    if override:
+        target = Path(override)
+        found = [target] if target.is_file() else sorted(target.rglob("cache.abf"))
+    else:
+        for ancestor in SKILL_ROOT.parents:
+            roots = [ancestor / name for name in ("examples", "migrations", "_probe-lab")]
+            if not any(root.is_dir() for root in roots):
+                continue
+            for root in roots:
+                if root.is_dir():
+                    found.extend(root.rglob(".pbi/cache.abf"))
+            break
+    return sorted((path for path in found if path.is_file()), key=lambda path: path.stat().st_size)
 
 
-def test_is_complete_abf_accepts_a_genuine_cfbf_container(tmp_path: Path) -> None:
-    """The positive control: a structurally valid minimal CFBF is accepted."""
+def _valid_abf_bytes() -> bytes:
+    """Bytes that pass `_is_complete_abf`: a small but structurally REAL Analysis Services backup."""
+    return _abf_bytes()
+
+
+def _no_staging_files(cache: Path) -> bool:
+    """No per-run staging file may be left behind in the cache directory.
+
+    Staging names are now UNIQUE per run (`cache.abf.<pid>-<token>.tmp`, #114) so two runs can't
+    delete each other's, so this globs the directory for any leftover `*.tmp` rather than checking a
+    single fixed name - a check against the old fixed `cache.abf.tmp` would silently pass while a
+    unique-named staging file leaked.
+    """
+    return not list(cache.parent.glob("*.tmp"))
+
+
+def test_the_builder_reproduces_a_real_cache_abf_header() -> None:
+    """The fixtures' oracle: rebuild a REAL cache's first block header and total size, byte for byte.
+
+    Without this, `_abf_bytes` and `_abf_rejection_reason` could drift together into a second private
+    format nobody has ever written - exactly how round 3's CFBF fixtures kept a broken predicate
+    green. The numbers come from `health-tracker`'s 116,237-byte cache, written by this script's own
+    ImageSave: block 1 declares 770,048 uncompressed bytes and 116,127 bytes from the magic onward.
+    """
+    blob = _abf_bytes(((_REAL_ABF_UNCOMPRESSED, _REAL_ABF_PAYLOAD_BYTES),))
+    assert blob[:100] == _ABF_PREAMBLE
+    assert blob[100:114].hex() == _REAL_ABF_HEADER_HEX
+    assert len(blob) == _REAL_ABF_TOTAL_BYTES
+
+
+def test_is_complete_abf_accepts_a_single_block_backup(tmp_path: Path) -> None:
+    """The positive control the old suite never had: a real-format backup is ACCEPTED."""
     good = tmp_path / "cache.abf"
-    good.write_bytes(_build_minimal_cfbf())
+    good.write_bytes(_abf_bytes())
     assert refresh_pbip_model._is_complete_abf(good) is True
 
 
-def test_is_complete_abf_rejects_magic_with_only_zero_padding(tmp_path: Path) -> None:
-    """The old fixture shape - CFBF magic then zeros - is NOT a container and must be rejected.
+def test_is_complete_abf_accepts_a_multi_block_backup(tmp_path: Path) -> None:
+    """A chain of blocks is walked to EOF: full 2 MiB blocks, then a short final one (the measured shape)."""
+    good = tmp_path / "cache.abf"
+    good.write_bytes(_abf_bytes(((_ABF_MAX_BLOCK_BYTES, 4096), (_ABF_MAX_BLOCK_BYTES, 4096), (131_072, 2048))))
+    assert refresh_pbip_model._is_complete_abf(good) is True
 
-    Its byte-order mark is 0 rather than 0xFFFE and it references no sectors, so the round-2 check
-    (magic + size>=512) waved it through while the structural check rejects it (round-3 blocker 1).
+
+def test_is_complete_abf_rejects_a_compound_file_binary(tmp_path: Path) -> None:
+    """The round-3 regression pin: a structurally valid CFBF is NOT a cache.abf and must be rejected.
+
+    Round 3 asserted the opposite and shipped a predicate that accepted only compound files - which no
+    real cache is - so the staged write never swapped. If this test ever starts failing, the predicate
+    has re-acquired that defect.
     """
     blob = tmp_path / "cache.abf"
-    blob.write_bytes(refresh_pbip_model._CFBF_MAGIC + b"\x00" * (refresh_pbip_model._CFBF_HEADER_BYTES - 8))
+    blob.write_bytes(_cfbf_bytes())
     assert refresh_pbip_model._is_complete_abf(blob) is False
+    assert "preamble" in (refresh_pbip_model._abf_rejection_reason(blob) or "")
 
 
-def test_is_complete_abf_rejects_a_non_sector_aligned_truncation(tmp_path: Path) -> None:
-    """A 600-byte torn write - keeps the magic, not a whole number of sectors - must be rejected.
+def test_is_complete_abf_rejects_a_preamble_only_file(tmp_path: Path) -> None:
+    """The preamble alone is a write that died before its first block header."""
+    stub = tmp_path / "cache.abf"
+    stub.write_bytes(_ABF_PREAMBLE + b"\x00\x00")
+    assert refresh_pbip_model._is_complete_abf(stub) is False
 
-    This is the reviewer's exact reproduction: 600 bytes passed round-2 (magic + >=512) and reached
-    `os.replace`, destroying the old cache (round-3 blocker 1). A complete container is a whole number
-    of sectors, so a length that is not is a partial write.
-    """
+
+def test_is_complete_abf_rejects_a_payload_truncation(tmp_path: Path) -> None:
+    """A block whose declared length runs past EOF is a torn write - the case the predicate exists for."""
     truncated = tmp_path / "cache.abf"
-    truncated.write_bytes(_build_minimal_cfbf()[:600])
+    truncated.write_bytes(_abf_bytes()[:-1])
     assert refresh_pbip_model._is_complete_abf(truncated) is False
+    assert "truncated" in (refresh_pbip_model._abf_rejection_reason(truncated) or "")
 
 
-def test_is_complete_abf_rejects_a_sector_aligned_truncation(tmp_path: Path) -> None:
-    """Even a sector-ALIGNED truncation is rejected: its header points at sectors now past EOF.
+def test_is_complete_abf_rejects_a_truncation_on_a_block_boundary(tmp_path: Path) -> None:
+    """The truncation a chain-walk ALONE cannot see: the file ends exactly where a block ends.
 
-    Truncating the valid 1536-byte container to 1024 keeps the header (which names a directory at
-    sector 1) but drops that sector, so the referenced index now sits beyond the file - the signature
-    of an interrupted write that a size/alignment-only check cannot catch (round-3 blocker 1).
+    Every one of the 60 measured non-final blocks declares a full 2 MiB uncompressed and every one of
+    the 13 final blocks declares less, so a file whose LAST block is full-sized stopped on a chunk
+    boundary with more still due. Dropping that rule is a mutation the suite must catch: without it
+    this file walks cleanly to EOF and is accepted.
     """
-    truncated = tmp_path / "cache.abf"
-    truncated.write_bytes(_build_minimal_cfbf()[:1024])
-    assert refresh_pbip_model._is_complete_abf(truncated) is False
+    full = _abf_bytes(((_ABF_MAX_BLOCK_BYTES, 4096), (131_072, 2048)))
+    boundary = tmp_path / "cache.abf"
+    boundary.write_bytes(full[: 102 + 8 + 4 + 4096])
+    assert refresh_pbip_model._is_complete_abf(boundary) is False
+    assert "boundary" in (refresh_pbip_model._abf_rejection_reason(boundary) or "")
 
 
-def test_is_complete_abf_rejects_a_header_only_file(tmp_path: Path) -> None:
-    """A lone 512-byte header (no data sectors) is not a usable backup and is rejected."""
-    header_only = tmp_path / "cache.abf"
-    header_only.write_bytes(_build_minimal_cfbf()[:512])
-    assert refresh_pbip_model._is_complete_abf(header_only) is False
+def test_every_proper_prefix_of_a_valid_backup_is_rejected(tmp_path: Path) -> None:
+    """Exhaustive: for a two-block image, EVERY prefix short of the whole file is a partial write.
+
+    A truncated write can stop at any byte, so spot-checking a few lengths proves little. Only the
+    complete file may be accepted.
+    """
+    blob = _abf_bytes(((_ABF_MAX_BLOCK_BYTES, 700), (65_536, 300)))
+    probe = tmp_path / "cache.abf"
+    for length in range(len(blob)):
+        probe.write_bytes(blob[:length])
+        assert refresh_pbip_model._is_complete_abf(probe) is False, f"prefix of {length} byte(s) was accepted"
+    probe.write_bytes(blob)
+    assert refresh_pbip_model._is_complete_abf(probe) is True
+
+
+def test_the_rejection_reason_names_the_defect(tmp_path: Path) -> None:
+    """A rejection must SAY why. Round 3's bug survived a whole round because the predicate could only
+    say "no": every run silently fell back to the UI save with no clue as to the cause."""
+    blob = tmp_path / "cache.abf"
+    blob.write_bytes(b"not a backup at all")
+    reason = refresh_pbip_model._abf_rejection_reason(blob)
+    assert reason and "preamble" in reason
+    assert refresh_pbip_model._abf_rejection_reason(tmp_path / "cache.abf") is not None
+    good = tmp_path / "good.abf"
+    good.write_bytes(_abf_bytes())
+    assert refresh_pbip_model._abf_rejection_reason(good) is None
+
+
+def test_a_rejected_staged_write_prints_the_reason(tmp_path: Path, capsys) -> None:
+    """The reason has to reach the operator, not just the function's caller."""
+    cache = _model(tmp_path)
+    cache.parent.mkdir(parents=True)
+    cache.write_bytes(b"GOOD-EXISTING-CACHE")
+
+    def write_rubbish(staging: Path) -> None:
+        staging.write_bytes(b"rubbish")
+
+    assert refresh_pbip_model._staged_image_write(cache, write_rubbish) is False
+    assert "REJECTED" in capsys.readouterr().out
+    assert cache.read_bytes() == b"GOOD-EXISTING-CACHE"
+
+
+def test_every_real_cache_abf_on_this_machine_is_accepted() -> None:
+    """Ground truth. The corpus that disproved round 3: every real cache must be ACCEPTED.
+
+    Round 3's predicate scored 0 out of 13 here, and no synthetic fixture could have shown that -
+    which is why this test reads the artefacts Desktop and this very script actually produced.
+    """
+    corpus = _real_cache_abf_files()
+    if not corpus:
+        pytest.skip("no real cache.abf on this machine (they are gitignored); set PBIP_REFRESH_REAL_ABF")
+    rejected = {str(path): refresh_pbip_model._abf_rejection_reason(path) for path in corpus}
+    assert not [path for path, reason in rejected.items() if reason], rejected
+
+
+def test_a_real_cache_abf_is_staged_and_swapped_in(tmp_path: Path) -> None:
+    """End to end on a REAL cache: the staged write must actually commit it.
+
+    This is the failure the round-3 predicate produced - not a crash, but `_staged_image_write`
+    returning False forever, so `_persist_image` always reported "not persisted" and every run fell
+    back to the UI save. Copies the real bytes into tmp_path; the source cache is never touched.
+    """
+    corpus = _real_cache_abf_files()
+    if not corpus:
+        pytest.skip("no real cache.abf on this machine (they are gitignored); set PBIP_REFRESH_REAL_ABF")
+    real_bytes = corpus[0].read_bytes()
+    cache = _model(tmp_path)
+    cache.parent.mkdir(parents=True)
+    cache.write_bytes(b"OLD-CACHE")
+
+    def write_real(staging: Path) -> None:
+        staging.write_bytes(real_bytes)
+
+    assert refresh_pbip_model._staged_image_write(cache, write_real) is True
+    assert cache.read_bytes() == real_bytes
+    assert _no_staging_files(cache)
+
+
+def test_a_truncated_real_cache_abf_is_rejected_and_the_old_cache_survives(tmp_path: Path) -> None:
+    """The other half of the job: a partially written REAL cache must never replace a good one."""
+    corpus = _real_cache_abf_files()
+    if not corpus:
+        pytest.skip("no real cache.abf on this machine (they are gitignored); set PBIP_REFRESH_REAL_ABF")
+    real_bytes = corpus[0].read_bytes()
+    cache = _model(tmp_path)
+    cache.parent.mkdir(parents=True)
+    cache.write_bytes(b"GOOD-EXISTING-CACHE")
+
+    def write_torn(staging: Path) -> None:
+        staging.write_bytes(real_bytes[: len(real_bytes) // 2])
+
+    assert refresh_pbip_model._staged_image_write(cache, write_torn) is False
+    assert cache.read_bytes() == b"GOOD-EXISTING-CACHE"
+    assert _no_staging_files(cache)
 
 
 def test_a_failed_write_does_not_destroy_an_existing_good_cache(tmp_path: Path) -> None:
@@ -172,7 +369,7 @@ def test_a_failed_write_does_not_destroy_an_existing_good_cache(tmp_path: Path) 
 
     assert refresh_pbip_model._staged_image_write(cache, write_nothing) is False
     assert cache.read_bytes() == b"GOOD-EXISTING-CACHE", "a failed write must leave the old cache intact"
-    assert not cache.with_name(cache.name + ".tmp").exists(), "no staging file may be left behind"
+    assert _no_staging_files(cache), "no staging file may be left behind"
 
 
 def test_a_raising_write_with_no_output_propagates_and_leaves_the_cache_intact(tmp_path: Path) -> None:
@@ -194,7 +391,7 @@ def test_a_raising_write_with_no_output_propagates_and_leaves_the_cache_intact(t
     with pytest.raises(RuntimeError):
         refresh_pbip_model._staged_image_write(cache, raise_without_writing)
     assert cache.read_bytes() == b"GOOD-EXISTING-CACHE"
-    assert not cache.with_name(cache.name + ".tmp").exists()
+    assert _no_staging_files(cache)
 
 
 def test_a_raising_write_that_produced_partial_bytes_does_not_replace_the_cache(tmp_path: Path) -> None:
@@ -216,7 +413,7 @@ def test_a_raising_write_that_produced_partial_bytes_does_not_replace_the_cache(
     with pytest.raises(RuntimeError):
         refresh_pbip_model._staged_image_write(cache, raise_after_partial_write)
     assert cache.read_bytes() == b"GOOD-EXISTING-CACHE", "a partial write must not replace the good cache"
-    assert not cache.with_name(cache.name + ".tmp").exists(), "the partial staging file must be removed"
+    assert _no_staging_files(cache), "the partial staging file must be removed"
 
 
 def test_a_clean_write_of_incomplete_bytes_is_rejected(tmp_path: Path) -> None:
@@ -235,7 +432,7 @@ def test_a_clean_write_of_incomplete_bytes_is_rejected(tmp_path: Path) -> None:
 
     assert refresh_pbip_model._staged_image_write(cache, write_incomplete) is False
     assert cache.read_bytes() == b"GOOD-EXISTING-CACHE", "an incomplete staged file must not replace the cache"
-    assert not cache.with_name(cache.name + ".tmp").exists()
+    assert _no_staging_files(cache)
 
 
 def test_a_successful_write_swaps_the_new_cache_in(tmp_path: Path) -> None:
@@ -358,7 +555,7 @@ def test_persist_rolls_back_the_compat_bump_when_os_replace_raises(tmp_path: Pat
         refresh_pbip_model._persist_image(cache, model_dir, 1702, good_write)
     assert database_tmdl.read_bytes() == before, "an exception on replace must restore database.tmdl exactly"
     assert not cache.exists(), "no cache may be left behind when the replace failed"
-    assert not cache.with_name(cache.name + ".tmp").exists(), "the staging file must be cleaned up"
+    assert _no_staging_files(cache), "the staging file must be cleaned up"
 
 
 def test_a_commit_then_raise_keeps_the_new_cache_and_the_aligned_compat(tmp_path: Path, monkeypatch) -> None:
@@ -395,7 +592,7 @@ def test_a_commit_then_raise_keeps_the_new_cache_and_the_aligned_compat(tmp_path
     assert "compatibilityLevel: 1702" in database_tmdl.read_text(encoding="utf-8"), (
         "compat must NOT be rolled back under a committed cache"
     )
-    assert not cache.with_name(cache.name + ".tmp").exists()
+    assert _no_staging_files(cache)
 
 
 def test_a_failed_rollback_is_fatal_and_raises_compat_rollback_error(tmp_path: Path, monkeypatch) -> None:
@@ -471,6 +668,239 @@ def test_every_rollback_path_is_attempted_even_when_the_first_fails(tmp_path: Pa
     assert not ledger.exists(), "the ledger must be rolled back even though database.tmdl's restore failed"
 
 
+# --------------------------------------------------------------------------------------------------
+# BLOCKER 1 (#118) - a KeyboardInterrupt must NOT bypass the compat rollback.
+#
+# `KeyboardInterrupt` inherits from `BaseException`, not `Exception`. The round-3 transaction caught
+# only `Exception`, so a Ctrl+C during alignment or ImageSave propagated straight past the commit
+# check AND the rollback (which are not in a `finally`), leaving `database.tmdl` declaring the bumped
+# level for a cache that was never written - the same brick as #113, by a different route. The fix
+# catches `BaseException`, and each test below FAILS on a revert to `except Exception` because the
+# interrupt then skips the rollback and `database.tmdl` is left at the bumped level.
+# --------------------------------------------------------------------------------------------------
+
+
+def test_a_keyboard_interrupt_during_imagesave_rolls_back_the_compat_bump_and_reraises(tmp_path: Path) -> None:
+    """Ctrl+C during the ImageSave: the 1702 bump must be undone AND the interrupt must propagate.
+
+    The alignment has already written 1702 to `database.tmdl` by the time `write_image` runs, so this
+    is the exact bricking window: bump on disk, no cache yet, interrupt raised. Reverting the fix to
+    `except Exception` leaves `database.tmdl` at 1702 (the interrupt skips the rollback), failing the
+    `== before` assertion even though the interrupt still propagates.
+    """
+    cache = _model(tmp_path, compat=1604)
+    model_dir = cache.parent.parent
+    database_tmdl = model_dir / "definition" / "database.tmdl"
+    before = database_tmdl.read_bytes()
+
+    def interrupted_write(_staging: Path) -> None:
+        raise KeyboardInterrupt
+
+    with pytest.raises(KeyboardInterrupt):
+        refresh_pbip_model._persist_image(cache, model_dir, 1702, interrupted_write)
+
+    assert database_tmdl.read_bytes() == before, "an interrupt must roll the compat bump back, not leave it declared"
+    assert not cache.exists(), "no cache may be left behind"
+    assert _no_staging_files(cache), "the staging file must be cleaned up on interrupt"
+
+
+def test_a_keyboard_interrupt_right_after_alignment_rolls_back_and_reraises(tmp_path: Path, monkeypatch) -> None:
+    """Ctrl+C the instant the 1702 bump lands, before the cache write even starts.
+
+    Injected by wrapping `align_declared_compatibility` so the real bump is written and THEN the
+    interrupt is raised - the narrowest possible bricking window. On the fixed code the bump is rolled
+    back and the interrupt re-raised; reverted to `except Exception`, the interrupt escapes with
+    `database.tmdl` still at 1702.
+    """
+    cache = _model(tmp_path, compat=1604)
+    model_dir = cache.parent.parent
+    database_tmdl = model_dir / "definition" / "database.tmdl"
+    before = database_tmdl.read_bytes()
+
+    real_align = refresh_pbip_model.align_declared_compatibility
+
+    def align_then_interrupt(path: Path, level: int) -> None:
+        real_align(path, level)  # the 1702 bump actually lands on disk...
+        raise KeyboardInterrupt  # ...then Ctrl+C arrives before anything writes the cache
+
+    monkeypatch.setattr(refresh_pbip_model, "align_declared_compatibility", align_then_interrupt)
+
+    def unreached_write(_staging: Path) -> None:
+        raise AssertionError("the cache write must not be reached after an interrupt during alignment")
+
+    with pytest.raises(KeyboardInterrupt):
+        refresh_pbip_model._persist_image(cache, model_dir, 1702, unreached_write)
+
+    assert database_tmdl.read_bytes() == before, "the 1702 bump must be rolled back after an interrupt"
+    assert not cache.exists()
+
+
+def test_a_failed_rollback_during_an_interrupt_raises_compat_rollback_error_over_the_interrupt(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """If the interrupt's rollback ITSELF fails, `CompatRollbackError` must win over the interrupt.
+
+    A bricked project (database.tmdl bumped, bump un-undoable) is worse than a tidy Ctrl+C, so the
+    fatal, actionable error must be what surfaces. Reverting to `except Exception` makes the interrupt
+    escape before any rollback is attempted, so `CompatRollbackError` is never raised and this test's
+    `pytest.raises` fails.
+    """
+    cache = _model(tmp_path, compat=1604)
+    model_dir = cache.parent.parent
+
+    def interrupted_write(_staging: Path) -> None:
+        raise KeyboardInterrupt
+
+    real_replace = refresh_pbip_model.os.replace
+
+    def block_rollback(src, dst):
+        if str(dst).endswith("database.tmdl"):
+            raise PermissionError("database.tmdl is locked")
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(refresh_pbip_model.os, "replace", block_rollback)
+
+    with pytest.raises(refresh_pbip_model.CompatRollbackError):
+        refresh_pbip_model._persist_image(cache, model_dir, 1702, interrupted_write)
+
+
+# --------------------------------------------------------------------------------------------------
+# BLOCKER 2 (#114) - concurrent runs against one model must not deterministically brick it.
+#
+# Two defences, both needed: a per-run PRIVATE staging name (so run B can't delete run A's in-flight
+# staging file), AND a per-model interprocess lock spanning the whole transaction (so the shared
+# compatibility edit on `database.tmdl` can't be interleaved - unique names alone don't cover that).
+# --------------------------------------------------------------------------------------------------
+
+
+def _distinct_valid_abf_bytes() -> bytes:
+    """A second, genuinely different, still-complete backup - so a run's own bytes are identifiable.
+
+    Same block geometry, different payload, so the blob stays a valid image while differing
+    byte-for-byte from `_valid_abf_bytes()`.
+    """
+    return _abf_bytes(seed=0xA5)
+
+
+def _reaped_pid() -> int:
+    """A PID that is now dead: spawn a trivial process, wait for it to exit, return its PID."""
+    proc = subprocess.Popen([sys.executable, "-c", "raise SystemExit(0)"])
+    proc.wait()
+    return proc.pid
+
+
+def test_a_distinct_valid_abf_is_still_complete_but_different(tmp_path: Path) -> None:
+    """Guard for the interleaving test's fixtures: the two payloads are both valid yet distinguishable."""
+    assert _distinct_valid_abf_bytes() != _valid_abf_bytes()
+    probe = tmp_path / "cache.abf"
+    probe.write_bytes(_distinct_valid_abf_bytes())
+    assert refresh_pbip_model._is_complete_abf(probe) is True
+
+
+def test_two_interleaved_staged_writes_keep_private_staging_files(tmp_path: Path) -> None:
+    """Forced hostile interleaving at the staging seam: run B must not disturb run A's staging file.
+
+    Run A's `write_image` stages its complete backup and THEN drives a second run B fully through
+    `_staged_image_write` before A finishes. On the fixed code each run stages to a private
+    `cache.abf.<pid>-<token>.tmp`, so B's own `if staging.exists(): unlink` targets B's file and A's
+    survives; A then commits its OWN bytes. Reverting to the shared fixed `cache.abf.tmp` makes B
+    delete A's staging, so `staging_a.exists()` (and the distinct-path assertion) fail.
+    """
+    cache = _model(tmp_path)
+    cache.parent.mkdir(parents=True)
+    cache.write_bytes(b"OLD")
+    a_bytes = _valid_abf_bytes()
+    b_bytes = _distinct_valid_abf_bytes()
+    seen: dict[str, Path] = {}
+
+    def b_write(staging_b: Path) -> None:
+        seen["b"] = staging_b
+        staging_b.write_bytes(b_bytes)
+
+    def a_write(staging_a: Path) -> None:
+        seen["a"] = staging_a
+        staging_a.write_bytes(a_bytes)  # A's complete backup is now staged
+        # HOSTILE INTERLEAVE: a concurrent run B does its entire staged write mid-A.
+        assert refresh_pbip_model._staged_image_write(cache, b_write) is True
+        assert staging_a.exists(), "run B must not delete run A's in-flight staging file"
+
+    assert refresh_pbip_model._staged_image_write(cache, a_write) is True
+    assert seen["a"] != seen["b"], "each concurrent run must stage to a private path"
+    assert cache.read_bytes() == a_bytes, "A committed its OWN bytes; the runs did not cross-contaminate"
+    assert _no_staging_files(cache)
+
+
+def test_staging_path_is_unique_per_call(tmp_path: Path) -> None:
+    """`_staging_path` never returns the same name twice, and never the old shared fixed name."""
+    cache = tmp_path / "Model.SemanticModel" / ".pbi" / "cache.abf"
+    first = refresh_pbip_model._staging_path(cache)
+    second = refresh_pbip_model._staging_path(cache)
+    assert first != second, "two runs must not share a staging path"
+    assert first != cache.with_name(cache.name + ".tmp"), "the fixed shared name is exactly the #114 bug"
+    assert first.suffix == ".tmp" and first.parent == cache.parent
+
+
+def test_model_lock_is_exclusive_and_times_out_then_releases(tmp_path: Path) -> None:
+    """The per-model lock is mutually exclusive, bounds the wait, and cleans up on release.
+
+    Reverting the fix removes `model_lock`/`ModelLockTimeout` entirely, so this test errors out.
+    """
+    lock_path = tmp_path / "cache.abf.lock"
+    with refresh_pbip_model.model_lock(lock_path, timeout=2.0, poll=0.02):
+        assert lock_path.exists()
+        with pytest.raises(refresh_pbip_model.ModelLockTimeout):
+            with refresh_pbip_model.model_lock(lock_path, timeout=0.2, poll=0.02):
+                raise AssertionError("a second acquisition must not succeed while the lock is held")
+    assert not lock_path.exists(), "the lock file is removed on release"
+    with refresh_pbip_model.model_lock(lock_path, timeout=2.0, poll=0.02):
+        assert lock_path.exists(), "the lock is re-acquirable once released"
+
+
+def test_model_lock_recovers_from_a_dead_holder(tmp_path: Path) -> None:
+    """A lock left behind by a process that has since died must be reclaimable, not a permanent block.
+
+    A lock that can wedge the tool forever is its own outage, so the acquirer detects the dead PID and
+    reclaims the lock instead of waiting out the timeout.
+    """
+    lock_path = tmp_path / "cache.abf.lock"
+    dead_pid = _reaped_pid()
+    lock_path.write_text(f"{dead_pid}\n{socket.gethostname()}\n{time.time()}\n", encoding="utf-8")
+
+    acquired = False
+    with refresh_pbip_model.model_lock(lock_path, timeout=2.0, poll=0.02):
+        acquired = True
+        assert lock_path.read_text(encoding="utf-8").splitlines()[0].strip() == str(os.getpid()), (
+            "the reclaimed lock must now record the live holder"
+        )
+    assert acquired, "a lock held by a dead process must be reclaimed, not blocked on"
+
+
+def test_a_locked_out_persist_cannot_touch_compat_or_cache(tmp_path: Path) -> None:
+    """Forced interleaving through `_persist_image`: while run A holds the lock, run B mutates nothing.
+
+    This is the reviewer's compat race: the shared resource is the alignment on `database.tmdl`, not
+    just the temp file. With run A holding the per-model lock across its transaction, run B's
+    `_persist_image` must be locked out BEFORE it can align or write - so `database.tmdl` and the
+    absent cache are exactly as A left them. Reverting the fix removes the lock (and the `lock_timeout`
+    parameter), so B is no longer serialised and this test errors/fails.
+    """
+    cache = _model(tmp_path, compat=1604)
+    model_dir = cache.parent.parent
+    database_tmdl = model_dir / "definition" / "database.tmdl"
+    before = database_tmdl.read_bytes()
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = cache.with_name(cache.name + ".lock")
+
+    def b_write(staging: Path) -> None:
+        staging.write_bytes(_valid_abf_bytes())
+
+    with refresh_pbip_model.model_lock(lock_path, timeout=2.0, poll=0.02):
+        with pytest.raises(refresh_pbip_model.ModelLockTimeout):
+            refresh_pbip_model._persist_image(cache, model_dir, 1606, b_write, lock_timeout=0.3)
+        assert database_tmdl.read_bytes() == before, "a locked-out run must not mutate database.tmdl"
+        assert not cache.exists(), "a locked-out run must not write a cache"
+
+
 def _frontmatter(text: str) -> str:
     """The YAML frontmatter block between the first pair of `---` fences."""
     assert text.startswith("---"), "SKILL.md must open with a YAML frontmatter fence"
@@ -499,3 +929,40 @@ def test_documented_persist_default_matches_the_argparse_default() -> None:
     # Bidirectional: the prose's claim and the parser's behaviour must agree.
     doc_persists_by_default = doc_says_default and not doc_says_opt_in
     assert doc_persists_by_default == code_persists_by_default
+
+
+# --------------------------------------------------------------------------------------------------
+# Round-4 finding 3: a failed persist must not invalidate the pre-existing good cache VIA MTIME.
+# --------------------------------------------------------------------------------------------------
+
+
+def test_a_failed_persist_preserves_the_definition_mtime(tmp_path: Path) -> None:
+    """Restoring `database.tmdl`'s BYTES is not enough - its MTIME is load-bearing.
+
+    The skill's own documented cache-discard trigger is "definition newer than cache": Desktop drops a
+    perfectly good 113 KB cache and reopens with NO_DATA when the model files look newer. So a failed
+    persist that rewrites database.tmdl with identical bytes still bricks the cache, purely by bumping
+    its timestamp - the rollback undoes the edit and destroys the cache in the same motion. The
+    snapshot therefore restores atime/mtime as well as content (round-4 finding 3).
+    """
+    cache = _model(tmp_path, compat=1604)
+    model_dir = cache.parent.parent
+    database_tmdl = model_dir / "definition" / "database.tmdl"
+    cache.parent.mkdir(parents=True)
+    cache.write_bytes(_valid_abf_bytes())
+
+    old = time.time() - 600  # the definition is comfortably older than the cache
+    for path in (database_tmdl, *(model_dir / "definition" / "tables").glob("*.tmdl")):
+        os.utime(path, (old, old))
+    assert cache.stat().st_mtime > database_tmdl.stat().st_mtime, "precondition: cache is newer"
+    before_bytes = database_tmdl.read_bytes()
+    before_mtime = database_tmdl.stat().st_mtime_ns
+
+    def failing_write(_staging: Path) -> None:
+        return None  # the engine refused; nothing is staged
+
+    ok, _message = refresh_pbip_model._persist_image(cache, model_dir, 1702, failing_write)
+    assert ok is False
+    assert database_tmdl.read_bytes() == before_bytes, "bytes must be restored exactly"
+    assert database_tmdl.stat().st_mtime_ns == before_mtime, "the mtime must be restored too"
+    assert cache.stat().st_mtime > database_tmdl.stat().st_mtime, "the existing cache must stay valid"

--- a/.github/skills/pbip-model-refresh/tests/test_persist_atomicity.py
+++ b/.github/skills/pbip-model-refresh/tests/test_persist_atomicity.py
@@ -261,6 +261,14 @@ def test_is_complete_abf_rejects_a_truncation_on_a_block_boundary(tmp_path: Path
     assert "boundary" in (refresh_pbip_model._abf_rejection_reason(boundary) or "")
 
 
+@pytest.mark.parametrize("chunk", (512 * 1024, 1024 * 1024, _ABF_MAX_BLOCK_BYTES, 4 * 1024 * 1024))
+def test_boundary_truncated_abf_is_rejected_for_review_chunk_sizes(tmp_path: Path, chunk: int) -> None:
+    """Pin the four measured boundary truncations: 512 KiB, 1 MiB, 2 MiB, and 4 MiB chunks."""
+    boundary = tmp_path / "cache.abf"
+    boundary.write_bytes(_abf_bytes(((chunk, 64), (chunk, 64), (chunk, 64))))
+    assert refresh_pbip_model._is_complete_abf(boundary) is False
+
+
 def test_every_proper_prefix_of_a_valid_backup_is_rejected(tmp_path: Path) -> None:
     """Exhaustive: for a two-block image, EVERY prefix short of the whole file is a partial write.
 
@@ -899,6 +907,31 @@ def test_a_locked_out_persist_cannot_touch_compat_or_cache(tmp_path: Path) -> No
             refresh_pbip_model._persist_image(cache, model_dir, 1606, b_write, lock_timeout=0.3)
         assert database_tmdl.read_bytes() == before, "a locked-out run must not mutate database.tmdl"
         assert not cache.exists(), "a locked-out run must not write a cache"
+
+
+def test_refresh_refuses_ui_save_after_model_lock_timeout(tmp_path: Path, monkeypatch, capsys) -> None:
+    """A live peer holding the persist lock must report NOT_PERSISTED, not fall back outside the lock."""
+    cache = _model(tmp_path, compat=1604)
+    args = refresh_pbip_model._build_arg_parser().parse_args([])
+    calls: list[str] = []
+
+    def locked_image_save(_port: int, _cache: Path, model_dir: Path | None = None):
+        calls.append(f"image:{model_dir}")
+        raise refresh_pbip_model.ModelLockTimeout("held by pid 123 on host buildbox")
+
+    def unlocked_ui_save(_pid: int) -> tuple[bool, str]:
+        calls.append("ui-save")
+        return True, "ui save should not run"
+
+    monkeypatch.setattr(refresh_pbip_model, "refresh", lambda *_args: (True, "refreshed"))
+    monkeypatch.setattr(refresh_pbip_model, "image_save", locked_image_save)
+    monkeypatch.setattr(refresh_pbip_model, "save", unlocked_ui_save)
+
+    assert refresh_pbip_model._refresh_and_save(456, 789, cache, args) == 1
+    out = capsys.readouterr().out
+    assert "REFRESH: NOT_PERSISTED" in out
+    assert "pid 123" in out
+    assert calls == [f"image:{cache.parent.parent}"]
 
 
 def _frontmatter(text: str) -> str:

--- a/.github/skills/pbip-model-refresh/tests/test_persist_atomicity.py
+++ b/.github/skills/pbip-model-refresh/tests/test_persist_atomicity.py
@@ -5,8 +5,9 @@ Two guarantees this file pins, both from #113:
 1. **Atomic swap.** `ImageSave` opens `cache.abf` with `FileMode.Create`, which TRUNCATES a good
    cache the instant the write begins - so a write that then fails half way leaves the project WORSE
    than before (no fresh cache and no old one). `_staged_image_write` writes `cache.abf.tmp` and only
-   `os.replace`s it over the original once it exists and is non-empty, so a failed/partial write can
-   never destroy an existing good cache.
+   `os.replace`s it over the original once it exists and is a COMPLETE ABF backup, so a failed or
+   partial write can never destroy an existing good cache. A raise, or a clean return that produced
+   only partial bytes, both preserve the existing cache (#113, round-2 blocker 1).
 2. **Compat rollback.** Saving raises `database.tmdl`'s declared compatibilityLevel to the live
    level. That edit is written eagerly (so the serialized cache matches the project), but it is
    PROVISIONAL: if the ImageSave that follows does not land, `_persist_image` restores
@@ -22,6 +23,8 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+
+import pytest
 
 # `conftest.py` next to this file puts the skill's own `scripts/` on `sys.path`.
 # ruff: noqa: E402  (the conftest-provided path must be in place before these imports)
@@ -40,6 +43,17 @@ def _model(root: Path, name: str = "MyMigration", compat: int | None = None) -> 
     return root / f"{name}.SemanticModel" / ".pbi" / "cache.abf"
 
 
+def _valid_abf_bytes() -> bytes:
+    """Bytes that pass `_is_complete_abf`: the CFBF signature padded to a full 512-byte header.
+
+    A real `cache.abf` is a Microsoft Compound File Binary, so the completeness check (#113, round-2
+    blocker 1) requires the OLE2 magic AND at least one header. Happy-path tests must therefore write
+    something that actually looks like a backup, not an arbitrary non-empty blob.
+    """
+    padding = refresh_pbip_model._CFBF_HEADER_BYTES - len(refresh_pbip_model._CFBF_MAGIC)
+    return refresh_pbip_model._CFBF_MAGIC + b"\x00" * padding
+
+
 def test_a_failed_write_does_not_destroy_an_existing_good_cache(tmp_path: Path) -> None:
     """FileMode.Create truncates on open; staging is what keeps a failed write from erasing the cache."""
     cache = _model(tmp_path)
@@ -55,47 +69,95 @@ def test_a_failed_write_does_not_destroy_an_existing_good_cache(tmp_path: Path) 
     assert not cache.with_name(cache.name + ".tmp").exists(), "no staging file may be left behind"
 
 
-def test_a_raising_write_with_no_output_leaves_the_cache_intact(tmp_path: Path) -> None:
-    """`write_image` is allowed to RAISE (the AMO client throws mid-write); judge by the file, not the
-    exception - and a raise that produced nothing must still not clobber the existing cache."""
+def test_a_raising_write_with_no_output_propagates_and_leaves_the_cache_intact(tmp_path: Path) -> None:
+    """`_staged_image_write` judges success by the FILE, and any raise is a REAL failure.
+
+    The one benign AMO response-parser error is absorbed a layer down (inside `image_save`'s writer
+    closure); by the time an exception reaches `_staged_image_write` it means the write genuinely
+    failed, so it must PROPAGATE (the caller then falls back to the UI save) and must not touch the
+    existing good cache. Round-1 suppressed every exception here and returned False, which hid real
+    disk/permission failures (#113, round-2 blocker 1).
+    """
     cache = _model(tmp_path)
     cache.parent.mkdir(parents=True)
     cache.write_bytes(b"GOOD-EXISTING-CACHE")
 
     def raise_without_writing(_staging: Path) -> None:
-        raise RuntimeError("The server sent an unrecognizable response")
+        raise RuntimeError("disk full")
 
-    assert refresh_pbip_model._staged_image_write(cache, raise_without_writing) is False
+    with pytest.raises(RuntimeError):
+        refresh_pbip_model._staged_image_write(cache, raise_without_writing)
     assert cache.read_bytes() == b"GOOD-EXISTING-CACHE"
     assert not cache.with_name(cache.name + ".tmp").exists()
 
 
-def test_a_raising_write_that_still_produced_bytes_counts_as_a_write(tmp_path: Path) -> None:
-    """The real client raises WHILE writing correctly, so a non-empty staging file is a success even
-    though the call raised - success is the FILE, never the absence of an exception."""
-    cache = _model(tmp_path)
+def test_a_raising_write_that_produced_partial_bytes_does_not_replace_the_cache(tmp_path: Path) -> None:
+    """A disk-full/interrupted write that left PARTIAL bytes must not be mistaken for a success.
 
-    def raise_after_writing(staging: Path) -> None:
+    This is the exact outcome #113 was filed to prevent: round-1 treated any non-empty staging file
+    as a completed write and swapped it in, so an interrupted write destroyed the existing good cache.
+    Now the raise propagates, the partial staging file is discarded, and the old cache survives.
+    """
+    cache = _model(tmp_path)
+    cache.parent.mkdir(parents=True)
+    cache.write_bytes(b"GOOD-EXISTING-CACHE")
+
+    def raise_after_partial_write(staging: Path) -> None:
         staging.parent.mkdir(parents=True, exist_ok=True)
-        staging.write_bytes(b"NEW-CACHE-BYTES")
+        staging.write_bytes(b"PARTIAL")
         raise RuntimeError("The server sent an unrecognizable response")
 
-    assert refresh_pbip_model._staged_image_write(cache, raise_after_writing) is True
-    assert cache.read_bytes() == b"NEW-CACHE-BYTES"
-    assert not cache.with_name(cache.name + ".tmp").exists(), "the staging file must be swapped, not left"
+    with pytest.raises(RuntimeError):
+        refresh_pbip_model._staged_image_write(cache, raise_after_partial_write)
+    assert cache.read_bytes() == b"GOOD-EXISTING-CACHE", "a partial write must not replace the good cache"
+    assert not cache.with_name(cache.name + ".tmp").exists(), "the partial staging file must be removed"
+
+
+def test_a_clean_write_of_incomplete_bytes_is_rejected(tmp_path: Path) -> None:
+    """Even a clean return must not swap in a staging file that is not a complete ABF.
+
+    The completeness check is what makes 'success' mean a loadable backup, not merely 'some bytes
+    landed'. Round-1 swapped on non-empty, so a truncated file that returned cleanly overwrote the
+    good cache; now it is discarded and the old cache is preserved (#113, round-2 blocker 1).
+    """
+    cache = _model(tmp_path)
+    cache.parent.mkdir(parents=True)
+    cache.write_bytes(b"GOOD-EXISTING-CACHE")
+
+    def write_incomplete(staging: Path) -> None:
+        staging.write_bytes(b"NOT-A-CFBF-BACKUP")
+
+    assert refresh_pbip_model._staged_image_write(cache, write_incomplete) is False
+    assert cache.read_bytes() == b"GOOD-EXISTING-CACHE", "an incomplete staged file must not replace the cache"
+    assert not cache.with_name(cache.name + ".tmp").exists()
 
 
 def test_a_successful_write_swaps_the_new_cache_in(tmp_path: Path) -> None:
-    """The happy path: staging is written, then atomically replaces the destination."""
+    """The happy path: a COMPLETE ABF staging file is written, then atomically replaces the destination."""
     cache = _model(tmp_path)
     cache.parent.mkdir(parents=True)
     cache.write_bytes(b"OLD")
+    new_bytes = _valid_abf_bytes()
 
     def write_new(staging: Path) -> None:
-        staging.write_bytes(b"NEW-CACHE-BYTES")
+        staging.write_bytes(new_bytes)
 
     assert refresh_pbip_model._staged_image_write(cache, write_new) is True
-    assert cache.read_bytes() == b"NEW-CACHE-BYTES"
+    assert cache.read_bytes() == new_bytes
+
+
+def test_benign_imagesave_error_is_recognised_but_a_real_failure_is_not(tmp_path: Path) -> None:
+    """Only AMO's known response-parser message is benign; every other failure must be treated as real.
+
+    This is the discriminator that lets `image_save`'s writer closure swallow the one error the client
+    raises even on a correct write, while re-raising a disk-full/permission failure so a partial write
+    is never mistaken for a success (#113, round-2 blocker 1).
+    """
+    _ = tmp_path  # unused; keeps a uniform signature with the file's other tests
+    benign = RuntimeError("The server sent an unrecognizable response")
+    real = RuntimeError("There is not enough space on the disk")
+    assert refresh_pbip_model._is_benign_imagesave_response_error(benign) is True
+    assert refresh_pbip_model._is_benign_imagesave_response_error(real) is False
 
 
 def test_persist_rolls_back_the_compat_bump_when_the_write_fails(tmp_path: Path) -> None:
@@ -144,15 +206,45 @@ def test_persist_aligns_and_writes_on_success(tmp_path: Path) -> None:
     cache = _model(tmp_path, compat=1604)
     model_dir = cache.parent.parent
     database_tmdl = model_dir / "definition" / "database.tmdl"
+    new_bytes = _valid_abf_bytes()
 
     def good_write(staging: Path) -> None:
-        staging.write_bytes(b"CACHE")
+        staging.write_bytes(new_bytes)
 
     ok, message = refresh_pbip_model._persist_image(cache, model_dir, 1702, good_write)
     assert ok is True
     assert "1702" in message
     assert "compatibilityLevel: 1702" in database_tmdl.read_text(encoding="utf-8")
-    assert cache.read_bytes() == b"CACHE"
+    assert cache.read_bytes() == new_bytes
+
+
+def test_persist_rolls_back_the_compat_bump_when_os_replace_raises(tmp_path: Path, monkeypatch) -> None:
+    """An EXCEPTION on the write/replace path must roll the compat bump back, not just a False return.
+
+    Round-1 rolled back only when `_staged_image_write` returned False; an `os.replace` that raises
+    (a Windows sharing-violation on a locked cache is the real case) bypassed the rollback entirely,
+    leaving database.tmdl declaring 1702 for a cache that was never written - state the caller then
+    carried into the UI Save (#113, round-2 blocker 2). The staging write here is a COMPLETE ABF, so
+    the failure is purely the replace, isolating the exception path.
+    """
+    cache = _model(tmp_path, compat=1604)
+    model_dir = cache.parent.parent
+    database_tmdl = model_dir / "definition" / "database.tmdl"
+    before = database_tmdl.read_bytes()
+
+    def good_write(staging: Path) -> None:
+        staging.write_bytes(_valid_abf_bytes())
+
+    def raising_replace(_src, _dst):
+        raise PermissionError("The process cannot access the file because it is being used")
+
+    monkeypatch.setattr(refresh_pbip_model.os, "replace", raising_replace)
+
+    with pytest.raises(PermissionError):
+        refresh_pbip_model._persist_image(cache, model_dir, 1702, good_write)
+    assert database_tmdl.read_bytes() == before, "an exception on replace must restore database.tmdl exactly"
+    assert not cache.exists(), "no cache may be left behind when the replace failed"
+    assert not cache.with_name(cache.name + ".tmp").exists(), "the staging file must be cleaned up"
 
 
 def _frontmatter(text: str) -> str:

--- a/.github/skills/pbip-model-refresh/tests/test_persist_atomicity.py
+++ b/.github/skills/pbip-model-refresh/tests/test_persist_atomicity.py
@@ -22,6 +22,7 @@ the code persisted by default).
 from __future__ import annotations
 
 import json
+import struct
 from pathlib import Path
 
 import pytest
@@ -43,15 +44,120 @@ def _model(root: Path, name: str = "MyMigration", compat: int | None = None) -> 
     return root / f"{name}.SemanticModel" / ".pbi" / "cache.abf"
 
 
-def _valid_abf_bytes() -> bytes:
-    """Bytes that pass `_is_complete_abf`: the CFBF signature padded to a full 512-byte header.
+def _build_minimal_cfbf() -> bytes:
+    """A genuine, minimal 3-sector Microsoft Compound File Binary (v3, 512-byte sectors).
 
-    A real `cache.abf` is a Microsoft Compound File Binary, so the completeness check (#113, round-2
-    blocker 1) requires the OLE2 magic AND at least one header. Happy-path tests must therefore write
-    something that actually looks like a backup, not an arbitrary non-empty blob.
+    Layout: a 512-byte header + one FAT sector + one directory sector (1536 bytes total). This is a
+    REAL CFBF container - header fields set to their only legal values, the FAT self-referencing, and
+    a Root Entry directory record - not merely the magic bytes with zero padding. `_is_complete_abf`
+    validates the header STRUCTURE (round-3 blocker 1), so fixtures must be structurally valid, and
+    every truncation of THIS blob is a realistic torn write.
     """
-    padding = refresh_pbip_model._CFBF_HEADER_BYTES - len(refresh_pbip_model._CFBF_MAGIC)
-    return refresh_pbip_model._CFBF_MAGIC + b"\x00" * padding
+    sector = 512
+    endofchain, freesect, fatsect, nostream = 0xFFFFFFFE, 0xFFFFFFFF, 0xFFFFFFFD, 0xFFFFFFFF
+
+    header = bytearray(sector)
+    header[0:8] = refresh_pbip_model._CFBF_MAGIC
+    struct.pack_into("<H", header, 24, 0x003E)  # minor version
+    struct.pack_into("<H", header, 26, 3)  # major version 3 -> 512-byte sectors
+    struct.pack_into("<H", header, 28, 0xFFFE)  # byte-order mark
+    struct.pack_into("<H", header, 30, 9)  # sector shift (1<<9 == 512)
+    struct.pack_into("<H", header, 32, 6)  # mini sector shift (fixed)
+    struct.pack_into("<I", header, 40, 0)  # num directory sectors (0 for v3)
+    struct.pack_into("<I", header, 44, 1)  # num FAT sectors
+    struct.pack_into("<I", header, 48, 1)  # first directory sector -> sector 1
+    struct.pack_into("<I", header, 56, 4096)  # mini-stream cutoff
+    struct.pack_into("<I", header, 60, endofchain)  # first mini-FAT sector
+    struct.pack_into("<I", header, 64, 0)  # num mini-FAT sectors
+    struct.pack_into("<I", header, 68, endofchain)  # first DIFAT sector
+    struct.pack_into("<I", header, 72, 0)  # num DIFAT sectors
+    for i in range(109):  # DIFAT: FAT lives at sector 0, the rest are free
+        struct.pack_into("<I", header, 76 + i * 4, 0 if i == 0 else freesect)
+
+    fat = bytearray(sector)
+    struct.pack_into("<I", fat, 0, fatsect)  # sector 0 is the FAT itself
+    struct.pack_into("<I", fat, 4, endofchain)  # sector 1 (directory) ends its chain
+    for i in range(2, sector // 4):
+        struct.pack_into("<I", fat, i * 4, freesect)
+
+    directory = bytearray(sector)
+    name = "Root Entry".encode("utf-16-le")
+    directory[0 : len(name)] = name
+    struct.pack_into("<H", directory, 64, len(name) + 2)  # name length incl. terminating NUL
+    directory[66] = 5  # object type: root storage
+    directory[67] = 1  # colour: black
+    struct.pack_into("<I", directory, 68, nostream)  # left sibling
+    struct.pack_into("<I", directory, 72, nostream)  # right sibling
+    struct.pack_into("<I", directory, 76, nostream)  # child
+    struct.pack_into("<I", directory, 116, endofchain)  # mini-stream start sector
+    struct.pack_into("<Q", directory, 120, 0)  # stream size
+    for entry in range(1, 4):  # remaining directory records are unallocated
+        base = entry * 128
+        struct.pack_into("<I", directory, base + 68, nostream)
+        struct.pack_into("<I", directory, base + 72, nostream)
+        struct.pack_into("<I", directory, base + 76, nostream)
+
+    return bytes(header) + bytes(fat) + bytes(directory)
+
+
+def _valid_abf_bytes() -> bytes:
+    """Bytes that pass `_is_complete_abf`: a genuine minimal CFBF container, not magic + zero padding.
+
+    A real `cache.abf` is a Microsoft Compound File Binary, and the completeness check validates the
+    CFBF header structure (#113, round-3 blocker 1), so happy-path tests must write something that is
+    actually a container - the previous magic-plus-zeros blob no longer qualifies (its byte-order mark
+    was 0, not 0xFFFE), which is the whole point of the stricter check.
+    """
+    return _build_minimal_cfbf()
+
+
+def test_is_complete_abf_accepts_a_genuine_cfbf_container(tmp_path: Path) -> None:
+    """The positive control: a structurally valid minimal CFBF is accepted."""
+    good = tmp_path / "cache.abf"
+    good.write_bytes(_build_minimal_cfbf())
+    assert refresh_pbip_model._is_complete_abf(good) is True
+
+
+def test_is_complete_abf_rejects_magic_with_only_zero_padding(tmp_path: Path) -> None:
+    """The old fixture shape - CFBF magic then zeros - is NOT a container and must be rejected.
+
+    Its byte-order mark is 0 rather than 0xFFFE and it references no sectors, so the round-2 check
+    (magic + size>=512) waved it through while the structural check rejects it (round-3 blocker 1).
+    """
+    blob = tmp_path / "cache.abf"
+    blob.write_bytes(refresh_pbip_model._CFBF_MAGIC + b"\x00" * (refresh_pbip_model._CFBF_HEADER_BYTES - 8))
+    assert refresh_pbip_model._is_complete_abf(blob) is False
+
+
+def test_is_complete_abf_rejects_a_non_sector_aligned_truncation(tmp_path: Path) -> None:
+    """A 600-byte torn write - keeps the magic, not a whole number of sectors - must be rejected.
+
+    This is the reviewer's exact reproduction: 600 bytes passed round-2 (magic + >=512) and reached
+    `os.replace`, destroying the old cache (round-3 blocker 1). A complete container is a whole number
+    of sectors, so a length that is not is a partial write.
+    """
+    truncated = tmp_path / "cache.abf"
+    truncated.write_bytes(_build_minimal_cfbf()[:600])
+    assert refresh_pbip_model._is_complete_abf(truncated) is False
+
+
+def test_is_complete_abf_rejects_a_sector_aligned_truncation(tmp_path: Path) -> None:
+    """Even a sector-ALIGNED truncation is rejected: its header points at sectors now past EOF.
+
+    Truncating the valid 1536-byte container to 1024 keeps the header (which names a directory at
+    sector 1) but drops that sector, so the referenced index now sits beyond the file - the signature
+    of an interrupted write that a size/alignment-only check cannot catch (round-3 blocker 1).
+    """
+    truncated = tmp_path / "cache.abf"
+    truncated.write_bytes(_build_minimal_cfbf()[:1024])
+    assert refresh_pbip_model._is_complete_abf(truncated) is False
+
+
+def test_is_complete_abf_rejects_a_header_only_file(tmp_path: Path) -> None:
+    """A lone 512-byte header (no data sectors) is not a usable backup and is rejected."""
+    header_only = tmp_path / "cache.abf"
+    header_only.write_bytes(_build_minimal_cfbf()[:512])
+    assert refresh_pbip_model._is_complete_abf(header_only) is False
 
 
 def test_a_failed_write_does_not_destroy_an_existing_good_cache(tmp_path: Path) -> None:
@@ -226,6 +332,10 @@ def test_persist_rolls_back_the_compat_bump_when_os_replace_raises(tmp_path: Pat
     leaving database.tmdl declaring 1702 for a cache that was never written - state the caller then
     carried into the UI Save (#113, round-2 blocker 2). The staging write here is a COMPLETE ABF, so
     the failure is purely the replace, isolating the exception path.
+
+    The patch is SCOPED to the cache swap (dst == cache.abf), because the rollback ITSELF now restores
+    atomically via `os.replace` (round-3 blocker 2); a blanket patch would break the very rollback the
+    test means to observe.
     """
     cache = _model(tmp_path, compat=1604)
     model_dir = cache.parent.parent
@@ -235,8 +345,12 @@ def test_persist_rolls_back_the_compat_bump_when_os_replace_raises(tmp_path: Pat
     def good_write(staging: Path) -> None:
         staging.write_bytes(_valid_abf_bytes())
 
-    def raising_replace(_src, _dst):
-        raise PermissionError("The process cannot access the file because it is being used")
+    real_replace = refresh_pbip_model.os.replace
+
+    def raising_replace(src, dst):
+        if str(dst).endswith("cache.abf"):
+            raise PermissionError("The process cannot access the file because it is being used")
+        return real_replace(src, dst)
 
     monkeypatch.setattr(refresh_pbip_model.os, "replace", raising_replace)
 
@@ -245,6 +359,116 @@ def test_persist_rolls_back_the_compat_bump_when_os_replace_raises(tmp_path: Pat
     assert database_tmdl.read_bytes() == before, "an exception on replace must restore database.tmdl exactly"
     assert not cache.exists(), "no cache may be left behind when the replace failed"
     assert not cache.with_name(cache.name + ".tmp").exists(), "the staging file must be cleaned up"
+
+
+def test_a_commit_then_raise_keeps_the_new_cache_and_the_aligned_compat(tmp_path: Path, monkeypatch) -> None:
+    """If `os.replace` MOVED the cache but still raised, that is a COMMIT - keep the aligned compat.
+
+    Commit is judged by the filesystem, not the writer's return flag (round-3 blocker 2). Here the
+    replace installs the new cache and then raises; the round-2 code saw the exception, treated the
+    write as "not committed", and rolled the compatibility level back UNDER the freshly installed
+    cache - a 1702 image in a project re-declared 1604, the downgrade crash on reopen. The alignment
+    must STAY at 1702 and no exception may escape.
+    """
+    cache = _model(tmp_path, compat=1604)
+    model_dir = cache.parent.parent
+    database_tmdl = model_dir / "definition" / "database.tmdl"
+    new_bytes = _valid_abf_bytes()
+
+    def good_write(staging: Path) -> None:
+        staging.write_bytes(new_bytes)
+
+    real_replace = refresh_pbip_model.os.replace
+
+    def commit_then_raise(src, dst):
+        if str(dst).endswith("cache.abf"):
+            real_replace(src, dst)  # actually install the cache...
+            raise PermissionError("moved, then lost the handle")  # ...then surface an error anyway
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(refresh_pbip_model.os, "replace", commit_then_raise)
+
+    ok, message = refresh_pbip_model._persist_image(cache, model_dir, 1702, good_write)
+    assert ok is True, "a moved-then-raised replace is a commit, judged by the filesystem"
+    assert "1702" in message
+    assert cache.read_bytes() == new_bytes, "the installed cache must be kept"
+    assert "compatibilityLevel: 1702" in database_tmdl.read_text(encoding="utf-8"), (
+        "compat must NOT be rolled back under a committed cache"
+    )
+    assert not cache.with_name(cache.name + ".tmp").exists()
+
+
+def test_a_failed_rollback_is_fatal_and_raises_compat_rollback_error(tmp_path: Path, monkeypatch) -> None:
+    """If the write did not land AND the compat rollback itself fails, that is FATAL, not a soft return.
+
+    A partial state where database.tmdl was bumped but the cache was never written, and the bump
+    cannot be undone, must NOT be quietly converted into a UI-save fallback (round-3 blocker 2): saving
+    would persist the mismatch. `_persist_image` raises `CompatRollbackError` so the caller can stop.
+    Here the write cleanly does nothing (not committed) and the rollback's `os.replace` onto
+    database.tmdl is blocked.
+    """
+    cache = _model(tmp_path, compat=1604)
+    model_dir = cache.parent.parent
+
+    def failing_write(_staging: Path) -> None:
+        return None
+
+    real_replace = refresh_pbip_model.os.replace
+
+    def block_rollback(src, dst):
+        if str(dst).endswith("database.tmdl"):
+            raise PermissionError("database.tmdl is locked")
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(refresh_pbip_model.os, "replace", block_rollback)
+
+    with pytest.raises(refresh_pbip_model.CompatRollbackError):
+        refresh_pbip_model._persist_image(cache, model_dir, 1702, failing_write)
+
+
+def test_every_rollback_path_is_attempted_even_when_the_first_fails(tmp_path: Path, monkeypatch) -> None:
+    """A failure on one rollback path must not abandon the others (round-3 blocker 2).
+
+    The alignment touches TWO files - database.tmdl and the generated-edit ledger. If restoring the
+    first fails, the second must STILL be restored (the round-2 loop stopped at the first failure,
+    leaving a subset reverted). We block database.tmdl's restore and assert the ledger was rolled back
+    regardless, while the overall failure is still surfaced as fatal.
+    """
+    cache = _model(tmp_path, compat=1604)
+    model_dir = cache.parent.parent
+    database_tmdl = model_dir / "definition" / "database.tmdl"
+    before_hash = refresh_pbip_model.sha256_file(database_tmdl)
+    (tmp_path / "input_manifest.json").write_text(
+        json.dumps(
+            {
+                "generated_artifacts": {
+                    "version": 1,
+                    "run_id": "engine-run",
+                    "recorded_at": "2026-08-10T08:00:00+00:00",
+                    "report_sha256": "report-hash",
+                    "files": {"MyMigration.SemanticModel/definition/database.tmdl": before_hash},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    def failing_write(_staging: Path) -> None:
+        return None
+
+    real_replace = refresh_pbip_model.os.replace
+
+    def block_database_tmdl(src, dst):
+        if str(dst).endswith("database.tmdl"):
+            raise PermissionError("database.tmdl is locked")
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(refresh_pbip_model.os, "replace", block_database_tmdl)
+
+    ledger = tmp_path / "_build" / "generated-edit-declarations.json"
+    with pytest.raises(refresh_pbip_model.CompatRollbackError):
+        refresh_pbip_model._persist_image(cache, model_dir, 1702, failing_write)
+    assert not ledger.exists(), "the ledger must be rolled back even though database.tmdl's restore failed"
 
 
 def _frontmatter(text: str) -> str:

--- a/scripts/probe_desktop_credential.ps1
+++ b/scripts/probe_desktop_credential.ps1
@@ -1,99 +1,32 @@
 <#
 .SYNOPSIS
-  Detect whether Power BI Desktop already has a cached credential for the live data source(s) in the
-  currently open model, WITHOUT the agent being able to type the credential itself.
+  Forwarding shim. The real credential arbiter now ships INSIDE the `pbip-model-refresh` skill, at
+  `.github/skills/pbip-model-refresh/scripts/probe_desktop_credential.ps1`, so the skill stays one
+  self-contained copyable unit.
 
 .DESCRIPTION
-  Live database sources (Databricks, SQL Server, Snowflake, ...) need a credential that is NOT in the
-  committed model files. In Power BI Desktop that credential is cached per-Windows-user (DPAPI) after
-  the user authenticates once in a modal dialog. The Desktop Bridge cannot fill that modal, so before
-  the agent's build/render/validate loop can work against live data, a human must sign in once.
+  This path used to hold a SECOND, DIVERGED copy of the arbiter, and the divergence was not cosmetic:
+  the root copy scanned only the FIRST top-level window for the credential modal (the modal is a
+  sibling window, so it could be missed), and - worse - it reported `CREDENTIAL_PRESENT` even when it
+  had never managed to invoke a Refresh at all. "No modal appeared" proves nothing if nothing was
+  triggered, so that was a FAIL-OPEN arbiter: it told an agent a credential was cached when it had
+  tested precisely nothing. The bundled copy scans every window and returns `UNKNOWN` (exit 3) in that
+  case. Meanwhile `scripts/README.md` and `docs/data-source-credentials.md` still point HERE, so the
+  documented path was the broken one.
 
-  This probe tells the two states apart so the migrator only prompts when needed. NOTE: for a
-  *serverless* source that cold-starts, the modal can appear only AFTER this probe's timeout, yielding a
-  false CREDENTIAL_PRESENT; treat the one-row data probe (DATA_OK vs NO_DATA) as the gate of record and
-  use this modal probe only to explain a NO_DATA. That probe ships inside the pbip-model-refresh skill:
-  .github/skills/pbip-model-refresh/scripts/probe_desktop_query.py (scripts/probe_desktop_query.py is a
-  forwarding shim kept for existing callers).
-    * If a credential modal is already open, or appears within -TimeoutSec of a refresh -> MISSING.
-    * If a refresh proceeds with no modal -> PRESENT (a credential is cached machine-wide; the loop
-      can run unattended) -- but re-confirm with the one-row data probe for serverless sources.
-
-  It triggers Refresh via UI Automation (the Bridge exposes no refresh verb) and watches every
-  top-level window of the target process for the connector credential dialog's signature text.
-
-  Windows-only by necessity (UI Automation / DPAPI). This is the sanctioned PowerShell exception to
-  the "committed scripts default to .py/.sh" rule, and it sits alongside scripts/preflight.ps1.
-
-.PARAMETER DesktopPid
-  The Power BI Desktop process id to drive (use the pid from `powerbi-desktop open`/`status`).
-
-.PARAMETER TimeoutSec
-  How long to wait for the credential modal after triggering refresh. Default 75s; use >=60s because a
-  serverless warehouse (e.g. Databricks) can cold-start before the prompt appears.
-
-.OUTPUTS
-  Final line `VERDICT: CREDENTIAL_MISSING` (exit 1) or `VERDICT: CREDENTIAL_PRESENT` (exit 0), or
-  `VERDICT: UNKNOWN` (exit 3) if the target window can't be found.
+  Forwarding rather than deleting keeps every existing caller working while guaranteeing there is only
+  ONE arbiter. Arguments and the exit code pass straight through.
 
 .EXAMPLE
   powershell -ExecutionPolicy Bypass -File scripts/probe_desktop_credential.ps1 -DesktopPid 42532
 #>
-param(
-  [Parameter(Mandatory = $true)][int]$DesktopPid,
-  [int]$TimeoutSec = 75
-)
 
-Add-Type -AssemblyName UIAutomationClient, UIAutomationTypes, WindowsBase
-
-$root = [System.Windows.Automation.AutomationElement]::RootElement
-$cond = New-Object System.Windows.Automation.PropertyCondition([System.Windows.Automation.AutomationElement]::ProcessIdProperty, $DesktopPid)
-
-# Connector credential-dialog signature text (covers Databricks / SQL / Snowflake / generic OAuth).
-$sig = 'You aren.t signed in|Personal Access Token|Databricks Client Credentials|specify how to connect|Account Key|Enter your credentials|Please specify how to connect'
-
-function Test-CredentialModal {
-  $cur = $root.FindFirst([System.Windows.Automation.TreeScope]::Children, $cond)
-  if (-not $cur) { return $null }
-  $desc = $cur.FindAll([System.Windows.Automation.TreeScope]::Descendants, [System.Windows.Automation.Condition]::TrueCondition)
-  foreach ($d in $desc) {
-    $n = $d.Current.Name
-    if ($n -and $n -match $sig) { return $n }
-  }
-  return $null
+$target = Join-Path $PSScriptRoot '..\.github\skills\pbip-model-refresh\scripts\probe_desktop_credential.ps1'
+if (-not (Test-Path -LiteralPath $target)) {
+  Write-Output "bundled credential probe not found at $target"
+  Write-Output "VERDICT: UNKNOWN"
+  exit 3
 }
 
-$win = $root.FindFirst([System.Windows.Automation.TreeScope]::Children, $cond)
-if (-not $win) { Write-Output "main window for pid $DesktopPid not found"; Write-Output "VERDICT: UNKNOWN"; exit 3 }
-
-# 1. If a credential modal is ALREADY open, the credential is missing - report immediately.
-$hit = Test-CredentialModal
-if ($hit) {
-  Write-Output ("credential modal already open: '{0}'" -f $hit.Substring(0, [Math]::Min(80, $hit.Length)))
-  Write-Output "VERDICT: CREDENTIAL_MISSING"
-  exit 1
-}
-
-# 2. Otherwise trigger a refresh and watch for the modal (generous timeout for warehouse cold-start).
-$all = $win.FindAll([System.Windows.Automation.TreeScope]::Descendants, [System.Windows.Automation.Condition]::TrueCondition)
-$invoked = $false
-foreach ($e in $all) {
-  if ($e.Current.Name -eq 'Refresh' -and (($e.GetSupportedPatterns() | ForEach-Object { $_.ProgrammaticName }) -match 'Invoke')) {
-    try { $e.GetCurrentPattern([System.Windows.Automation.InvokePattern]::Pattern).Invoke(); $invoked = $true; break } catch {}
-  }
-}
-Write-Output "refresh invoked: $invoked"
-
-$deadline = (Get-Date).AddSeconds($TimeoutSec)
-while ((Get-Date) -lt $deadline) {
-  Start-Sleep -Milliseconds 2000
-  $hit = Test-CredentialModal
-  if ($hit) {
-    Write-Output ("credential modal detected: '{0}'" -f $hit.Substring(0, [Math]::Min(80, $hit.Length)))
-    Write-Output "VERDICT: CREDENTIAL_MISSING"
-    exit 1
-  }
-}
-Write-Output "no credential modal within ${TimeoutSec}s (refresh proceeded)"
-Write-Output "VERDICT: CREDENTIAL_PRESENT"
-exit 0
+& $target @args
+exit $LASTEXITCODE


### PR DESCRIPTION
## What this fixes

Four filed bugs in the `pbip-model-refresh` skill bundle. Scope is strictly
`.github/skills/pbip-model-refresh/**` — the `powerbi-report-gotchas` /
`powerbi-semantic-model-gotchas` bundles are owned by a parallel change and were
not touched.

### #113 — persist-by-default doc drift + non-atomic write + premature compat bump
- **Docs corrected to match the code, not vice-versa.** The frontmatter said
  persisting was "opt-in via `--save`" while the code persists by DEFAULT
  (`--no-save` opts out). The in-code reasoning for persist-by-default is sound
  (it is the script's stated purpose, and the compat-mismatch hazard that once
  justified opt-in is now aligned away), so I fixed the prose.
- **Atomic write.** The cache is staged to `cache.abf.tmp` and swapped with
  `os.replace` only once it exists and is non-empty (`_staged_image_write`), so a
  failed/partial `ImageSave` can no longer truncate an existing good cache.
- **Compat rollback.** The `database.tmdl` `compatibilityLevel` bump is now
  provisional — `_persist_image` snapshots `database.tmdl` (and the generated-edit
  ledger) and restores them if the write does not land, so compat is never raised
  for a cache that was never written.
- **Anti-drift test** asserts the frontmatter's persistence default equals the
  parsed argparse default, so doc and code cannot silently diverge again.

### #114 — fail-open instance identity
- `same_model()` now **fails closed**: no resolvable model folder, or no TMDL
  tables to fingerprint, returns `(False, …)` instead of "unverified → proceed".
- The fingerprint is now an **exact table-for-table match**. A sibling with a
  **superset** schema (all your tables plus more) is refused, not reported
  "confirmed" — that subset match was the core hole.
- `main()` refuses a `--port` that does not **equal** the pid-derived port, before
  any read or write, so `--port` can never bypass PID-based discovery on the
  mutating path.
- `cache_file()` resolves an ambiguous multi-model folder from the
  `.pbip → report → definition.pbir` `byPath` **binding**, and returns `None`
  (fail closed) rather than the old arbitrary `models[0]`.

### #115 — DATA_OK from an arbitrary single table
- A model-level `DATA_OK` is emitted only when explicit canaries (`--tables`, one
  per distinct live source) all return rows. With no canary named, only the first
  queryable table is probed and the verdict is **downgraded** to
  `TABLE_OK '<table>'`, naming the single table actually read. Applied to both the
  read-only probe and the refresh's own data check.

### #118 — dangling reference broke bundle self-containment
- `probe_desktop_credential.ps1` (the arbiter the refresh names on `TIMEOUT`) now
  ships **inside** the bundle, and `refresh_pbip_model` prints its own bundled path
  (`CREDENTIAL_PROBE`) so the runtime instruction always resolves to a file that is
  present wherever the folder is copied.

## Evidence the tests catch the bugs (not just green)

The existing tests encoded the buggy behaviour, so "green" is not proof. I
reverted the two scripts to their pre-change state and re-ran the suite: **30 of
the new/changed tests FAIL** against the old code, while the **38 unchanged tests
still pass**. Every behaviour change is pinned by a test that fails without the fix.
With the fixes in place the full bundle suite is green (**68 passed**); scripts are
`ruff`-clean and pylint **10.00/10** (tests are not held to 10.00/10, matching CI).

## Where I diverged from the issues' proposed fix (pushback with evidence)

- **#114 fingerprint compares tables AND columns AND measures.** An earlier
  revision of this body claimed "exact table-set, NOT columns+measures" — that
  sentence was stale and the blind review was right to flag the contradiction.
  The code has compared all three since round 2: `same_model` calls
  `_first_table_difference` on the table-name set and `_first_schema_difference`
  on the `(table, column)` and `(table, measure)` pair sets, each case-folded and
  each pinned by its own test. The false-negative risk that stale sentence named
  (RowNumber, date-hierarchy columns) is handled where it belongs — those columns
  are filtered out of the TMDL side before comparison — not by dropping the check.
  Prose corrected; no code change was warranted.

## What I deliberately did NOT change (follow-up)

- **`probe_desktop_query`'s read-only `--port` override** is left as-is. #114's
  "don't let `--port` bypass PID discovery" is scoped to the **mutating** path; the
  probe writes nothing, so an explicit port there is a legitimate escape hatch.
- ~~**Two-copies drift** between the bundled `probe_desktop_credential.ps1` and
  the repo-root original.~~ **Done in round 4** — the root copy is now a
  forwarding shim, so there is one arbiter and it is the fail-closed one.
- **Auditing OTHER bundles for their own dangling references** was explicitly out
  of scope; only this bundle's own dangling reference was fixed.

---

## Round 4 — addressing the blind review

The review returned **request changes** with one reproduced blocker. All six
findings are answered below.

### BLOCKER (Findings 1 + 2) — `_is_complete_abf` validated the wrong file format

Confirmed and fixed. Round 3's predicate asserted a persisted `cache.abf` was a
Microsoft Compound File Binary (magic `D0 CF 11 E0 A1 B1 1A E1`). **It is not.**
Measured over 13 real caches (17,478 B – 60,688,851 B) written by Power BI
Desktop *and* by this toolkit's own ImageSave: **0 of 13 match CFBF**. So the
staged write never swapped, `_persist_image` always returned `False`, and every
run fell through to the legacy UI-Automation save — persist-by-default, the
entire subject of #113, was silently dead. The reviewer's diagnosis of the shape
is exactly right: round 3 replaced a loose-but-correct predicate
(exists + non-empty + mtime newer) with a strict-and-wrong one.

The real format, derived from the corpus rather than assumed, and verified
byte-for-byte on every file:

```
0..99    UTF-16LE "This backup was created using XPress9 compression."   (exactly 100 bytes)
100..101 uint16 pad
102..    per block: uint32 uncompressedBytes, uint32 lengthFromTheMagic,
         magic 2A D7 86 4E, payload
         next header = offset + 8 + length ; the chain ends EXACTLY at EOF
```

Detecting a **partial write** is the whole point of the predicate, so the check
is a full chain walk, not a header sniff. Two properties make truncation
detectable: the chain must land exactly on EOF, and all 60 measured non-final
blocks declare exactly 2 MiB uncompressed while every final block declares less —
so a truncation that happens to fall on a chunk boundary (which a chain walk
alone cannot see) is still caught. Known and accepted false-reject: an image
whose uncompressed size is an exact multiple of 2 MiB. That is a deliberate
fail-closed choice and its cost is a fallback to the UI save, not data loss; it
is documented in the module.

**The predicate now returns a rejection *reason*, not a bool**, and
`_staged_image_write` prints it (`save   : staged cache REJECTED - <reason>`).
The CFBF bug survived a whole round precisely because the predicate could only
say "no", and nothing said why.

**Tests rebuilt on the real format (Finding 2).** `_build_minimal_cfbf` and
`_valid_abf_bytes` are gone, along with the false docstring; `_cfbf_bytes`
survives only as a **negative control**. New fixtures **hard-code** the format
constants rather than importing them from the module under test — a fixture
built from the predicate's own constants can only ever confirm the predicate,
never contradict it, which is the structural lesson of this finding. Added: a
golden real-header test, block-boundary truncation, exhaustive prefix rejection,
rejection-reason printing, and — as the reviewer asked — **three tests that feed
real `cache.abf` files through `_staged_image_write` and assert the swap
happens**. They discover the corpus via `PBIP_REFRESH_REAL_ABF` and **skip** when
it is absent, so the bundle stays portable: `tests/test_skills.py` (copied to a
temp dir, repo unimportable) still passes, 23 tests. The reviewer's inverse
mutation now fails **0** tests, was 5.

### Finding 3 (HIGH) — a failed persist invalidated the good cache via mtime

Confirmed and fixed. `_restore_rollback_snapshot` restored `database.tmdl`
byte-for-byte but with a fresh mtime, leaving the definition newer than the
cache — the skill's own documented cache-discard trigger. Reproduced (`cache
newer than definition` flipping `True → False` with bytes unchanged) before the
fix. `_snapshot_rollback_paths` now captures `(bytes, atime_ns, mtime_ns)` and
the restore replays them with `os.utime(..., ns=…)`; pinned by a test.

### Finding 4 (HIGH) — body-vs-code contradiction on #114

**The body was stale; the code is correct** — see the corrected bullet above.
`same_model` has compared tables, `(table, column)` pairs and `(table, measure)`
pairs since round 2, each pinned by a test. No code change was warranted.

### Finding 5 (MEDIUM) — `DATA_OK → TABLE_OK` broke host-repo gates

Fixed by **decoupling, not weakening**. `--tables` is the refresh **scope**;
`--canaries` (new) is the **verification set**.

| invocation | verdict |
|---|---|
| whole-database refresh + `--canaries a b` all return rows | `DATA_OK` |
| refresh narrowed by `--tables` | `TABLES_OK` — never model-level, however many canaries pass |
| no canary named | `TABLE_OK '<table>'`, naming the single table read |
| `--verify-only --tables a b` | `DATA_OK` — nothing was narrowed |
| any canary empty | `NO_DATA`, which outranks everything |

This closes the trap the reviewer identified: an agent chasing the mandated
`DATA_OK` can no longer get it by adding `--tables a b`, because narrowing the
refresh now *caps* the verdict at `TABLES_OK`. `--tables` alone still supplies
canaries, so existing callers keep their probe — they simply cannot certify a
model-level verdict over a partially-refreshed model. Mirrored in
`probe_desktop_query.py`, where `--tables`/`--table` remain plain aliases because
that script never refreshes.

**Host-repo changes this needs, which I do not own and did not make:**

- `.github/agents/pbi-semantic-builder.agent.md:301` mandates `DATA_OK +
  PERSISTED` from a call **without** `--tables`. With no canary named that call
  now yields `TABLE_OK`, so it must add `--canaries <one per distinct live
  source>`. It must **not** add `--tables` — that would cap it at `TABLES_OK`.
- The two other `SKILL.md` files instructing `-> PREFLIGHT: DATA_OK` need the
  same `--canaries` switch.

### Finding 6 (LOW/MEDIUM) — two same-named credential arbiters, one fail-open

Fixed, since the reviewer is right that it was ~20 lines away. Rather than
duplicating the fix into the root copy (which recreates the drift), the root
`scripts/probe_desktop_credential.ps1` is now a **forwarding shim** to the
bundled arbiter — matching this repo's existing shim convention for
`probe_desktop_query.py`. There is one arbiter again, it is the fail-closed one
(`UNKNOWN` when no Refresh was invoked, never falling through to
`CREDENTIAL_PRESENT`), and `scripts/README.md` / `docs/data-source-credentials.md`
stay correct without edits. Two tests pin it: the bundled arbiter never fails
open, and the root file is a shim rather than a re-grown implementation.

### Also in this round

`_verdict.py` extracted from `refresh_pbip_model.py` to stay under the pylint
module-length cap, and the interprocess-lock work for #114 (`_lock.py`, per-run
staging paths, `BaseException` rollback) that was already in the working tree
lands here too.

### Round-4 verification

- **13/13 real caches accepted**; every truncation of the smallest real cache
  rejected; a real block-boundary truncation rejected with the boundary reason.
- Reviewer's inverse mutation: correcting the format fails **0** tests, was 5.
- Bundle suite **125 passed** with the real corpus, **122 passed + 3 skipped**
  without it. `tests/test_skills.py` portability gate: **23 passed**.
- Gates by exit code: `ruff format --check` 0, `ruff check` 0, `pylint` 0
  (10.00/10), `pytest` 0.
- **Ten mutations injected, ten caught**: CFBF magic restored; final-block rule
  dropped; chain walked past EOF and accepted; staged file swapped without
  validation; rejection reason not printed; `os.utime` removed from rollback;
  `--tables` re-coupled to canaries; the `TABLES_OK` branch disabled; the bundled
  arbiter made to fail open again; the root shim re-grown into a UIA
  implementation.

---

Closes: Fixes #113 Fixes #114 Fixes #115 Fixes #118



Fixes #114
