### PR TITLE
Make the probe's hand-written PBIP scaffold pass our own PBIR gate (partial #129)

### DIFF
--- a/scripts/probe_live_source.py
+++ b/scripts/probe_live_source.py
@@ -83,6 +83,20 @@ _SCHEMA_BASE = "https://developer.microsoft.com/json-schemas/fabric/item/report/
 _PLATFORM_SCHEMA = (
     "https://developer.microsoft.com/json-schemas/fabric/gitIntegration/platformProperties/2.0.0/schema.json"
 )
+# `definition.pbir` sits one level ABOVE `definition/`, so it does not share `_SCHEMA_BASE`, and it
+# is NOT optional: omitting it is `PBIR_JSON_FILE_NO_SCHEMA` ("Fabric rejects PBIR definition JSON
+# files without $schema"). Value copied from the committed deliverable
+# `examples/shipping-kpis/fabric/ShippingKPIs.Report/definition.pbir`.
+_PBIR_PROPERTIES_SCHEMA = (
+    "https://developer.microsoft.com/json-schemas/fabric/item/report/definitionProperties/2.0.0/schema.json"
+)
+# `.pbip` / `.pbism` are project-level, not PBIR, so they have their own schema roots again. The
+# `.pbip` one must end in a LITERAL numeric version, never the placeholder `1.x.x`
+# (`.github/skills/powerbi-semantic-model-gotchas/SKILL.md`).
+_PBIP_PROPERTIES_SCHEMA = "https://developer.microsoft.com/json-schemas/fabric/pbip/pbipProperties/1.0.0/schema.json"
+_PBISM_PROPERTIES_SCHEMA = (
+    "https://developer.microsoft.com/json-schemas/fabric/item/semanticModel/definitionProperties/1.0.0/schema.json"
+)
 
 # A "table not found" is a SPEC error, not a reachability one - the connection plainly worked well
 # enough for the server to tell us the object is missing. Classifying it as UNREACHABLE would send a
@@ -128,7 +142,11 @@ def _pbip_files(name: str, m_query: str, table: str, column: str) -> dict[str, s
     indented = "\n".join("\t\t\t\t" + line for line in m_query.split("\n"))
     return {
         f"{name}.pbip": json.dumps(
-            {"version": "1.0", "artifacts": [{"report": {"path": f"{name}.Report"}}]},
+            {
+                "$schema": _PBIP_PROPERTIES_SCHEMA,
+                "version": "1.0",
+                "artifacts": [{"report": {"path": f"{name}.Report"}}],
+            },
             indent=2,
         ),
         f"{name}.SemanticModel/.platform": json.dumps(
@@ -139,7 +157,12 @@ def _pbip_files(name: str, m_query: str, table: str, column: str) -> dict[str, s
             },
             indent=2,
         ),
-        f"{name}.SemanticModel/definition.pbism": json.dumps({"version": "4.0", "settings": {}}, indent=2),
+        # 4.2, matching all 16 shipped examples under `examples/*/fabric/*.SemanticModel/`. 4.0 is
+        # an older project version this repo no longer produces anywhere else.
+        f"{name}.SemanticModel/definition.pbism": json.dumps(
+            {"$schema": _PBISM_PROPERTIES_SCHEMA, "version": "4.2", "settings": {}},
+            indent=2,
+        ),
         f"{name}.SemanticModel/definition/database.tmdl": (
             # 1702, never lower. Measured 2026-08-03 (a real Power BI Desktop crash, "Frown"
             # feedback): TOM refuses to load a model that requests a LOWER compatibilityLevel than
@@ -180,23 +203,37 @@ def _pbip_files(name: str, m_query: str, table: str, column: str) -> dict[str, s
             indent=2,
         ),
         f"{name}.Report/definition.pbir": json.dumps(
-            {"version": "4.0", "datasetReference": {"byPath": {"path": f"../{name}.SemanticModel"}}},
+            {
+                "$schema": _PBIR_PROPERTIES_SCHEMA,
+                "version": "4.0",
+                "datasetReference": {"byPath": {"path": f"../{name}.SemanticModel"}},
+            },
             indent=2,
         ),
         f"{name}.Report/definition/version.json": json.dumps(
             {
                 "$schema": _SCHEMA_BASE + "versionMetadata/1.0.0/schema.json",
-                "version": "4.0",
+                # Three-part and MUST match `^[1-9][0-9]*\.(0|[1-9][0-9]*)\.0$`, so the two-part
+                # "4.0" this used to carry is a schema error, not a variant spelling. This is the
+                # PBIR *definition* version (2.0.0 in every shipped example), which is a different
+                # number from `definition.pbir`'s project `version` above - do not sync them.
+                "version": "2.0.0",
             },
             indent=2,
         ),
         f"{name}.Report/definition/report.json": json.dumps(
             {
                 "$schema": _SCHEMA_BASE + "report/1.0.0/schema.json",
+                # `reportVersionAtImport` is LOCATION-DEPENDENT, and this scaffold is the place the
+                # confusion already cost us once. It is FORBIDDEN here at the top level (`/ must NOT
+                # have additional properties`) and REQUIRED inside each `themeCollection` entry
+                # (`PBIR_THEME_VERSION_AT_IMPORT_MISSING`). The probe registers no theme at all, so
+                # there is no entry to carry it and the correct scaffold has it nowhere. If you ever
+                # add a `baseTheme`/`customTheme` here, that entry must carry its own
+                # `reportVersionAtImport` - see `examples/shipping-kpis/.../definition/report.json`.
                 "themeCollection": {},
                 "layoutOptimization": "None",
                 "resourcePackages": [],
-                "reportVersionAtImport": "5.55",
             },
             indent=2,
         ),

--- a/tests/test_probe_live_source.py
+++ b/tests/test_probe_live_source.py
@@ -1,0 +1,155 @@
+"""Regression tests for the throwaway PBIP scaffold `scripts/probe_live_source.py` hand-writes.
+
+That scaffold is the only hand-written PBIP/PBIR/TMDL in the repo, and it shipped for weeks in a
+state the repo's own gate rejects: `powerbi-report-author validate` returned `errorCount: 3`. The
+headline test here is the one that costs a single `validate` call and would have caught it on the
+day it landed.
+
+Two deliberate design points, both learned from that miss:
+
+* **The validate test SKIPS when the CLI is absent** (CI runs on Ubuntu without the npm bridge), so
+  it can never be the reason CI is red - but it also skips on `PBIR_SCHEMA_UNREACHABLE`, because
+  the validator *silently* stops schema-checking when it cannot fetch the schema and still prints
+  "0 errors". Treating that as a pass would rebuild the exact false green this file exists to stop.
+* **The structural tests run everywhere and encode each of the three defects separately**, so the
+  guard still bites on a machine with no validator. `validate` alone is not enough anyway: measured
+  2026-08-13, it walks only the `.Report` tree, so it reports 0 errors on a scaffold whose `.pbip`
+  has no `$schema` at all. The last test is the only thing covering the project-level files.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO / "scripts"))
+
+import probe_live_source  # noqa: E402  # pylint: disable=wrong-import-position
+
+# Copied verbatim from the validator's own failure text for `definition/version.json`.
+VERSION_PATTERN = re.compile(r"^[1-9][0-9]*\.(0|[1-9][0-9]*)\.0$")
+
+# Committed, Desktop-opened deliverables - the ground truth the scaffold is measured against.
+EXAMPLE_FABRIC = REPO / "examples" / "shipping-kpis" / "fabric"
+EXAMPLE_MODEL = EXAMPLE_FABRIC / "ShippingKPIs.SemanticModel"
+EXAMPLE_REPORT = EXAMPLE_FABRIC / "ShippingKPIs.Report"
+
+PROBE_M = "let\n    Source = #table({}, {})\nin\n    Source"
+
+VALIDATOR = shutil.which("powerbi-report-author")
+requires_validator = pytest.mark.skipif(
+    VALIDATOR is None,
+    reason="powerbi-report-author not installed (npm bridge CLI; absent on Linux CI)",
+)
+
+
+@pytest.fixture(name="scaffold")
+def scaffold_fixture() -> dict[str, str]:
+    """The scaffold exactly as the probe emits it, keyed by relative path."""
+    return probe_live_source._pbip_files("Probe", PROBE_M, "T", "C")  # pylint: disable=protected-access
+
+
+@pytest.fixture(name="scaffold_dir")
+def scaffold_dir_fixture(scaffold: dict[str, str], tmp_path: Path) -> Path:
+    """The same scaffold materialised on disk, mirroring `_write_probe_model`."""
+    for rel, content in scaffold.items():
+        target = tmp_path / rel
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(content, encoding="utf-8")
+    return tmp_path
+
+
+def _json(scaffold: dict[str, str], rel: str) -> dict:
+    return json.loads(scaffold[rel])
+
+
+@requires_validator
+def test_scaffold_passes_the_repos_own_pbir_gate(scaffold_dir: Path) -> None:
+    """The probe must not hand Power BI Desktop a scaffold our own validator rejects."""
+    proc = subprocess.run(
+        [VALIDATOR, "validate", str(scaffold_dir / "Probe.pbip"), "--format", "json"],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=300,
+    )
+    payload = json.loads(proc.stdout)["data"]
+
+    if "PBIR_SCHEMA_UNREACHABLE" in payload.get("diagnostics", {}):
+        pytest.skip("validator could not fetch the PBIR schema - schema checks did NOT run")
+
+    # The `.pbip` resolves to the report; without this a scaffold that resolved to nothing would
+    # also report 0 errors.
+    assert Path(payload["reportPath"]).name == "Probe.Report"
+    assert payload["errorCount"] == 0, proc.stdout
+    assert payload["result"] == "succeeded", proc.stdout
+
+
+def test_pbir_definition_declares_a_schema(scaffold: dict[str, str]) -> None:
+    """`definition.pbir` without `$schema` is `PBIR_JSON_FILE_NO_SCHEMA` - Fabric rejects it."""
+    pbir = _json(scaffold, "Probe.Report/definition.pbir")
+
+    assert pbir["$schema"].endswith("/report/definitionProperties/2.0.0/schema.json")
+    assert pbir["datasetReference"]["byPath"]["path"] == "../Probe.SemanticModel"
+
+
+def test_report_definition_version_is_three_part(scaffold: dict[str, str]) -> None:
+    """`definition/version.json` must match the schema pattern - a two-part "4.0" is an error."""
+    version = _json(scaffold, "Probe.Report/definition/version.json")["version"]
+
+    assert VERSION_PATTERN.match(version), f"{version!r} fails {VERSION_PATTERN.pattern}"
+
+
+def test_report_version_at_import_is_never_top_level(scaffold: dict[str, str]) -> None:
+    """Location-dependent: forbidden at the top level, required inside each theme entry.
+
+    The probe registers no theme, so its `themeCollection` is empty and the loop below is vacuous
+    *for the scaffold* - which is why the companion test pins the other half of the rule against a
+    committed report that does have theme entries.
+    """
+    report = _json(scaffold, "Probe.Report/definition/report.json")
+
+    assert "reportVersionAtImport" not in report
+    for name, theme in report["themeCollection"].items():
+        assert "reportVersionAtImport" in theme, f"themeCollection.{name} is missing it"
+
+
+def test_shipped_report_keeps_report_version_at_import_inside_each_theme_entry() -> None:
+    """The other half of the rule, on ground truth - so "relocate" can never decay into "delete".
+
+    Stripping it from a theme entry is `PBIR_THEME_VERSION_AT_IMPORT_MISSING`. If the probe ever
+    grows a `baseTheme`/`customTheme`, this is the shape it has to copy.
+    """
+    report = json.loads((EXAMPLE_REPORT / "definition" / "report.json").read_text(encoding="utf-8"))
+    themes = report["themeCollection"]
+
+    assert themes, "ground-truth example has no theme entries - this test would be vacuous"
+    assert "reportVersionAtImport" not in report
+    for name, theme in themes.items():
+        assert "reportVersionAtImport" in theme, f"themeCollection.{name} is missing it"
+
+
+def test_project_files_carry_literal_numeric_schemas(scaffold: dict[str, str]) -> None:
+    """`.pbip`/`.pbism` are invisible to `validate`, so only this test covers them.
+
+    `.pbism` is tied to a committed deliverable rather than a hard-coded literal: the point is that
+    the probe emits what this repo actually ships, not what someone believed it ships.
+    """
+    pbip = _json(scaffold, "Probe.pbip")
+    pbism = _json(scaffold, "Probe.SemanticModel/definition.pbism")
+
+    assert (
+        pbip["$schema"] == "https://developer.microsoft.com/json-schemas/fabric/pbip/pbipProperties/1.0.0/schema.json"
+    )
+    assert "x.x" not in pbip["$schema"]
+
+    shipped = json.loads((EXAMPLE_MODEL / "definition.pbism").read_text(encoding="utf-8"))
+    assert pbism["$schema"] == shipped["$schema"]
+    assert pbism["version"] == shipped["version"]


### PR DESCRIPTION
Partial fix for #129 — the **code half** only. The doc wording in `AGENTS.md`,
`.github/copilot-instructions.md` and `scripts/preflight.ps1` is owned by a sibling change, so this
PR deliberately touches neither. Files changed: `scripts/probe_live_source.py` and the new
`tests/test_probe_live_source.py`.

## The defect

`scripts/probe_live_source.py` is the only script in the repo that hand-writes a PBIP/PBIR/TMDL
scaffold, and its output failed the gate every other artifact has to clear.

### Before — `powerbi-report-author validate` on the emitted scaffold

```
$ powerbi-report-author validate <scaffold>\Probe.Report --format text
ERROR [PBIR_JSON_FILE_NO_SCHEMA] ×1
  JSON file has no "$schema" and cannot be schema-validated; Fabric rejects PBIR definition JSON files without "$schema": ...\Probe.Report\definition.pbir
ERROR [PBIR_SCHEMA_VALIDATION_ERROR] ×2
  Schema validation: /version must match pattern "^[1-9][0-9]*\.(0|[1-9][0-9]*)\.0$": ...\Probe.Report\definition\version.json
  Schema validation: / must NOT have additional properties (property: "reportVersionAtImport"): ...\Probe.Report\definition\report.json
3 error(s), 0 warning(s); result=failed
```

### After

```
$ powerbi-report-author validate <scaffold>\Probe.Report --format text
No diagnostics.
0 error(s), 0 warning(s); result=succeeded

$ powerbi-report-author validate <scaffold>\Probe.pbip --format text
No diagnostics.
0 error(s), 0 warning(s); result=succeeded
```

Validator: `@microsoft/powerbi-report-authoring-cli` **0.1.4** (the correctness floor), Windows.

## What changed, and why each value

| file | before | after | evidence |
|---|---|---|---|
| `Probe.Report/definition.pbir` | no `$schema` | `.../report/definitionProperties/2.0.0/schema.json` | committed `examples/shipping-kpis/fabric/ShippingKPIs.Report/definition.pbir` |
| `Probe.Report/definition/version.json` | `"4.0"` | `"2.0.0"` | schema pattern in the error text; `2.0.0` in the shipped example |
| `Probe.Report/definition/report.json` | top-level `reportVersionAtImport: "5.55"` | key removed | `/ must NOT have additional properties` |
| `Probe.pbip` | no `$schema` | `.../fabric/pbip/pbipProperties/1.0.0/schema.json` | `.github/skills/powerbi-semantic-model-gotchas/SKILL.md`; all 16 shipped examples |
| `Probe.SemanticModel/definition.pbism` | no `$schema`, `version 4.0` | `.../semanticModel/definitionProperties/1.0.0/schema.json`, `4.2` | all 16 shipped examples |

`definition.pbir`'s own `"version": "4.0"` is **kept** — that is the project version, a different
number from `definition/version.json`'s PBIR definition version, and the shipped example carries
both exactly this way. The code comment says so, because syncing them is the obvious wrong fix.

## `reportVersionAtImport` is a relocation rule — measured in both directions

The scaffold registers **no theme**, so its `themeCollection` is `{}` and the correct scaffold
carries the key nowhere. That is the *end state* of the relocation here, not a shortcut, and both
directions were measured against 0.1.4 rather than assumed:

- **top level, present** → `/ must NOT have additional properties (property: "reportVersionAtImport")`
- **theme entry, absent** — I added a `themeCollection.baseTheme` without it →
  `/themeCollection/baseTheme must have required property 'reportVersionAtImport'`
- **`themeCollection: {}`, key nowhere** → `0 error(s)`

Because the scaffold's theme loop is therefore vacuous, the theme-entry half of the rule is pinned
against ground truth instead: `test_shipped_report_keeps_report_version_at_import_inside_each_theme_entry`
reads the committed `examples/shipping-kpis/.../definition/report.json` and asserts the key is absent
at the top level and present in **each** of its two theme entries, with an explicit
`assert themes` so the loop can never silently become vacuous there either. If the probe ever grows a
theme, that is the shape it must copy.

## The test

`tests/test_probe_live_source.py`, 6 tests. One `validate` call, as the issue suggested, plus
structural assertions.

Two things a reviewer should look at specifically:

- **It skips, never fails, when the CLI is missing** (`shutil.which`) — CI runs on Ubuntu without the
  npm bridge. It **also skips on `PBIR_SCHEMA_UNREACHABLE`**, because that diagnostic means the
  validator silently stopped schema-checking *and still prints "0 errors"*. Treating that as a pass
  would rebuild the exact false green this file exists to prevent. It asserts
  `reportPath` ends in `Probe.Report` too, so a scaffold that resolved to nothing cannot pass as 0
  errors.
- **`validate` does not cover the `.pbip`/`.pbism` at all** — measured: with `$schema` deleted from
  `Probe.pbip`, `validate <path>\Probe.pbip` still returns `0 error(s); result=succeeded`, because it
  walks only the `.Report` tree. `test_project_files_carry_literal_numeric_schemas` is the only cover
  for those two files, which is why the structural tests exist alongside the validate test rather
  than as decoration.

## Mutation test — all 5 caught

Each defect was reintroduced in turn and the suite re-run (harness was scratch, not committed):

| # | mutation | result | failing tests |
|---|---|---|---|
| 1 | drop `$schema` from `definition.pbir` | **CAUGHT** | `test_pbir_definition_declares_a_schema`, `test_scaffold_passes_the_repos_own_pbir_gate` |
| 2 | `version.json` back to `"4.0"` | **CAUGHT** | `test_report_definition_version_is_three_part`, `test_scaffold_passes_the_repos_own_pbir_gate` |
| 3 | re-add top-level `reportVersionAtImport` | **CAUGHT** | `test_report_version_at_import_is_never_top_level`, `test_scaffold_passes_the_repos_own_pbir_gate` |
| 4 | drop `$schema` from `.pbip` | **CAUGHT** | `test_project_files_carry_literal_numeric_schemas` (validate is blind to it — see above) |
| 5 | `.pbism` back to `version 4.0` | **CAUGHT** | `test_project_files_carry_literal_numeric_schemas` |

## Gates (by exit code)

| command | exit |
|---|---|
| `ruff format --check scripts tests` | 0 (`84 files already formatted`) |
| `ruff check scripts tests` | 0 (`All checks passed!`) |
| `pylint scripts` | 0 (`10.00/10`) |
| `pytest -q` | 0 (`1001 passed, 4 skipped in 190s`) |

No Fabric/Tableau writes, no live database probe, no Power BI Desktop opened — the scaffold was
materialised to a scratch folder and validated offline-of-those-systems.

## Please delete `origin/fix/probe-pbir-schema`

That branch fixes items 1–3 but is **145 commits behind / 1 ahead**; merging it would revert
`--bundle`, `ACCESS_DENIED` handling and `network_fault_observed`. Its diff was read for reference
only; everything here was re-applied fresh on `master`, and it goes further (items 4–5, the
theme-entry direction, and the `PBIR_SCHEMA_UNREACHABLE` / `.pbip`-blindness handling). It is
superseded and should be deleted.

## Out of scope, deliberately

#130's question — whether this probe should be the mandatory gate at all — is untouched here. This PR
only makes the scaffold correct.
