### PR TITLE
Make harvest ignore rules prefix globs, and refuse an unignored --out

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,9 +68,12 @@ build/
 [Bb]in/
 [Oo]bj/
 
-# Tableau Public harvester downloads + parsed specs (bulk .twbx + specs, transient
-# corpus for parser stress-testing / hard-workbook selection - never commit).
-/_harvest/
+# `harvest_tableau_public.py` output (`--out-dir`, default `_harvest`): Tableau Public downloads +
+# parsed specs (bulk .twbx + specs, transient corpus for parser stress-testing / hard-workbook
+# selection - never commit). `classify_harvest_hardness.py` reads `_harvest/specs` from here.
+# GLOB, not an exact name: a second run under `_harvest-2`/`_harvest-2026-08-13` - the natural move
+# once `_harvest/` is occupied - was NOT ignored, and staged .twbx on a PUBLIC repo (issue #125).
+/_harvest*/
 candidates.json
 
 # assess_estate.py output. This is a REAL CUSTOMER ESTATE: workbook and project names,
@@ -79,9 +82,14 @@ candidates.json
 # so ignore the conventional name rather than relying on everyone remembering.
 /_assessment*/
 
-# harvest_estate_assets.py output: downloaded .twbx/.tdsx from a REAL site plus the parse
-# sweep over them. Vendor workbooks and customer content - never commit.
-/_sweep/
+# `harvest_estate_assets.py` output (`--out`): downloaded .twbx/.tdsx from a REAL site plus the parse
+# sweep over them (`parse-sweep.json` carries every workbook and datasource NAME). Customer content -
+# never commit. `_sweep` is THE convention for this tool; `_harvest*` above belongs to the OTHER
+# harvester, and one folder documented for two tools is how a name collision starts (issue #125).
+# GLOB for the same reason as above, so `_sweep2`/`_sweep-2026-08-13` are covered by default. The
+# script itself now refuses to write to an unignored in-repo path, so this rule is enforced, not
+# merely hoped for.
+/_sweep*/
 
 # run_estate.py output (the conventional `--output` name, and dated/suffixed variants). A bundle is
 # the most customer-identifying artifact this toolkit produces: report.json carries every workbook

--- a/scripts/harvest_estate_assets.py
+++ b/scripts/harvest_estate_assets.py
@@ -4,6 +4,15 @@ purpose: download every workbook and published datasource on a Tableau site, the
          from which upstream feature requests can be written with evidence instead of anecdote.
 usage:   python scripts/harvest_estate_assets.py --out <dir> [--env .env] [--limit N]
                                                  [--skip-download] [--workbooks-only]
+                                                 [--allow-unignored-out]
+
+Where the output goes
+---------------------
+`--out` is `_sweep` by convention (`.gitignore`: `/_sweep*/`; `_harvest*` belongs to the OTHER
+harvester, `harvest_tableau_public.py`). Anything under `--out` is a real customer's workbooks and
+their names, and THIS REPO IS PUBLIC, so when the target sits inside a git work tree this script
+refuses to start unless git already ignores it -- see `unignored_output_paths` below. A target
+outside any work tree is fine and runs unguarded.
 
 Why this exists
 ---------------
@@ -59,6 +68,110 @@ from engine_source import EngineNotFoundError, engine_scripts_dir  # noqa: E402 
 from tableau_env import engine_child_env, pat_secret, redact, require, resolve_env  # noqa: E402  # pylint: disable=wrong-import-position
 
 LOG = logging.getLogger("harvest_estate_assets")
+
+# The FILES this script writes under `--out`, probed as files on purpose. Two reasons:
+#   * a directory-only rule (`/_sweep*/`, or a hand-written `_myout/assets/`) is applied by
+#     `git check-ignore` only to a path it knows is a directory, and a not-yet-created `--out` is
+#     not - so probing `assets` as a bare name reports a false "not ignored" for exactly the rule
+#     shape people write. A file path underneath makes every parent a directory by construction.
+#   * it is the honest question: these are the paths a `git add -A` would stage.
+# `assets/` holds the downloaded workbooks/datasources; the sweep files record every asset's NAME
+# and LUID even under `--skip-download`, so all of them are checked, not just the downloads.
+OUTPUT_ARTIFACTS = (
+    "assets/harvested-workbook.twbx",
+    "assets/harvested-datasource.tdsx",
+    "parse-sweep.json",
+    "parse-sweep.md",
+)
+
+
+class OutputPathNotIgnoredError(RuntimeError):
+    """`--out` is inside a git work tree that would commit it, or git cannot prove otherwise."""
+
+
+def _git(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str] | None:
+    """Run git in `cwd`. Returns None when git itself could not be run at all."""
+    try:
+        return subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True, timeout=60, check=False)
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+
+def _existing_ancestor(path: Path) -> Path | None:
+    """Nearest existing directory at or above `path` - git needs a real directory to run in."""
+    return next((p for p in (path, *path.parents) if p.is_dir()), None)
+
+
+def unignored_output_paths(out: Path) -> list[Path]:
+    """Which artifacts under `out` git would offer to commit. Empty list means safe to write.
+
+    Two measured details decide this implementation, and getting either wrong yields a guard that
+    silently always passes - worse than no guard, because it also reassures:
+
+    * **Ask about paths INSIDE `out`, never `out` itself.** `/_sweep*/` is a directory-only pattern,
+      and `git check-ignore` applies such a pattern only to a path it knows is a directory - which,
+      for an `--out` that does not exist yet, it does not (measured: `_assessment-x` -> exit 1,
+      `_assessment-x/assets/f.twbx` -> exit 0, same rule, same repo). A trailing component makes the
+      parent a directory by construction, so the rule applies without creating anything on disk.
+    * **NEVER append a trailing slash to work around that.** On git 2.55.0.windows.3,
+      `git check-ignore -- 'zzz_not_ignored/'` exits 0 reporting an EMPTY matched pattern: with a
+      trailing slash EVERY path looks ignored.
+
+    Raises `OutputPathNotIgnoredError` when git is present but cannot answer, or is absent while a
+    `.git` checkout is in scope: an unprovable path is treated as unsafe, never as safe.
+    """
+    out = out.expanduser().resolve()
+    anchor = _existing_ancestor(out)
+    if anchor is None:  # pragma: no cover - a drive/filesystem root always exists
+        return []
+
+    inside = _git(["rev-parse", "--is-inside-work-tree"], anchor)
+    if inside is None:
+        # git being un-runnable is not evidence that no repository is here, so look for the checkout
+        # directly rather than letting a missing binary quietly disable the guard.
+        if any((parent / ".git").exists() for parent in (anchor, *anchor.parents)):
+            raise OutputPathNotIgnoredError(
+                f"cannot run git, but {out} is inside a .git checkout, so it cannot be proven ignored"
+            )
+        return []
+    if inside.returncode != 0 or inside.stdout.strip() != "true":
+        return []  # outside any work tree: nothing here can be committed by accident
+
+    unignored: list[Path] = []
+    for artifact in OUTPUT_ARTIFACTS:
+        target = out / artifact
+        probe = _git(["check-ignore", "-q", "--", str(target)], anchor)
+        # 0 = ignored, 1 = not ignored, anything else (128, or no git) = no answer, so do not guess.
+        if probe is None or probe.returncode not in (0, 1):
+            detail = "git could not be run" if probe is None else (probe.stderr.strip() or f"exit {probe.returncode}")
+            raise OutputPathNotIgnoredError(f"could not ask git whether {target} is ignored: {detail}")
+        if probe.returncode == 1:
+            unignored.append(target)
+    return unignored
+
+
+def refuse_unignored_output(out: Path, allow_unignored: bool) -> bool:
+    """True when the run must STOP before downloading anything. Logs the reason either way."""
+    try:
+        unignored = unignored_output_paths(out)
+    except OutputPathNotIgnoredError as exc:
+        message = str(exc)
+    else:
+        if not unignored:
+            return False
+        message = (
+            f"git does not ignore {', '.join(str(p) for p in unignored)}. This run downloads a real "
+            "site's .twbx/.tdsx and records every workbook name, and this repo is PUBLIC, so a "
+            "`git add -A` would stage customer content (issue #125). Fix: use the ignored convention "
+            "`--out _sweep` (any `_sweep*` variant works, e.g. `_sweep-2026-08-13`), point --out "
+            "outside the checkout, or add a rule to .gitignore."
+        )
+    if allow_unignored:
+        LOG.warning("--allow-unignored-out: proceeding anyway, but %s", message)
+        return False
+    LOG.error("REFUSING to harvest into %s: %s", out, message)
+    LOG.error("Nothing was downloaded. Pass --allow-unignored-out to override this deliberately.")
+    return True
 
 
 def download(kind: str, luid: str, out_file: Path, env: dict[str, str], scripts: Path) -> tuple[bool, str]:
@@ -217,17 +330,26 @@ def summarise(results: list[dict], out: Path) -> str:  # pylint: disable=too-man
 
 
 def main() -> int:  # pylint: disable=too-many-locals,too-many-statements  # one linear sweep
-    """Harvest and sweep. Exit 1 only when nothing could be assessed at all."""
+    """Harvest and sweep. Exit 2 when `--out` is committable, 1 when nothing could be assessed."""
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    ap.add_argument("--out", required=True, type=Path, help="output directory (should be git-ignored)")
+    ap.add_argument("--out", required=True, type=Path, help="output directory (must be git-ignored, see below)")
     ap.add_argument("--env", type=Path, default=REPO_ROOT / ".env")
     ap.add_argument("--db", type=Path, help="assess_estate.py estate.db to take LUIDs from")
     ap.add_argument("--limit", type=int, help="stop after N assets (for a quick pass)")
     ap.add_argument("--skip-download", action="store_true", help="reuse whatever is already in --out/assets")
     ap.add_argument("--workbooks-only", action="store_true", help="skip published datasources; sweep workbooks only")
+    ap.add_argument(
+        "--allow-unignored-out",
+        action="store_true",
+        help="write to --out even when git does not ignore it (escape hatch; logs a warning instead)",
+    )
     args = ap.parse_args()
 
     logging.basicConfig(level=logging.INFO, format="%(message)s")
+    # Before the engine, the .env, the database and above all the download: a customer's workbooks
+    # must never land somewhere this PUBLIC repo would commit them (issue #125).
+    if refuse_unignored_output(args.out, args.allow_unignored_out):
+        return 2
     # One resolver, no fallback: the installed plugin is the single canonical engine (issue #107).
     try:
         scripts = engine_scripts_dir()

--- a/tests/test_harvest_output_guard.py
+++ b/tests/test_harvest_output_guard.py
@@ -62,15 +62,17 @@ def _is_ignored(path: Path, cwd: Path) -> bool:
 
 @pytest.fixture(name="repo")
 def repo_fixture(tmp_path: Path) -> Path:
-    """A throwaway git repo carrying this repo's real harvest ignore rules."""
+    """A throwaway git repo carrying this repo's REAL .gitignore, byte for byte.
+
+    Copied whole rather than filtered down to the harvest rules: a reduced fixture answered
+    `check-ignore` differently from the real file (see
+    `test_the_trailing_slash_trap_is_real_and_the_guard_avoids_it`), so a subset would have proved
+    something about a file nobody has.
+    """
     _git(["init", "-q"], tmp_path)
-    rules = [
-        line
-        for line in (REPO_ROOT / ".gitignore").read_text(encoding="utf-8").splitlines()
-        if line.startswith(("/_harvest", "/_sweep", "/_assessment", "/_bundle", "/_estate"))
-    ]
-    assert rules, "no harvest-family rules found in .gitignore - this fixture would prove nothing"
-    (tmp_path / ".gitignore").write_text("\n".join(rules) + "\n", encoding="utf-8")
+    ignore_text = (REPO_ROOT / ".gitignore").read_bytes()
+    assert b"/_sweep" in ignore_text and b"/_harvest" in ignore_text, "no harvest rules - fixture proves nothing"
+    (tmp_path / ".gitignore").write_bytes(ignore_text)
     return tmp_path
 
 
@@ -119,6 +121,20 @@ def test_guard_refuses_an_unignored_path_inside_a_work_tree(repo: Path) -> None:
 def test_guard_proceeds_for_an_ignored_path(repo: Path) -> None:
     assert h.unignored_output_paths(repo / "_sweep-2026-08-13") == []
     assert h.refuse_unignored_output(repo / "_sweep-2026-08-13", allow_unignored=False) is False
+
+
+def test_the_trailing_slash_trap_is_real_and_the_guard_avoids_it(repo: Path) -> None:
+    """Appending a slash to make a directory rule match turns the guard into a rubber stamp.
+
+    Measured on git 2.55.0.windows.3 against a realistic `.gitignore`: `check-ignore -- 'x/'` exits
+    0 for ANY path, reporting an EMPTY matched pattern - so a guard that probes with a trailing
+    slash reports every target as safely ignored, including the one this test refuses. The
+    workaround for the directory-rule problem is a path COMPONENT under `--out`, never a slash.
+    """
+    stamp = _git(["check-ignore", "-q", "--", f"{repo / 'definitely-not-ignored'}/"], repo)
+    if stamp.returncode != 0:
+        pytest.skip("this git no longer reports every trailing-slash path as ignored")
+    assert h.refuse_unignored_output(repo / "_leaky", allow_unignored=False) is True
 
 
 def test_guard_proceeds_when_the_directory_already_exists(repo: Path) -> None:

--- a/tests/test_harvest_output_guard.py
+++ b/tests/test_harvest_output_guard.py
@@ -1,0 +1,214 @@
+"""`harvest_estate_assets.py --out` must be a path git ignores, and the rules must be prefix globs.
+
+Issue #125. `.gitignore` reserved `/_harvest/` and `/_sweep/` as EXACT directory names while their
+siblings (`/_assessment*/`, `/_bundle*/`, `/_estate*/`) were prefix globs. The natural move when
+`_harvest/` already holds a previous run - `_harvest-2`, `_sweep-2026-08-13` - therefore staged a
+real customer's `.twbx` in a PUBLIC repo. This repo has already had one customer-data incident that
+needed a history rewrite, so the class is proven, not hypothetical.
+
+Two independent guards, because either alone fails open:
+
+1. the ignore rules themselves (`test_ignore_rules_*`), read out of the live repo via
+   `git check-ignore`, so a future edit that narrows a glob back to an exact name fails here;
+2. the script's own refusal (`test_guard_*`), because an operator can always invent a name no rule
+   anticipated - and a download that has already happened cannot be un-leaked.
+
+No customer data is used or created anywhere below: every fixture is an empty temp directory.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import harvest_estate_assets as h  # noqa: E402  # pylint: disable=wrong-import-position
+
+# The exact names from issue #125, plus the `_sweep*` variants the fix now makes usable. Each was
+# NOT IGNORED before the fix except the two bare names, and `git status --porcelain` listed the rest
+# as untracked - i.e. one `git add -A` from a public commit.
+CANDIDATE_OUTPUT_DIRS = (
+    "_harvest",
+    "_sweep",
+    "_harvest-op",
+    "_sweep2",
+    "_harvest-2026-08-13",
+    "_sweep-op",
+    "_sweep-2026-08-13",
+)
+
+
+def _git(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True, timeout=60, check=False)
+
+
+def _is_ignored(path: Path, cwd: Path) -> bool:
+    """Ask git the same question the guard asks: would a downloaded file under `path` be staged?
+
+    Probed as a FILE inside the directory, not as `path` itself: a directory-only rule
+    (`/_sweep*/`) can only be applied to a path git knows is a directory, which for a not-yet-created
+    `--out` it does not. And never with a trailing slash - on git 2.55.0.windows.3 that reports EVERY
+    path as ignored (empty matched pattern), so a trailing-slash probe would make this file pass
+    vacuously.
+    """
+    probe = path / "assets" / "harvested-workbook.twbx"
+    return _git(["check-ignore", "-q", "--", str(probe)], cwd).returncode == 0
+
+
+@pytest.fixture(name="repo")
+def repo_fixture(tmp_path: Path) -> Path:
+    """A throwaway git repo carrying this repo's real harvest ignore rules."""
+    _git(["init", "-q"], tmp_path)
+    rules = [
+        line
+        for line in (REPO_ROOT / ".gitignore").read_text(encoding="utf-8").splitlines()
+        if line.startswith(("/_harvest", "/_sweep", "/_assessment", "/_bundle", "/_estate"))
+    ]
+    assert rules, "no harvest-family rules found in .gitignore - this fixture would prove nothing"
+    (tmp_path / ".gitignore").write_text("\n".join(rules) + "\n", encoding="utf-8")
+    return tmp_path
+
+
+# --------------------------------------------------------------------------- the ignore rules
+
+
+@pytest.mark.parametrize("name", CANDIDATE_OUTPUT_DIRS)
+def test_ignore_rules_cover_dated_and_suffixed_variants(repo: Path, name: str) -> None:
+    """Every candidate name an operator might reach for must already be ignored."""
+    assert _is_ignored(repo / name, repo), (
+        f"{name}/ is NOT ignored - a harvest run into it would stage customer .twbx in a public repo"
+    )
+
+
+def test_ignore_rules_are_globs_in_the_live_repo() -> None:
+    """The same claim against the real working tree, not just a reconstructed fixture."""
+    if _git(["rev-parse", "--is-inside-work-tree"], REPO_ROOT).stdout.strip() != "true":
+        pytest.skip("not a git work tree (exported source?)")
+    for name in CANDIDATE_OUTPUT_DIRS:
+        assert _is_ignored(REPO_ROOT / name, REPO_ROOT), f"{name}/ is not ignored in this repo"
+
+
+def test_a_name_outside_the_convention_is_still_reported_unignored(repo: Path) -> None:
+    """The control. Without it, an accidental `*` rule would make every assertion above vacuous."""
+    assert not _is_ignored(repo / "sweep-without-underscore", repo)
+
+
+def test_the_two_harvesters_do_not_share_one_documented_folder() -> None:
+    """`.gitignore` must say WHICH tool writes where; one folder for two tools is the collision."""
+    text = (REPO_ROOT / ".gitignore").read_text(encoding="utf-8")
+    harvest_block = text.split("/_harvest*/")[0].rsplit("\n\n", 1)[-1]
+    sweep_block = text.split("/_sweep*/")[0].rsplit("\n\n", 1)[-1]
+    assert "harvest_tableau_public.py" in harvest_block, "_harvest* rule does not name its owning tool"
+    assert "harvest_estate_assets.py" in sweep_block, "_sweep* rule does not name its owning tool"
+    assert "harvest_estate_assets.py" not in harvest_block, "both harvesters documented into _harvest*"
+
+
+# --------------------------------------------------------------------------- the script's guard
+
+
+def test_guard_refuses_an_unignored_path_inside_a_work_tree(repo: Path) -> None:
+    assert h.unignored_output_paths(repo / "_leaky") == [repo / "_leaky" / artifact for artifact in h.OUTPUT_ARTIFACTS]
+    assert h.refuse_unignored_output(repo / "_leaky", allow_unignored=False) is True
+
+
+def test_guard_proceeds_for_an_ignored_path(repo: Path) -> None:
+    assert h.unignored_output_paths(repo / "_sweep-2026-08-13") == []
+    assert h.refuse_unignored_output(repo / "_sweep-2026-08-13", allow_unignored=False) is False
+
+
+def test_guard_proceeds_when_the_directory_already_exists(repo: Path) -> None:
+    """An existing `--out` (the `--skip-download` re-run) must be judged the same way."""
+    (repo / "_sweep-again" / "assets").mkdir(parents=True)
+    (repo / "_leaky-again" / "assets").mkdir(parents=True)
+    assert h.refuse_unignored_output(repo / "_sweep-again", allow_unignored=False) is False
+    assert h.refuse_unignored_output(repo / "_leaky-again", allow_unignored=False) is True
+
+
+def test_guard_proceeds_outside_any_git_work_tree(tmp_path: Path) -> None:
+    """Harvesting to a scratch disk outside the repo is a NORMAL run and must not be blocked."""
+    if _git(["rev-parse", "--is-inside-work-tree"], tmp_path).stdout.strip() == "true":
+        pytest.skip("pytest tmp_path is itself inside a git work tree on this machine")
+    assert h.unignored_output_paths(tmp_path / "anything-at-all") == []
+    assert h.refuse_unignored_output(tmp_path / "anything-at-all", allow_unignored=False) is False
+
+
+def test_guard_covers_a_target_whose_parents_do_not_exist_yet(repo: Path) -> None:
+    """The common case: `--out` is created by the run, so the guard must judge a missing path."""
+    target = repo / "not" / "created" / "yet"
+    assert not target.exists()
+    assert h.refuse_unignored_output(target, allow_unignored=False) is True
+
+
+def test_guard_checks_every_artifact_not_just_the_downloads(repo: Path) -> None:
+    """A rule covering only `assets/` still leaks the sweep, which lists every workbook name."""
+    (repo / ".gitignore").write_text("/_partial/assets/\n", encoding="utf-8")
+    unignored = h.unignored_output_paths(repo / "_partial")
+    assert [p.name for p in unignored] == ["parse-sweep.json", "parse-sweep.md"]
+    assert h.refuse_unignored_output(repo / "_partial", allow_unignored=False) is True
+
+
+def test_override_flag_downgrades_the_refusal_to_a_warning(repo: Path, caplog) -> None:
+    with caplog.at_level("WARNING"):
+        assert h.refuse_unignored_output(repo / "_leaky", allow_unignored=True) is False
+    assert "--allow-unignored-out" in caplog.text
+
+
+def test_an_unanswerable_git_is_treated_as_unsafe(repo: Path, monkeypatch) -> None:
+    """A git that errors (128, a broken index, a permissions failure) proves nothing - so refuse."""
+    real_run = subprocess.run
+
+    def fake_run(cmd, **kwargs):
+        if "check-ignore" in cmd:
+            return subprocess.CompletedProcess(cmd, 128, "", "fatal: something went wrong")
+        return real_run(cmd, **kwargs)
+
+    monkeypatch.setattr(h.subprocess, "run", fake_run)
+    with pytest.raises(h.OutputPathNotIgnoredError):
+        h.unignored_output_paths(repo / "_sweep")
+    assert h.refuse_unignored_output(repo / "_sweep", allow_unignored=False) is True
+
+
+def test_a_missing_git_binary_does_not_silently_disable_the_guard(repo: Path, monkeypatch) -> None:
+    """No git binary is not evidence of no repository - the `.git` directory is still there."""
+    monkeypatch.setattr(h.subprocess, "run", _raise_missing_git)
+    with pytest.raises(h.OutputPathNotIgnoredError):
+        h.unignored_output_paths(repo / "_sweep")
+    assert h.refuse_unignored_output(repo / "_sweep", allow_unignored=False) is True
+
+
+def test_a_missing_git_binary_outside_a_checkout_still_runs(tmp_path: Path, monkeypatch) -> None:
+    """...but with no `.git` anywhere above it, there is nothing to leak into."""
+    if any((parent / ".git").exists() for parent in (tmp_path, *tmp_path.parents)):
+        pytest.skip("pytest tmp_path sits inside a checkout on this machine")
+    monkeypatch.setattr(h.subprocess, "run", _raise_missing_git)
+    assert h.refuse_unignored_output(tmp_path / "out", allow_unignored=False) is False
+
+
+def _raise_missing_git(*_args, **_kwargs):
+    raise FileNotFoundError("git")
+
+
+# --------------------------------------------------------------------------- end to end
+
+
+def test_cli_exits_nonzero_before_touching_anything(repo: Path) -> None:
+    """The refusal must beat `--out` creation, the .env, the estate DB and every network call.
+
+    Run with `--skip-download` on purpose: even the no-download path writes `parse-sweep.json`,
+    which carries every workbook name, so the guard cannot be conditional on downloading.
+    """
+    result = subprocess.run(
+        [sys.executable, str(REPO_ROOT / "scripts" / "harvest_estate_assets.py"), "--out", "_leaky", "--skip-download"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode != 0, f"the CLI accepted an unignored --out:\n{result.stdout}\n{result.stderr}"
+    assert "REFUSING" in (result.stdout + result.stderr)
+    assert not (repo / "_leaky").exists(), "the refusal ran too late - it already created --out"


### PR DESCRIPTION
Fixes #125 (the ignore + script half; the runbook half is a separate PR).

## What changed

**1. The harvest ignore rules are prefix globs now.** `/_harvest/` and `/_sweep/` were exact
directory names while every sibling (`/_assessment*/`, `/_bundle*/`, `/_estate*/`) was a glob, so
the natural second-run name leaked. Both are now `/_harvest*/` and `/_sweep*/`.

**2. The naming contradiction is resolved the way `.gitignore` itself already stated:**
`_harvest*` belongs to `harvest_tableau_public.py` (`classify_harvest_hardness.py` reads
`_harvest/specs`), `_sweep*` belongs to `harvest_estate_assets.py`. Each rule now names its owning
tool in its comment, and the script's own docstring says the same. **The runbook should therefore
change `--out _harvest` to `--out _sweep`** — that is the convention this PR lands. Any
`_sweep*` variant (`_sweep-2026-08-13`) is now safe by construction, so a second run no longer
needs a new name to be invented.

**3. `harvest_estate_assets.py` refuses to write to an unignored path.** Before the engine, the
`.env`, the estate DB and any download, it asks git whether the files it is about to write are
ignored; if `--out` is inside a work tree and they are not, it logs `REFUSING`, exits **2**, and
creates nothing. `--allow-unignored-out` downgrades it to a warning. A target **outside** any git
work tree runs unguarded, because that is a normal way to run it.

An ignore rule only ever covers names someone anticipated. The guard covers the rest — which is the
half that actually generalises past the three names in the issue.

### Two measured traps encoded in the guard

Both would produce a guard that *always passes* — worse than no guard, because it also reassures:

* **`check-ignore` cannot apply a directory-only rule to a path it has not seen as a directory.**
  With nothing on disk: `_assessment-x` → exit 1 (**"not ignored"**), `_assessment-x/assets/f.twbx`
  → exit 0, same rule, same repo. So the guard probes the **files** it will write, never `--out`
  itself.
* **A trailing slash makes git report everything as ignored.** On git 2.55.0.windows.3, against a
  realistic `.gitignore`, `check-ignore -q -- 'zzz_not_ignored/'` exits **0** with an *empty*
  matched pattern. The obvious workaround for the first trap is therefore a rubber stamp.

Anything git cannot answer (exit 128, or no git binary while a `.git` checkout is in scope) is
treated as **unsafe**, never as safe.

## Verification

### `git check-ignore -v`, before → after

Empty directories with a placeholder file, no trailing slash, `git status` as the cross-check. No
customer data was created at any point.

**BEFORE** (master):

```
_harvest               IGNORED     .gitignore:73:/_harvest/	_harvest
_sweep                 IGNORED     .gitignore:84:/_sweep/	_sweep
_harvest-op            NOT IGNORED (exit 1)
_sweep2                NOT IGNORED (exit 1)
_harvest-2026-08-13    NOT IGNORED (exit 1)
_sweep-op              NOT IGNORED (exit 1)
_sweep-2026-08-13      NOT IGNORED (exit 1)
_assessment-x          IGNORED     .gitignore:80:/_assessment*/	_assessment-x
_bundle-x              IGNORED     .gitignore:90:/_bundle*/	_bundle-x
_estate-x              IGNORED     .gitignore:91:/_estate*/	_estate-x

$ git status --porcelain
?? _harvest-2026-08-13/
?? _harvest-op/
?? _sweep-2026-08-13/
?? _sweep-op/
?? _sweep2/
```

**AFTER** (this branch):

```
_harvest               IGNORED     .gitignore:76:/_harvest*/	_harvest
_sweep                 IGNORED     .gitignore:92:/_sweep*/	_sweep
_harvest-op            IGNORED     .gitignore:76:/_harvest*/	_harvest-op
_sweep2                IGNORED     .gitignore:92:/_sweep*/	_sweep2
_harvest-2026-08-13    IGNORED     .gitignore:76:/_harvest*/	_harvest-2026-08-13
_sweep-op              IGNORED     .gitignore:92:/_sweep*/	_sweep-op
_sweep-2026-08-13      IGNORED     .gitignore:92:/_sweep*/	_sweep-2026-08-13
_assessment-x          IGNORED     .gitignore:83:/_assessment*/	_assessment-x
_bundle-x              IGNORED     .gitignore:98:/_bundle*/	_bundle-x
_estate-x              IGNORED     .gitignore:99:/_estate*/	_estate-x

$ git status --porcelain
(empty)
```

### The guard, end to end

```
$ python scripts/harvest_estate_assets.py --out harvest-output --skip-download
REFUSING to harvest into harvest-output: git does not ignore
  ...\harvest-output\assets\harvested-workbook.twbx, ...\assets\harvested-datasource.tdsx,
  ...\parse-sweep.json, ...\parse-sweep.md.
  This run downloads a real site's .twbx/.tdsx and records every workbook name, and this repo is
  PUBLIC, so a `git add -A` would stage customer content (issue #125). Fix: use the ignored
  convention `--out _sweep` (any `_sweep*` variant works, e.g. `_sweep-2026-08-13`), point --out
  outside the checkout, or add a rule to .gitignore.
Nothing was downloaded. Pass --allow-unignored-out to override this deliberately.
exit=2      created? False

$ python scripts/harvest_estate_assets.py --out _harvest-op --skip-download ...
(no refusal — proceeds past the guard to the estate DB)

$ python scripts/harvest_estate_assets.py --out C:\<outside-any-repo>\out --skip-download ...
(no refusal — proceeds past the guard)

$ python scripts/harvest_estate_assets.py --out harvest-output --allow-unignored-out ...
--allow-unignored-out: proceeding anyway, but git does not ignore ...
```

Run with `--skip-download` on purpose: even the no-download path writes `parse-sweep.json`, which
carries every workbook name, so the guard cannot be conditional on downloading.

### Mutation testing — 9 deliberate breaks, 9 caught

| mutation | result |
|---|---|
| M1 probe with a trailing slash (the classic false-pass) | CAUGHT (6 failed) |
| M2 probe `--out` itself instead of paths inside it | CAUGHT (3 failed) |
| M3 unanswerable git (exit 128) treated as ignored | CAUGHT (1 failed) |
| M4 missing git binary silently disables the guard | CAUGHT (1 failed) |
| M5 only the downloads probed, not the sweep files | CAUGHT (1 failed) |
| M6 guard call removed from `main()` | CAUGHT (1 failed) |
| M7 refusal downgraded to a warning | CAUGHT (8 failed) |
| M8 `/_sweep*/` narrowed back to `/_sweep/` | CAUGHT (7 failed) |
| M9 `/_harvest*/` narrowed back to `/_harvest/` | CAUGHT (4 failed) |

**M1 survived on the first pass**, and that is the most useful thing in this PR. The test fixture
built its own reduced `.gitignore` (harvest rules only), which does **not** reproduce git's
trailing-slash behaviour — so a guard mutated into a rubber stamp passed all 22 tests. Second
commit copies the real `.gitignore` byte for byte into the fixture and states the trap as its own
test (skipped if a future git drops the behaviour). A reduced fixture proves things about a file
nobody has.

### Gates (by exit code)

| gate | result |
|---|---|
| `ruff format --check scripts tests` | 0 — 84 files already formatted |
| `ruff check scripts tests` | 0 — All checks passed |
| `pylint scripts` (project venv) | 0 — 10.00/10 |
| `pytest -q` | 0 — **1017 passed, 4 skipped** |

`pylint scripts` from a *global* interpreter exits 10 on a pre-existing `E0401: Unable to import
'lxml'` in `trace_customer_text.py` (missing dependency in that environment, untouched here); the
project venv scores 10.00/10 and exits 0.

## Scope

`.gitignore`, `scripts/harvest_estate_assets.py`, and the new `tests/test_harvest_output_guard.py`
only. Nothing was downloaded from any Tableau site and nothing was written to any Fabric tenant.
