### PR TITLE
Give tableau_lineage.py a --survey input, and stop calling hard dependencies abandoned

### DIFF
--- a/scripts/tableau_lineage.py
+++ b/scripts/tableau_lineage.py
@@ -10,7 +10,20 @@ purpose: discover the Tableau dependency graph BEFORE migrating anything, so a T
          This script asks Tableau itself who depends on what:
            * Metadata API (GraphQL) -> publishedDatasources { downstreamWorkbooks } lineage
            * REST API               -> download each .tdsx so the model layer can actually be parsed
+           * estate_survey.json     -> the REST-derived dependency graph, supplied via --survey
          and emits a migration PLAN ordered by leverage (most-consumed data source first).
+
+         WHY --survey EXISTS. The Metadata API is BLIND to 'sqlproxy' connections (a workbook that
+         embeds a published data source), so it reports such a data source as having no downstream
+         workbooks at all. Without a survey this script therefore under-reports the graph, and used
+         to call those data sources "possibly abandoned" - the exact opposite of the truth, about
+         data sources every consumer hard-depends on. `estate_survey.py --json` reads each
+         workbook's real connections over REST and does see them. So:
+
+           PRECEDENCE: where the survey and the Metadata API disagree, the SURVEY WINS. Metadata-API
+           silence is not evidence of absence. Edges only the Metadata API saw are still KEPT (never
+           dropped - losing a real dependency is the failure this whole script guards against) and
+           labelled 'metadata-api', so an operator can see which source produced which claim.
 
          The dedup key it prints is the SAME key `scripts/parse_tableau.py` stamps on a parsed
          workbook (`data_sources[].published_datasource.key`), so server-side lineage and locally
@@ -22,12 +35,12 @@ usage:   # credentials come from a git-ignored .env (see .env.example) or the en
          #   TABLEAU_SITE=mysitecontenturl        (empty string for Tableau Server's Default site)
          #   TABLEAU_PAT_NAME=<personal access token name>
          #   TABLEAU_PAT_SECRET=<personal access token secret>
-         python scripts/tableau_lineage.py --plan
+         python scripts/tableau_lineage.py --plan --survey _assessment/estate_survey.json
          python scripts/tableau_lineage.py --plan --env .env
          python scripts/tableau_lineage.py --plan --download migrations/datasources/_downloads
 
          # offline: re-plan from a previously saved API response, no server needed
-         python scripts/tableau_lineage.py --plan --from-json lineage.json
+         python scripts/tableau_lineage.py --plan --from-json lineage.json --survey estate_survey.json
 
 Docs: Metadata API endpoint POST <server>/api/metadata/graphql (help.tableau.com/current/api/
 metadata_api/en-us/docs/meta_api_start.html); datasource download GET
@@ -42,6 +55,7 @@ import logging
 import sys
 import urllib.error
 import urllib.request
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, NamedTuple
 
@@ -52,6 +66,27 @@ logging.basicConfig(level=logging.INFO, format="%(message)s")
 log = logging.getLogger("tableau_lineage")
 
 DEFAULT_API_VERSION = "3.19"
+
+# How an edge (data source -> workbook) was learned. Printed next to every edge so a plan is
+# self-describing: an operator never has to guess which system made which claim.
+FROM_SURVEY = "survey"
+FROM_METADATA = "metadata-api"
+FROM_BOTH = "both"
+
+PRECEDENCE_NOTE = (
+    "PRECEDENCE: where the survey and the Metadata API disagree, the SURVEY WINS - it reads each\n"
+    "            workbook's real connections over REST, while the Metadata API is blind to\n"
+    "            'sqlproxy' (published data source) connections, so its silence is NOT evidence of\n"
+    "            absence. Edges only the Metadata API saw are kept, never dropped, and marked\n"
+    "            [metadata-api]."
+)
+
+NO_SURVEY_WARNING = (
+    "NO --survey WAS SUPPLIED, so this plan is the Metadata API's view ALONE, and that view is\n"
+    "known-incomplete: it does not see 'sqlproxy' (published data source) connections. Read every\n"
+    "'no downstream workbooks' line below as UNKNOWN, never as unused. Re-run with:\n"
+    "    python scripts/tableau_lineage.py --plan --survey _assessment/estate_survey.json"
+)
 
 # Tableau content lineage (workbook -> published datasource) is available WITHOUT the Data Management
 # license; only *external* assets (databases/tables upstream of Tableau) require it. This query stays
@@ -81,6 +116,154 @@ def dedup_key(site: str, name: str) -> str:
     site omitted when there isn't one (Tableau Server's Default site publishes no `site=` attribute).
     """
     return "/".join(p for p in (site, name) if p).lower()
+
+
+def _norm(name: str | None) -> str:
+    """Case/whitespace-insensitive matching key for a Tableau content name."""
+    return (name or "").strip().lower()
+
+
+@dataclass
+class SurveyDatasource:
+    """One published data source as the survey saw it, with every workbook that binds to it."""
+
+    name: str
+    luid: str | None = None
+    project: str | None = None
+    consumers: set[str] = field(default_factory=set)
+
+
+@dataclass(frozen=True)
+class Survey:
+    """The REST-derived dependency graph from `estate_survey.py --json`.
+
+    This is GROUND TRUTH for whether a dependency exists: it was read from each workbook's own
+    connections. `gaps` records the ways this particular survey is nevertheless incomplete (a
+    workbook whose connections could not be read, a dependency that resolved to no data source).
+    An incomplete survey may still ADD edges, but it must not be used to claim a data source is
+    unused, because the edge proving otherwise may be exactly the one it failed to read.
+    """
+
+    path: Path
+    datasources: dict[str, SurveyDatasource] = field(default_factory=dict)
+    workbook_names: dict[str, str] = field(default_factory=dict)
+    by_luid: dict[str, str] = field(default_factory=dict)
+    workbooks_total: int = 0
+    gaps: tuple[str, ...] = ()
+
+    @property
+    def complete(self) -> bool:
+        """True when nothing stopped this survey from seeing the whole estate."""
+        return not self.gaps
+
+    def match(self, luid: str | None, name: str | None) -> str | None:
+        """Resolve a Metadata-API data source to this survey's key: LUID first, then name."""
+        if luid and luid in self.by_luid:
+            return self.by_luid[luid]
+        key = _norm(name)
+        return key if key in self.datasources else None
+
+    def consumers(self, key: str) -> list[str]:
+        """Every workbook the survey saw binding to this data source, by display name."""
+        entry = self.datasources.get(key)
+        if not entry:
+            return []
+        return sorted((self.workbook_names.get(w, w) for w in entry.consumers), key=str.lower)
+
+
+def _survey_gaps(data: dict[str, Any], unresolved_deps: int) -> tuple[str, ...]:
+    """Describe every reason this survey's view of the estate is incomplete."""
+    gaps: list[str] = []
+    read_errors = data.get("connection_read_errors") or []
+    if read_errors:
+        gaps.append(f"{len(read_errors)} workbook connection(s) could not be read")
+    declared_unresolved = data.get("unresolved_dependencies") or []
+    if declared_unresolved:
+        gaps.append(f"{len(declared_unresolved)} declared dependency(ies) resolved to no data source")
+    if unresolved_deps:
+        gaps.append(f"{unresolved_deps} dependency(ies) did not resolve to a published data source")
+    return tuple(gaps)
+
+
+def _read_survey_edges(
+    workbooks: list[dict[str, Any]],
+    datasources: dict[str, SurveyDatasource],
+    workbook_names: dict[str, str],
+) -> int:
+    """Index every workbook -> published data source edge the survey recorded.
+
+    Returns the number of dependencies that did NOT resolve to a published data source.
+    """
+    unresolved = 0
+    for workbook in workbooks:
+        wb_display = workbook.get("name") or "?"
+        workbook_names[_norm(wb_display)] = wb_display
+        for dep in workbook.get("published_dependencies") or []:
+            if not isinstance(dep, dict):
+                continue
+            # `datasource_name` is estate_survey.py's field, read explicitly rather than guessed at
+            # (see assess_estate.py::_parse_dependencies, which learned the same lesson): a guess
+            # that yields nothing is indistinguishable from an estate with no dependencies.
+            name = dep.get("datasource_name")
+            if not name:
+                continue
+            entry = datasources.setdefault(_norm(name), SurveyDatasource(name=name))
+            entry.consumers.add(_norm(wb_display))
+            entry.luid = entry.luid or dep.get("luid")
+            entry.project = entry.project or dep.get("project")
+            if dep.get("status") and dep.get("status") != "resolved":
+                unresolved += 1
+    return unresolved
+
+
+def load_survey(path: Path) -> Survey:
+    """Read `estate_survey.py --json` output into a matchable dependency graph.
+
+    Raises rather than under-reporting. A survey whose schema has moved would otherwise parse to
+    zero edges, and "no edges" is indistinguishable from "no dependencies" - which sequences the
+    migration wrong and re-creates the very defect --survey exists to fix.
+    """
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict) or "workbooks" not in data:
+        raise RuntimeError(
+            f"{path} has no 'workbooks' key - this does not look like estate_survey.py --json output. "
+            "Refusing to plan from it: an unreadable survey must not be mistaken for an estate with "
+            "no dependencies."
+        )
+
+    workbooks = data.get("workbooks") or []
+    datasources: dict[str, SurveyDatasource] = {}
+    workbook_names: dict[str, str] = {}
+    unresolved = _read_survey_edges(workbooks, datasources, workbook_names)
+
+    # `required_datasources` names the same data sources again, with the LUID/project the download
+    # step needs. It also keeps a required data source in the plan when its consumers were listed
+    # under a name variant, so nothing that must be fetched first can fall out of the sequence.
+    for required in data.get("required_datasources") or []:
+        if not isinstance(required, dict):
+            continue
+        name = required.get("datasource_name")
+        if not name:
+            continue
+        entry = datasources.setdefault(_norm(name), SurveyDatasource(name=name))
+        entry.luid = entry.luid or required.get("luid")
+        entry.project = entry.project or required.get("project")
+
+    declared = sum(len(wb.get("published_dependencies") or []) for wb in workbooks)
+    if declared and not any(ds.consumers for ds in datasources.values()):
+        raise RuntimeError(
+            f"{path} declares {declared} dependency entries but none parsed - its schema has changed. "
+            "Refusing to report 'no dependencies', which would sequence the migration wrong."
+        )
+
+    return Survey(
+        path=path,
+        datasources=datasources,
+        workbook_names=workbook_names,
+        by_luid={ds.luid: key for key, ds in datasources.items() if ds.luid},
+        workbooks_total=len(workbooks),
+        gaps=_survey_gaps(data, unresolved),
+    )
 
 
 class TableauSession(NamedTuple):
@@ -148,68 +331,298 @@ def download_datasource(session: TableauSession, luid: str, dest: Path) -> Path:
     return dest
 
 
-def build_plan(datasources: list[dict[str, Any]], site: str) -> list[dict[str, Any]]:
-    """Turn raw lineage into a migration plan ordered by LEVERAGE (most downstream workbooks first).
+def _origin(key: str, metadata_keys: set[str], survey_keys: set[str]) -> str:
+    """Label one edge with the source(s) that saw it."""
+    if key in metadata_keys and key in survey_keys:
+        return FROM_BOTH
+    return FROM_SURVEY if key in survey_keys else FROM_METADATA
+
+
+def _entry(
+    site: str,
+    source: dict[str, Any],
+    metadata_workbooks: list[str],
+    survey_workbooks: list[str] | None,
+) -> dict[str, Any]:
+    """Build one plan row, merging both sources' edges and recording where each edge came from.
+
+    Merging (rather than replacing) is deliberate. The precedence rule settles the CLAIM - whether a
+    data source has consumers, and therefore where it lands in the order - and the survey always
+    wins that, because it can see edges the Metadata API structurally cannot. It does not license
+    DELETING an edge the Metadata API reported: that would be the same class of error in the other
+    direction, dropping a real dependency and rebuilding its consumer first.
+    """
+    seen: dict[str, str] = {_norm(w): w for w in metadata_workbooks}
+    # The survey's spelling wins for display too, in step with the precedence rule.
+    seen.update({_norm(w): w for w in survey_workbooks or []})
+
+    metadata_keys = {_norm(w) for w in metadata_workbooks}
+    survey_keys = {_norm(w) for w in survey_workbooks or []}
+    downstream = sorted(seen.values(), key=str.lower)
+    if survey_keys:
+        evidence = FROM_BOTH if metadata_keys else FROM_SURVEY
+    else:
+        evidence = FROM_METADATA if metadata_keys else "none"
+    name = source.get("name") or ""
+    return {
+        "key": dedup_key(site, name),
+        "name": name,
+        "luid": source.get("luid"),
+        "project": source.get("project"),
+        "has_extracts": source.get("has_extracts"),
+        "downstream_count": len(downstream),
+        "downstream_workbooks": downstream,
+        "edge_origin": {seen[key]: _origin(key, metadata_keys, survey_keys) for key in seen},
+        "metadata_count": len(metadata_keys),
+        "survey_count": len(survey_keys),
+        "survey_only": sorted((seen[k] for k in survey_keys - metadata_keys), key=str.lower),
+        "metadata_only": sorted((seen[k] for k in metadata_keys - survey_keys), key=str.lower),
+        "evidence": evidence,
+        "known_to_survey": survey_workbooks is not None,
+    }
+
+
+def build_plan(datasources: list[dict[str, Any]], site: str, survey: Survey | None = None) -> list[dict[str, Any]]:
+    """Turn raw lineage (plus an optional survey) into a plan ordered by LEVERAGE.
 
     Highest fan-out first is deliberate: migrating the data source that 12 workbooks depend on saves
     11 duplicate semantic models, so it is the highest-value unit of work in the estate.
+
+    The survey does not merely annotate rows. A data source the Metadata API reports as having NO
+    downstream workbooks is promoted into phase 1 as soon as the survey names one consumer, and a
+    data source the Metadata API never listed at all is added from the survey - because a hard
+    dependency missing from the plan is exactly how a report gets rebuilt before the model it binds
+    to, which is the empty-report failure this script exists to prevent.
     """
-    plan = []
-    for ds in datasources:
-        downstream = ds.get("downstreamWorkbooks") or []
-        plan.append(
-            {
-                "key": dedup_key(site, ds.get("name") or ""),
-                "name": ds.get("name"),
-                "luid": ds.get("luid"),
-                "project": ds.get("projectName"),
-                "has_extracts": ds.get("hasExtracts"),
-                "downstream_count": len(downstream),
-                "downstream_workbooks": [w.get("name") for w in downstream],
-            }
-        )
+    plan: list[dict[str, Any]] = []
+    matched: set[str] = set()
+    for datasource in datasources:
+        name = datasource.get("name") or ""
+        downstream = [w.get("name") or "?" for w in datasource.get("downstreamWorkbooks") or []]
+        survey_key = survey.match(datasource.get("luid"), name) if survey else None
+        if survey_key:
+            matched.add(survey_key)
+        source = {
+            "name": name,
+            "luid": datasource.get("luid"),
+            "project": datasource.get("projectName"),
+            "has_extracts": datasource.get("hasExtracts"),
+        }
+        survey_workbooks = survey.consumers(survey_key) if survey and survey_key is not None else None
+        plan.append(_entry(site, source, downstream, survey_workbooks))
+
+    if survey:
+        for key, entry in survey.datasources.items():
+            if key in matched:
+                continue
+            source = {"name": entry.name, "luid": entry.luid, "project": entry.project, "has_extracts": None}
+            plan.append(_entry(site, source, [], survey.consumers(key)))
+
     return sorted(plan, key=lambda p: (-p["downstream_count"], (p["name"] or "").lower()))
 
 
-def print_plan(plan: list[dict[str, Any]]) -> None:
-    """Print the model-first migration plan."""
-    if not plan:
-        log.info("No published data sources found on this site.")
-        log.info("Every workbook embeds its own data source -> migrate workbook-by-workbook as usual.")
-        return
+def build_order(plan: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Flatten the plan into ONE migration sequence: every data source before any consumer of it.
 
+    Ordering is the whole point of this script, so it is emitted as data (and asserted in tests)
+    rather than left implicit in two printed phase headings.
+    """
+    order: list[dict[str, Any]] = []
+    rank: dict[str, int] = {}
+    for entry in plan:
+        if entry["downstream_count"] == 0:
+            continue
+        rank[entry["name"]] = len(order)
+        order.append({"kind": "datasource", "name": entry["name"], "luid": entry["luid"], "requires": []})
+
+    requires: dict[str, list[str]] = {}
+    for entry in plan:
+        for workbook in entry["downstream_workbooks"]:
+            requires.setdefault(workbook, []).append(entry["name"])
+    for workbook in sorted(requires, key=lambda w: (min(rank.get(d, 0) for d in requires[w]), w.lower())):
+        order.append({"kind": "workbook", "name": workbook, "luid": None, "requires": sorted(requires[workbook])})
+    return order
+
+
+def _print_sources(survey: Survey | None) -> None:
+    """Print which systems this plan was built from, and how their disagreements are settled."""
+    if survey:
+        log.info(
+            "SOURCES: Metadata API (GraphQL) + survey %s (REST, %d workbook(s))",
+            survey.path,
+            survey.workbooks_total,
+        )
+        for line in PRECEDENCE_NOTE.splitlines():
+            log.info("%s", line)
+        if survey.gaps:
+            log.info("SURVEY IS INCOMPLETE: %s.", "; ".join(survey.gaps))
+    else:
+        log.info("SOURCES: Metadata API (GraphQL) only")
+        for line in NO_SURVEY_WARNING.splitlines():
+            log.info("%s", line)
+
+
+def _print_header(plan: list[dict[str, Any]], survey: Survey | None) -> None:
+    """Print the sources, the precedence rule, and the headline counts."""
     shared = [p for p in plan if p["downstream_count"] > 1]
-    orphans = [p for p in plan if p["downstream_count"] == 0]
-    workbooks = {w for p in plan for w in p["downstream_workbooks"]}
+    workbooks = {_norm(w) for p in plan for w in p["downstream_workbooks"]}
+    consumed = [p for p in plan if p["downstream_count"] > 0]
 
     log.info("=" * 78)
     log.info("MIGRATION PLAN - model layer first")
     log.info("=" * 78)
+    _print_sources(survey)
+    log.info("")
     log.info(
         "%d published data source(s) feed %d workbook(s). %d are SHARED by more than one workbook.",
-        len(plan),
+        len(consumed),
         len(workbooks),
         len(shared),
     )
-    log.info("\nPHASE 1 - migrate these data sources to semantic models (highest leverage first):\n")
-    for i, p in enumerate(plan, 1):
-        if p["downstream_count"] == 0:
-            continue
-        saved = max(0, p["downstream_count"] - 1)
-        log.info("  %2d. %-38s  %2d workbook(s)   key=%s", i, (p["name"] or "?")[:38], p["downstream_count"], p["key"])
+    if survey:
+        metadata_sources = [p for p in plan if p["metadata_count"] > 0]
+        metadata_workbooks = {_norm(w) for p in plan for w in p["downstream_workbooks"] if p["metadata_count"]}
         log.info(
-            "      project=%-24s extracts=%-5s saves %d duplicate model(s)", p["project"], p["has_extracts"], saved
+            "         (the Metadata API alone saw %d data source(s) feeding %d workbook(s); "
+            "the survey raised that to %d and %d.)",
+            len(metadata_sources),
+            len(metadata_workbooks),
+            len(consumed),
+            len(workbooks),
         )
-        for wb in p["downstream_workbooks"]:
-            log.info("        -> %s", wb)
+
+
+def _print_phase1(plan: list[dict[str, Any]]) -> None:
+    """Print the data sources to migrate first, highest leverage first, edge by edge."""
+    log.info("\nPHASE 1 - migrate these data sources to semantic models (highest leverage first):\n")
+    for i, entry in enumerate(plan, 1):
+        if entry["downstream_count"] == 0:
+            continue
+        saved = max(0, entry["downstream_count"] - 1)
+        log.info(
+            "  %2d. %-38s  %2d workbook(s)   key=%s",
+            i,
+            (entry["name"] or "?")[:38],
+            entry["downstream_count"],
+            entry["key"],
+        )
+        log.info(
+            "      project=%-24s extracts=%-5s saves %d duplicate model(s)   evidence=%s",
+            entry["project"],
+            entry["has_extracts"],
+            saved,
+            entry["evidence"],
+        )
+        for workbook in entry["downstream_workbooks"]:
+            log.info("        -> %-44s [%s]", workbook, entry["edge_origin"][workbook])
+
+
+def _print_disagreements(plan: list[dict[str, Any]], survey: Survey | None) -> None:
+    """Name every data source the two systems describe differently, and how it was resolved."""
+    if not survey:
+        return
+    conflicted = [p for p in plan if p["survey_only"] or p["metadata_only"]]
+    if not conflicted:
+        log.info("\nThe survey and the Metadata API agree on every data source.")
+        return
+    log.info("\nDISAGREEMENTS - resolved by the precedence rule above (the survey wins):")
+    for entry in conflicted:
+        if entry["survey_only"]:
+            log.info(
+                "  - %s: Metadata API saw %d consumer(s), survey saw %d -> SURVEY WINS, %d edge(s) added: %s",
+                entry["name"],
+                entry["metadata_count"],
+                entry["survey_count"],
+                len(entry["survey_only"]),
+                ", ".join(entry["survey_only"]),
+            )
+        if entry["metadata_only"]:
+            log.info(
+                "  - %s: the survey did not see %d Metadata-API edge(s) - KEPT (dropping a real "
+                "dependency is the risk this guards against), marked [metadata-api]: %s",
+                entry["name"],
+                len(entry["metadata_only"]),
+                ", ".join(entry["metadata_only"]),
+            )
+
+
+def _print_phase2(order: list[dict[str, Any]]) -> None:
+    """Print the workbook half of the sequence, each with the data sources it must follow."""
     log.info("\nPHASE 2 - migrate each workbook to a REPORT bound to the model built in phase 1.")
     log.info("          Do NOT rebuild the model per workbook; check first with:")
     log.info("          python scripts/published_datasource_registry.py --spec <spec.json>")
-    if orphans:
-        log.info("\nNOTE: %d published data source(s) have NO downstream workbooks:", len(orphans))
-        for p in orphans:
-            log.info("        - %s (%s)", p["name"], p["project"])
-        log.info("      Confirm with the customer before migrating - these may be abandoned.")
+    if not any(step["kind"] == "workbook" for step in order):
+        return
+    log.info("\n          migration ORDER (every data source precedes every workbook that binds to it):")
+    for i, step in enumerate(order, 1):
+        if step["kind"] == "datasource":
+            log.info("          %2d. [datasource] %s", i, step["name"])
+        else:
+            log.info("          %2d. [workbook]   %-38s after: %s", i, step["name"], ", ".join(step["requires"]))
+
+
+def _orphan_heading(orphans: list[dict[str, Any]], survey: Survey | None) -> None:
+    """Introduce the no-consumer list with only the claim the available evidence supports."""
+    if survey and survey.complete:
+        log.info("\nNOTE: %d published data source(s) have NO downstream workbooks in EITHER source:", len(orphans))
+    elif survey:
+        log.info(
+            "\nNOTE: %d published data source(s) have no downstream workbooks in either source, but "
+            "the survey is incomplete (%s):",
+            len(orphans),
+            "; ".join(survey.gaps),
+        )
+    else:
+        log.info(
+            "\nNOTE: %d published data source(s) have no downstream usage VISIBLE TO THE METADATA API:",
+            len(orphans),
+        )
+
+
+def _print_orphans(plan: list[dict[str, Any]], survey: Survey | None) -> None:
+    """Report data sources with no consumers - with only the claim the evidence actually supports.
+
+    Without a survey the honest statement is "no downstream usage VISIBLE TO THE METADATA API",
+    which is materially weaker than "abandoned" and is the one this tool can support: the Metadata
+    API cannot see sqlproxy connections at all, so its silence says nothing about usage. The
+    stronger claim requires a COMPLETE survey that also found no consumer, so the word itself must
+    not appear anywhere on the no-survey path - `tests/test_tableau_lineage.py` greps for it.
+    """
+    orphans = [p for p in plan if p["downstream_count"] == 0]
+    if not orphans:
+        return
+    _orphan_heading(orphans, survey)
+    for entry in orphans:
+        log.info("        - %s (%s)", entry["name"], entry["project"])
+    if survey and survey.complete:
+        log.info("      Both the Metadata API and the survey found no consumer - these may be abandoned.")
+        log.info("      Confirm with the customer before migrating.")
+    elif survey:
+        log.info("      UNCONFIRMED: an incomplete survey cannot show a data source is unused - the workbook")
+        log.info("      it failed to read may be the consumer. Close the survey's gaps before deciding.")
+    else:
+        log.info("      This is NOT evidence they are unused: the Metadata API does not see 'sqlproxy'")
+        log.info("      (published data source) connections at all, so it cannot observe a consumer even")
+        log.info("      when one exists. Re-run with --survey _assessment/estate_survey.json before")
+        log.info("      drawing any conclusion about usage.")
+
+
+def print_plan(plan: list[dict[str, Any]], survey: Survey | None = None) -> None:
+    """Print the model-first migration plan, attributing every claim to the system that made it."""
+    if not plan:
+        log.info("No published data sources found on this site.")
+        if survey:
+            log.info("The survey found no published-datasource dependency either -> migrate workbook-by-workbook.")
+        else:
+            log.info("Every workbook embeds its own data source -> migrate workbook-by-workbook as usual.")
+            log.info("Confirm with --survey: the Metadata API cannot see 'sqlproxy' connections.")
+        return
+
+    _print_header(plan, survey)
+    _print_phase1(plan)
+    _print_disagreements(plan, survey)
+    _print_phase2(build_order(plan))
+    _print_orphans(plan, survey)
 
 
 def _env_config(env_path: Path | None = None) -> tuple[str, str, str, str]:
@@ -229,12 +642,20 @@ def _env_config(env_path: Path | None = None) -> tuple[str, str, str, str]:
     )
 
 
-def main(argv: list[str] | None = None) -> int:
-    """CLI entry point."""
+def _build_parser() -> argparse.ArgumentParser:
+    """Define the CLI."""
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("--plan", action="store_true", help="Print the model-first migration plan")
     parser.add_argument("--download", type=Path, help="Download every published data source (.tdsx) to this folder")
     parser.add_argument("--from-json", type=Path, help="Re-plan offline from a saved lineage response")
+    parser.add_argument(
+        "--survey",
+        type=Path,
+        help=(
+            "estate_survey.py --json output. Its dependency edges OVERRIDE the Metadata API's, which "
+            "is blind to 'sqlproxy' connections. Without this the plan is known-incomplete."
+        ),
+    )
     parser.add_argument(
         "--env", type=Path, default=Path(".env"), help="git-ignored KEY=VALUE credentials (default .env)"
     )
@@ -242,11 +663,36 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--api-version", default=DEFAULT_API_VERSION, help=f"REST API version (default {DEFAULT_API_VERSION})"
     )
-    args = parser.parse_args(argv)
+    return parser
+
+
+def _resolve_survey(path: Path | None) -> tuple[Survey | None, bool]:
+    """Load --survey if given. Returns (survey, ok); a survey that fails to load is FATAL.
+
+    Continuing without it would silently produce the known-incomplete plan the operator explicitly
+    asked not to have, under a heading that no longer warns about it.
+    """
+    if not path:
+        log.warning("no --survey: the Metadata API cannot see 'sqlproxy' connections, so this plan may be incomplete")
+        return None, True
+    try:
+        return load_survey(path), True
+    except (OSError, ValueError, RuntimeError) as exc:
+        log.error("--survey could not be read: %s", exc)
+        return None, False
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    args = _build_parser().parse_args(argv)
+
+    survey, ok = _resolve_survey(args.survey)
+    if not ok:
+        return 1
 
     if args.from_json:
         payload = json.loads(args.from_json.read_text(encoding="utf-8"))
-        print_plan(build_plan(payload.get("datasources", []), payload.get("site", "")))
+        print_plan(build_plan(payload.get("datasources", []), payload.get("site", ""), survey), survey)
         return 0
 
     server, site, pat_name, pat_secret = _env_config(args.env)
@@ -263,21 +709,21 @@ def main(argv: list[str] | None = None) -> int:
         args.save_json.write_text(json.dumps({"site": site, "datasources": datasources}, indent=2), encoding="utf-8")
         log.info("raw lineage saved to %s", args.save_json)
 
-    plan = build_plan(datasources, site)
+    plan = build_plan(datasources, site, survey)
     if args.plan or not args.download:
-        print_plan(plan)
+        print_plan(plan, survey)
 
     if args.download:
         log.info("\nDownloading %d data source(s) to %s ...", len(plan), args.download)
-        for p in plan:
-            if not p["luid"]:
+        for entry in plan:
+            if not entry["luid"]:
                 continue
-            dest = args.download / f"{p['name']}.tdsx"
+            dest = args.download / f"{entry['name']}.tdsx"
             try:
-                download_datasource(session, p["luid"], dest)
+                download_datasource(session, entry["luid"], dest)
                 log.info("  OK  %s", dest)
             except (urllib.error.URLError, urllib.error.HTTPError) as exc:
-                log.warning("  !!  %s failed: %s", p["name"], exc)
+                log.warning("  !!  %s failed: %s", entry["name"], exc)
         log.info("\nParse each with: python scripts/parse_tableau.py <file>.tdsx -o <spec>.json")
     return 0
 

--- a/scripts/tableau_lineage.py
+++ b/scripts/tableau_lineage.py
@@ -61,6 +61,7 @@ import logging
 import sys
 import urllib.error
 import urllib.request
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, NamedTuple
@@ -141,13 +142,27 @@ class SurveyDatasource:
     luids: set[str] = field(default_factory=set)
 
     def observe(self, luid: str | None, project: str | None) -> None:
-        """Record one sighting of this data source; the survey names it once per consumer."""
+        """Record a RESOLVED sighting: this is the identity the download step will use."""
         if luid:
             self.luids.add(luid)
             self.luid = self.luid or luid
         if project:
             self.projects.add(project)
             self.project = self.project or project
+
+    def note_candidate(self, luid: str | None, project: str | None) -> None:
+        """Record one candidate the survey could NOT choose between - evidence, never identity.
+
+        `resolve_dependency` returns `status='ambiguous', luid='', project=''` plus a `candidates`
+        list naming every data source that shares the name, and it "NEVER picks one" on purpose.
+        Neither does this: candidates feed the ambiguity evidence only, so `luid`/`project` stay
+        empty and the download step skips a data source nobody can identify - instead of quietly
+        fetching whichever candidate happened to be listed first.
+        """
+        if luid:
+            self.luids.add(luid)
+        if project:
+            self.projects.add(project)
 
     @property
     def ambiguous(self) -> bool:
@@ -220,7 +235,7 @@ def _count(*values: Any) -> int:
     return max((c for c in counts if isinstance(c, int) and not isinstance(c, bool)), default=0)
 
 
-def _flag_gaps(data: dict[str, Any]) -> list[str]:
+def _flag_gaps(data: dict[str, Any], other_gaps: Sequence[str] = ()) -> list[str]:
     """Read the survey's OWN verdict on itself: `degraded`.
 
     `survey_site()` sets `degraded = bool(errors or listing_errors)` and documents it as "this
@@ -231,12 +246,26 @@ def _flag_gaps(data: dict[str, Any]) -> list[str]:
 
     Its ABSENCE is a gap too. A survey with no flag cannot show it saw the whole estate, and the
     only claim gated on completeness here is the strongest one this tool makes ("may be abandoned").
+
+    That gate stays strict even for the common benign cause - an OLD survey. `degraded` and
+    `listing_errors` arrived in engine 2.117.0 (upstream commit 72f983a8, 2026-08-10), so every
+    survey taken before that date lacks them; a pre-2.117.0 survey that silently lost a listing call
+    is genuinely indistinguishable from a healthy one, which is why the flag was added. What this
+    DOES do is name that likely cause when nothing else in the survey looks wrong, so an operator
+    five days from a workshop is not sent hunting for a failure that never happened - or, worse,
+    told only to "re-run estate_survey.py", which needs live Tableau credentials.
     """
     declared = data.get("degraded", _summary(data).get("degraded"))
     if declared is None:
+        cause = (
+            " - no other error is reported, so this survey most likely predates engine 2.117.0 "
+            "(2026-08-10), which added the flag"
+            if not other_gaps
+            else ""
+        )
         return [
             "the survey carries no 'degraded' flag, so it cannot show it saw the whole estate "
-            "(re-run estate_survey.py to produce one)"
+            f"(re-run estate_survey.py to produce one){cause}"
         ]
     return ["the survey reports itself DEGRADED (estate_survey.py's own flag)"] if declared else []
 
@@ -269,14 +298,20 @@ def _visibility_gaps(data: dict[str, Any]) -> list[str]:
 
 
 def _resolution_gaps(data: dict[str, Any], unresolved_deps: int) -> list[str]:
-    """Every dependency the survey saw but could not tie to a published data source."""
-    gaps: list[str] = []
-    declared_unresolved = _count(data.get("unresolved_dependencies"), _summary(data).get("unresolved_dependencies"))
-    if declared_unresolved:
-        gaps.append(f"{declared_unresolved} declared dependency(ies) resolved to no data source")
-    if unresolved_deps:
-        gaps.append(f"{unresolved_deps} dependency(ies) did not resolve to a published data source")
-    return gaps
+    """Every dependency the survey saw but could not tie to a published data source.
+
+    The survey declares this count in `unresolved_dependencies` (and in its summary) AND it is
+    visible per-row in the parsed edges; `_count` reports the ONE failure once, so a listing failure
+    does not print the same 38 dependencies under two different sentences.
+    """
+    unresolved = _count(
+        data.get("unresolved_dependencies"),
+        _summary(data).get("unresolved_dependencies"),
+        unresolved_deps,
+    )
+    if not unresolved:
+        return []
+    return [f"{unresolved} dependency(ies) did not resolve to a published data source"]
 
 
 def _survey_gaps(data: dict[str, Any], unresolved_deps: int) -> tuple[str, ...]:
@@ -289,7 +324,8 @@ def _survey_gaps(data: dict[str, Any], unresolved_deps: int) -> tuple[str, ...]:
     original ("Both the Metadata API and the survey found no consumer"). The missing workbook is
     precisely the consumer that would have disproved it.
     """
-    return tuple(_flag_gaps(data) + _visibility_gaps(data) + _resolution_gaps(data, unresolved_deps))
+    observed = _visibility_gaps(data) + _resolution_gaps(data, unresolved_deps)
+    return tuple(_flag_gaps(data, observed) + observed)
 
 
 def _read_survey_edges(
@@ -317,6 +353,15 @@ def _read_survey_edges(
             entry = datasources.setdefault(_norm(name), SurveyDatasource(name=name))
             entry.consumers.add(_norm(wb_display))
             entry.observe(dep.get("luid"), dep.get("project"))
+            # An AMBIGUOUS dependency carries `luid: ""`, `project: ""` and a `candidates` list -
+            # `resolve_dependency` "NEVER picks one" when a name matches several data sources. Read
+            # that list: it is the only place the collision is visible when the Metadata API lists
+            # at most one row for the name, and without it the merge this tool performs on purpose
+            # (over-migrate, never orphan) would happen SILENTLY, which is the one thing it must
+            # not do.
+            for candidate in dep.get("candidates") or []:
+                if isinstance(candidate, dict):
+                    entry.note_candidate(candidate.get("luid"), candidate.get("project"))
             if dep.get("status") and dep.get("status") != "resolved":
                 unresolved += 1
     return unresolved
@@ -509,9 +554,28 @@ def _flag_name_collisions(by_key: dict[str, list[dict[str, Any]]], survey: Surve
         survey_projects = sorted(entry.projects) if entry and entry.ambiguous else []
         if len(rows) < 2 and not survey_projects:
             continue
-        projects = sorted({str(row["project"]) for row in rows} | set(survey_projects))
+        projects = sorted({str(row["project"]) for row in rows if row["project"]} | set(survey_projects))
         for row in rows:
-            row["name_collision"] = projects
+            row["name_collision"] = projects or ["?"]
+
+
+def _survey_only_rows(site: str, survey: Survey, by_key: dict[str, list[dict[str, Any]]]) -> list[dict[str, Any]]:
+    """Plan rows for data sources the Metadata API never listed at all.
+
+    They are registered in `by_key` as well, not merely appended to the plan: a collision the
+    Metadata API cannot see (it lists at most one row for the name - and for a `sqlproxy` source,
+    often none) would otherwise reach the operator as a single quiet row, and the name merge this
+    script performs on purpose would happen with no warning printed anywhere.
+    """
+    rows: list[dict[str, Any]] = []
+    for key, seen in survey.datasources.items():
+        if key in by_key:
+            continue
+        source = {"name": seen.name, "luid": seen.luid, "project": seen.project, "has_extracts": None}
+        row = _entry(site, source, [], survey.consumers(key), "survey-only")
+        rows.append(row)
+        by_key.setdefault(key, []).append(row)
+    return rows
 
 
 def build_plan(datasources: list[dict[str, Any]], site: str, survey: Survey | None = None) -> list[dict[str, Any]]:
@@ -545,11 +609,7 @@ def build_plan(datasources: list[dict[str, Any]], site: str, survey: Survey | No
             by_key.setdefault(survey_key, []).append(entry)
 
     if survey:
-        for key, seen in survey.datasources.items():
-            if key in by_key:
-                continue
-            source = {"name": seen.name, "luid": seen.luid, "project": seen.project, "has_extracts": None}
-            plan.append(_entry(site, source, [], survey.consumers(key), "survey-only"))
+        plan.extend(_survey_only_rows(site, survey, by_key))
         _flag_name_collisions(by_key, survey)
 
     return sorted(plan, key=lambda p: (-p["downstream_count"], (p["name"] or "").lower()))

--- a/scripts/tableau_lineage.py
+++ b/scripts/tableau_lineage.py
@@ -25,6 +25,12 @@ purpose: discover the Tableau dependency graph BEFORE migrating anything, so a T
            dropped - losing a real dependency is the failure this whole script guards against) and
            labelled 'metadata-api', so an operator can see which source produced which claim.
 
+           COMPLETENESS: a survey also reports on ITSELF - `degraded`, `listing_errors`,
+           per-workbook `dependencies_unknown`. Every one of those means it did not see the whole
+           estate, so its silence about a data source is not evidence either. Such a survey still
+           CONTRIBUTES every edge it did see (that only ever adds dependencies, which is the safe
+           direction); what it cannot do is license the word "abandoned".
+
          The dedup key it prints is the SAME key `scripts/parse_tableau.py` stamps on a parsed
          workbook (`data_sources[].published_datasource.key`), so server-side lineage and locally
          parsed workbooks line up.
@@ -131,6 +137,22 @@ class SurveyDatasource:
     luid: str | None = None
     project: str | None = None
     consumers: set[str] = field(default_factory=set)
+    projects: set[str] = field(default_factory=set)
+    luids: set[str] = field(default_factory=set)
+
+    def observe(self, luid: str | None, project: str | None) -> None:
+        """Record one sighting of this data source; the survey names it once per consumer."""
+        if luid:
+            self.luids.add(luid)
+            self.luid = self.luid or luid
+        if project:
+            self.projects.add(project)
+            self.project = self.project or project
+
+    @property
+    def ambiguous(self) -> bool:
+        """True when this ONE key covers several data sources that merely share a name."""
+        return len(self.projects) > 1 or len(self.luids) > 1
 
 
 @dataclass(frozen=True)
@@ -138,9 +160,10 @@ class Survey:
     """The REST-derived dependency graph from `estate_survey.py --json`.
 
     This is GROUND TRUTH for whether a dependency exists: it was read from each workbook's own
-    connections. `gaps` records the ways this particular survey is nevertheless incomplete (a
-    workbook whose connections could not be read, a dependency that resolved to no data source).
-    An incomplete survey may still ADD edges, but it must not be used to claim a data source is
+    connections. `gaps` records the ways this particular survey is nevertheless incomplete (it
+    reports itself DEGRADED, a site listing failed so workbooks are missing from it entirely, a
+    workbook's connections could not be read, a dependency resolved to no data source). An
+    incomplete survey may still ADD edges, but it must not be used to claim a data source is
     unused, because the edge proving otherwise may be exactly the one it failed to read.
     """
 
@@ -156,12 +179,19 @@ class Survey:
         """True when nothing stopped this survey from seeing the whole estate."""
         return not self.gaps
 
-    def match(self, luid: str | None, name: str | None) -> str | None:
-        """Resolve a Metadata-API data source to this survey's key: LUID first, then name."""
+    def match(self, luid: str | None, name: str | None) -> tuple[str | None, str | None]:
+        """Resolve a Metadata-API data source to this survey's key -> (key, how it was matched).
+
+        LUID first because it is an identity; NAME only as a fallback, because it is not. The
+        fallback is load-bearing rather than decorative: `estate_survey.py::resolve_dependency`
+        emits `luid: ""` for any dependency it could not resolve to exactly one data source, so on a
+        real site the name path is what carries those edges. HOW the match was made is returned with
+        it so the caller can flag a name match that landed on more than one data source.
+        """
         if luid and luid in self.by_luid:
-            return self.by_luid[luid]
+            return self.by_luid[luid], "luid"
         key = _norm(name)
-        return key if key in self.datasources else None
+        return (key, "name") if key in self.datasources else (None, None)
 
     def consumers(self, key: str) -> list[str]:
         """Every workbook the survey saw binding to this data source, by display name."""
@@ -171,18 +201,95 @@ class Survey:
         return sorted((self.workbook_names.get(w, w) for w in entry.consumers), key=str.lower)
 
 
-def _survey_gaps(data: dict[str, Any], unresolved_deps: int) -> tuple[str, ...]:
-    """Describe every reason this survey's view of the estate is incomplete."""
+def _summary(data: dict[str, Any]) -> dict[str, Any]:
+    """The survey's own summary block, or an empty one."""
+    summary = data.get("summary")
+    return summary if isinstance(summary, dict) else {}
+
+
+def _count(*values: Any) -> int:
+    """The largest of several counts of the SAME failure, ignoring anything that is not a count.
+
+    `estate_survey.py` records one failure in more than one place (`connection_read_errors`, the
+    per-workbook `dependencies_unknown` flag, `summary.dependencies_unknown`). Taking the max
+    reports it ONCE, while still catching a survey that carries only one of the three - which is
+    exactly what `build_survey()` produces when it is called directly, without `survey_site()`'s
+    error bookkeeping.
+    """
+    counts = [len(v) if isinstance(v, list) else v for v in values]
+    return max((c for c in counts if isinstance(c, int) and not isinstance(c, bool)), default=0)
+
+
+def _flag_gaps(data: dict[str, Any]) -> list[str]:
+    """Read the survey's OWN verdict on itself: `degraded`.
+
+    `survey_site()` sets `degraded = bool(errors or listing_errors)` and documents it as "this
+    survey did NOT see the whole estate, so its 'no dependency' answers are not evidence of
+    independence". That is the single flag every consumer is told to trust, so it is read first and
+    honoured on its own - never re-derived from the error lists, which is how a NEW failure class
+    added upstream would silently stop counting.
+
+    Its ABSENCE is a gap too. A survey with no flag cannot show it saw the whole estate, and the
+    only claim gated on completeness here is the strongest one this tool makes ("may be abandoned").
+    """
+    declared = data.get("degraded", _summary(data).get("degraded"))
+    if declared is None:
+        return [
+            "the survey carries no 'degraded' flag, so it cannot show it saw the whole estate "
+            "(re-run estate_survey.py to produce one)"
+        ]
+    return ["the survey reports itself DEGRADED (estate_survey.py's own flag)"] if declared else []
+
+
+def _visibility_gaps(data: dict[str, Any]) -> list[str]:
+    """Every way this survey failed to SEE part of the estate."""
     gaps: list[str] = []
-    read_errors = data.get("connection_read_errors") or []
-    if read_errors:
-        gaps.append(f"{len(read_errors)} workbook connection(s) could not be read")
-    declared_unresolved = data.get("unresolved_dependencies") or []
+    summary = _summary(data)
+    workbooks = data.get("workbooks") or []
+
+    listing = _count(data.get("listing_errors"), summary.get("listing_errors"))
+    if listing:
+        gaps.append(
+            f"{listing} site listing(s) failed - workbooks or data sources are MISSING from this survey entirely"
+        )
+    unread = _count(
+        data.get("connection_read_errors"),
+        summary.get("connection_read_errors"),
+        summary.get("dependencies_unknown"),
+        sum(1 for wb in workbooks if isinstance(wb, dict) and wb.get("dependencies_unknown")),
+    )
+    if unread:
+        gaps.append(f"{unread} workbook connection(s) could not be read")
+    if not workbooks:
+        gaps.append("the survey lists no workbooks at all, so it observed no consumer edge")
+    total = summary.get("workbooks_total")
+    if isinstance(total, int) and total > len(workbooks):
+        gaps.append(f"the survey lists {len(workbooks)} of the {total} workbook(s) it counted")
+    return gaps
+
+
+def _resolution_gaps(data: dict[str, Any], unresolved_deps: int) -> list[str]:
+    """Every dependency the survey saw but could not tie to a published data source."""
+    gaps: list[str] = []
+    declared_unresolved = _count(data.get("unresolved_dependencies"), _summary(data).get("unresolved_dependencies"))
     if declared_unresolved:
-        gaps.append(f"{len(declared_unresolved)} declared dependency(ies) resolved to no data source")
+        gaps.append(f"{declared_unresolved} declared dependency(ies) resolved to no data source")
     if unresolved_deps:
         gaps.append(f"{unresolved_deps} dependency(ies) did not resolve to a published data source")
-    return tuple(gaps)
+    return gaps
+
+
+def _survey_gaps(data: dict[str, Any], unresolved_deps: int) -> tuple[str, ...]:
+    """Describe every reason this survey's view of the estate is incomplete.
+
+    Read EVERY signal `estate_survey.py` publishes about its own completeness, not the subset that
+    happens to be convenient. Reading only `connection_read_errors` + `unresolved_dependencies` let
+    a survey with `degraded: true` and a failed site listing - i.e. one with whole workbooks missing
+    - report `complete`, which re-armed issue #126's wrong claim with MORE authority than the
+    original ("Both the Metadata API and the survey found no consumer"). The missing workbook is
+    precisely the consumer that would have disproved it.
+    """
+    return tuple(_flag_gaps(data) + _visibility_gaps(data) + _resolution_gaps(data, unresolved_deps))
 
 
 def _read_survey_edges(
@@ -209,8 +316,7 @@ def _read_survey_edges(
                 continue
             entry = datasources.setdefault(_norm(name), SurveyDatasource(name=name))
             entry.consumers.add(_norm(wb_display))
-            entry.luid = entry.luid or dep.get("luid")
-            entry.project = entry.project or dep.get("project")
+            entry.observe(dep.get("luid"), dep.get("project"))
             if dep.get("status") and dep.get("status") != "resolved":
                 unresolved += 1
     return unresolved
@@ -246,8 +352,7 @@ def load_survey(path: Path) -> Survey:
         if not name:
             continue
         entry = datasources.setdefault(_norm(name), SurveyDatasource(name=name))
-        entry.luid = entry.luid or required.get("luid")
-        entry.project = entry.project or required.get("project")
+        entry.observe(required.get("luid"), required.get("project"))
 
     declared = sum(len(wb.get("published_dependencies") or []) for wb in workbooks)
     if declared and not any(ds.consumers for ds in datasources.values()):
@@ -343,6 +448,7 @@ def _entry(
     source: dict[str, Any],
     metadata_workbooks: list[str],
     survey_workbooks: list[str] | None,
+    matched_via: str | None = None,
 ) -> dict[str, Any]:
     """Build one plan row, merging both sources' edges and recording where each edge came from.
 
@@ -379,7 +485,33 @@ def _entry(
         "metadata_only": sorted((seen[k] for k in metadata_keys - survey_keys), key=str.lower),
         "evidence": evidence,
         "known_to_survey": survey_workbooks is not None,
+        "matched_via": matched_via,
+        "name_collision": [],
     }
+
+
+def _flag_name_collisions(by_key: dict[str, list[dict[str, Any]]], survey: Survey) -> None:
+    """Mark every plan row whose survey edges were attached by NAME to more than one data source.
+
+    A name is not an identity - two data sources called 'Sales' in different projects normalise to
+    one survey key, so the survey's consumers get attributed to BOTH. That merge is kept rather than
+    refused, and the direction is the reason: attaching a consumer to one data source too many
+    over-migrates (recoverable, and the order still holds because both are sequenced ahead of it),
+    while refusing the match would orphan a real consumer and rebuild it as an empty report - the
+    failure this whole script exists to prevent. `estate_survey.py::resolve_dependency` refuses the
+    same ambiguity and is right to: it is deciding an IDENTITY. This is only deciding an ORDER.
+
+    What is not acceptable is doing it silently, so every affected row is flagged and printed. The
+    edges are usable; the per-project attribution is not.
+    """
+    for key, rows in by_key.items():
+        entry = survey.datasources.get(key)
+        survey_projects = sorted(entry.projects) if entry and entry.ambiguous else []
+        if len(rows) < 2 and not survey_projects:
+            continue
+        projects = sorted({str(row["project"]) for row in rows} | set(survey_projects))
+        for row in rows:
+            row["name_collision"] = projects
 
 
 def build_plan(datasources: list[dict[str, Any]], site: str, survey: Survey | None = None) -> list[dict[str, Any]]:
@@ -395,13 +527,11 @@ def build_plan(datasources: list[dict[str, Any]], site: str, survey: Survey | No
     to, which is the empty-report failure this script exists to prevent.
     """
     plan: list[dict[str, Any]] = []
-    matched: set[str] = set()
+    by_key: dict[str, list[dict[str, Any]]] = {}
     for datasource in datasources:
         name = datasource.get("name") or ""
         downstream = [w.get("name") or "?" for w in datasource.get("downstreamWorkbooks") or []]
-        survey_key = survey.match(datasource.get("luid"), name) if survey else None
-        if survey_key:
-            matched.add(survey_key)
+        survey_key, matched_via = survey.match(datasource.get("luid"), name) if survey else (None, None)
         source = {
             "name": name,
             "luid": datasource.get("luid"),
@@ -409,14 +539,18 @@ def build_plan(datasources: list[dict[str, Any]], site: str, survey: Survey | No
             "has_extracts": datasource.get("hasExtracts"),
         }
         survey_workbooks = survey.consumers(survey_key) if survey and survey_key is not None else None
-        plan.append(_entry(site, source, downstream, survey_workbooks))
+        entry = _entry(site, source, downstream, survey_workbooks, matched_via)
+        plan.append(entry)
+        if survey_key:
+            by_key.setdefault(survey_key, []).append(entry)
 
     if survey:
-        for key, entry in survey.datasources.items():
-            if key in matched:
+        for key, seen in survey.datasources.items():
+            if key in by_key:
                 continue
-            source = {"name": entry.name, "luid": entry.luid, "project": entry.project, "has_extracts": None}
-            plan.append(_entry(site, source, [], survey.consumers(key)))
+            source = {"name": seen.name, "luid": seen.luid, "project": seen.project, "has_extracts": None}
+            plan.append(_entry(site, source, [], survey.consumers(key), "survey-only"))
+        _flag_name_collisions(by_key, survey)
 
     return sorted(plan, key=lambda p: (-p["downstream_count"], (p["name"] or "").lower()))
 
@@ -440,7 +574,11 @@ def build_order(plan: list[dict[str, Any]]) -> list[dict[str, Any]]:
         for workbook in entry["downstream_workbooks"]:
             requires.setdefault(workbook, []).append(entry["name"])
     for workbook in sorted(requires, key=lambda w: (min(rank.get(d, 0) for d in requires[w]), w.lower())):
-        order.append({"kind": "workbook", "name": workbook, "luid": None, "requires": sorted(requires[workbook])})
+        # De-duplicated because two data sources that merely SHARE a name are indistinguishable in a
+        # list of names: printing "after: Sales, Sales" states nothing the reader can act on. Both
+        # rows still appear in the data source half of the order, so the guarantee is unaffected;
+        # the collision itself is reported separately rather than smuggled in as a repeat.
+        order.append({"kind": "workbook", "name": workbook, "luid": None, "requires": sorted(set(requires[workbook]))})
     return order
 
 
@@ -546,6 +684,31 @@ def _print_disagreements(plan: list[dict[str, Any]], survey: Survey | None) -> N
             )
 
 
+def _print_name_collisions(plan: list[dict[str, Any]]) -> None:
+    """Name every data source whose survey edges were attached on a shared NAME, not an identity.
+
+    Silence here would be the same mistake as the "abandoned" claim in a different place: a merge
+    the operator cannot see is a merge they cannot check. The edges are kept (see
+    `_flag_name_collisions`); what is withheld is the confident per-project attribution.
+    """
+    collided = [entry for entry in plan if entry["name_collision"]]
+    if not collided:
+        return
+    log.info("\nNAME COLLISION - a name is not an identity, so this attribution is UNCONFIRMED:")
+    for entry in collided:
+        log.info(
+            "  - %r exists in %d project(s) (%s); the survey's %d consumer edge(s) are attributed to "
+            "EVERY one of them.",
+            entry["name"],
+            len(entry["name_collision"]),
+            ", ".join(entry["name_collision"]),
+            entry["survey_count"],
+        )
+    log.info("      Over-migrating a shared name is recoverable and keeps the order valid; refusing the")
+    log.info("      match would orphan a real consumer, which is not. Disambiguate by LUID (re-run the")
+    log.info("      survey so its dependencies resolve) before quoting per-project usage.")
+
+
 def _print_phase2(order: list[dict[str, Any]]) -> None:
     """Print the workbook half of the sequence, each with the data sources it must follow."""
     log.info("\nPHASE 2 - migrate each workbook to a REPORT bound to the model built in phase 1.")
@@ -621,6 +784,7 @@ def print_plan(plan: list[dict[str, Any]], survey: Survey | None = None) -> None
     _print_header(plan, survey)
     _print_phase1(plan)
     _print_disagreements(plan, survey)
+    _print_name_collisions(plan)
     _print_phase2(build_order(plan))
     _print_orphans(plan, survey)
 

--- a/tests/test_tableau_lineage.py
+++ b/tests/test_tableau_lineage.py
@@ -85,26 +85,54 @@ def _survey_workbook(
     dependencies: list[tuple[str, str | None]],
     project: str = "Certified Sources",
     unknown: bool = False,
+    candidates: dict[str, list[tuple[str, str]]] | None = None,
 ) -> dict[str, Any]:
     """One workbook entry as `estate_survey.py --json` writes it.
 
-    `luid=""` on a dependency is not a synthetic edge case: `resolve_dependency` emits exactly that
-    - together with a non-`resolved` status - for any dependency it could not tie to exactly one
-    data source (AMBIGUOUS / NOT_FOUND), so the two travel together here as well.
+    A dependency row is `dict(dep)` updated with `resolve_dependency`'s return, so the three shapes
+    it can take are reproduced exactly:
+
+    * RESOLVED  -> `luid`/`project` filled, `candidates` holding the ONE match;
+    * AMBIGUOUS -> `luid: ""` AND `project: ""` (it "NEVER picks one"), `candidates` naming every
+      data source that shares the name;
+    * NOT_FOUND -> `luid: ""`, `project: ""`, `candidates: []`.
+
+    Blanking `project` alongside `luid` is the detail a fixture is most tempted to skip, and it is
+    load-bearing: on real output the ambiguity is visible ONLY in `candidates`, so a fixture that
+    leaves `project` populated tests a shape the engine cannot emit.
     """
+    matches = candidates or {}
+    deps: list[dict[str, Any]] = []
+    for ds_name, luid in dependencies:
+        found = [
+            {"luid": c_luid, "name": ds_name, "project": c_project} for c_luid, c_project in matches.get(ds_name, [])
+        ]
+        if luid is None or luid:
+            resolved_luid = f"luid-{ds_name}" if luid is None else luid
+            deps.append(
+                {
+                    "datasource_name": ds_name,
+                    "status": "resolved",
+                    "luid": resolved_luid,
+                    "project": project,
+                    "candidates": found or [{"luid": resolved_luid, "name": ds_name, "project": project}],
+                }
+            )
+            continue
+        deps.append(
+            {
+                "datasource_name": ds_name,
+                "status": "ambiguous" if found else "not_found",
+                "luid": "",
+                "project": "",
+                "candidates": found,
+            }
+        )
     return {
         "name": name,
         "luid": f"wb-{name}",
         "project": "Reports",
-        "published_dependencies": [
-            {
-                "datasource_name": ds_name,
-                "status": "resolved" if luid is None or luid else "ambiguous",
-                "luid": f"luid-{ds_name}" if luid is None else luid,
-                "project": project,
-            }
-            for ds_name, luid in dependencies
-        ],
+        "published_dependencies": deps,
         # `build_survey` stamps both of these on every workbook row; the fixtures carry them so a
         # gap check that reads them is exercised against the shape the engine actually writes.
         "dependencies_unknown": unknown,
@@ -136,7 +164,7 @@ def _survey_file(tmp_path: Path, workbooks: list[dict[str, Any]], **extra: Any) 
                     "workbook": workbook["name"],
                     "datasource_name": dep["datasource_name"],
                     "status": dep["status"],
-                    "candidates": [],
+                    "candidates": dep["candidates"],
                 }
             )
     payload: dict[str, Any] = {
@@ -159,6 +187,32 @@ def _survey_file(tmp_path: Path, workbooks: list[dict[str, Any]], **extra: Any) 
         **extra,
     }
     path = tmp_path / "estate_survey.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+# `build_survey()` alone returns these four summary keys and nothing else - verified against engine
+# 2.126.0. `survey_site()` is what adds `degraded`, `listing_errors`, `connection_read_errors` and
+# `summary.dependencies_unknown` on top.
+_OFFLINE_SUMMARY_KEYS = frozenset(
+    {"workbooks_total", "workbooks_with_published_dependency", "required_datasources", "unresolved_dependencies"}
+)
+
+
+def _offline_survey(tmp_path: Path, workbooks: list[dict[str, Any]], **extra: Any) -> Path:
+    """A survey as `build_survey()` writes it WITHOUT `survey_site()` - i.e. no error bookkeeping.
+
+    This is not a hypothetical: `build_survey` is the no-network assembly entry point, and every
+    survey written before engine 2.117.0 (2026-08-10) has this shape too. It is also the only shape
+    in which the per-workbook `dependencies_unknown` flag is the SOLE evidence that a workbook went
+    unread - which is exactly why a fixture must be able to produce it. A fixture that stamps
+    `summary.dependencies_unknown` supplies the very signal the test claims to be testing.
+    """
+    payload = json.loads(_survey_file(tmp_path, workbooks, **extra).read_text("utf-8"))
+    for key in ("degraded", "listing_errors", "connection_read_errors"):
+        payload.pop(key, None)
+    payload["summary"] = {k: v for k, v in payload["summary"].items() if k in _OFFLINE_SUMMARY_KEYS}
+    path = tmp_path / "offline_survey.json"
     path.write_text(json.dumps(payload), encoding="utf-8")
     return path
 
@@ -388,13 +442,26 @@ def test_an_incomplete_survey_withholds_the_stronger_claim(tmp_path: Path, caplo
 
 
 def test_an_unresolved_dependency_also_counts_as_a_gap(tmp_path: Path) -> None:
-    """A dependency the survey could not resolve leaves a hole in the graph; say so."""
-    workbook = _survey_workbook(REVENUE_WB, [(SALES_DS, None)])
-    workbook["published_dependencies"][0]["status"] = "ambiguous"
-    survey = load_survey(_survey_file(tmp_path, [workbook]))
+    """A dependency the survey could not resolve leaves a hole in the graph; say so.
+
+    This is the PARSED direction on its own: the declared list is emptied, so only the workbook row
+    carries the evidence. The declared direction has its own test below - the two must not be able
+    to cover for each other, because a listing failure is exactly when they disagree.
+    """
+    workbook = _survey_workbook(REVENUE_WB, [(SALES_DS, "")])
+    survey = load_survey(
+        _survey_file(
+            tmp_path,
+            [workbook],
+            unresolved_dependencies=[],
+            summary={"workbooks_total": 1, "unresolved_dependencies": 0, "degraded": False},
+        )
+    )
 
     assert not survey.complete
-    assert "did not resolve" in " ".join(survey.gaps)
+    assert [gap for gap in survey.gaps if "resolve" in gap] == [
+        "1 dependency(ies) did not resolve to a published data source"
+    ]
 
 
 # --- the survey's OWN completeness signals -------------------------------------------------------
@@ -467,14 +534,37 @@ def test_a_survey_listing_no_workbooks_at_all_is_evidence_of_nothing(
 def test_a_workbook_with_unknown_dependencies_is_a_gap_with_no_error_list_present(tmp_path: Path) -> None:
     """`build_survey` marks the row; only `survey_site` adds the error list. Read the row too.
 
-    A survey assembled by `build_survey()` alone carries `dependencies_unknown` per workbook and
-    none of `survey_site`'s bookkeeping, and "unknown" is the opposite of "none" - which is the
-    engine's own stated reason for the flag.
+    The fixture here is `build_survey()`'s output with NONE of `survey_site`'s bookkeeping - no
+    `connection_read_errors`, no `summary.dependencies_unknown` - so the per-workbook flag is the
+    only evidence in the file. That matters: with the summary counter present the scan is never the
+    sole signal, and deleting it leaves the suite green (measured). "Unknown" is the opposite of
+    "none", which is the engine's own stated reason for the flag.
+    """
+    survey = load_survey(
+        _offline_survey(
+            tmp_path,
+            [_survey_workbook(REVENUE_WB, [(SALES_DS, None)]), _survey_workbook("Unreadable", [], unknown=True)],
+        )
+    )
+
+    assert "dependencies_unknown" not in json.loads(survey.path.read_text("utf-8"))["summary"]
+    assert not survey.complete
+    assert "1 workbook connection(s) could not be read" in " ".join(survey.gaps)
+
+
+def test_the_summary_counter_is_read_even_when_no_workbook_row_carries_the_flag(tmp_path: Path) -> None:
+    """The mirror of the test above: the SUMMARY on its own, with clean rows.
+
+    `survey_site` computes `summary.dependencies_unknown` from the LUIDs whose connections it could
+    not read, while the per-row flag is stamped by `build_survey` - so the two can disagree exactly
+    when it matters, e.g. when the listing that would have carried the row failed as well. Each
+    source needs a test in which it is the only evidence, or one of them can quietly stop counting.
     """
     survey = load_survey(
         _survey_file(
             tmp_path,
-            [_survey_workbook(REVENUE_WB, [(SALES_DS, None)]), _survey_workbook("Unreadable", [], unknown=True)],
+            [_survey_workbook(REVENUE_WB, [(SALES_DS, None)])],
+            summary={"workbooks_total": 1, "dependencies_unknown": 1, "degraded": False},
         )
     )
 
@@ -485,11 +575,15 @@ def test_a_workbook_with_unknown_dependencies_is_a_gap_with_no_error_list_presen
 def test_a_survey_carrying_no_degraded_flag_cannot_claim_it_saw_the_estate(tmp_path: Path) -> None:
     """Completeness needs positive evidence; the absence of the flag is not it.
 
-    Every survey the canonical engine writes carries `degraded` (`main()` dumps `survey_site`'s
-    dict whole). A JSON without it is either older than the flag or not the engine's - and neither
-    can license the strongest claim this tool makes. Measured on the 2026-08-13 operator run whose
-    artifact is still on disk: that survey has no `degraded` and no `listing_errors` key at all, so
-    the pre-fix code was reading two fields out of a file that could not have contained the others.
+    Every survey the canonical engine writes today carries `degraded` (`main()` dumps
+    `survey_site`'s dict whole). A JSON without it is either older than the flag or not the
+    engine's - and neither can license the strongest claim this tool makes.
+
+    Measured on the three survey artifacts on this machine: the 2026-08-13 operator run carries
+    `degraded: false`, empty error lists and 38/38 workbooks, and is classified COMPLETE - a
+    healthy survey is unaffected by this gate. The two older dry-run artifacts (2026-08-12 and
+    2026-08-11) carry no `degraded` and no `listing_errors` key at all, so the pre-fix code was
+    reading two fields out of files that could not have contained the others.
     """
     payload = json.loads(_survey_file(tmp_path, [_survey_workbook(REVENUE_WB, [(SALES_DS, None)])]).read_text("utf-8"))
     del payload["degraded"]
@@ -500,6 +594,37 @@ def test_a_survey_carrying_no_degraded_flag_cannot_claim_it_saw_the_estate(tmp_p
 
     assert not survey.complete
     assert "no 'degraded' flag" in " ".join(survey.gaps)
+
+
+def test_an_otherwise_clean_survey_with_no_flag_is_told_the_likely_cause(tmp_path: Path) -> None:
+    """Name the cheap explanation instead of sending an operator after a phantom failure.
+
+    `degraded` and `listing_errors` arrived in engine 2.117.0 (upstream commit 72f983a8,
+    2026-08-10), so every survey this repo took before that date now reads INCOMPLETE. The gate
+    stays exactly as strict - a pre-2.117.0 survey that lost a listing call is genuinely
+    indistinguishable from a healthy one, which is why the flag was added - but the remedy it
+    prints ("re-run estate_survey.py") needs live Tableau credentials, so an operator who cannot
+    get them deserves to know the likely reason before spending the afternoon on it.
+    """
+    survey = load_survey(_offline_survey(tmp_path, [_survey_workbook(REVENUE_WB, [(SALES_DS, None)])]))
+    gaps = " ".join(survey.gaps)
+
+    assert not survey.complete
+    assert "predates engine 2.117.0 (2026-08-10)" in gaps
+
+
+def test_the_version_hint_is_withheld_when_the_survey_shows_a_REAL_failure(tmp_path: Path) -> None:
+    """An old survey that ALSO lost a listing call is not merely old; do not explain it away."""
+    survey = load_survey(
+        _offline_survey(
+            tmp_path,
+            [_survey_workbook(REVENUE_WB, [(SALES_DS, None)]), _survey_workbook("Unreadable", [], unknown=True)],
+        )
+    )
+    gaps = " ".join(survey.gaps)
+
+    assert "no 'degraded' flag" in gaps
+    assert "predates engine" not in gaps
 
 
 def test_a_workbook_list_shorter_than_the_surveys_own_count_is_a_gap(tmp_path: Path) -> None:
@@ -530,6 +655,24 @@ def test_one_failure_recorded_three_ways_is_reported_once(tmp_path: Path) -> Non
 
     unread = [gap for gap in survey.gaps if "could not be read" in gap]
     assert unread == ["1 workbook connection(s) could not be read"]
+
+
+def test_an_incomplete_survey_says_so_even_when_there_is_nothing_to_warn_about(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The gaps have to REACH the operator, not merely exist on the object.
+
+    With no orphan data sources there is no UNCONFIRMED heading to soften, so the header's
+    'SURVEY IS INCOMPLETE' line is the only place the gaps are printed at all. Silencing it left
+    the whole suite green (measured), which means every other completeness test was asserting on
+    `survey.gaps` rather than on what an operator actually reads.
+    """
+    datasources = [_metadata(SALES_DS, downstream=[REVENUE_WB])]
+    survey = load_survey(_survey_file(tmp_path, [_survey_workbook(REVENUE_WB, [(SALES_DS, None)])], degraded=True))
+    output = _rendered(caplog, build_plan(datasources, "", survey), survey)
+
+    assert "UNCONFIRMED" not in output
+    assert "SURVEY IS INCOMPLETE: the survey reports itself DEGRADED" in output
 
 
 def test_an_incomplete_survey_still_contributes_every_edge_it_did_see(
@@ -638,7 +781,8 @@ def test_a_declared_unresolved_dependency_is_a_gap_even_when_every_row_resolved(
     `survey_site` records an unresolvable dependency in `unresolved_dependencies` as well as on the
     row, and the two can disagree - a row can be missing entirely when the listing that would have
     carried it failed. Reading only the rows would then miss a hole the survey is explicitly
-    declaring.
+    declaring. They are counted as ONE failure, not two: on a listing failure both carry the same
+    38 dependencies, and printing them under two different sentences reads as 76.
     """
     survey = load_survey(
         _survey_file(
@@ -651,22 +795,37 @@ def test_a_declared_unresolved_dependency_is_a_gap_even_when_every_row_resolved(
     )
 
     assert not survey.complete
-    assert "1 declared dependency(ies) resolved to no data source" in " ".join(survey.gaps)
+    assert [gap for gap in survey.gaps if "resolve" in gap] == [
+        "1 dependency(ies) did not resolve to a published data source"
+    ]
+
+
+def test_one_unresolved_dependency_declared_and_parsed_is_reported_once(tmp_path: Path) -> None:
+    """The same hole seen from both sides is one hole. `_count`'s contract says ONCE."""
+    survey = load_survey(_survey_file(tmp_path, [_survey_workbook(REVENUE_WB, [(SALES_DS, "")])]))
+
+    assert [gap for gap in survey.gaps if "resolve" in gap] == [
+        "1 dependency(ies) did not resolve to a published data source"
+    ]
 
 
 def test_a_survey_listing_one_name_under_two_identities_is_flagged_too(tmp_path: Path) -> None:
     """The collision can arrive from the SURVEY side, not just the Metadata API's.
 
-    Two rows naming 'Quarterly Figures' with different LUIDs/projects collapse into one key here,
-    so both workbooks look like consumers of one data source. Same decision as the other direction:
-    keep the merged edges (the order stays safe) and say plainly that the attribution is not known.
+    This is the shape `resolve_dependency` ACTUALLY emits for a duplicated name: `status:
+    "ambiguous"`, `luid: ""`, `project: ""` and a `candidates` list naming both data sources. It
+    "NEVER picks one", so neither identity field carries the evidence - only `candidates` does, and
+    a fixture that hands over two populated LUIDs instead is testing a shape the engine cannot
+    produce. Here the Metadata API lists ONE row for the name, so `len(rows) >= 2` cannot fire
+    either: without reading `candidates` the merge happens with nothing printed.
     """
+    both = {SHARED_DS: [("luid-finance", "Finance"), ("luid-marketing", "Marketing")]}
     survey = load_survey(
         _survey_file(
             tmp_path,
             [
-                _survey_workbook(FINANCE_WB, [(SHARED_DS, "luid-finance")], project="Finance"),
-                _survey_workbook(MARKETING_WB, [(SHARED_DS, "luid-marketing")], project="Marketing"),
+                _survey_workbook(FINANCE_WB, [(SHARED_DS, "")], candidates=both),
+                _survey_workbook(MARKETING_WB, [(SHARED_DS, "")], candidates=both),
             ],
         )
     )
@@ -675,10 +834,42 @@ def test_a_survey_listing_one_name_under_two_identities_is_flagged_too(tmp_path:
     assert entry.ambiguous
     assert entry.projects == {"Finance", "Marketing"}
     assert entry.luids == {"luid-finance", "luid-marketing"}
+    # Evidence only: the survey could not choose, so neither does this. A row with no LUID is
+    # skipped by the download step instead of fetching whichever candidate was listed first.
+    assert (entry.luid, entry.project) == (None, None)
 
     plan = build_plan([_metadata(SHARED_DS, luid="luid-finance", project="Finance")], "", survey)
     assert plan[0]["downstream_workbooks"] == [FINANCE_WB, MARKETING_WB]
     assert plan[0]["name_collision"] == ["Finance", "Marketing"]
+
+
+def test_a_collision_the_metadata_api_cannot_see_at_all_is_still_reported(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The silent-merge hole: no Metadata API row for the name, ambiguous survey dependencies.
+
+    A `sqlproxy` data source can be invisible to the Metadata API entirely - that IS issue #126 -
+    so the row is survey-only and `len(rows) >= 2` never fires. The merge is still the right call
+    (it over-migrates rather than orphans), but it is the one decision that must never be made
+    quietly, so the survey-only row is checked for the collision too.
+    """
+    both = {SHARED_DS: [("luid-finance", "Finance"), ("luid-marketing", "Marketing")]}
+    survey = load_survey(
+        _survey_file(
+            tmp_path,
+            [
+                _survey_workbook(FINANCE_WB, [(SHARED_DS, "")], candidates=both),
+                _survey_workbook(MARKETING_WB, [(SHARED_DS, "")], candidates=both),
+            ],
+        )
+    )
+    plan = build_plan([], "", survey)
+    output = _rendered(caplog, plan, survey)
+
+    assert [entry["matched_via"] for entry in plan] == ["survey-only"]
+    assert plan[0]["name_collision"] == ["Finance", "Marketing"]
+    assert "NAME COLLISION" in output
+    assert f"{SHARED_DS!r} exists in 2 project(s) (Finance, Marketing)" in output
 
 
 def test_a_unique_name_reports_no_collision(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:

--- a/tests/test_tableau_lineage.py
+++ b/tests/test_tableau_lineage.py
@@ -1,0 +1,388 @@
+"""Tests for scripts/tableau_lineage.py - the model-first migration ORDER.
+
+Issue #126: step 1 of the documented pipeline (`estate_survey.py`, REST) proved that 10 workbooks
+hard-depend on published data sources, and minutes later step 3 (`tableau_lineage.py --plan`,
+Metadata API) listed those same certified sources as having no downstream workbooks and said they
+"may be abandoned". Acting on that at a customer decision point means migrating consumers before
+their data sources, which rebuilds them as EMPTY REPORTS - the exact failure the model-first order
+exists to prevent.
+
+Root cause: the Metadata API is structurally blind to `sqlproxy` connections (a workbook embedding a
+published data source), and the script had no way to be told otherwise - no `--survey` flag existed.
+
+So these tests gate three separate things, because fixing only the first would leave the tool wrong
+in a different way:
+
+1. **Merge + precedence** - a survey edge promotes a data source the Metadata API called an orphan
+   into phase 1, and a Metadata-API-only edge is never silently dropped in the other direction.
+2. **Attribution** - the printed plan says which system made which claim, and states the precedence
+   rule, so an operator reading it can tell.
+3. **Wording** - without a survey the tool must not use the word "abandoned" at all; it can only
+   support "no downstream usage visible to the Metadata API". The stronger claim needs a COMPLETE
+   survey that also found no consumer.
+
+All fixtures use synthetic names on purpose: this is a public repo.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+# ruff: noqa: E402  (the sys.path insert above must precede these imports)
+from tableau_lineage import build_order, build_plan, load_survey, main, print_plan
+
+SALES_DS = "Lakeside Sales (Live Warehouse)"
+TRIPS_DS = "Lakeside Trips (Live Lakehouse)"
+UNUSED_DS = "Retired Pilot Extract"
+REVENUE_WB = "Regional Revenue"
+SEGMENTS_WB = "Customer Segments"
+TRIPS_WB = "Trip Economics"
+ADMIN_DS = "Site Usage"
+ADMIN_WB = "Usage Starter"
+
+
+def _metadata(name: str, downstream: list[str] | None = None, luid: str | None = None) -> dict[str, Any]:
+    """One `publishedDatasources` node as the Metadata API returns it."""
+    return {
+        "id": luid or f"id-{name}",
+        "luid": luid or f"luid-{name}",
+        "name": name,
+        "projectName": "Certified Sources",
+        "hasExtracts": False,
+        "downstreamWorkbooks": [{"luid": f"wb-{w}", "name": w, "projectName": "Reports"} for w in downstream or []],
+    }
+
+
+def _survey_workbook(name: str, dependencies: list[tuple[str, str | None]]) -> dict[str, Any]:
+    """One workbook entry as `estate_survey.py --json` writes it."""
+    return {
+        "name": name,
+        "luid": f"wb-{name}",
+        "project": "Reports",
+        "published_dependencies": [
+            {
+                "datasource_name": ds_name,
+                "status": "resolved",
+                "luid": luid or f"luid-{ds_name}",
+                "project": "Certified Sources",
+            }
+            for ds_name, luid in dependencies
+        ],
+        "complexity_understated": bool(dependencies),
+    }
+
+
+def _survey_file(tmp_path: Path, workbooks: list[dict[str, Any]], **extra: Any) -> Path:
+    """Write an `estate_survey.json` and return its path."""
+    required = sorted(
+        {dep["datasource_name"] for wb in workbooks for dep in wb["published_dependencies"]},
+    )
+    payload = {
+        "workbooks": workbooks,
+        "required_datasources": [
+            {"datasource_name": name, "luid": f"luid-{name}", "project": "Certified Sources"} for name in required
+        ],
+        "unresolved_dependencies": [],
+        "fetch_order": [],
+        "summary": {"workbooks_total": len(workbooks)},
+        "connection_read_errors": [],
+        **extra,
+    }
+    path = tmp_path / "estate_survey.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _sqlproxy_estate(tmp_path: Path) -> tuple[list[dict[str, Any]], Path]:
+    """The shape of issue #126: the Metadata API sees NONE of the sqlproxy edges the survey saw."""
+    datasources = [
+        _metadata(SALES_DS),
+        _metadata(TRIPS_DS),
+        _metadata(UNUSED_DS),
+        _metadata(ADMIN_DS, downstream=[ADMIN_WB]),
+    ]
+    survey = _survey_file(
+        tmp_path,
+        [
+            _survey_workbook(REVENUE_WB, [(SALES_DS, None)]),
+            _survey_workbook(SEGMENTS_WB, [(SALES_DS, None)]),
+            _survey_workbook(TRIPS_WB, [(TRIPS_DS, None)]),
+            _survey_workbook(ADMIN_WB, [(ADMIN_DS, None)]),
+            _survey_workbook("Embedded Only", []),
+        ],
+    )
+    return datasources, survey
+
+
+def _by_name(plan: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    return {entry["name"]: entry for entry in plan}
+
+
+def _rendered(caplog: pytest.LogCaptureFixture, plan: list[dict[str, Any]], survey: Any = None) -> str:
+    """Capture exactly what an operator reads on stdout."""
+    caplog.clear()
+    with caplog.at_level(logging.INFO, logger="tableau_lineage"):
+        print_plan(plan, survey)
+    return "\n".join(record.getMessage() for record in caplog.records)
+
+
+def test_survey_promotes_a_metadata_api_orphan_into_phase_1(tmp_path: Path) -> None:
+    """The defect itself: a hard dependency the Metadata API reports as having no consumers.
+
+    Both consumers come from the survey, so the plan must show 2 - not 0 - and the data source must
+    appear in phase 1, ahead of the workbooks that bind to it.
+    """
+    datasources, survey_path = _sqlproxy_estate(tmp_path)
+    plan = build_plan(datasources, "", load_survey(survey_path))
+    sales = _by_name(plan)[SALES_DS]
+
+    assert sales["downstream_count"] == 2
+    assert sales["downstream_workbooks"] == [SEGMENTS_WB, REVENUE_WB]
+    assert sales["metadata_count"] == 0
+    assert sales["evidence"] == "survey"
+    assert [step["name"] for step in build_order(plan) if step["kind"] == "datasource"][:1] == [SALES_DS]
+
+
+def test_without_a_survey_the_same_estate_still_reports_the_orphans(tmp_path: Path) -> None:
+    """The degraded path must stay HONEST, not silently wrong: the edges are simply not visible."""
+    datasources, _ = _sqlproxy_estate(tmp_path)
+    plan = build_plan(datasources, "")
+    assert _by_name(plan)[SALES_DS]["downstream_count"] == 0
+    assert _by_name(plan)[SALES_DS]["evidence"] == "none"
+    assert _by_name(plan)[ADMIN_DS]["evidence"] == "metadata-api"
+
+
+def test_survey_only_datasource_absent_from_the_metadata_api_is_still_planned(tmp_path: Path) -> None:
+    """A data source the Metadata API never listed must not fall out of the plan.
+
+    A required data source missing from the sequence is how its consumer gets rebuilt first - the
+    empty-report failure this script exists to prevent - so absence from one source cannot delete it.
+    """
+    survey_path = _survey_file(tmp_path, [_survey_workbook(REVENUE_WB, [(SALES_DS, None)])])
+    plan = build_plan([_metadata(ADMIN_DS, downstream=[ADMIN_WB])], "", load_survey(survey_path))
+
+    sales = _by_name(plan)[SALES_DS]
+    assert sales["downstream_workbooks"] == [REVENUE_WB]
+    assert sales["luid"] == f"luid-{SALES_DS}"
+    assert sales["project"] == "Certified Sources"
+
+
+def test_a_metadata_only_edge_is_kept_never_dropped(tmp_path: Path) -> None:
+    """Precedence settles the CLAIM; it does not license DELETING an edge.
+
+    The survey wins where the two disagree, but "wins" must not mean discarding a consumer only the
+    Metadata API saw - that is the same defect pointing the other way, and it would drop a real
+    dependency from the order.
+    """
+    datasources = [_metadata(SALES_DS, downstream=[SEGMENTS_WB])]
+    survey_path = _survey_file(tmp_path, [_survey_workbook(REVENUE_WB, [(SALES_DS, None)])])
+    sales = _by_name(build_plan(datasources, "", load_survey(survey_path)))[SALES_DS]
+
+    assert sales["downstream_workbooks"] == [SEGMENTS_WB, REVENUE_WB]
+    assert sales["metadata_only"] == [SEGMENTS_WB]
+    assert sales["survey_only"] == [REVENUE_WB]
+    assert sales["edge_origin"] == {SEGMENTS_WB: "metadata-api", REVENUE_WB: "survey"}
+
+
+def test_an_edge_both_sources_saw_is_labelled_both(tmp_path: Path) -> None:
+    """Agreement has to be visible too, or 'survey' would look like the only trustworthy label."""
+    datasources = [_metadata(ADMIN_DS, downstream=[ADMIN_WB])]
+    survey_path = _survey_file(tmp_path, [_survey_workbook(ADMIN_WB, [(ADMIN_DS, None)])])
+    admin = _by_name(build_plan(datasources, "", load_survey(survey_path)))[ADMIN_DS]
+
+    assert admin["evidence"] == "both"
+    assert admin["edge_origin"] == {ADMIN_WB: "both"}
+    assert not admin["survey_only"] and not admin["metadata_only"]
+
+
+def test_a_renamed_datasource_is_matched_by_luid(tmp_path: Path) -> None:
+    """Matching by name alone would double-count a data source renamed since the survey ran."""
+    datasources = [_metadata("Lakeside Sales (renamed)", luid=f"luid-{SALES_DS}")]
+    survey_path = _survey_file(tmp_path, [_survey_workbook(REVENUE_WB, [(SALES_DS, None)])])
+    plan = build_plan(datasources, "", load_survey(survey_path))
+
+    assert len(plan) == 1
+    assert plan[0]["downstream_workbooks"] == [REVENUE_WB]
+
+
+def test_migration_order_places_every_datasource_before_its_consumers(tmp_path: Path) -> None:
+    """The ordering guarantee, asserted on the emitted sequence rather than on two phase headings."""
+    datasources, survey_path = _sqlproxy_estate(tmp_path)
+    plan = build_plan(datasources, "", load_survey(survey_path))
+    order = build_order(plan)
+    position = {(step["kind"], step["name"]): i for i, step in enumerate(order)}
+
+    for entry in plan:
+        for workbook in entry["downstream_workbooks"]:
+            assert position[("datasource", entry["name"])] < position[("workbook", workbook)], (
+                f"{entry['name']} must be migrated before {workbook}"
+            )
+    assert ("workbook", REVENUE_WB) in position
+    assert ("datasource", UNUSED_DS) not in position
+
+
+def test_the_printed_plan_states_the_precedence_rule_and_attributes_each_edge(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """An operator must be able to see WHICH source produced WHICH claim, without re-running it."""
+    datasources, survey_path = _sqlproxy_estate(tmp_path)
+    survey = load_survey(survey_path)
+    output = _rendered(caplog, build_plan(datasources, "", survey), survey)
+
+    assert "PRECEDENCE: where the survey and the Metadata API disagree, the SURVEY WINS" in output
+    assert "SOURCES: Metadata API (GraphQL) + survey" in output
+    assert "DISAGREEMENTS" in output
+    assert f"{SALES_DS}: Metadata API saw 0 consumer(s), survey saw 2" in output
+    assert f"-> {REVENUE_WB:<44} [survey]" in output
+    assert f"-> {ADMIN_WB:<44} [both]" in output
+
+
+def test_the_precedence_rule_is_stated_even_when_the_two_sources_agree(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The rule is what tells a reader how to weigh the plan, so it cannot depend on a conflict.
+
+    An estate where nothing disagrees today still needs the rule printed, otherwise the only place
+    it appears is the disagreement block that this estate does not have.
+    """
+    datasources = [_metadata(ADMIN_DS, downstream=[ADMIN_WB])]
+    survey = load_survey(_survey_file(tmp_path, [_survey_workbook(ADMIN_WB, [(ADMIN_DS, None)])]))
+    output = _rendered(caplog, build_plan(datasources, "", survey), survey)
+
+    assert "PRECEDENCE: where the survey and the Metadata API disagree, the SURVEY WINS" in output
+    assert "agree on every data source" in output
+    assert "DISAGREEMENTS" not in output
+
+
+def test_headline_counts_come_from_the_merged_graph(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """The summary line is what gets quoted at a decision point, so it must reflect the merge."""
+    datasources, survey_path = _sqlproxy_estate(tmp_path)
+    survey = load_survey(survey_path)
+    output = _rendered(caplog, build_plan(datasources, "", survey), survey)
+
+    assert "3 published data source(s) feed 4 workbook(s). 1 are SHARED by more than one workbook." in output
+    assert "the Metadata API alone saw 1 data source(s) feeding 1 workbook(s); the survey raised that to 3 and 4."
+
+
+def test_without_a_survey_the_output_never_says_abandoned(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """The wording guard. Without a survey the tool cannot support the word at all.
+
+    The Metadata API's silence about a data source is not a statement about usage, because it cannot
+    see sqlproxy connections in the first place. The claim it CAN support is the weaker one.
+    """
+    datasources, _ = _sqlproxy_estate(tmp_path)
+    output = _rendered(caplog, build_plan(datasources, ""))
+
+    assert "abandon" not in output.lower()
+    assert "no downstream usage VISIBLE TO THE METADATA API" in output
+    assert "NO --survey WAS SUPPLIED" in output
+    assert "python scripts/tableau_lineage.py --plan --survey" in output
+
+
+def test_with_a_complete_survey_a_genuine_orphan_may_be_called_abandoned(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """With both sources agreeing there is no consumer, the stronger claim IS supported."""
+    datasources, survey_path = _sqlproxy_estate(tmp_path)
+    survey = load_survey(survey_path)
+    output = _rendered(caplog, build_plan(datasources, "", survey), survey)
+
+    assert "NO downstream workbooks in EITHER source" in output
+    assert "these may be abandoned" in output
+    orphans = output.split("EITHER source")[1]
+    assert UNUSED_DS in orphans
+    assert SALES_DS not in orphans
+
+
+def test_an_incomplete_survey_withholds_the_stronger_claim(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """A survey that could not read every workbook cannot prove a data source is unused.
+
+    The workbook whose connections failed to read may be the very consumer, so "abandoned" is
+    withheld and the gap is named instead.
+    """
+    datasources, _ = _sqlproxy_estate(tmp_path)
+    survey_path = _survey_file(
+        tmp_path,
+        [_survey_workbook(REVENUE_WB, [(SALES_DS, None)])],
+        connection_read_errors=[{"workbook": "Unreadable", "error": "403"}],
+    )
+    survey = load_survey(survey_path)
+    output = _rendered(caplog, build_plan(datasources, "", survey), survey)
+
+    assert not survey.complete
+    assert "abandon" not in output.lower()
+    assert "UNCONFIRMED" in output
+    assert "1 workbook connection(s) could not be read" in output
+
+
+def test_an_unresolved_dependency_also_counts_as_a_gap(tmp_path: Path) -> None:
+    """A dependency the survey could not resolve leaves a hole in the graph; say so."""
+    workbook = _survey_workbook(REVENUE_WB, [(SALES_DS, None)])
+    workbook["published_dependencies"][0]["status"] = "ambiguous"
+    survey = load_survey(_survey_file(tmp_path, [workbook]))
+
+    assert not survey.complete
+    assert "did not resolve" in " ".join(survey.gaps)
+
+
+def test_a_survey_whose_schema_moved_raises_instead_of_reporting_no_dependencies(tmp_path: Path) -> None:
+    """Silently parsing zero edges would re-create the defect under a green run.
+
+    "No edges parsed" and "this estate has no dependencies" are indistinguishable downstream, and
+    one of them sequences the migration wrong - so refuse rather than guess.
+    """
+    path = tmp_path / "estate_survey.json"
+    path.write_text(
+        json.dumps({"workbooks": [{"name": REVENUE_WB, "published_dependencies": [{"datasource": SALES_DS}]}]}),
+        encoding="utf-8",
+    )
+    with pytest.raises(RuntimeError, match="schema has changed"):
+        load_survey(path)
+
+
+def test_a_file_that_is_not_a_survey_is_rejected(tmp_path: Path) -> None:
+    """Pointing --survey at the wrong JSON must fail loudly, not plan from an empty graph."""
+    path = tmp_path / "lineage.json"
+    path.write_text(json.dumps({"site": "", "datasources": []}), encoding="utf-8")
+    with pytest.raises(RuntimeError, match="does not look like estate_survey"):
+        load_survey(path)
+
+
+def test_an_estate_with_no_dependencies_at_all_stays_quiet(tmp_path: Path) -> None:
+    """A survey that genuinely found nothing is legal and must not raise."""
+    survey = load_survey(_survey_file(tmp_path, [_survey_workbook("Embedded Only", [])]))
+    assert survey.complete
+    assert build_plan([], "", survey) == []
+
+
+def test_cli_runs_offline_with_from_json_plus_survey(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """End to end through argv, the way the runbook invokes it - no server, no credentials."""
+    datasources, survey_path = _sqlproxy_estate(tmp_path)
+    lineage = tmp_path / "lineage.json"
+    lineage.write_text(json.dumps({"site": "", "datasources": datasources}), encoding="utf-8")
+
+    with caplog.at_level(logging.INFO, logger="tableau_lineage"):
+        exit_code = main(["--plan", "--from-json", str(lineage), "--survey", str(survey_path)])
+    output = "\n".join(record.getMessage() for record in caplog.records)
+
+    assert exit_code == 0
+    assert "SURVEY WINS" in output
+    assert f"-> {REVENUE_WB:<44} [survey]" in output
+
+
+def test_cli_fails_loudly_when_the_survey_cannot_be_read(tmp_path: Path) -> None:
+    """A --survey that will not load must not degrade to the plan the operator asked to avoid."""
+    lineage = tmp_path / "lineage.json"
+    lineage.write_text(json.dumps({"site": "", "datasources": []}), encoding="utf-8")
+    missing = tmp_path / "nope.json"
+
+    assert main(["--plan", "--from-json", str(lineage), "--survey", str(missing)]) == 1

--- a/tests/test_tableau_lineage.py
+++ b/tests/test_tableau_lineage.py
@@ -20,6 +20,16 @@ in a different way:
 3. **Wording** - without a survey the tool must not use the word "abandoned" at all; it can only
    support "no downstream usage visible to the Metadata API". The stronger claim needs a COMPLETE
    survey that also found no consumer.
+4. **Completeness** - "complete" must be read from EVERY signal `estate_survey.py` publishes about
+   itself (`degraded`, `listing_errors`, per-workbook `dependencies_unknown`, an empty or truncated
+   workbook list), not the two that were convenient. A blind review found that a survey with
+   `degraded: true` and a failed site listing - workbooks MISSING from it entirely - still reported
+   `complete`, so the "abandoned" claim came back with MORE authority than issue #126's original
+   ("Both the Metadata API and the survey found no consumer"). The missing workbook is exactly the
+   consumer that would have disproved it.
+5. **Identity** - a LUID is an identity and a name is not. Both matching paths are exercised,
+   because the engine emits `luid: ""` for every dependency it could not resolve, which makes the
+   name fallback the one carrying those edges in production.
 
 All fixtures use synthetic names on purpose: this is a public repo.
 """
@@ -48,22 +58,40 @@ SEGMENTS_WB = "Customer Segments"
 TRIPS_WB = "Trip Economics"
 ADMIN_DS = "Site Usage"
 ADMIN_WB = "Usage Starter"
+SHARED_DS = "Quarterly Figures"
+FINANCE_WB = "Finance Report"
+MARKETING_WB = "Marketing Report"
 
 
-def _metadata(name: str, downstream: list[str] | None = None, luid: str | None = None) -> dict[str, Any]:
+def _metadata(
+    name: str,
+    downstream: list[str] | None = None,
+    luid: str | None = None,
+    project: str = "Certified Sources",
+) -> dict[str, Any]:
     """One `publishedDatasources` node as the Metadata API returns it."""
     return {
         "id": luid or f"id-{name}",
         "luid": luid or f"luid-{name}",
         "name": name,
-        "projectName": "Certified Sources",
+        "projectName": project,
         "hasExtracts": False,
         "downstreamWorkbooks": [{"luid": f"wb-{w}", "name": w, "projectName": "Reports"} for w in downstream or []],
     }
 
 
-def _survey_workbook(name: str, dependencies: list[tuple[str, str | None]]) -> dict[str, Any]:
-    """One workbook entry as `estate_survey.py --json` writes it."""
+def _survey_workbook(
+    name: str,
+    dependencies: list[tuple[str, str | None]],
+    project: str = "Certified Sources",
+    unknown: bool = False,
+) -> dict[str, Any]:
+    """One workbook entry as `estate_survey.py --json` writes it.
+
+    `luid=""` on a dependency is not a synthetic edge case: `resolve_dependency` emits exactly that
+    - together with a non-`resolved` status - for any dependency it could not tie to exactly one
+    data source (AMBIGUOUS / NOT_FOUND), so the two travel together here as well.
+    """
     return {
         "name": name,
         "luid": f"wb-{name}",
@@ -71,30 +99,63 @@ def _survey_workbook(name: str, dependencies: list[tuple[str, str | None]]) -> d
         "published_dependencies": [
             {
                 "datasource_name": ds_name,
-                "status": "resolved",
-                "luid": luid or f"luid-{ds_name}",
-                "project": "Certified Sources",
+                "status": "resolved" if luid is None or luid else "ambiguous",
+                "luid": f"luid-{ds_name}" if luid is None else luid,
+                "project": project,
             }
             for ds_name, luid in dependencies
         ],
-        "complexity_understated": bool(dependencies),
+        # `build_survey` stamps both of these on every workbook row; the fixtures carry them so a
+        # gap check that reads them is exercised against the shape the engine actually writes.
+        "dependencies_unknown": unknown,
+        "complexity_understated": bool(dependencies) or unknown,
     }
 
 
 def _survey_file(tmp_path: Path, workbooks: list[dict[str, Any]], **extra: Any) -> Path:
-    """Write an `estate_survey.json` and return its path."""
-    required = sorted(
-        {dep["datasource_name"] for wb in workbooks for dep in wb["published_dependencies"]},
-    )
-    payload = {
+    """Write an `estate_survey.json` and return its path.
+
+    The defaults mirror a run of `estate_survey.py::survey_site` field for field - including
+    `degraded`, `listing_errors` and the `summary` counters, and including the rule that only a
+    RESOLVED dependency reaches `required_datasources` while every other one is echoed in
+    `unresolved_dependencies`. Fixtures that omitted those are how the degraded-survey hole got
+    through review the first time: a gap check cannot be tested against a flag no fixture ever sets.
+    """
+    deps = [(wb, dep) for wb in workbooks for dep in wb["published_dependencies"]]
+    required: dict[str, dict[str, Any]] = {}
+    unresolved: list[dict[str, Any]] = []
+    for workbook, dep in deps:
+        if dep["status"] == "resolved":
+            required.setdefault(
+                dep["datasource_name"],
+                {"datasource_name": dep["datasource_name"], "luid": dep["luid"], "project": dep["project"]},
+            )
+        else:
+            unresolved.append(
+                {
+                    "workbook": workbook["name"],
+                    "datasource_name": dep["datasource_name"],
+                    "status": dep["status"],
+                    "candidates": [],
+                }
+            )
+    payload: dict[str, Any] = {
         "workbooks": workbooks,
-        "required_datasources": [
-            {"datasource_name": name, "luid": f"luid-{name}", "project": "Certified Sources"} for name in required
-        ],
-        "unresolved_dependencies": [],
+        "required_datasources": [required[name] for name in sorted(required)],
+        "unresolved_dependencies": unresolved,
         "fetch_order": [],
-        "summary": {"workbooks_total": len(workbooks)},
         "connection_read_errors": [],
+        "listing_errors": [],
+        "degraded": False,
+        "summary": {
+            "workbooks_total": len(workbooks),
+            "required_datasources": len(required),
+            "unresolved_dependencies": len(unresolved),
+            "connection_read_errors": 0,
+            "listing_errors": 0,
+            "dependencies_unknown": sum(1 for wb in workbooks if wb.get("dependencies_unknown")),
+            "degraded": False,
+        },
         **extra,
     }
     path = tmp_path / "estate_survey.json"
@@ -270,7 +331,9 @@ def test_headline_counts_come_from_the_merged_graph(tmp_path: Path, caplog: pyte
     output = _rendered(caplog, build_plan(datasources, "", survey), survey)
 
     assert "3 published data source(s) feed 4 workbook(s). 1 are SHARED by more than one workbook." in output
-    assert "the Metadata API alone saw 1 data source(s) feeding 1 workbook(s); the survey raised that to 3 and 4."
+    assert "the Metadata API alone saw 1 data source(s) feeding 1 workbook(s); the survey raised that to 3 and 4." in (
+        output
+    )
 
 
 def test_without_a_survey_the_output_never_says_abandoned(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
@@ -332,6 +395,300 @@ def test_an_unresolved_dependency_also_counts_as_a_gap(tmp_path: Path) -> None:
 
     assert not survey.complete
     assert "did not resolve" in " ".join(survey.gaps)
+
+
+# --- the survey's OWN completeness signals -------------------------------------------------------
+# `estate_survey.py::survey_site` publishes several, and every one of them means the same thing in
+# its own words: this survey "did NOT see the whole estate, so its 'no dependency' answers are not
+# evidence of independence". Reading a subset is how the strong claim came back with MORE authority
+# than issue #126's original, so each signal gets its own test.
+
+
+def test_a_survey_that_reports_itself_degraded_cannot_support_the_abandoned_claim(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """`degraded` is the engine's own verdict on itself, and it is authoritative on its own.
+
+    It is honoured directly rather than re-derived from the error lists: a new failure class added
+    upstream would flip this flag while every list this script knows about stayed empty.
+    """
+    datasources, _ = _sqlproxy_estate(tmp_path)
+    survey_path = _survey_file(
+        tmp_path,
+        [_survey_workbook(REVENUE_WB, [(SALES_DS, None)])],
+        degraded=True,
+    )
+    survey = load_survey(survey_path)
+    output = _rendered(caplog, build_plan(datasources, "", survey), survey)
+
+    assert not survey.complete
+    assert "DEGRADED" in " ".join(survey.gaps)
+    assert "abandon" not in output.lower()
+    assert "UNCONFIRMED" in output
+
+
+def test_a_failed_site_listing_means_workbooks_are_missing_from_the_survey_entirely(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """`listing_errors` is the worst gap of all: the consumer may never have been listed.
+
+    `paged_list` returns the rows it managed to read plus an error, so the survey is a PARTIAL
+    listing - a data source can look consumer-less purely because the page naming its consumer
+    never arrived.
+    """
+    datasources, _ = _sqlproxy_estate(tmp_path)
+    survey_path = _survey_file(
+        tmp_path,
+        [_survey_workbook(REVENUE_WB, [(SALES_DS, None)])],
+        listing_errors=[{"path": "/sites/s/workbooks", "page": 2, "error": "500"}],
+        degraded=True,
+    )
+    survey = load_survey(survey_path)
+    output = _rendered(caplog, build_plan(datasources, "", survey), survey)
+
+    assert not survey.complete
+    assert "MISSING from this survey entirely" in " ".join(survey.gaps)
+    assert "abandon" not in output.lower()
+
+
+def test_a_survey_listing_no_workbooks_at_all_is_evidence_of_nothing(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Zero workbooks means zero consumer edges were OBSERVED, not that none exist."""
+    datasources, _ = _sqlproxy_estate(tmp_path)
+    survey = load_survey(_survey_file(tmp_path, []))
+    output = _rendered(caplog, build_plan(datasources, "", survey), survey)
+
+    assert not survey.complete
+    assert "no workbooks at all" in " ".join(survey.gaps)
+    assert "abandon" not in output.lower()
+
+
+def test_a_workbook_with_unknown_dependencies_is_a_gap_with_no_error_list_present(tmp_path: Path) -> None:
+    """`build_survey` marks the row; only `survey_site` adds the error list. Read the row too.
+
+    A survey assembled by `build_survey()` alone carries `dependencies_unknown` per workbook and
+    none of `survey_site`'s bookkeeping, and "unknown" is the opposite of "none" - which is the
+    engine's own stated reason for the flag.
+    """
+    survey = load_survey(
+        _survey_file(
+            tmp_path,
+            [_survey_workbook(REVENUE_WB, [(SALES_DS, None)]), _survey_workbook("Unreadable", [], unknown=True)],
+        )
+    )
+
+    assert not survey.complete
+    assert "1 workbook connection(s) could not be read" in " ".join(survey.gaps)
+
+
+def test_a_survey_carrying_no_degraded_flag_cannot_claim_it_saw_the_estate(tmp_path: Path) -> None:
+    """Completeness needs positive evidence; the absence of the flag is not it.
+
+    Every survey the canonical engine writes carries `degraded` (`main()` dumps `survey_site`'s
+    dict whole). A JSON without it is either older than the flag or not the engine's - and neither
+    can license the strongest claim this tool makes. Measured on the 2026-08-13 operator run whose
+    artifact is still on disk: that survey has no `degraded` and no `listing_errors` key at all, so
+    the pre-fix code was reading two fields out of a file that could not have contained the others.
+    """
+    payload = json.loads(_survey_file(tmp_path, [_survey_workbook(REVENUE_WB, [(SALES_DS, None)])]).read_text("utf-8"))
+    del payload["degraded"]
+    del payload["summary"]["degraded"]
+    path = tmp_path / "no_flag.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    survey = load_survey(path)
+
+    assert not survey.complete
+    assert "no 'degraded' flag" in " ".join(survey.gaps)
+
+
+def test_a_workbook_list_shorter_than_the_surveys_own_count_is_a_gap(tmp_path: Path) -> None:
+    """A survey that contradicts its own summary was truncated somewhere; do not trust the rows."""
+    workbooks = [_survey_workbook(REVENUE_WB, [(SALES_DS, None)])]
+    survey = load_survey(
+        _survey_file(
+            tmp_path,
+            workbooks,
+            summary={"workbooks_total": 38, "degraded": False},
+        )
+    )
+
+    assert not survey.complete
+    assert "lists 1 of the 38 workbook(s)" in " ".join(survey.gaps)
+
+
+def test_one_failure_recorded_three_ways_is_reported_once(tmp_path: Path) -> None:
+    """`survey_site` records an unread workbook in three places; three gap lines would be noise."""
+    survey = load_survey(
+        _survey_file(
+            tmp_path,
+            [_survey_workbook(REVENUE_WB, [(SALES_DS, None)]), _survey_workbook("Unreadable", [], unknown=True)],
+            connection_read_errors=[{"workbook": "Unreadable", "luid": "wb-Unreadable", "error": "403"}],
+            degraded=True,
+        )
+    )
+
+    unread = [gap for gap in survey.gaps if "could not be read" in gap]
+    assert unread == ["1 workbook connection(s) could not be read"]
+
+
+def test_an_incomplete_survey_still_contributes_every_edge_it_did_see(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Withholding the CLAIM must not mean discarding the EVIDENCE.
+
+    A degraded survey is still the only system that can see a sqlproxy edge, so it must keep
+    promoting a Metadata-API "orphan" into phase 1. Rejecting a degraded survey outright would fix
+    the wording by re-breaking the order - the more expensive half of issue #126.
+    """
+    datasources, _ = _sqlproxy_estate(tmp_path)
+    survey = load_survey(_survey_file(tmp_path, [_survey_workbook(REVENUE_WB, [(SALES_DS, None)])], degraded=True))
+    plan = build_plan(datasources, "", survey)
+    output = _rendered(caplog, plan, survey)
+
+    assert _by_name(plan)[SALES_DS]["downstream_workbooks"] == [REVENUE_WB]
+    assert [step["name"] for step in build_order(plan) if step["kind"] == "datasource"][:1] == [SALES_DS]
+    assert "SURVEY WINS" in output
+
+
+# --- identity: a LUID is one, a name is not ------------------------------------------------------
+
+
+def test_a_dependency_the_survey_could_not_luid_resolve_is_matched_by_name(tmp_path: Path) -> None:
+    """The name fallback is load-bearing, not decorative.
+
+    `resolve_dependency` returns `luid: ""` for every AMBIGUOUS or NOT_FOUND dependency, so on a
+    real site the survey's edges for those data sources carry no LUID at all. Without the fallback
+    they match nothing, the data source drops back to zero consumers, and issue #126 returns.
+    """
+    survey = load_survey(_survey_file(tmp_path, [_survey_workbook(REVENUE_WB, [(SALES_DS, "")])]))
+    assert survey.by_luid == {}
+
+    key, how = survey.match(f"luid-{SALES_DS}", SALES_DS)
+    assert (key, how) == (SALES_DS.lower(), "name")
+
+    plan = build_plan([_metadata(SALES_DS)], "", survey)
+    assert _by_name(plan)[SALES_DS]["downstream_workbooks"] == [REVENUE_WB]
+    assert _by_name(plan)[SALES_DS]["matched_via"] == "name"
+
+
+def test_the_name_fallback_matches_across_a_case_and_whitespace_difference(tmp_path: Path) -> None:
+    """Tableau round-trips display names; a case difference must not orphan a real dependency."""
+    survey = load_survey(_survey_file(tmp_path, [_survey_workbook(REVENUE_WB, [(SALES_DS, "")])]))
+    key, how = survey.match(None, f"  {SALES_DS.upper()}  ")
+
+    assert (key, how) == (SALES_DS.lower(), "name")
+
+
+def test_a_luid_match_beats_a_name_match_and_says_so(tmp_path: Path) -> None:
+    """LUID first, because it is the only identity Tableau guarantees across a rename."""
+    survey = load_survey(_survey_file(tmp_path, [_survey_workbook(REVENUE_WB, [(SALES_DS, None)])]))
+
+    assert survey.match(f"luid-{SALES_DS}", "Renamed Since The Survey") == (SALES_DS.lower(), "luid")
+    assert survey.match("luid-nothing-like-it", "Not A Data Source") == (None, None)
+
+
+# --- a shared name is merged, but never silently -------------------------------------------------
+
+
+def test_two_projects_sharing_a_datasource_name_are_merged_and_flagged(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The merge is kept - it over-migrates rather than orphans - but it is stated, not hidden.
+
+    `estate_survey.py::resolve_dependency` REFUSES this ambiguity because it is deciding an
+    identity. This script is deciding an order, where the safe direction is the opposite one: build
+    both data sources before the workbook. What it must not do is present the per-project
+    attribution as if it were known.
+    """
+    datasources = [
+        _metadata(SHARED_DS, luid="luid-finance", project="Finance"),
+        _metadata(SHARED_DS, luid="luid-marketing", project="Marketing"),
+    ]
+    survey = load_survey(_survey_file(tmp_path, [_survey_workbook(FINANCE_WB, [(SHARED_DS, "")])]))
+    plan = build_plan(datasources, "", survey)
+    output = _rendered(caplog, plan, survey)
+
+    assert [entry["downstream_workbooks"] for entry in plan] == [[FINANCE_WB], [FINANCE_WB]]
+    assert [entry["name_collision"] for entry in plan] == [["Finance", "Marketing"]] * 2
+    assert "NAME COLLISION" in output
+    assert "a name is not an identity" in output
+    assert f"{SHARED_DS!r} exists in 2 project(s) (Finance, Marketing)" in output
+
+
+def test_a_shared_name_still_sequences_both_data_sources_before_the_workbook(tmp_path: Path) -> None:
+    """The over-migrate direction has to actually hold in the emitted order, not just in prose."""
+    datasources = [
+        _metadata(SHARED_DS, luid="luid-finance", project="Finance"),
+        _metadata(SHARED_DS, luid="luid-marketing", project="Marketing"),
+    ]
+    survey = load_survey(_survey_file(tmp_path, [_survey_workbook(FINANCE_WB, [(SHARED_DS, "")])]))
+    order = build_order(build_plan(datasources, "", survey))
+
+    kinds = [step["kind"] for step in order]
+    assert kinds == ["datasource", "datasource", "workbook"]
+    # De-duplicated: two data sources that merely share a name are indistinguishable in a list of
+    # names, so "after: Quarterly Figures, Quarterly Figures" tells the reader nothing actionable.
+    assert order[-1]["requires"] == [SHARED_DS]
+
+
+def test_a_declared_unresolved_dependency_is_a_gap_even_when_every_row_resolved(tmp_path: Path) -> None:
+    """The top-level list is read on its own, not inferred from the workbook rows.
+
+    `survey_site` records an unresolvable dependency in `unresolved_dependencies` as well as on the
+    row, and the two can disagree - a row can be missing entirely when the listing that would have
+    carried it failed. Reading only the rows would then miss a hole the survey is explicitly
+    declaring.
+    """
+    survey = load_survey(
+        _survey_file(
+            tmp_path,
+            [_survey_workbook(REVENUE_WB, [(SALES_DS, None)])],
+            unresolved_dependencies=[
+                {"workbook": "Elsewhere", "datasource_name": "Missing Source", "status": "not_found", "candidates": []}
+            ],
+        )
+    )
+
+    assert not survey.complete
+    assert "1 declared dependency(ies) resolved to no data source" in " ".join(survey.gaps)
+
+
+def test_a_survey_listing_one_name_under_two_identities_is_flagged_too(tmp_path: Path) -> None:
+    """The collision can arrive from the SURVEY side, not just the Metadata API's.
+
+    Two rows naming 'Quarterly Figures' with different LUIDs/projects collapse into one key here,
+    so both workbooks look like consumers of one data source. Same decision as the other direction:
+    keep the merged edges (the order stays safe) and say plainly that the attribution is not known.
+    """
+    survey = load_survey(
+        _survey_file(
+            tmp_path,
+            [
+                _survey_workbook(FINANCE_WB, [(SHARED_DS, "luid-finance")], project="Finance"),
+                _survey_workbook(MARKETING_WB, [(SHARED_DS, "luid-marketing")], project="Marketing"),
+            ],
+        )
+    )
+    entry = survey.datasources[SHARED_DS.lower()]
+
+    assert entry.ambiguous
+    assert entry.projects == {"Finance", "Marketing"}
+    assert entry.luids == {"luid-finance", "luid-marketing"}
+
+    plan = build_plan([_metadata(SHARED_DS, luid="luid-finance", project="Finance")], "", survey)
+    assert plan[0]["downstream_workbooks"] == [FINANCE_WB, MARKETING_WB]
+    assert plan[0]["name_collision"] == ["Finance", "Marketing"]
+
+
+def test_a_unique_name_reports_no_collision(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """The collision block must stay silent on an unambiguous estate, or it is just noise."""
+    datasources, survey_path = _sqlproxy_estate(tmp_path)
+    survey = load_survey(survey_path)
+    plan = build_plan(datasources, "", survey)
+
+    assert all(not entry["name_collision"] for entry in plan)
+    assert "NAME COLLISION" not in _rendered(caplog, plan, survey)
 
 
 def test_a_survey_whose_schema_moved_raises_instead_of_reporting_no_dependencies(tmp_path: Path) -> None:


### PR DESCRIPTION
Fixes #126

## What was wrong

`tableau_lineage.py --plan` and `estate_survey.py` described the same estate in opposite terms,
minutes apart, and there was no flag to reconcile them. The Metadata API is structurally blind to
`sqlproxy` connections (a workbook embedding a published data source), so every certified source the
survey had just proved was a hard dependency came back with zero downstream workbooks — and the
script converted that silence into **"these may be abandoned"**. Acting on it means migrating
consumers before their data sources, i.e. the empty-report failure the model-first order exists to
prevent.

## What changed (one file + its tests)

1. **`--survey <estate_survey.json>`** merges the REST-derived dependency graph into the plan. A data
   source the Metadata API called an orphan is promoted into phase 1 as soon as the survey names one
   consumer; a data source the Metadata API never listed at all is added from the survey, so a
   required fetch cannot fall out of the sequence.
2. **Precedence is printed and applied.** The header states the rule; a `DISAGREEMENTS` block names
   each conflict and how it was resolved; every edge is tagged `[survey]` / `[metadata-api]` /
   `[both]`. "The survey wins" settles the **claim**, not the graph — an edge only the Metadata API
   saw is **kept** and marked, because deleting a real dependency is the same defect pointing the
   other way. A survey that fails to load is fatal (exit 1) rather than a silent downgrade to the
   plan the operator explicitly asked not to have.
3. **The wording now matches the evidence.** Without a survey the tool says *"no downstream usage
   VISIBLE TO THE METADATA API"* and the word "abandoned" does not appear at all (a test greps for
   it). The stronger claim is allowed only when a **complete** survey also found no consumer; a
   survey with unread workbooks or unresolved dependencies prints `UNCONFIRMED` and names its gaps.
4. **Order is emitted as data** (`build_order`) instead of being implied by two phase headings, and
   asserted edge by edge.

## Verified against the real estate from the issue

Offline, from committed artifacts — **no Tableau API calls**. The GraphQL response itself was never
saved, so it was reconstructed from the same run's read-only `estate.db` (17 data sources) with the
only edges the issue reports the Metadata API returning (5 Admin Insights sources → 1 workbook); that
reproduces the issue's numbers exactly (17 / 1 / 0 shared / 12 orphans). The survey half is the real
`estate_survey.json`.

**Before** (master, same input):

```
17 published data source(s) feed 1 workbook(s). 0 are SHARED by more than one workbook.
NOTE: 12 published data source(s) have NO downstream workbooks:
        - <certified source A> ... - <certified source F> ...
      Confirm with the customer before migrating - these may be abandoned.
```

**After, with `--survey`:**

```
11 published data source(s) feed 10 workbook(s). 3 are SHARED by more than one workbook.
         (the Metadata API alone saw 5 data source(s) feeding 1 workbook(s); the survey raised that to 11 and 10.)
...
DISAGREEMENTS - resolved by the precedence rule above (the survey wins):
  - <certified source A>: Metadata API saw 0 consumer(s), survey saw 2 -> SURVEY WINS, 2 edge(s) added: ...
...
          migration ORDER (every data source precedes every workbook that binds to it):
           1. [datasource] ...            12. [workbook]   ... after: <its data source>
...
NOTE: 6 published data source(s) have NO downstream workbooks in EITHER source:
      Both the Metadata API and the survey found no consumer - these may be abandoned.
```

All six falsely-flagged certified sources are now in phase 1; the 6 that remain are exactly those
with no consumer in either source. Phase 1 (11 data sources) equals the survey's own
`required_datasources` (11) — nothing missing — and 10 consumer workbooks are sequenced after them.
An independent check asserted `index(datasource) < index(workbook)` for every edge.

**After, without `--survey`** (degraded but honest — many callers won't pass it):

```
SOURCES: Metadata API (GraphQL) only
NO --survey WAS SUPPLIED, so this plan is the Metadata API's view ALONE, and that view is
known-incomplete: it does not see 'sqlproxy' (published data source) connections. ...
5 published data source(s) feed 1 workbook(s). ...
NOTE: 12 published data source(s) have no downstream usage VISIBLE TO THE METADATA API:
      This is NOT evidence they are unused: ... Re-run with --survey ... before drawing any
      conclusion about usage.
```

Note the headline also stopped saying "17 … feed 1 workbook": it now counts data sources that
actually have a consumer.

## Gates

`ruff format --check scripts tests` 0 · `ruff check scripts tests` 0 · `pylint scripts` 0 (10.00/10)
· `pytest -q` 0 (**1014 passed, 4 skipped**; 19 of them new).

## Mutation testing

Nine deliberate breakages; **all nine caught** (an earlier run left M7 uncaught — the header
precedence note was only covered transitively via the disagreement block — so a test was added and
the mutation re-run):

| # | mutation | caught by |
|---|---|---|
| M1 | precedence dropped, Metadata API wins where it listed the source | `..._metadata_only_edge_is_kept...`, `..._labelled_both`, both precedence-output tests |
| M2 | survey-only data sources omitted from the plan | `..._survey_only_datasource_absent_from_the_metadata_api_is_still_planned` |
| M3 | "survey wins" misread as "survey replaces" (metadata edges dropped) | `..._metadata_only_edge_is_kept_never_dropped` |
| M4 | "may be abandoned" restored on the no-survey path | `..._without_a_survey_the_output_never_says_abandoned` |
| M5 | an incomplete survey treated as complete | `..._incomplete_survey_withholds_the_stronger_claim`, `..._unresolved_dependency_also_counts_as_a_gap` |
| M6 | order inverted (workbooks before data sources) | `..._migration_order_places_every_datasource_before_its_consumers` |
| M7 | precedence rule removed from the header | both precedence-output tests |
| M8 | every edge labelled `both` | three tests incl. the CLI end-to-end |
| M9 | no-survey incompleteness warning removed | `..._without_a_survey_the_output_never_says_abandoned` |

## Scope / notes

- Only `scripts/tableau_lineage.py` and the new `tests/test_tableau_lineage.py` are touched.
  `dedup_key`'s signature is unchanged (`test_repo_layout.py` and `test_parse_tableau.py` import it).
- Issue suggestion 4 (repeating the Metadata-API-blindness warning on step 3 of the runbook) belongs
  to the runbook and is **not** in this PR.
- All test fixtures use synthetic names; no customer or site identifiers were added anywhere.
