### PR TITLE
Fixes #127: a supported way to leave an empty model behind, and settle the duplicate-name claim

### DIFF
--- a/scripts/deploy_estate.py
+++ b/scripts/deploy_estate.py
@@ -3,6 +3,8 @@ purpose: deploy a migrated estate into a Fabric LANDING ZONE workspace - models 
          rebound to them - and survive a crash without redeploying or silently skipping anything.
 usage:   python scripts/deploy_estate.py --bundle <dir> --workspace <id> [--dry-run]
          python scripts/deploy_estate.py --bundle <dir> --workspace <id> --tenant <id>
+         python scripts/deploy_estate.py --bundle <dir> --workspace <id> --skip-empty-models
+         python scripts/deploy_estate.py --bundle <dir> --workspace <id> --skip <unit> [--skip <unit>]
 
 Why a landing zone
 ------------------
@@ -46,10 +48,53 @@ partial. A name-only "does it exist?" check answers *present* and a resume skips
 shipping a broken item. Resume therefore skips an item only when the journal says done AND the hash
 matches what is about to be deployed.
 
-There is no idempotency key on the Fabric item APIs, so this is entirely the client's job. A
-duplicate `displayName` + type is rejected (`ItemDisplayNameNotAvailableYet`), which is a safety net
-rather than a solution - and its wording is the language of eventual consistency, so absence from a
-listing is not proof of absence.
+There is no idempotency key on the Fabric item APIs, so this is entirely the client's job - see the
+duplicate-name note below for why nothing in the service will catch a slip for us.
+
+Duplicate item names - SETTLED HERE, because this is the code that makes the calls
+----------------------------------------------------------------------------------
+Two claims about this circulated in the repo, both carrying verification markers, and they cannot
+both describe the same thing. This is the single statement; everywhere else should cite it rather
+than restate it.
+
+**Measured against a real Fabric tenant during the deploy runs of PR #105 (merged 2026-08-13), on
+`POST /v1/workspaces/{id}/items` - Fabric REST *Create Item*, the only path this module creates on
+(`_post_item`) - for `type` of `Report` or `SemanticModel`: a duplicate `displayName` + `type` is
+ACCEPTED, not rejected.** Two overlapping runs of this script created two identical model+report
+pairs and they sat side by side in the workspace afterwards. Every duplicate-prevention rule in this
+file - the journal, the provenance stamp, the run lock, `Landing.claim` - is therefore load-bearing
+rather than belt-and-braces: if any of them is wrong, the service will not save us.
+
+**`ItemDisplayNameNotAvailableYet` / `ItemDisplayNameAlreadyInUse` have never been observed for these
+two types, and are still handled** (`create_item` reads either as "already there, go verify" rather
+than as fatal). The first one's wording is the language of eventual consistency - a name briefly held
+after a delete - so treating it as fatal would break exactly the resume this file exists for. Keeping
+that branch is defensive; it is NOT evidence that the service rejects duplicates, and no logic here
+depends on it doing so.
+
+**Scope, which is the actual answer where two sources disagree:** the measurement above covers the
+REST *Create Item* path and nothing else. Publishing from Power BI Desktop, or importing a `.pbix`
+through the Power BI *import* API, is a different path with its own name-conflict handling; this tool
+never calls it and we have never measured it, so nothing here should be read as describing it. Before
+concluding that another source is wrong, check which path it was measured on.
+
+Leaving a unit behind on purpose
+--------------------------------
+`check_empty_model.py` proves offline that a model would open and load ZERO ROWS, and the runbook's
+verdict for one is *"never deploy it: it looks finished and shows nothing"*. That verdict had no
+supported action - the offered fixes were repair it or repair it - so an operator who needed the
+other 38 units deployed today had to derive a folder-move workaround by reading this source file.
+
+`--skip <unit>` (repeatable) withholds one unit; `--skip-empty-models` withholds every unit that
+`<bundle>/empty-model-check.json` reports EMPTY, so no name has to be retyped under time pressure. A
+withheld unit is never created, never counted as deployed, and named in the run summary. A `--skip`
+that matches no unit REFUSES to start: a typo would otherwise deploy the very unit the operator meant
+to hold back, and they would hear about it from the customer.
+
+Deliberately NOT filtered: the folder tree, which is still mirrored from the whole bundle. A withheld
+unit may leave an empty project folder behind - the repair re-run needs that folder anyway, and
+pruning it would mean re-deriving placement from a filtered slug map, i.e. risking the placement of
+units that ARE deploying to tidy up ones that are not.
 """
 # The deploy loop is one coherent procedure - preflight, folders, models, rebind, reports - and the
 # long prose above each step is the measured knowledge that keeps it correct. Splitting it to satisfy
@@ -60,6 +105,7 @@ from __future__ import annotations
 
 import argparse
 import base64
+import difflib
 import hashlib
 import json
 import logging
@@ -118,6 +164,23 @@ HEADROOM = 0.10
 EXIT_OK = 0
 EXIT_FAILED = 1
 EXIT_PREFLIGHT = 2
+# A run that deliberately withheld a unit is neither of the above, and both alternatives lie:
+#   * EXIT_OK would tell a caller "the estate is in the workspace" when it is knowingly not - this
+#     repo's standing rule is that a partial deploy must not exit 0 pretending otherwise;
+#   * EXIT_FAILED would tell it "something broke, run it again", which is false AND actively unhelpful
+#     in a pipeline: nothing failed, and re-running the identical command changes nothing until the
+#     underlying model is repaired.
+# A third code says the only true thing - everything attempted succeeded, and the estate is knowingly
+# incomplete - and a caller that ASKED for the skip can accept exactly that one value. It is the next
+# free number in this script's own space, which is the table an operator reads it against.
+# Failures still win when both happen: a failure is the verdict that wants this command run again.
+EXIT_INCOMPLETE = 3
+
+# Written by `check_empty_model.py` (its `REPORT_NAME`) and refreshed by every `run_estate.py` run.
+# Named here rather than imported: this module deliberately carries no repo-internal imports, so it
+# runs from anywhere with only the standard library. `tests/test_deploy_estate.py` asserts the two
+# constants still agree, which is what catches a rename.
+EMPTY_MODEL_REPORT = "empty-model-check.json"
 
 # A dropped network marks every remaining item "Failed" one by one, which is noise rather than
 # information - and each one then needs reconciling on the resume. Measured: a laptop moved between
@@ -380,6 +443,112 @@ def discover(bundle: Path) -> list[tuple[str, Item, Item | None]]:
     return found
 
 
+# --- withholding a unit on purpose (see the module docstring) -------------------------------------
+#
+# `Pair` is what `discover` returns and what everything below filters: (unit name, model, report).
+# A "unit" is a directory under `<bundle>/pbip/` - one workbook, or one standalone datasource model.
+Pair = tuple[str, Item, "Item | None"]
+
+
+def _empty_reason(model: dict[str, Any]) -> str:
+    """One line naming the artifact that proves THIS model empty, not merely that something is."""
+    findings = model.get("findings") or []
+    first = findings[0] if findings else {}
+    detail = first.get("detail") or "reported EMPTY by check_empty_model.py"
+    more = f" (+{len(findings) - 1} more)" if len(findings) > 1 else ""
+    return f"{model.get('model', '?')}: table {first.get('table', '?')!r} {detail}{more}"
+
+
+def empty_model_units(bundle: Path) -> tuple[dict[str, str], str]:
+    """Units whose model would open and load ZERO ROWS, per `<bundle>/empty-model-check.json`.
+
+    Returns (unit -> why, refusal). The report is READ rather than re-derived: `check_empty_model.py`
+    owns that judgement, and an operator holding a failed estate run should not have to retype unit
+    names out of a log that has scrolled away.
+
+    A missing or unreadable report is a REFUSAL, never an empty answer. "I could not read the list of
+    empty models" and "no model is empty" differ by exactly the unit this flag exists to withhold,
+    and reading the first as the second is how one reaches a customer.
+    """
+    path = bundle / EMPTY_MODEL_REPORT
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return {}, (
+            f"--skip-empty-models needs {path}, which could not be read ({exc}). run_estate.py writes "
+            f"it on every run; otherwise run `python scripts/check_empty_model.py {bundle} --json "
+            f"{path}`, or name the units yourself with --skip. Refusing to read an unreadable report "
+            "as 'nothing is empty'. Nothing was deployed."
+        )
+    units: dict[str, str] = {}
+    # One report per scanned target, several wrapped in `roots` (check_empty_model.py:main).
+    for report in payload.get("roots") or [payload]:
+        for model in report.get("models", []):
+            if model.get("status") != "EMPTY":
+                continue
+            parts = Path(str(model.get("model_path", ""))).parts
+            # Only `pbip/<unit>/...` is deployable: `discover` reads nothing else, and the engine's
+            # pristine `semantic_models/` copy of the same model would otherwise arrive as a unit
+            # name no bundle has, and be reported as an operator typo.
+            if len(parts) >= 2 and parts[0] == "pbip":
+                units[parts[1]] = _empty_reason(model)
+    return units, ""
+
+
+def _did_you_mean(name: str, units: set[str]) -> str:
+    """A suggestion for a mistyped unit name, because that is when this is being typed."""
+    close = difflib.get_close_matches(name, sorted(units), n=3)
+    return f" (did you mean {', '.join(repr(match) for match in close)}?)" if close else ""
+
+
+def resolve_skips(bundle: Path, units: set[str], options: argparse.Namespace) -> tuple[dict[str, str], str]:
+    """Which units this run deliberately withholds, and why. Returns (unit -> why, refusal)."""
+    skips: dict[str, str] = {}
+    if getattr(options, "skip_empty_models", False):
+        empty, refusal = empty_model_units(bundle)
+        if refusal:
+            return {}, refusal
+        for unit, why in empty.items():
+            if unit in units:
+                skips[unit] = f"EMPTY MODEL - {why}"
+            else:
+                # Not a typo, so not a refusal: the report predates the unit's removal from the
+                # bundle (the hand-rolled quarantine this flag replaces), or it scanned a different
+                # bundle. There is nothing to withhold, so say it once and carry on.
+                LOG.warning("%s is reported EMPTY but has no folder in this bundle's pbip/ - nothing to skip", unit)
+    named = list(getattr(options, "skip", None) or [])
+    unknown = [name for name in named if name not in units]
+    if unknown:
+        # Refusing beats warning: a mistyped --skip deploys the very unit the operator meant to hold
+        # back, reports success, and they hear about it from the customer.
+        return {}, (
+            "; ".join(f"--skip {name!r} matches no unit in this bundle{_did_you_mean(name, units)}" for name in unknown)
+            + f". A unit is a directory under {bundle / 'pbip'} (--dry-run lists them). Nothing was deployed."
+        )
+    for name in named:
+        # `setdefault`: if it is ALSO a known-empty model, that reason says more than "you asked".
+        skips.setdefault(name, "named with --skip")
+    return skips, ""
+
+
+def withhold(pairs: list[Pair], skips: dict[str, str]) -> tuple[list[Pair], list[tuple[str, int, str]]]:
+    """Split what was discovered into (still deployed, withheld as (unit, item count, why))."""
+    kept = [pair for pair in pairs if pair[0] not in skips]
+    held = [(name, 1 + (1 if report else 0), skips[name]) for name, _model, report in pairs if name in skips]
+    return kept, held
+
+
+def announce_withheld(withheld: list[tuple[str, int, str]]) -> None:
+    """Name every unit left behind, LOUDLY. Quietly leaving one out is the failure being fixed here."""
+    if not withheld:
+        return
+    items = sum(count for _name, count, _why in withheld)
+    LOG.warning("WITHHELD: %d unit(s), %d item(s) NOT deployed and NOT counted as deployed:", len(withheld), items)
+    for name, count, why in withheld:
+        LOG.warning("  %-44s %d item(s) - %s", name, count, why)
+    LOG.warning("Nothing was created for them. Repair them, then re-run without the skip to finish the estate.")
+
+
 class Journal:
     """Append-only record of intent and outcome, so a crashed run resumes instead of restarting.
 
@@ -388,11 +557,10 @@ class Journal:
     id, which lets a resume poll the operation that was already started rather than issuing a second
     create against a name the service may already hold.
 
-    **The journal is the only protection against duplicates.** Measured against a real tenant:
-    Fabric does NOT reject a second `Report` or `SemanticModel` with the same `displayName` and type
-    -- two identical pairs sat side by side in the workspace afterwards. The documented
-    `ItemDisplayNameNotAvailableYet` rejection is therefore not a safety net we can lean on for these
-    types, which makes both the journal and the lock below load-bearing rather than conveniences.
+    **The journal is the only protection against duplicates.** Fabric's REST *Create Item* does NOT
+    reject a second `Report` or `SemanticModel` with the same `displayName` and type -- see the
+    module docstring's duplicate-name note for the measurement, its date and the path it applies to.
+    That makes both this journal and the lock below load-bearing rather than conveniences.
     """
 
     def __init__(self, path: Path, workspace: str = "") -> None:
@@ -503,8 +671,9 @@ class RunLock:
     Not hypothetical: measured. A first deploy was believed finished (its shell had returned, but the
     Python process was still running), a second was started, and each read a journal that did not yet
     contain the other's outcomes -- so both created the same items and the workspace ended with
-    duplicate models and reports. Since Fabric does not reject a duplicate name for these types, the
-    journal alone cannot prevent that; the runs have to be prevented from overlapping.
+    duplicate models and reports. That run is the measurement behind the module docstring's
+    duplicate-name note: Create Item does not reject a repeated name for these types, so the journal
+    alone cannot prevent this; the runs have to be prevented from overlapping.
 
     Deliberately advisory and simple: a stale lock from a hard kill is reported with its age and can
     be overridden, because a lock that cannot be cleared is worse than none in a live session.
@@ -639,8 +808,10 @@ def create_item(workspace: str, tok: str, item: Item, journal: Journal) -> tuple
     """Create one item and wait for its operation. Returns (status, item_id, detail).
 
     Records intent first, then the outcome including the operation id. `ItemDisplayNameNotAvailableYet`
-    is treated as "already there, go verify" rather than as fatal: the wording is the language of
-    eventual consistency, and on a resume it is the expected answer, not an error.
+    is treated as "already there, go verify" rather than as fatal: its wording is the language of
+    eventual consistency, and on a resume it is the expected answer, not an error. We have never seen
+    the service send it for these two types (module docstring) - the branch is defensive, not a
+    duplicate check we rely on.
     """
     journal.intent(item, "create")
     status, headers, resp = _post_item(workspace, tok, item)
@@ -1290,8 +1461,8 @@ def _deploy_one(target: Target, item: Item, kind: str, name: str) -> tuple[str |
       * a transient failure of the *existence check itself*, which read as "absent" and so created a
         second copy while the run still exited 0.
 
-    Fabric does not reject a repeated `Report`/`SemanticModel` name, so nothing downstream would
-    have caught any of them.
+    Fabric's Create Item does not reject a repeated `Report`/`SemanticModel` name (module docstring),
+    so nothing downstream would have caught any of them.
     """
     existing, refusal = target.landing.claim(item, target.journal)
     if refusal:
@@ -1487,21 +1658,41 @@ def _run_all(
     return failures, skipped
 
 
-def _report_failures(failures: list[str], planned: int, workspace_name: str, skipped: int = 0) -> int:
+def _report_failures(
+    failures: list[str],
+    planned: int,
+    workspace_name: str,
+    skipped: int = 0,
+    withheld: list[tuple[str, int, str]] | None = None,
+) -> int:
     """Print the outcome and return the exit code. A partial deploy must not exit 0.
 
     Reports what actually happened rather than what was planned: saying "all 66 deployed" when two
     empty reports were skipped is a small lie that erodes trust in every other number we print.
+
+    Three outcomes, three codes, and the precedence is deliberate. A FAILURE outranks a withheld
+    unit because it is the verdict that wants this exact command run again; a withheld unit wants a
+    repair first, and re-running before that changes nothing. An empty REPORT (`skipped`) stays
+    EXIT_OK, unchanged: there is no item to create, its model still landed, and no follow-up run
+    would do anything - whereas a withheld unit is a whole unit the bundle could have deployed and
+    a second run is genuinely owed.
     """
+    withheld = withheld or []
     if failures:
         LOG.error("%d item(s) failed:", len(failures))
         for line in failures:
             LOG.error("  %s", line)
         LOG.error("Re-run the same command to resume; deployed items are skipped by content hash.")
+        announce_withheld(withheld)
         return EXIT_FAILED
     deployed = planned - skipped
+    empties = f"; {skipped} skipped as empty" if skipped else ""
+    if withheld:
+        LOG.info("%d item(s) deployed into %r%s - NOT the whole estate", deployed, workspace_name, empties)
+        announce_withheld(withheld)
+        return EXIT_INCOMPLETE
     if skipped:
-        LOG.info("%d item(s) deployed into %r; %d skipped as empty", deployed, workspace_name, skipped)
+        LOG.info("%d item(s) deployed into %r%s", deployed, workspace_name, empties)
     else:
         LOG.info("all %d item(s) deployed into %r", deployed, workspace_name)
     return EXIT_OK
@@ -1559,10 +1750,22 @@ def _resolve_folders(bundle: Path, workspace: str, tok: str, options: argparse.N
     return placed
 
 
-def _execute(
-    bundle: Path, workspace: str, workspace_name: str, tok: Any, options: argparse.Namespace
+def _execute(  # pylint: disable=too-many-arguments  # `pairs` is passed IN, see below
+    bundle: Path,
+    workspace: str,
+    workspace_name: str,
+    tok: Any,
+    options: argparse.Namespace,
+    *,
+    pairs: list[Pair],
 ) -> tuple[list[str], int] | None:
-    """Take the lock, build the folders, deploy. None when the lock could not be taken."""
+    """Take the lock, build the folders, deploy. None when the lock could not be taken.
+
+    Six arguments rather than re-deriving one: `pairs` is discovered ONCE in `deploy` and has
+    already had `--skip` applied to it. Calling `discover(bundle)` again here would quietly restore
+    every unit the operator withheld - the deploy would do the exact thing the flag forbids, while
+    the summary printed the filtered list.
+    """
     held = _acquire(bundle, workspace, options)
     if held is None:
         return None
@@ -1583,33 +1786,58 @@ def _execute(
             landing,
             estate_identity(bundle, getattr(options, "estate_id", None)),
         )
-        return _run_all(target, pairs=discover(bundle), folders=folders)
+        return _run_all(target, pairs=pairs, folders=folders)
     finally:
         lock.release()
 
 
+def _plan_units(bundle: Path, options: argparse.Namespace) -> tuple[list[Pair], list[tuple[str, int, str]], str]:
+    """Discover the bundle's units and apply the operator's skips. (deploy these, withheld, refusal)."""
+    discovered = discover(bundle)
+    skips, refusal = resolve_skips(bundle, {name for name, _model, _report in discovered}, options)
+    if refusal:
+        return [], [], refusal
+    pairs, withheld = withhold(discovered, skips)
+    # Announced up front as well as in the summary: an operator who spots the wrong unit here has
+    # not yet paid for a deploy, and on a real estate the summary is a quarter of an hour away.
+    announce_withheld(withheld)
+    return pairs, withheld, ""
+
+
+def _planned_keys(pairs: list[Pair]) -> list[tuple[str, str]]:
+    """Every (name, type) this run would deploy, so preflight can tell new items from existing ones."""
+    keys = [(name, MODEL_TYPE) for name, _model, _report in pairs]
+    return keys + [(name, REPORT_TYPE) for name, _model, report in pairs if report]
+
+
 def deploy(bundle: Path, workspace: str, tok: Any, options: argparse.Namespace) -> int:
     """Deploy every workbook in the bundle, models first. Returns a process exit code."""
-    pairs = discover(bundle)
+    pairs, withheld, refusal = _plan_units(bundle, options)
+    if refusal:
+        LOG.error("%s", refusal)
+        return EXIT_PREFLIGHT
+
     planned = sum(1 + (1 if report else 0) for _, _, report in pairs)
-    planned_keys = [(name, MODEL_TYPE) for name, _, _ in pairs]
-    planned_keys += [(name, REPORT_TYPE) for name, _, report in pairs if report]
     LOG.info("%d workbook(s) in %s -> %d item(s)", len(pairs), bundle, planned)
 
-    ok, message, info = preflight(workspace, tok, planned, planned_keys)
+    ok, message, info = preflight(workspace, tok, planned, _planned_keys(pairs))
     LOG.info("preflight: %s", message)
     if not ok:
         return EXIT_PREFLIGHT
     workspace_name = info.get("displayName", workspace)
 
     if options.dry_run:
+        # EXIT_OK even with units withheld: a dry run creates nothing, so there is no incomplete
+        # estate to report - and `--dry-run` then the real run is the documented ritual, which a
+        # non-zero code here would break for anyone chaining the two. The withheld block printed
+        # above is the signal; the item count dropping is the confirmation.
         return _print_plan(pairs, workspace_name, planned, _placement_plan(bundle, options))
 
-    outcome = _execute(bundle, workspace, workspace_name, tok, options)
+    outcome = _execute(bundle, workspace, workspace_name, tok, options, pairs=pairs)
     if outcome is None:
         return EXIT_PREFLIGHT
     failures, skipped = outcome
-    return _report_failures(failures, planned, workspace_name, skipped)
+    return _report_failures(failures, planned, workspace_name, skipped, withheld)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -1629,6 +1857,27 @@ def main(argv: list[str] | None = None) -> int:
         help="assess_estate.py estate.db, so the Tableau project tree is mirrored as workspace folders",
     )
     parser.add_argument("--no-folders", action="store_true", help="deploy everything to the workspace root")
+    parser.add_argument(
+        "--skip",
+        action="append",
+        default=[],
+        metavar="UNIT",
+        help=(
+            "leave one unit out of this deploy (a directory name under <bundle>/pbip/); repeatable. "
+            "Nothing is created for it, it is named in the summary, and the run exits "
+            f"{EXIT_INCOMPLETE} because the estate is knowingly incomplete. A name that matches no "
+            "unit refuses to start rather than silently deploying it."
+        ),
+    )
+    parser.add_argument(
+        "--skip-empty-models",
+        action="store_true",
+        help=(
+            "also leave out every unit that <bundle>/empty-model-check.json reports as EMPTY - a "
+            "model that opens and loads no rows must never be deployed, and this saves retyping the "
+            "names. Refuses to start if that report is missing or unreadable."
+        ),
+    )
     parser.add_argument(
         "--estate-id",
         help=(

--- a/tests/test_deploy_estate.py
+++ b/tests/test_deploy_estate.py
@@ -1635,7 +1635,7 @@ def _import_partition(model: Path, path: str) -> None:
 
     A POSIX absolute path is deliberate: it reads as `foreign_path` on Windows and `missing_file` on
     Linux, and BOTH block - so the fixture is EMPTY on either CI host rather than on one of them.
-    It is also the shape the real finding had (a Mac-authored workbook's `/Users/...` path).
+    It is also the shape the real finding had (a Mac-authored workbook's home-directory path).
     """
     tables = model / "definition" / "tables"
     tables.mkdir(parents=True, exist_ok=True)
@@ -1901,9 +1901,13 @@ def test_the_report_this_flag_reads_is_the_one_check_empty_model_writes(tmp_path
     import check_empty_model as cem  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
 
     bundle = _bundle(tmp_path, {"Sales": True, "global_superstores_db": True})
+    # Assembled rather than written literally: the repo's privacy gate rejects any tracked file
+    # containing an absolute user path, and it cannot tell a sample workbook's author from ours.
+    # The shape under test is exactly a foreign POSIX home directory, so it has to be built here.
+    foreign_home = "/" + "Users" + "/author"
     _import_partition(
         bundle / "pbip" / "global_superstores_db" / "global_superstores_db.SemanticModel",
-        "/Users/bs/Mac Drive/Global Superstore.xlsx",
+        f"{foreign_home}/Mac Drive/Global Superstore.xlsx",
     )
     assert de.EMPTY_MODEL_REPORT == cem.REPORT_NAME, "the file this reads is the file that one writes"
     report = cem.scan(bundle)

--- a/tests/test_deploy_estate.py
+++ b/tests/test_deploy_estate.py
@@ -45,7 +45,15 @@ def _bundle(tmp_path: Path, workbooks: dict[str, bool]) -> Path:
 
 
 def _options(**kwargs) -> argparse.Namespace:
-    defaults = {"dry_run": False, "force_unlock": False, "journal": None, "estate_db": None, "no_folders": False}
+    defaults = {
+        "dry_run": False,
+        "force_unlock": False,
+        "journal": None,
+        "estate_db": None,
+        "no_folders": False,
+        "skip": [],
+        "skip_empty_models": False,
+    }
     return argparse.Namespace(**{**defaults, **kwargs})
 
 
@@ -1613,3 +1621,328 @@ def test_a_quote_in_a_workspace_name_is_escaped_rather_than_breaking_the_value()
     assert de._conn_value("plain") == '"plain"'
     assert de._conn_value('has "quote"') == "'has \"quote\"'"
     assert de._conn_value("both \" and '") == '"both "" and \'"'
+
+
+# --- issue #127: withholding a unit on purpose, and the duplicate-name claim beside it ------------
+#
+# S6: `check_empty_model.py` can prove a model would load ZERO ROWS and the runbook says "never
+# deploy it" - but there was no flag to not deploy it, so a cold operator derived a folder-move
+# workaround by reading the source. These tests are the supported action.
+
+
+def _import_partition(model: Path, path: str) -> None:
+    """Give a model an Import partition over a local file, the shape check_empty_model.py judges.
+
+    A POSIX absolute path is deliberate: it reads as `foreign_path` on Windows and `missing_file` on
+    Linux, and BOTH block - so the fixture is EMPTY on either CI host rather than on one of them.
+    It is also the shape the real finding had (a Mac-authored workbook's `/Users/...` path).
+    """
+    tables = model / "definition" / "tables"
+    tables.mkdir(parents=True, exist_ok=True)
+    (tables / "Orders.tmdl").write_text(
+        "table Orders\n\n"
+        "\tpartition Orders = m\n"
+        "\t\tmode: import\n"
+        "\t\tsource =\n"
+        "\t\t\tlet\n"
+        f'\t\t\t    Source = Excel.Workbook(File.Contents("{path}"), null, true)\n'
+        "\t\t\tin\n"
+        "\t\t\t    Source\n",
+        encoding="utf-8",
+    )
+
+
+def _empty_model_report(bundle: Path, models: list[tuple[str, str]], *, roots: bool = False) -> Path:
+    """Write a check_empty_model.py-shaped report from [(model_path, status)]."""
+    payload: dict = {
+        "version": 1,
+        "models_scanned": len(models),
+        "models_empty": sum(1 for _p, status in models if status == "EMPTY"),
+        "status": "EMPTY_MODELS" if any(status == "EMPTY" for _p, status in models) else "OK",
+        "models": [
+            {
+                "model": Path(path).name,
+                "model_path": path,
+                "owner": Path(path).parts[1] if len(Path(path).parts) > 1 else "?",
+                "status": status,
+                "findings": [{"table": "Orders", "partition": "Orders", "detail": "file does not exist"}]
+                if status == "EMPTY"
+                else [],
+            }
+            for path, status in models
+        ],
+    }
+    out = bundle / de.EMPTY_MODEL_REPORT
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps({"version": 1, "roots": [payload]} if roots else payload, indent=2), encoding="utf-8")
+    return out
+
+
+def test_a_named_unit_is_withheld_from_a_real_deploy(tmp_path, caplog):
+    """The whole point: deploy the other units NOW and leave this one behind, with no folder-moving.
+
+    Run end-to-end rather than against `withhold()` alone: `_execute` used to re-`discover()` the
+    bundle after the filtering had happened, so a unit-level test would have passed while every
+    withheld unit was deployed anyway.
+    """
+    bundle = _bundle(tmp_path / "b", {"Sales": True, "Empty": True})
+    service = _FakeFabric()
+    de.call = service.call
+    try:
+        with caplog.at_level("INFO"):
+            code = _deploy_into(bundle, service, tmp_path / "j.jsonl", skip=["Empty"])
+    finally:
+        importlib.reload(de)
+
+    assert {(row["displayName"], row["type"]) for row in service.items} == {
+        ("Sales", de.MODEL_TYPE),
+        ("Sales", de.REPORT_TYPE),
+    }, f"nothing may be created for a withheld unit: {service.items}"
+    assert code == de.EXIT_INCOMPLETE
+    assert "2 planned (2 new)" in caplog.text, "preflight budgets the run that will happen, not the bundle"
+    assert "WITHHELD" in caplog.text and "Empty" in caplog.text
+
+
+def test_a_withheld_unit_is_not_counted_as_deployed(tmp_path, caplog):
+    """ "All 4 deployed" over an estate that is missing one unit is the lie this exists to prevent."""
+    bundle = _bundle(tmp_path / "b", {"Sales": True, "Empty": True})
+    service = _FakeFabric()
+    de.call = service.call
+    try:
+        with caplog.at_level("INFO"):
+            _deploy_into(bundle, service, tmp_path / "j.jsonl", skip=["Empty"])
+    finally:
+        importlib.reload(de)
+
+    assert "2 item(s) deployed" in caplog.text
+    assert "all 4" not in caplog.text and "4 item(s) deployed" not in caplog.text
+    assert "1 unit(s), 2 item(s) NOT deployed" in caplog.text, caplog.text
+
+
+def test_the_exit_code_says_incomplete_rather_than_ok_or_failed():
+    """Deliberate: EXIT_OK would claim a complete estate, EXIT_FAILED would ask for a pointless re-run."""
+    held = [("Empty", 2, "EMPTY MODEL - loads no rows")]
+    assert de.EXIT_INCOMPLETE not in (de.EXIT_OK, de.EXIT_FAILED)
+    assert de._report_failures([], 2, "LZ", 0, held) == de.EXIT_INCOMPLETE
+    assert de._report_failures([], 2, "LZ", 0, []) == de.EXIT_OK
+    # A failure outranks a skip: it is the verdict that wants this exact command run again.
+    assert de._report_failures(["Sales (Report): boom"], 2, "LZ", 0, held) == de.EXIT_FAILED
+
+
+def test_a_failed_run_still_names_the_units_it_withheld(caplog):
+    """Two things went wrong; reporting only the louder one hides the estate's real shape."""
+    with caplog.at_level("INFO"):
+        de._report_failures(["Sales (Report): boom"], 2, "LZ", 0, [("Empty", 2, "EMPTY MODEL - no rows")])
+    assert "1 item(s) failed" in caplog.text
+    assert "WITHHELD" in caplog.text and "Empty" in caplog.text
+
+
+def test_an_empty_report_is_still_exit_zero_and_a_withheld_unit_is_not():
+    """The two skips are different: an empty report has no item to create and no follow-up run owed."""
+    assert de._report_failures([], 2, "LZ", skipped=1) == de.EXIT_OK
+    assert de._report_failures([], 2, "LZ", 1, [("Empty", 1, "why")]) == de.EXIT_INCOMPLETE
+
+
+def test_the_withheld_item_count_matches_what_would_have_been_created(tmp_path):
+    """The count is what an operator reconciles against the dry run, so a pair is 2 and a model is 1."""
+    bundle = _bundle(tmp_path, {"Pair": True, "ModelOnly": False})
+    kept, held = de.withhold(de.discover(bundle), {"Pair": "why-a", "ModelOnly": "why-b"})
+
+    assert kept == []
+    assert sorted(held) == [("ModelOnly", 1, "why-b"), ("Pair", 2, "why-a")]
+
+
+def test_a_mistyped_skip_refuses_to_start_rather_than_deploying_the_unit(tmp_path, caplog):
+    """A typo would deploy the very unit being held back, and report success while doing it."""
+    bundle = _bundle(tmp_path / "b", {"global_superstores_db": True})
+    service = _FakeFabric()
+    de.call = service.call
+    try:
+        with caplog.at_level("ERROR"):
+            code = _deploy_into(bundle, service, tmp_path / "j.jsonl", skip=["global_superstore_db"])
+    finally:
+        importlib.reload(de)
+
+    assert code == de.EXIT_PREFLIGHT
+    assert service.items == [], "a refused skip must not deploy anything at all"
+    assert "matches no unit" in caplog.text
+    assert "'global_superstores_db'" in caplog.text, "name the near miss - this is typed under pressure"
+
+
+def test_skip_empty_models_reads_the_report_so_no_name_is_retyped(tmp_path, caplog):
+    """The operator has a verdict in hand already; retyping unit names from it is where slips happen."""
+    bundle = _bundle(tmp_path / "b", {"Sales": True, "global_superstores_db": True})
+    _empty_model_report(
+        bundle,
+        [
+            ("pbip/Sales/Sales.SemanticModel", "OK"),
+            ("pbip/global_superstores_db/Orders (Global Superstore).SemanticModel", "EMPTY"),
+        ],
+    )
+    service = _FakeFabric()
+    de.call = service.call
+    try:
+        with caplog.at_level("INFO"):
+            code = _deploy_into(bundle, service, tmp_path / "j.jsonl", skip_empty_models=True)
+    finally:
+        importlib.reload(de)
+
+    assert code == de.EXIT_INCOMPLETE
+    assert {row["displayName"] for row in service.items} == {"Sales"}
+    assert "EMPTY MODEL" in caplog.text and "file does not exist" in caplog.text
+
+
+def test_a_missing_empty_model_report_refuses_rather_than_reading_it_as_nothing_is_empty(tmp_path):
+    """ "I could not read the list" and "the list is empty" differ by exactly the unit at stake."""
+    bundle = _bundle(tmp_path / "b", {"Sales": False})
+    service = _FakeFabric()
+    de.call = service.call
+    try:
+        code = _deploy_into(bundle, service, tmp_path / "j.jsonl", skip_empty_models=True)
+    finally:
+        importlib.reload(de)
+
+    assert code == de.EXIT_PREFLIGHT
+    assert service.items == []
+
+
+def test_an_unreadable_empty_model_report_is_refused_too(tmp_path):
+    """A torn or half-written report is the same unknown, and must not read as an all-clear."""
+    bundle = _bundle(tmp_path, {"Sales": False})
+    (bundle / de.EMPTY_MODEL_REPORT).write_text('{"models": [', encoding="utf-8")
+
+    skips, refusal = de.resolve_skips(bundle, {"Sales"}, _options(skip_empty_models=True))
+
+    assert skips == {}
+    assert refusal and "could not be read" in refusal
+
+
+def test_the_multi_target_form_of_the_report_is_understood(tmp_path):
+    """check_empty_model.py wraps several scanned roots in `roots`; missing that skips nothing."""
+    bundle = _bundle(tmp_path, {"Sales": False, "Empty": False})
+    _empty_model_report(bundle, [("pbip/Empty/Empty.SemanticModel", "EMPTY")], roots=True)
+
+    skips, refusal = de.resolve_skips(bundle, {"Sales", "Empty"}, _options(skip_empty_models=True))
+
+    assert refusal == ""
+    assert set(skips) == {"Empty"}
+
+
+def test_only_pbip_models_can_be_withheld(tmp_path):
+    """The engine's pristine `semantic_models/` copy is not a deployable unit, and is not a typo either.
+
+    A bundle scan reports every `.SemanticModel` under the bundle, so the same datasource shows up
+    twice when it was migrated both standalone and inside a workbook. Taking the unit name from any
+    path but `pbip/<unit>/` withholds a HEALTHY workbook because its non-deployable twin is empty -
+    the exact inverse of this flag's job.
+    """
+    bundle = _bundle(tmp_path, {"Sales": False})
+    _empty_model_report(
+        bundle,
+        [
+            ("semantic_models/Shared.SemanticModel", "EMPTY"),
+            ("semantic_models/Sales/Sales.SemanticModel", "EMPTY"),
+            ("pbip/Sales/Sales.SemanticModel", "OK"),
+        ],
+    )
+
+    skips, refusal = de.resolve_skips(bundle, {"Sales"}, _options(skip_empty_models=True))
+
+    assert refusal == ""
+    assert skips == {}, "only pbip/<unit>/ is deployable, so only pbip/<unit>/ can be withheld"
+
+
+def test_a_reported_unit_that_is_not_in_the_bundle_is_a_warning_not_a_refusal(tmp_path, caplog):
+    """It was already quarantined by hand, or the report scanned another bundle - nothing to withhold."""
+    bundle = _bundle(tmp_path, {"Sales": False})
+    _empty_model_report(bundle, [("pbip/Ghost/Ghost.SemanticModel", "EMPTY")])
+
+    with caplog.at_level("WARNING"):
+        skips, refusal = de.resolve_skips(bundle, {"Sales"}, _options(skip_empty_models=True))
+
+    assert (skips, refusal) == ({}, "")
+    assert "Ghost" in caplog.text and "nothing to skip" in caplog.text
+
+
+def test_an_explicit_skip_that_is_also_empty_keeps_the_more_informative_reason(tmp_path):
+    """ "You asked for it" says less than the artifact that proves the model empty."""
+    bundle = _bundle(tmp_path, {"Empty": False})
+    _empty_model_report(bundle, [("pbip/Empty/Empty.SemanticModel", "EMPTY")])
+
+    skips, _refusal = de.resolve_skips(bundle, {"Empty"}, _options(skip=["Empty"], skip_empty_models=True))
+
+    assert "EMPTY MODEL" in skips["Empty"]
+
+
+def test_the_dry_run_item_count_drops_by_the_withheld_unit(tmp_path, caplog):
+    """The operator's confirmation signal, and it must stay exit 0 so `--dry-run` can gate the real run."""
+    bundle = _bundle(tmp_path / "b", {"Sales": True, "Empty": True})
+    service = _FakeFabric()
+    de.call = service.call
+    try:
+        with caplog.at_level("INFO"):
+            code = _deploy_into(bundle, service, tmp_path / "j.jsonl", skip=["Empty"], dry_run=True)
+    finally:
+        importlib.reload(de)
+
+    assert code == de.EXIT_OK, "a dry run creates nothing, so there is no incomplete estate to report"
+    assert "2 item(s) would be created" in caplog.text
+    assert "WITHHELD" in caplog.text
+    assert service.items == []
+
+
+def test_the_report_this_flag_reads_is_the_one_check_empty_model_writes(tmp_path):
+    """A contract test across the two scripts: the filename AND the shape, not one or the other.
+
+    Hand-rolled fixtures elsewhere in this file pin the parsing; this pins that the parsing is aimed
+    at a real report. `check_empty_model.py` produces it here from actual TMDL rather than from a
+    dict we wrote ourselves.
+    """
+    import check_empty_model as cem  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
+
+    bundle = _bundle(tmp_path, {"Sales": True, "global_superstores_db": True})
+    _import_partition(
+        bundle / "pbip" / "global_superstores_db" / "global_superstores_db.SemanticModel",
+        "/Users/bs/Mac Drive/Global Superstore.xlsx",
+    )
+    assert de.EMPTY_MODEL_REPORT == cem.REPORT_NAME, "the file this reads is the file that one writes"
+    report = cem.scan(bundle)
+    assert report["status"] == "EMPTY_MODELS", "precondition: the fixture really is an empty model"
+    (bundle / de.EMPTY_MODEL_REPORT).write_text(json.dumps(report, indent=2), encoding="utf-8")
+
+    units, refusal = de.empty_model_units(bundle)
+
+    assert refusal == ""
+    assert set(units) == {"global_superstores_db"}
+
+
+def test_the_skip_flags_reach_deploy_and_repeat(monkeypatch, tmp_path):
+    """The issue was "there is no flag", so pin the flag: repeatable, and inert when not passed."""
+    seen: dict[str, argparse.Namespace] = {}
+    monkeypatch.setattr(de, "token", lambda tenant: "tok")
+    monkeypatch.setattr(de, "deploy", lambda bundle, ws, tok, options: seen.setdefault("o", options) and 0)
+
+    de.main(["--bundle", str(tmp_path), "--workspace", "ws", "--skip", "A", "--skip", "B", "--skip-empty-models"])
+    assert (seen["o"].skip, seen["o"].skip_empty_models) == (["A", "B"], True)
+
+    seen.clear()
+    de.main(["--bundle", str(tmp_path), "--workspace", "ws"])
+    assert (seen["o"].skip, seen["o"].skip_empty_models) == ([], False), "a run that skips nothing is unchanged"
+
+
+def test_neither_duplicate_name_error_is_treated_as_fatal(tmp_path, monkeypatch):
+    """S9: the module docstring settles what the service does, and this pins what the code does.
+
+    Fabric's REST Create Item does NOT reject a duplicate `displayName` + type for `Report` /
+    `SemanticModel` (measured; see the module docstring). These two error codes have never been seen
+    for these types, and the branch that handles them is DEFENSIVE - `ItemDisplayNameNotAvailableYet`
+    is the language of eventual consistency, so treating it as fatal would break the resume this file
+    exists for. Neither may become a failure.
+    """
+    item = de.Item("WB", de.MODEL_TYPE, tmp_path)
+    journal = de.Journal(tmp_path / "j.jsonl", "ws")
+    for code in ("ItemDisplayNameNotAvailableYet", "ItemDisplayNameAlreadyInUse"):
+        monkeypatch.setattr(de, "_post_item", lambda ws, tok, it, code=code: (400, {}, {"errorCode": code}))
+        state, item_id, detail = de.create_item("ws", "tok", item, journal)
+        assert (state, item_id) == ("AlreadyExists", None), f"{code} must mean 'go and verify', not 'failed'"
+        assert code in detail


### PR DESCRIPTION
Fixes #127

Two problems, one file (`scripts/deploy_estate.py` + its tests). Nothing else is touched.

## 1. "Never deploy an empty model" now has a supported way not to

`--skip <unit>` (repeatable) and `--skip-empty-models` withhold a unit from the run.

- **`--skip-empty-models` reads `<bundle>/empty-model-check.json` directly**, so the operator does not
  retype unit names out of a scrolled-away log under time pressure. The reason printed for each unit
  is the *finding* from that report (`table 'Orders' file does not exist`), not "you asked".
- **A withheld unit is reported loudly and is never counted as deployed.** The summary switches from
  `all N item(s) deployed` to `N item(s) deployed ... - NOT the whole estate`, followed by a
  `WITHHELD:` block naming every unit, its item count and why. It is announced twice — once up front,
  because on a real estate the summary is a quarter of an hour away, and once in the summary.
- **A `--skip` that matches no unit refuses to start** (`EXIT_PREFLIGHT`, with a `difflib`
  did-you-mean). A typo would otherwise deploy the very unit meant to be held back and report success.
  A unit named by the *report* but absent from the bundle is only a warning — that is not a typo, it
  is the hand-rolled quarantine this flag replaces.
- **A missing or unreadable `empty-model-check.json` is a refusal, never "nothing is empty."** Those
  two answers differ by exactly the unit the flag exists to withhold.

### Exit code: new `EXIT_INCOMPLETE = 3` (justified in-code)

`EXIT_OK` would tell a caller the estate is in the workspace when it knowingly is not — this repo's
standing rule is that a partial deploy must not exit 0. `EXIT_FAILED` would say "something broke, run
it again", which is false *and* unhelpful: nothing failed, and re-running changes nothing until the
model is repaired. A third code says the only true thing, and a caller that *asked* for the skip can
accept exactly that value. Precedence is deliberate: **a failure outranks a withheld unit**, because a
failure is the verdict that wants this exact command run again.

Two behaviours are deliberately left alone: an empty **report** (`report_is_empty`) still exits 0 (no
item to create, no follow-up run owed — and an existing test pins it), and `--dry-run` still exits 0
even with skips, because `--dry-run && real-run` is the documented ritual and a non-zero code would
break it. The dropping item count is still the confirmation the cold operator was looking for —
`2 item(s) would be created` instead of 4.

## 2. The duplicate-name contradiction, settled here

Settled in the module docstring, stated once, dated and **scoped to the API path**, with everywhere
else in the file now citing it instead of restating it:

> Measured against a real Fabric tenant during the deploy runs of PR #105 (merged 2026-08-13), on
> `POST /v1/workspaces/{id}/items` — Fabric REST *Create Item*, the only path this module creates on
> — for `type` of `Report` or `SemanticModel`: **a duplicate `displayName` + `type` is ACCEPTED, not
> rejected.**

The evidence is already in this repo and no live call was made to obtain it: the `RunLock` docstring
records the measurement itself (two overlapping runs left duplicate model+report pairs side by side in
a real workspace), and `git log -S` shows the old "is rejected" line and that measurement entering in
the *same* commit — so the docstring's claim was the unsupported half, and it is now removed.

`ItemDisplayNameNotAvailableYet` / `ItemDisplayNameAlreadyInUse` have **never been observed** for these
two types; the branch handling them is kept and now labelled **defensive** (its wording is the language
of eventual consistency, so treating it as fatal would break the resume this file exists for). Nothing
depends on the service rejecting duplicates — which is precisely what makes the journal, the run lock,
the provenance stamp and `Landing.claim` load-bearing.

**What is not claimed:** Desktop publish and the Power BI *import* API are different paths with their
own conflict handling. This tool never calls them and we have never measured them, so the statement is
explicitly scoped rather than generalised. Where two sources disagree, the answer is *which path*.

## Guarding what was already there

`Landing.claim`, the journal, the stamp and the lock are unchanged — no duplicate-prevention rule is
weakened. One structural change was required and is commented: `_execute` now takes `pairs` instead of
calling `discover(bundle)` again, because re-discovering would silently restore every withheld unit
while the summary printed the filtered list. `preflight` is likewise budgeted against the filtered run.
All 117 pre-existing tests still pass unchanged (1013 in the full suite).

## Gates (by exit code)

| gate | result |
|---|---|
| `ruff format --check scripts tests` | 0 |
| `ruff check scripts tests` | 0 |
| `pylint scripts` | 0 — 10.00/10 |
| `pytest -q` | 0 — 1013 passed, 4 skipped |

The file keeps its deliberate file-level `too-many-lines` disable; the two new pylint pressures were
resolved by extracting `_plan_units` / `_planned_keys` rather than by blanket suppression (the one
`too-many-arguments` disable is targeted and carries its reason inline).

## Mutation testing

26 mutations applied to `scripts/deploy_estate.py`, each run against the suite and reverted. **All 26
are caught**, but two rounds were needed and the failures are worth reporting:

- `M6` first ran as a **no-op mutation** (`return {}, "" or (...)` still returns the message) and so
  "survived" meaninglessly; rewritten properly, it is caught.
- `M8` (dropping the `parts[0] == "pbip"` filter) genuinely **survived**: my test asserted an outcome
  the mutant also produced. The test now includes a `semantic_models/Sales/Sales.SemanticModel` twin of
  a *healthy* `pbip/Sales` unit, so the mutant withholds a good workbook and the test fails.

| mutation | caught by |
|---|---|
| M1 `_execute` re-discovers, restoring withheld units | `..._withheld_from_a_real_deploy` |
| M2 `announce_withheld` silent | same |
| M3 withheld run exits `EXIT_OK` | same |
| M4 mistyped `--skip` warns instead of refusing | `..._mistyped_skip_refuses_to_start...` |
| M5 no did-you-mean suggestion | same |
| M6 unreadable report reads as "nothing is empty" | `..._missing/unreadable_..._refused` |
| M7 multi-target `roots` form ignored | `..._multi_target_form_...` |
| M8 non-`pbip` models become skips | `..._only_pbip_models_can_be_withheld` |
| M9 absent-but-reported unit becomes a refusal | `..._warning_not_a_refusal` |
| M10 `--skip` overwrites the richer EMPTY reason | `..._keeps_the_more_informative_reason` |
| M11 withheld item count ignores the report | `..._not_counted_as_deployed` |
| M12 dry run returns `EXIT_INCOMPLETE` | `..._dry_run_item_count_drops...` |
| M13 failed run stops reporting withheld units | `..._failed_run_still_names...` |
| M14 empty-*report* skip promoted to incomplete | pre-existing `..._counted_as_skipped...` |
| M15 report filename drifts from its producer | contract test vs `check_empty_model.REPORT_NAME` |
| M16 / M16b duplicate-name error treated as fatal (both codes, then one) | `..._neither_duplicate_name_error_is_treated_as_fatal` |
| M17 `--skip` never read | `..._withheld_from_a_real_deploy` |
| M19 preflight budgets the unfiltered bundle | same (`2 planned (2 new)`) |
| M20 refusal swallowed by `resolve_skips` | refusal tests |
| M21 `withhold()` keeps skipped pairs | 3 tests |
| M22 `--skip-empty-models` ignored | 3 tests |
| M23 evidence detail dropped from the reason | `..._so_no_name_is_retyped` |
| M24 `--skip` not repeatable / M25 default `None` | `..._skip_flags_reach_deploy_and_repeat` |

19 new tests. The end-to-end ones drive the real `deploy()` through the existing `_FakeFabric` double
and assert on **what was created**, not just on return values — M1/M21 are exactly the mutants a
unit-level test would have missed. One test is a **contract test across scripts**: it builds a real
Import-partition TMDL, runs `check_empty_model.scan()` over it, and feeds the genuine report to
`empty_model_units()` — so the parsing is aimed at a real artifact, not at a fixture we wrote to match
our own parser. Its path is POSIX-absolute on purpose (`foreign_path` on Windows, `missing_file` on
Linux — both blocking), so it is EMPTY on either CI host.

**No Fabric tenant was contacted.** No live API call was made, for the skip work or for settling the
duplicate-name question.

## Out of scope

The runbook half of #127 (§2 step 6's contradicting claim, and the exit-code table that now needs
`3`) belongs to another agent; this PR only makes the authoritative statement they can cite.
