### PR TITLE
Catch a wrong-tenant Fabric token, and stop blocking on a Desktop-only pin

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,3 +28,17 @@ TABLEAU_PAT_SECRET=
 
 # Optional overrides (defaults shown are what the scripts fall back to if unset).
 # TABLEAU_REST_API_VERSION=3.21
+
+# --- Fabric side (read by scripts/preflight.ps1 only) ---
+# The Entra tenant you intend to DEPLOY into - the same value you pass to `deploy_estate.py
+# --tenant`. Setting it turns on preflight's wrong-tenant check, which decodes the `tid` claim of a
+# Fabric token and compares it, so `az` pointing at the wrong tenant is reported here rather than as
+# a WorkspaceNotFound on a workspace that plainly exists. Leave it empty and preflight skips the
+# check entirely (and never calls `az`), so a parse-only machine pays nothing.
+#
+# The GUID form is what gets compared; `az account show --query tenantId -o tsv` prints it. A
+# default domain (contoso.onmicrosoft.com) also works - preflight resolves it via
+# `az account list --all`. Quotes, surrounding whitespace and a trailing `# comment` are all fine.
+# Declared HERE a mismatch is a warning; passed as `preflight.ps1 -Tenant <id>` on a run that is
+# about to deploy, it blocks.
+FABRIC_TENANT_ID=

--- a/scripts/preflight.ps1
+++ b/scripts/preflight.ps1
@@ -15,8 +15,10 @@
   `tableau-fabric-skills` plugin, which is its SINGLE canonical source - a second copy anywhere is a
   hard failure, see issue #107), both skill plugins
   (powerbi-authoring@fabric-collection and powerbi-migration-skills@powerbi-migration-collection),
-  the MCP servers, Power BI Desktop + its Bridge CLI, npx, the .NET SDK, and the npm CLI version
-  matrix. Prints a per-item status (OK / WARN / MISS) with an install hint for anything absent.
+  the MCP servers, Power BI Desktop + its Bridge CLI, npx, the .NET SDK, the npm CLI version matrix,
+  and - when you declare an intended tenant - that the Fabric token this machine mints is actually
+  for THAT tenant. Prints a per-item status (OK / WARN / MISS) with an install hint for anything
+  absent.
 
 .PARAMETER Update
   Session-start only. Upgrades the npm bridge CLIs, but ONLY when they are below the correctness
@@ -36,13 +38,28 @@
   This asks npm for the latest bridge CLIs and GitHub for the conversion engine's upstream VERSION.
   It never upgrades and never fails the run.
 
+.PARAMETER Tenant
+  The Entra tenant id you INTEND to deploy into - the same id you pass to `deploy_estate.py
+  --tenant`. Declaring it turns on the wrong-tenant check (see the "Fabric token tenant" block
+  below); omitting it costs nothing and skips that check, so preflight never pays for `az` on a
+  machine that is only parsing workbooks.
+
+  It can also come from `$env:FABRIC_TENANT_ID`, or `FABRIC_TENANT_ID` in the git-ignored `.env` -
+  which is the right home for a real customer tenant id, because this repository is PUBLIC.
+
+.PARAMETER Subscription
+  Optional subscription id/name passed verbatim to `az account get-access-token --subscription`,
+  so the tenant check can verify the NON-MUTATING fix for a wrong-tenant token before you rely on
+  it. `az account set` fixes the same problem by rewriting the CLI's on-disk profile, which every
+  other process on this machine then inherits.
+
 .NOTES
-  Run:  powershell -ExecutionPolicy Bypass -File scripts\preflight.ps1 [-Update]
+  Run:  powershell -ExecutionPolicy Bypass -File scripts\preflight.ps1 [-Update] [-Tenant <id>]
   Exit: 0 if every CRITICAL item is present; 1 if any CRITICAL item is missing.
         RECOMMENDED and OPTIONAL items are surfaced as warnings but do not stop a migration.
 #>
 #Requires -Version 5.1
-param([switch]$Update, [switch]$CheckUpstream)
+param([switch]$Update, [switch]$CheckUpstream, [string]$Tenant, [string]$Subscription)
 
 $ErrorActionPreference = 'SilentlyContinue'
 $copilot = Join-Path $HOME '.copilot'
@@ -101,9 +118,14 @@ Add-Cli 'powerbi-report-author' 'critical' 'npm install -g @microsoft/powerbi-re
 # These CLIs are unpinned GLOBAL installs (the official skill installs them with @latest), so they can
 # change under you without any repo diff. Two distinct thresholds:
 #   * FLOOR      - below this is a CORRECTNESS bug, not a nicety. powerbi-report-author < 0.1.4 returns
-#                  errorCount:0 for PBIR that Desktop cannot open (e.g. report.json missing the
-#                  schema-required `reportVersionAtImport`) -- a stale CLI silently green-lights a
-#                  broken report. `-Update` repairs this, and only this.
+#                  errorCount:0 for PBIR that Desktop cannot open (e.g. a report.json whose
+#                  themeCollection entries are missing the schema-required `reportVersionAtImport` --
+#                  it belongs INSIDE each themeCollection entry, where it is required, and is
+#                  FORBIDDEN at the top level of report.json, which answers "must NOT have additional
+#                  properties". Ground truth:
+#                  examples/shipping-kpis/fabric/ShippingKPIs.Report/definition/report.json)
+#                  -- a stale CLI silently green-lights a broken report.
+#                  `-Update` repairs this, and only this.
 #   * KNOWN-GOOD - the version the agent Gotchas were verified against. ABOVE it is not an error, but
 #                  it does mean version-specific prose may be stale -> WARN, don't "fix" it.
 $cliFloor     = @{ 'powerbi-report-author' = '0.1.4'; 'powerbi-desktop' = '0.1.2' }
@@ -264,7 +286,7 @@ else {
 #     checks above enforce correctness when the installed plugin is present and shadowing the repo.
 #   * powerbi-modeling-mcp: useful authoring accelerator; local PBIP/TMDL edits can still proceed.
 #   * Power BI Desktop version drift: advisory re-verification trigger only; the exact bridge target
-#     is enforced by the critical PBI_DESKTOP_PATH pin below.
+#     is pinned by the recommended PBI_DESKTOP_PATH check below.
 # --- MCP servers ---
 $mcp = Read-CopilotJson 'mcp-config.json'
 foreach ($srv in @(@('powerbi-modeling-mcp', 'recommended'), @('powerbi-remote', 'optional'))) {
@@ -367,10 +389,28 @@ if ($appx) {
 
 # The mismatch-remover. A set PBI_DESKTOP_PATH means the bridge and this script resolve the SAME exe;
 # unset means the bridge is guessing from a version-pinned list and may already be wrong.
+#
+# RECOMMENDED, not critical (#124). It was critical, and that made a machine with the engine, both
+# plugins, both CLIs at known-good versions, Desktop installed, az, uv and ODBC 18 report NOT READY
+# over one unset variable. Two things are wrong with that:
+#   * it is a DESKTOP-only pin, and the estate pipeline (steps 1-6) never opens Desktop -
+#     `run_estate.py`'s own docstring says "never opens Power BI Desktop". Blocking a run on a
+#     dependency that run cannot use is a false blocker, and the operator who proceeded anyway was
+#     right - nothing in the estate pipeline needed it;
+#   * exit 1 means "resolve before migrating", so spending it on an item the operator runbook never
+#     names teaches people to ignore exit 1 - which is the one signal this script has.
+# It stays VISIBLE (a WARN, counted in the summary line) because the failure it prevents is real:
+# Desktop auto-updates and the bridge then cannot find the exe. The phase that actually needs it -
+# report authoring / Desktop verification - is where it must be resolved, and `powerbi-desktop open`
+# fails loudly there rather than silently.
 $pathPinned = [bool]($env:PBI_DESKTOP_PATH -and (Test-Path $env:PBI_DESKTOP_PATH))
-Add-Check 'PBI_DESKTOP_PATH (bridge exe pin)' 'critical' $pathPinned `
-    $(if ($pathPinned) { $env:PBI_DESKTOP_PATH } else { 'not set - the bridge is using its own version-pinned discovery' }) `
-    $(if ($desktop) { "setx PBI_DESKTOP_PATH `"$desktop`"   (then reopen the shell)" } else { 'install Power BI Desktop first' })
+# The hint must work IN THE SHELL THAT READS IT. `setx` writes the user profile and is inherited only
+# by processes started LATER - and an agent's tool shells inherit the environment of a parent that is
+# already running, so "then reopen the shell" is advice they cannot act on. `$env:` is the fix that
+# takes effect immediately; `setx` is offered second, for persistence, correctly labelled.
+Add-Check 'PBI_DESKTOP_PATH (bridge exe pin)' 'recommended' $pathPinned `
+    $(if ($pathPinned) { $env:PBI_DESKTOP_PATH } else { 'not set - the bridge is using its own version-pinned discovery; needed only for the Desktop refresh/screenshot phase, not for the estate pipeline' }) `
+    $(if ($desktop) { "THIS shell (takes effect now): `$env:PBI_DESKTOP_PATH = `"$desktop`"   |   persist for NEW shells only (does NOT affect this one): setx PBI_DESKTOP_PATH `"$desktop`"" } else { 'install Power BI Desktop first' })
 
 # --- Privacy Levels: a MANUAL prerequisite this script cannot verify -------------------------------
 # Opening a model that spans more than one data source raises a modal ("Potential security risk: This
@@ -399,6 +439,115 @@ Add-Cli 'dotnet' 'critical' 'Install the .NET SDK - needed to build/run the offl
 
 Add-Cli 'uv' 'optional' 'Install uv for env/dependency management (uv venv && uv sync).'
 Add-Cli 'az' 'optional' 'Azure CLI - only for Fabric REST / token-based operations.'
+
+# --- Fabric token TENANT: a token that mints successfully can still be for the WRONG tenant (#124) --
+#
+# Measured 2026-08-13, FOUR times across two independent operators, ~15 minutes each: on a
+# multi-account machine `az account get-access-token` succeeds and hands back a token for whatever
+# tenant the CLI's default context points at. `GET /workspaces/{id}` then answers `WorkspaceNotFound`
+# for a workspace that exists and was just filled with 74 items - a 404 that reads as "your deploy
+# went somewhere else" rather than as an identity problem, and it lands in the phase where you are
+# reassuring a customer. The runbook's whole Fabric-side credential guidance was "the token must
+# mint", which is exactly the thing that was already true.
+#
+# This belongs in preflight rather than in a doc note because it is the class of failure preflight
+# exists for: deterministic, checkable BEFORE any work, and expensive to diagnose afterwards.
+#
+# The TOKEN is the ground truth, not the CLI's profile: `tid` is the tenant the resource will
+# actually see. A JWT's payload is its middle dot-separated segment, base64url-encoded, so .NET
+# decodes it with no new dependency.
+#
+# NEVER print, log or truncate the token itself. Only the decoded `tid` - an identifier, not a
+# secret - reaches the output.
+function Get-JwtTenantId([string]$Token) {
+    # base64url is not base64: it swaps '+/' for '-_' and drops the '=' padding, both of which
+    # [Convert]::FromBase64String rejects. A length of 1 mod 4 cannot be valid base64 at all.
+    if (-not $Token) { return $null }
+    $seg = ($Token -split '\.')[1]
+    if (-not $seg) { return $null }
+    $b64 = $seg.Replace('-', '+').Replace('_', '/')
+    switch ($b64.Length % 4) { 1 { return $null } 2 { $b64 += '==' } 3 { $b64 += '=' } }
+    try { return ((([Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($b64))) | ConvertFrom-Json).tid) }
+    catch { return $null }
+}
+
+function Get-DotEnvValue([string]$Key) {
+    # Deliberately the SAME minimal KEY=VALUE parse as scripts/tableau_env.py's load_env (trim, skip
+    # blank/'#', split on the first '='), so a single .env line cannot mean one thing to Python and
+    # another to PowerShell. .env is git-ignored, which is where a real customer tenant id belongs:
+    # this repository is public.
+    $envFile = Join-Path $repoRoot '.env'
+    if (-not (Test-Path $envFile)) { return $null }
+    foreach ($line in (Get-Content $envFile)) {
+        $trimmed = $line.Trim()
+        if (-not $trimmed -or $trimmed.StartsWith('#') -or ($trimmed -notmatch '=')) { continue }
+        $pair = $trimmed -split '=', 2
+        if ($pair[0].Trim() -eq $Key) { return $pair[1].Trim() }
+    }
+    return $null
+}
+
+# Declaration of intent, in the order a caller expects to win: flag > exported env > git-ignored .env.
+# Trimmed because the comparison below is the only thing standing between an operator and a blocked
+# migration: a trailing space in an exported variable is not a wrong tenant, and must not read as one.
+$intendedTenant = @($Tenant, $env:FABRIC_TENANT_ID, (Get-DotEnvValue 'FABRIC_TENANT_ID')) |
+    Where-Object { $_ -and $_.Trim() } | Select-Object -First 1
+if ($intendedTenant) { $intendedTenant = $intendedTenant.Trim() }
+
+# Mirrors deploy_estate.py's FABRIC_RESOURCE. Duplicating a well-known constant is a smaller risk
+# than making this PowerShell bootstrap depend on importing Python (see the engine block above for
+# the case where re-deriving a LIST would have been the real defect); if it ever changed, the deploy
+# would fail loudly on its own.
+$fabricResource = 'https://api.fabric.microsoft.com'
+
+if (-not $intendedTenant) {
+    # No declaration -> no `az` call at all, so an operator who only parses workbooks pays nothing.
+    # Reported as a WARN rather than an OK because the check did not RUN: a skipped check that
+    # renders as passing is the false-green shape this whole script exists to prevent.
+    Add-Check 'Fabric token tenant' 'optional' $false 'no intended tenant declared - not checked' `
+        'Declare the tenant you deploy into and this becomes automatic: -Tenant <id>, $env:FABRIC_TENANT_ID, or FABRIC_TENANT_ID in the git-ignored .env. Same id you pass to deploy_estate.py --tenant. Until then, a WorkspaceNotFound on a workspace you know exists may simply be a token for another tenant.'
+}
+elseif (-not (Get-Command az -ErrorAction SilentlyContinue)) {
+    Add-Check 'Fabric token tenant' 'optional' $false "intended $intendedTenant - not verified (az not on PATH)" `
+        'Install the Azure CLI to verify which tenant this machine actually mints Fabric tokens for.'
+}
+else {
+    $azArgs = @('account', 'get-access-token', '--resource', $fabricResource, '-o', 'json')
+    # --subscription scopes ONE call. It is offered here so the fix can be verified with the same
+    # command shape that applies it, rather than by mutating the CLI profile and hoping.
+    if ($Subscription) { $azArgs += @('--subscription', $Subscription) }
+    # $tokenJson holds a BEARER TOKEN. It is never echoed, never added to a Detail, and az's own
+    # stderr is discarded rather than surfaced, so no code path can leak it.
+    $tokenJson = & az @azArgs 2>$null
+    $actualTenant = $null
+    if ($tokenJson) {
+        try { $actualTenant = Get-JwtTenantId ((($tokenJson | Out-String) | ConvertFrom-Json).accessToken) } catch { $actualTenant = $null }
+    }
+    $scoped = if ($Subscription) { " (scoped: --subscription $Subscription)" } else { ' (default az context)' }
+
+    if (-not $actualTenant) {
+        Add-Check 'Fabric token tenant' 'optional' $false "intended $intendedTenant - no Fabric token could be minted or decoded$scoped" `
+            'Run `az login`, then re-run preflight. (Preflight never prints the token - only its decoded `tid` claim.)'
+    }
+    else {
+        $tenantOk = ($actualTenant -eq $intendedTenant)
+        # A mismatch is CRITICAL and a match is a quiet OK. Critical is defensible precisely because
+        # the check is OPT-IN: it can only fire once someone has declared "I intend to deploy into
+        # tenant X", and at that point a token for tenant Y makes every Fabric call answer 404 for
+        # things that exist. Nobody who has not declared a tenant can ever be blocked by it.
+        $exampleSub = $null
+        if (-not $tenantOk) {
+            # Turn the advice into something copy-pasteable: name a subscription this machine can
+            # already see INSIDE the intended tenant. Costs one extra `az` call, on the failure path
+            # only.
+            $exampleSub = (& az account list --all --query "[?tenantId=='$intendedTenant'].id" -o tsv 2>$null | Select-Object -First 1)
+        }
+        $subHint = if ($exampleSub) { "e.g. --subscription $exampleSub" } else { '--subscription <a subscription inside that tenant>' }
+        Add-Check 'Fabric token tenant' $(if ($tenantOk) { 'optional' } else { 'critical' }) $tenantOk `
+            $(if ($tenantOk) { "tid matches intended $intendedTenant$scoped" } else { "WRONG TENANT: token is for $actualTenant, intended $intendedTenant$scoped" }) `
+            "This is an IDENTITY problem, not a missing workspace: Fabric will answer WorkspaceNotFound/EntityNotFound for items that exist. Prefer the non-mutating fix, which scopes a single call: az account get-access-token --resource $fabricResource $subHint (re-run preflight with -Subscription <same> to confirm). ``az account set`` also works but rewrites the CLI profile on disk, so every other process on this machine silently follows you - restore it afterwards if you use it. Note deploy_estate.py --tenant is passed to az verbatim and inherits the same ambiguity (az may resolve a different ACCOUNT against that tenant and answer AADSTS90072)."
+    }
+}
 
 $odbc = (Get-OdbcDriver -ErrorAction SilentlyContinue | Where-Object Name -like '*SQL Server*').Name
 Add-Check 'ODBC Driver 18 (SQL)' 'optional' ($odbc -contains 'ODBC Driver 18 for SQL Server') `

--- a/scripts/preflight.ps1
+++ b/scripts/preflight.ps1
@@ -39,13 +39,23 @@
   It never upgrades and never fails the run.
 
 .PARAMETER Tenant
-  The Entra tenant id you INTEND to deploy into - the same id you pass to `deploy_estate.py
-  --tenant`. Declaring it turns on the wrong-tenant check (see the "Fabric token tenant" block
-  below); omitting it costs nothing and skips that check, so preflight never pays for `az` on a
-  machine that is only parsing workbooks.
+  The Entra tenant id (a GUID) you INTEND to deploy into - the same id you pass to
+  `deploy_estate.py --tenant`. Declaring it turns on the wrong-tenant check (see the "Fabric token
+  tenant" block below); omitting it costs nothing and skips that check, so preflight never pays for
+  `az` on a machine that is only parsing workbooks.
 
   It can also come from `$env:FABRIC_TENANT_ID`, or `FABRIC_TENANT_ID` in the git-ignored `.env` -
   which is the right home for a real customer tenant id, because this repository is PUBLIC.
+  Surrounding whitespace and a matched pair of quotes are accepted from any of the three
+  (`FABRIC_TENANT_ID="72f9..."` is ordinary dotenv spelling, not a wrong tenant).
+
+  WHERE the declaration came from decides how loudly a mismatch lands, because it is the only
+  evidence preflight has of deploy INTENT for THIS run:
+    * `-Tenant` on the command line  -> a mismatch is CRITICAL (exit 1). You said, in this
+      invocation, that you are pointing at a tenant; a token for another one is a blocker.
+    * `$env:FABRIC_TENANT_ID` / `.env` -> a mismatch is RECOMMENDED (a visible WARN, exit 0).
+      Persisted configuration is a standing preference, not a statement that this run deploys -
+      and steps 1-6 of an estate run never touch Fabric at all.
 
 .PARAMETER Subscription
   Optional subscription id/name passed verbatim to `az account get-access-token --subscription`,
@@ -471,28 +481,120 @@ function Get-JwtTenantId([string]$Token) {
     catch { return $null }
 }
 
-function Get-DotEnvValue([string]$Key) {
-    # Deliberately the SAME minimal KEY=VALUE parse as scripts/tableau_env.py's load_env (trim, skip
-    # blank/'#', split on the first '='), so a single .env line cannot mean one thing to Python and
-    # another to PowerShell. .env is git-ignored, which is where a real customer tenant id belongs:
-    # this repository is public.
-    $envFile = Join-Path $repoRoot '.env'
-    if (-not (Test-Path $envFile)) { return $null }
-    foreach ($line in (Get-Content $envFile)) {
+function Remove-SurroundingQuotes([string]$Value) {
+    # Be LIBERAL in what you accept, strict in what you compare. `KEY="value"` is ordinary dotenv
+    # spelling - it is what `.env.example` files teach and what python-dotenv, docker and every
+    # shell `source` accept - so a quoted value is an operator SPELLING, never a different value.
+    # Measured 2026-08-13: without this, `FABRIC_TENANT_ID="72f988bf-..."` naming the CORRECT tenant
+    # produced `MISS WRONG TENANT: token is for 72f988bf-..., intended "72f988bf-..."` and exit 1 on
+    # a perfectly configured machine - a false blocker in front of a customer, which is worse than
+    # the false blocker this same change set removed.
+    # Only a MATCHED pair is stripped, and only the outermost one, so a value that legitimately
+    # contains a quote survives untouched.
+    if (-not $Value) { return '' }
+    $v = $Value.Trim()
+    if ($v.Length -ge 2 -and (($v.StartsWith('"') -and $v.EndsWith('"')) -or ($v.StartsWith("'") -and $v.EndsWith("'")))) {
+        $v = $v.Substring(1, $v.Length - 2).Trim()
+    }
+    return $v
+}
+
+function Get-DotEnvValue([string]$Key, [string]$Path) {
+    # The same minimal KEY=VALUE parse as scripts/tableau_env.py's load_env (trim, skip blank/'#',
+    # split on the FIRST '='), plus ONE deliberate divergence: matched surrounding quotes are
+    # stripped. That divergence is the fix, not an accident - the two parsers previously agreed by
+    # being wrong in the same way, and "identical to Python" was the argument that kept it.
+    # `scripts/tableau_env.py:load_env` should get the same treatment; it is owned elsewhere, so it
+    # is flagged rather than edited here. Nothing in Python reads FABRIC_TENANT_ID today, so the
+    # divergence is inert until that happens.
+    # .env is git-ignored, which is where a real customer tenant id belongs: this repository is public.
+    if (-not $Path) { $Path = Join-Path $repoRoot '.env' }
+    if (-not (Test-Path $Path)) { return $null }
+    foreach ($line in (Get-Content $Path)) {
         $trimmed = $line.Trim()
         if (-not $trimmed -or $trimmed.StartsWith('#') -or ($trimmed -notmatch '=')) { continue }
         $pair = $trimmed -split '=', 2
-        if ($pair[0].Trim() -eq $Key) { return $pair[1].Trim() }
+        if ($pair[0].Trim() -eq $Key) { return (Remove-SurroundingQuotes $pair[1]) }
     }
     return $null
 }
 
+function Test-TenantIdShape([string]$Value) {
+    # The `tid` claim is ALWAYS a GUID. An intended tenant that is not one cannot be compared
+    # against it, and two spellings that are not GUIDs are entirely plausible here:
+    #   * `contoso.onmicrosoft.com` - which `az --tenant` and `deploy_estate.py --tenant` both
+    #     accept, so an operator has every reason to think it belongs in FABRIC_TENANT_ID;
+    #   * a placeholder like `<your-tenant-id>` copied out of a `.env.example`.
+    # Comparing either against a GUID answers "wrong tenant" - the same false blocker as the quoting
+    # bug, arriving by a different route. Preflight says "cannot compare" instead, and never blocks.
+    return [bool]($Value -match '^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$')
+}
+
+function Get-TenantVerdict {
+    <#
+      THE decision. Everything above this gathers evidence; this function alone turns it into
+      Ok/Tier/Detail, so the one line that decides the verdict can be EXECUTED by the test harness
+      rather than matched as a source string. That matters more than usual here: CI cannot run
+      PowerShell, and a mutation test showed both `$tenantOk = $true` (the check can never fire) and
+      an inverted comparison (fires on every correct machine) surviving the whole suite while it was
+      inline.
+
+      Kind is part of the contract: the caller maps it to a hint, and a Kind with no hint branch is
+      a check that renders as silence - the false-green shape this script exists to prevent.
+    #>
+    param(
+        [string]$IntendedTenant,
+        [string]$ActualTenant,
+        [bool]$IntentIsExplicit,
+        [bool]$AzPresent,
+        [string]$Scope = ''
+    )
+    # Normalized HERE, not only at the call site, so the comparator is correct in isolation: it is
+    # the unit the tests execute, and a caller that forgets cannot manufacture a false WRONG TENANT.
+    # Idempotent, so doing it twice costs nothing.
+    $IntendedTenant = Remove-SurroundingQuotes $IntendedTenant
+    $ActualTenant = Remove-SurroundingQuotes $ActualTenant
+
+    if (-not $IntendedTenant) {
+        return [pscustomobject]@{ Kind = 'no-intent'; Ok = $false; Tier = 'optional'; Detail = 'no intended tenant declared - not checked' }
+    }
+    if (-not (Test-TenantIdShape $IntendedTenant)) {
+        return [pscustomobject]@{ Kind = 'malformed'; Ok = $false; Tier = 'optional'; Detail = "intended '$IntendedTenant' is not a tenant GUID - not compared" }
+    }
+    if (-not $AzPresent) {
+        return [pscustomobject]@{ Kind = 'no-az'; Ok = $false; Tier = 'optional'; Detail = "intended $IntendedTenant - not verified (az not on PATH)" }
+    }
+    if (-not $ActualTenant) {
+        return [pscustomobject]@{ Kind = 'no-token'; Ok = $false; Tier = 'optional'; Detail = "intended $IntendedTenant - no Fabric token could be minted or decoded$Scope" }
+    }
+
+    # The verdict. `-eq` on strings is case-insensitive in PowerShell, which is exactly right for a
+    # GUID: the portal shows one casing, the `tid` claim another, and neither is a wrong tenant.
+    # Do NOT "tighten" this to -ceq.
+    $tenantOk = ($ActualTenant -eq $IntendedTenant)
+
+    if ($tenantOk) {
+        return [pscustomobject]@{ Kind = 'match'; Ok = $true; Tier = 'optional'; Detail = "tid matches intended $IntendedTenant$Scope" }
+    }
+    # A mismatch blocks only when THIS run declared the tenant on the command line. The check is
+    # opt-in either way, but the two opt-ins are not the same statement: `-Tenant <id>` is "I am
+    # pointing at that tenant right now", while FABRIC_TENANT_ID in `.env` is a persisted preference
+    # that survives every later run - including a parse-only estate sweep whose steps 1-6 never call
+    # Fabric. Blocking those would re-create, from the other side, the false blocker this change set
+    # removed (a Desktop-only pin failing a run that never opens Desktop). A WARN still names the
+    # problem loudly, and the deploy path - which does pass --tenant - is where exit 1 belongs.
+    $tier = if ($IntentIsExplicit) { 'critical' } else { 'recommended' }
+    $detail = "WRONG TENANT: token is for $ActualTenant, intended $IntendedTenant$Scope"
+    if (-not $IntentIsExplicit) { $detail += ' [warning only: declared by configuration, not by -Tenant on this run]' }
+    return [pscustomobject]@{ Kind = 'mismatch'; Ok = $false; Tier = $tier; Detail = $detail }
+}
+
 # Declaration of intent, in the order a caller expects to win: flag > exported env > git-ignored .env.
-# Trimmed because the comparison below is the only thing standing between an operator and a blocked
-# migration: a trailing space in an exported variable is not a wrong tenant, and must not read as one.
+# Every channel is normalized, because none of them is a place an operator expects to be punished for
+# quoting or for a stray trailing space.
+$tenantIntentIsExplicit = [bool](Remove-SurroundingQuotes $Tenant)
 $intendedTenant = @($Tenant, $env:FABRIC_TENANT_ID, (Get-DotEnvValue 'FABRIC_TENANT_ID')) |
-    Where-Object { $_ -and $_.Trim() } | Select-Object -First 1
-if ($intendedTenant) { $intendedTenant = $intendedTenant.Trim() }
+    ForEach-Object { Remove-SurroundingQuotes $_ } | Where-Object { $_ } | Select-Object -First 1
 
 # Mirrors deploy_estate.py's FABRIC_RESOURCE. Duplicating a well-known constant is a smaller risk
 # than making this PowerShell bootstrap depend on importing Python (see the engine block above for
@@ -500,18 +602,15 @@ if ($intendedTenant) { $intendedTenant = $intendedTenant.Trim() }
 # would fail loudly on its own.
 $fabricResource = 'https://api.fabric.microsoft.com'
 
-if (-not $intendedTenant) {
-    # No declaration -> no `az` call at all, so an operator who only parses workbooks pays nothing.
-    # Reported as a WARN rather than an OK because the check did not RUN: a skipped check that
-    # renders as passing is the false-green shape this whole script exists to prevent.
-    Add-Check 'Fabric token tenant' 'optional' $false 'no intended tenant declared - not checked' `
-        'Declare the tenant you deploy into and this becomes automatic: -Tenant <id>, $env:FABRIC_TENANT_ID, or FABRIC_TENANT_ID in the git-ignored .env. Same id you pass to deploy_estate.py --tenant. Until then, a WorkspaceNotFound on a workspace you know exists may simply be a token for another tenant.'
-}
-elseif (-not (Get-Command az -ErrorAction SilentlyContinue)) {
-    Add-Check 'Fabric token tenant' 'optional' $false "intended $intendedTenant - not verified (az not on PATH)" `
-        'Install the Azure CLI to verify which tenant this machine actually mints Fabric tokens for.'
-}
-else {
+$azPresent = [bool](Get-Command az -ErrorAction SilentlyContinue)
+$scoped = if ($Subscription) { " (scoped: --subscription $Subscription)" } else { ' (default az context)' }
+$actualTenant = ''
+
+# The mint sits behind the declaration guard: no declared tenant - or one that cannot be compared -
+# means no `az` call at all, so an operator who only parses workbooks pays nothing. Preflight runs
+# before EVERY migration, so a mandatory token mint here would tax every run for a check that has
+# nothing to compare against.
+if ($intendedTenant -and (Test-TenantIdShape $intendedTenant) -and $azPresent) {
     $azArgs = @('account', 'get-access-token', '--resource', $fabricResource, '-o', 'json')
     # --subscription scopes ONE call. It is offered here so the fix can be verified with the same
     # command shape that applies it, rather than by mutating the CLI profile and hoping.
@@ -519,35 +618,41 @@ else {
     # $tokenJson holds a BEARER TOKEN. It is never echoed, never added to a Detail, and az's own
     # stderr is discarded rather than surfaced, so no code path can leak it.
     $tokenJson = & az @azArgs 2>$null
-    $actualTenant = $null
     if ($tokenJson) {
-        try { $actualTenant = Get-JwtTenantId ((($tokenJson | Out-String) | ConvertFrom-Json).accessToken) } catch { $actualTenant = $null }
-    }
-    $scoped = if ($Subscription) { " (scoped: --subscription $Subscription)" } else { ' (default az context)' }
-
-    if (-not $actualTenant) {
-        Add-Check 'Fabric token tenant' 'optional' $false "intended $intendedTenant - no Fabric token could be minted or decoded$scoped" `
-            'Run `az login`, then re-run preflight. (Preflight never prints the token - only its decoded `tid` claim.)'
-    }
-    else {
-        $tenantOk = ($actualTenant -eq $intendedTenant)
-        # A mismatch is CRITICAL and a match is a quiet OK. Critical is defensible precisely because
-        # the check is OPT-IN: it can only fire once someone has declared "I intend to deploy into
-        # tenant X", and at that point a token for tenant Y makes every Fabric call answer 404 for
-        # things that exist. Nobody who has not declared a tenant can ever be blocked by it.
-        $exampleSub = $null
-        if (-not $tenantOk) {
-            # Turn the advice into something copy-pasteable: name a subscription this machine can
-            # already see INSIDE the intended tenant. Costs one extra `az` call, on the failure path
-            # only.
-            $exampleSub = (& az account list --all --query "[?tenantId=='$intendedTenant'].id" -o tsv 2>$null | Select-Object -First 1)
-        }
-        $subHint = if ($exampleSub) { "e.g. --subscription $exampleSub" } else { '--subscription <a subscription inside that tenant>' }
-        Add-Check 'Fabric token tenant' $(if ($tenantOk) { 'optional' } else { 'critical' }) $tenantOk `
-            $(if ($tenantOk) { "tid matches intended $intendedTenant$scoped" } else { "WRONG TENANT: token is for $actualTenant, intended $intendedTenant$scoped" }) `
-            "This is an IDENTITY problem, not a missing workspace: Fabric will answer WorkspaceNotFound/EntityNotFound for items that exist. Prefer the non-mutating fix, which scopes a single call: az account get-access-token --resource $fabricResource $subHint (re-run preflight with -Subscription <same> to confirm). ``az account set`` also works but rewrites the CLI profile on disk, so every other process on this machine silently follows you - restore it afterwards if you use it. Note deploy_estate.py --tenant is passed to az verbatim and inherits the same ambiguity (az may resolve a different ACCOUNT against that tenant and answer AADSTS90072)."
+        try { $actualTenant = Get-JwtTenantId ((($tokenJson | Out-String) | ConvertFrom-Json).accessToken) } catch { $actualTenant = '' }
     }
 }
+
+$verdict = Get-TenantVerdict -IntendedTenant $intendedTenant -ActualTenant $actualTenant `
+    -IntentIsExplicit $tenantIntentIsExplicit -AzPresent $azPresent -Scope $scoped
+
+# One hint per Kind. Anything that needs an extra `az` call lives in its own branch, so the failure
+# path is the only one that pays for it.
+$tenantHint = switch ($verdict.Kind) {
+    'no-intent' {
+        'Declare the tenant you deploy into and this becomes automatic: -Tenant <id> (blocking, for a run that is about to deploy), $env:FABRIC_TENANT_ID, or FABRIC_TENANT_ID in the git-ignored .env (both warn-only). Same id you pass to deploy_estate.py --tenant. Until then, a WorkspaceNotFound on a workspace you know exists may simply be a token for another tenant.'
+    }
+    'malformed' {
+        'A token''s `tid` claim is always a GUID, so preflight has nothing to compare a domain name or a placeholder against. Use the GUID form: az account show --query tenantId -o tsv (or Entra > Overview). Note `az --tenant` and deploy_estate.py DO accept contoso.onmicrosoft.com, so this is a preflight-only requirement - and it never blocks.'
+    }
+    'no-az' {
+        'Install the Azure CLI to verify which tenant this machine actually mints Fabric tokens for.'
+    }
+    'no-token' {
+        'Run `az login`, then re-run preflight. (Preflight never prints the token - only its decoded `tid` claim.)'
+    }
+    'mismatch' {
+        # Turn the advice into something copy-pasteable: name a subscription this machine can
+        # already see INSIDE the intended tenant. Costs one extra `az` call, on this path only.
+        $exampleSub = (& az account list --all --query "[?tenantId=='$intendedTenant'].id" -o tsv 2>$null | Select-Object -First 1)
+        $subHint = if ($exampleSub) { "e.g. --subscription $exampleSub" } else { '--subscription <a subscription inside that tenant>' }
+        $escalation = if ($verdict.Tier -eq 'critical') { '' } else { ' This is a WARNING rather than a blocker because the intended tenant came from configuration ($env:FABRIC_TENANT_ID or .env), not from -Tenant on this run; pass -Tenant <id> on the run that actually deploys and the same mismatch fails preflight.' }
+        "This is an IDENTITY problem, not a missing workspace: Fabric will answer WorkspaceNotFound/EntityNotFound for items that exist. Prefer the non-mutating fix, which scopes a single call: az account get-access-token --resource $fabricResource $subHint (re-run preflight with -Subscription <same> to confirm). ``az account set`` also works but rewrites the CLI profile on disk, so every other process on this machine silently follows you - restore it afterwards if you use it. Note deploy_estate.py --tenant is passed to az verbatim and inherits the same ambiguity (az may resolve a different ACCOUNT against that tenant and answer AADSTS90072).$escalation"
+    }
+    default { '' }
+}
+
+Add-Check 'Fabric token tenant' $verdict.Tier $verdict.Ok $verdict.Detail $tenantHint
 
 $odbc = (Get-OdbcDriver -ErrorAction SilentlyContinue | Where-Object Name -like '*SQL Server*').Name
 Add-Check 'ODBC Driver 18 (SQL)' 'optional' ($odbc -contains 'ODBC Driver 18 for SQL Server') `

--- a/scripts/preflight.ps1
+++ b/scripts/preflight.ps1
@@ -47,15 +47,24 @@
   It can also come from `$env:FABRIC_TENANT_ID`, or `FABRIC_TENANT_ID` in the git-ignored `.env` -
   which is the right home for a real customer tenant id, because this repository is PUBLIC.
   Surrounding whitespace and a matched pair of quotes are accepted from any of the three
-  (`FABRIC_TENANT_ID="72f9..."` is ordinary dotenv spelling, not a wrong tenant).
+  (`FABRIC_TENANT_ID="72f9..."` is ordinary dotenv spelling, not a wrong tenant), and a `.env` value
+  may carry a trailing `# comment` - which, next to a GUID nobody recognizes by sight, is exactly
+  where one belongs.
+
+  A default DOMAIN (`contoso.onmicrosoft.com`) is accepted too and resolved to its GUID via
+  `az account list --all`, because `az --tenant` and `deploy_estate.py --tenant` both take that form.
+  A vanity domain, or a tenant this machine has never signed in to, cannot be resolved - preflight
+  then says so rather than guessing, and never blocks on it.
 
   WHERE the declaration came from decides how loudly a mismatch lands, because it is the only
   evidence preflight has of deploy INTENT for THIS run:
     * `-Tenant` on the command line  -> a mismatch is CRITICAL (exit 1). You said, in this
-      invocation, that you are pointing at a tenant; a token for another one is a blocker.
-    * `$env:FABRIC_TENANT_ID` / `.env` -> a mismatch is RECOMMENDED (a visible WARN, exit 0).
-      Persisted configuration is a standing preference, not a statement that this run deploys -
-      and steps 1-6 of an estate run never touch Fabric at all.
+      invocation, that you are pointing at a tenant; a token for another one is a blocker. If it
+      could not be verified at all (unresolvable spelling, no `az`, no token), that is a RECOMMENDED
+      warning: a declared check that did not run is not a pass.
+    * `$env:FABRIC_TENANT_ID` / `.env` -> a mismatch is RECOMMENDED (a visible WARN, exit 0), and a
+      failure to verify is OPTIONAL. Persisted configuration is a standing preference, not a
+      statement that this run deploys - and steps 1-6 of an estate run never touch Fabric at all.
 
 .PARAMETER Subscription
   Optional subscription id/name passed verbatim to `az account get-access-token --subscription`,
@@ -499,11 +508,41 @@ function Remove-SurroundingQuotes([string]$Value) {
     return $v
 }
 
+function ConvertFrom-DotEnvValue([string]$Raw) {
+    # A .env value, read the way every other dotenv consumer reads one: matched surrounding quotes
+    # are a SPELLING, and an inline `# comment` after the value is a comment. Both are ordinary -
+    # `FABRIC_TENANT_ID=72f9... # customer tenant` is the natural thing to write next to a GUID
+    # nobody can recognize by sight - and neither is part of the value.
+    #
+    # Inside quotes, a '#' is DATA. Outside them, a comment starts at the beginning of the value or
+    # after whitespace, so `abc#def` stays whole: over-stripping a legitimate value would be the
+    # same class of bug (quiet corruption of a declaration) as not stripping at all.
+    #
+    # The quoted form only wins when the closing quote actually ENDS the value (bar whitespace or a
+    # comment) - so the closer is the first candidate that satisfies that, which is what every
+    # dotenv reader does. `""guid""` and `"a"b"` therefore have no valid closer until their final
+    # quote and stay visibly malformed, rather than silently decoding to '' or to a fragment.
+    $v = ([string]$Raw).Trim()
+    if ($v.Length -ge 2) {
+        $q = $v.Substring(0, 1)
+        if ($q -eq '"' -or $q -eq "'") {
+            for ($i = 1; $i -lt $v.Length; $i++) {
+                if ($v[$i] -ne $q) { continue }
+                $tail = $v.Substring($i + 1).Trim()
+                if (-not $tail -or $tail.StartsWith('#')) { return $v.Substring(1, $i - 1) }
+            }
+        }
+    }
+    $comment = [regex]::Match($v, '(^|\s)#')
+    if ($comment.Success) { $v = $v.Substring(0, $comment.Index) }
+    return (Remove-SurroundingQuotes $v)
+}
+
 function Get-DotEnvValue([string]$Key, [string]$Path) {
-    # The same minimal KEY=VALUE parse as scripts/tableau_env.py's load_env (trim, skip blank/'#',
-    # split on the FIRST '='), plus ONE deliberate divergence: matched surrounding quotes are
-    # stripped. That divergence is the fix, not an accident - the two parsers previously agreed by
-    # being wrong in the same way, and "identical to Python" was the argument that kept it.
+    # The same minimal KEY=VALUE scan as scripts/tableau_env.py's load_env (trim, skip blank/'#',
+    # split on the FIRST '='), plus the deliberate divergence in ConvertFrom-DotEnvValue above.
+    # That divergence is the fix, not an accident - the two parsers previously agreed by being wrong
+    # in the same way, and "identical to Python" was the argument that kept it.
     # `scripts/tableau_env.py:load_env` should get the same treatment; it is owned elsewhere, so it
     # is flagged rather than edited here. Nothing in Python reads FABRIC_TENANT_ID today, so the
     # divergence is inert until that happens.
@@ -514,30 +553,60 @@ function Get-DotEnvValue([string]$Key, [string]$Path) {
         $trimmed = $line.Trim()
         if (-not $trimmed -or $trimmed.StartsWith('#') -or ($trimmed -notmatch '=')) { continue }
         $pair = $trimmed -split '=', 2
-        if ($pair[0].Trim() -eq $Key) { return (Remove-SurroundingQuotes $pair[1]) }
+        if ($pair[0].Trim() -eq $Key) { return (ConvertFrom-DotEnvValue $pair[1]) }
     }
     return $null
 }
 
+function Resolve-IntendedTenant([string]$FromFlag, [string]$FromEnv, [string]$FromDotEnv) {
+    # Declaration of intent, in the order a caller expects to win: flag > exported env > .env.
+    # A function rather than an inline pipeline because WHICH channel won decides whether a mismatch
+    # blocks, and because normalizing only two of the three channels is a silent way to reintroduce
+    # the quoting bug through the third (measured: a quoted $env:FABRIC_TENANT_ID then fails the
+    # GUID guard and degrades to "no token could be minted" - the same false negative wearing a
+    # different message). Here it is one line, executed by the tests.
+    $candidates = @($FromFlag, $FromEnv, $FromDotEnv) | ForEach-Object { Remove-SurroundingQuotes $_ }
+    $tenant = $candidates | Where-Object { $_ } | Select-Object -First 1
+    # "$tenant" rather than [string]$tenant: an empty pipeline yields AutomationNull, whose [string]
+    # cast survives as null through ConvertTo-Json and would make "nothing declared" indistinguishable
+    # from a serialization accident to any caller inspecting the object.
+    return [pscustomobject]@{ Tenant = "$tenant"; IsExplicit = [bool]$candidates[0] }
+}
+
 function Test-TenantIdShape([string]$Value) {
-    # The `tid` claim is ALWAYS a GUID. An intended tenant that is not one cannot be compared
-    # against it, and two spellings that are not GUIDs are entirely plausible here:
-    #   * `contoso.onmicrosoft.com` - which `az --tenant` and `deploy_estate.py --tenant` both
-    #     accept, so an operator has every reason to think it belongs in FABRIC_TENANT_ID;
-    #   * a placeholder like `<your-tenant-id>` copied out of a `.env.example`.
-    # Comparing either against a GUID answers "wrong tenant" - the same false blocker as the quoting
-    # bug, arriving by a different route. Preflight says "cannot compare" instead, and never blocks.
+    # The `tid` claim is ALWAYS a GUID, so only a GUID can be compared against it.
     return [bool]($Value -match '^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$')
+}
+
+function Resolve-TenantIdFromDomain([string]$Domain) {
+    # `contoso.onmicrosoft.com` is a legitimate spelling everywhere else in this toolchain - both
+    # `az --tenant` and `deploy_estate.py --tenant` accept it - so an operator has every reason to
+    # put one in -Tenant or FABRIC_TENANT_ID. Answering "cannot compare" to that is a CHOICE, not a
+    # necessity: the CLI already holds the mapping, and `az account list --all` returns
+    # tenantDefaultDomain next to tenantId. Giving up would leave a declared, blocking-channel
+    # intent completely unverified under a green "Ready to migrate".
+    #
+    # Resolution is best-effort by design: a VANITY domain (contoso.com) is not the default domain
+    # and will not be found, and a tenant the profile has never seen cannot be mapped. Those fall
+    # back to "cannot compare", which is honest - it is silence that is not.
+    if (-not $Domain) { return '' }
+    $listed = & az account list --all -o json 2>$null
+    if (-not $listed) { return '' }
+    try { $accounts = (($listed | Out-String) | ConvertFrom-Json) } catch { return '' }
+    # -eq is case-insensitive, which is right for a DNS name.
+    $hit = $accounts | Where-Object { $_.tenantDefaultDomain -eq $Domain } | Select-Object -First 1
+    if ($hit -and (Test-TenantIdShape $hit.tenantId)) { return [string]$hit.tenantId }
+    return ''
 }
 
 function Get-TenantVerdict {
     <#
       THE decision. Everything above this gathers evidence; this function alone turns it into
-      Ok/Tier/Detail, so the one line that decides the verdict can be EXECUTED by the test harness
-      rather than matched as a source string. That matters more than usual here: CI cannot run
-      PowerShell, and a mutation test showed both `$tenantOk = $true` (the check can never fire) and
-      an inverted comparison (fires on every correct machine) surviving the whole suite while it was
-      inline.
+      Ok/Tier/Detail/Summary, so the one line that decides the verdict can be EXECUTED by the test
+      harness rather than matched as a source string. That matters more than usual here: CI cannot
+      run PowerShell, and a mutation test showed both `$tenantOk = $true` (the check can never fire)
+      and an inverted comparison (fires on every correct machine) surviving the whole suite while it
+      was inline.
 
       Kind is part of the contract: the caller maps it to a hint, and a Kind with no hint branch is
       a check that renders as silence - the false-green shape this script exists to prevent.
@@ -547,25 +616,48 @@ function Get-TenantVerdict {
         [string]$ActualTenant,
         [bool]$IntentIsExplicit,
         [bool]$AzPresent,
-        [string]$Scope = ''
+        [string]$Scope = '',
+        [string]$DeclaredAs = ''
     )
     # Normalized HERE, not only at the call site, so the comparator is correct in isolation: it is
     # the unit the tests execute, and a caller that forgets cannot manufacture a false WRONG TENANT.
     # Idempotent, so doing it twice costs nothing.
     $IntendedTenant = Remove-SurroundingQuotes $IntendedTenant
     $ActualTenant = Remove-SurroundingQuotes $ActualTenant
+    $DeclaredAs = Remove-SurroundingQuotes $DeclaredAs
+    # Only worth showing when the operator wrote something other than the id being compared - i.e.
+    # when a domain was resolved to a GUID. Otherwise it is the same string twice.
+    $as = if ($DeclaredAs -and $DeclaredAs -ne $IntendedTenant) { " (declared as $DeclaredAs)" } else { '' }
+
+    # An intent DECLARED FOR THIS RUN that could not be verified is not a clean bill of health: it
+    # is a blank space where the operator asked for a check. OPTIONAL is where such a line goes to
+    # be ignored - measured: `-Tenant contoso.onmicrosoft.com` produced zero verification, filed
+    # under OPTIONAL, beneath "Ready to migrate". Configuration-declared intent stays optional,
+    # because it is a standing preference rather than a statement about this run.
+    $unverified = if ($IntentIsExplicit) { 'recommended' } else { 'optional' }
 
     if (-not $IntendedTenant) {
-        return [pscustomobject]@{ Kind = 'no-intent'; Ok = $false; Tier = 'optional'; Detail = 'no intended tenant declared - not checked' }
+        return [pscustomobject]@{ Kind = 'no-intent'; Ok = $false; Tier = 'optional'; Summary = ''
+            Detail                    = 'no intended tenant declared - not checked'
+        }
     }
     if (-not (Test-TenantIdShape $IntendedTenant)) {
-        return [pscustomobject]@{ Kind = 'malformed'; Ok = $false; Tier = 'optional'; Detail = "intended '$IntendedTenant' is not a tenant GUID - not compared" }
+        return [pscustomobject]@{ Kind = 'malformed'; Ok = $false; Tier = $unverified
+            Detail                     = "intended '$IntendedTenant' is not a tenant GUID and could not be resolved to one - not compared"
+            Summary                    = if ($IntentIsExplicit) { "tenant NOT VERIFIED: '$IntendedTenant' could not be resolved to a GUID" } else { '' }
+        }
     }
     if (-not $AzPresent) {
-        return [pscustomobject]@{ Kind = 'no-az'; Ok = $false; Tier = 'optional'; Detail = "intended $IntendedTenant - not verified (az not on PATH)" }
+        return [pscustomobject]@{ Kind = 'no-az'; Ok = $false; Tier = $unverified
+            Detail                     = "intended $IntendedTenant$as - not verified (az not on PATH)"
+            Summary                    = if ($IntentIsExplicit) { "tenant NOT VERIFIED: az not on PATH (intended $IntendedTenant)" } else { '' }
+        }
     }
     if (-not $ActualTenant) {
-        return [pscustomobject]@{ Kind = 'no-token'; Ok = $false; Tier = 'optional'; Detail = "intended $IntendedTenant - no Fabric token could be minted or decoded$Scope" }
+        return [pscustomobject]@{ Kind = 'no-token'; Ok = $false; Tier = $unverified
+            Detail                     = "intended $IntendedTenant$as - no Fabric token could be minted or decoded$Scope"
+            Summary                    = if ($IntentIsExplicit) { "tenant NOT VERIFIED: no Fabric token could be minted (intended $IntendedTenant)" } else { '' }
+        }
     }
 
     # The verdict. `-eq` on strings is case-insensitive in PowerShell, which is exactly right for a
@@ -574,7 +666,9 @@ function Get-TenantVerdict {
     $tenantOk = ($ActualTenant -eq $IntendedTenant)
 
     if ($tenantOk) {
-        return [pscustomobject]@{ Kind = 'match'; Ok = $true; Tier = 'optional'; Detail = "tid matches intended $IntendedTenant$Scope" }
+        return [pscustomobject]@{ Kind = 'match'; Ok = $true; Tier = 'optional'; Summary = ''
+            Detail                     = "tid matches intended $IntendedTenant$as$Scope"
+        }
     }
     # A mismatch blocks only when THIS run declared the tenant on the command line. The check is
     # opt-in either way, but the two opt-ins are not the same statement: `-Tenant <id>` is "I am
@@ -584,17 +678,12 @@ function Get-TenantVerdict {
     # removed (a Desktop-only pin failing a run that never opens Desktop). A WARN still names the
     # problem loudly, and the deploy path - which does pass --tenant - is where exit 1 belongs.
     $tier = if ($IntentIsExplicit) { 'critical' } else { 'recommended' }
-    $detail = "WRONG TENANT: token is for $ActualTenant, intended $IntendedTenant$Scope"
+    $detail = "WRONG TENANT: token is for $ActualTenant, intended $IntendedTenant$as$Scope"
     if (-not $IntentIsExplicit) { $detail += ' [warning only: declared by configuration, not by -Tenant on this run]' }
-    return [pscustomobject]@{ Kind = 'mismatch'; Ok = $false; Tier = $tier; Detail = $detail }
+    return [pscustomobject]@{ Kind = 'mismatch'; Ok = $false; Tier = $tier; Detail = $detail
+        Summary                     = "WRONG TENANT: token is for $ActualTenant, intended $IntendedTenant$as"
+    }
 }
-
-# Declaration of intent, in the order a caller expects to win: flag > exported env > git-ignored .env.
-# Every channel is normalized, because none of them is a place an operator expects to be punished for
-# quoting or for a stray trailing space.
-$tenantIntentIsExplicit = [bool](Remove-SurroundingQuotes $Tenant)
-$intendedTenant = @($Tenant, $env:FABRIC_TENANT_ID, (Get-DotEnvValue 'FABRIC_TENANT_ID')) |
-    ForEach-Object { Remove-SurroundingQuotes $_ } | Where-Object { $_ } | Select-Object -First 1
 
 # Mirrors deploy_estate.py's FABRIC_RESOURCE. Duplicating a well-known constant is a smaller risk
 # than making this PowerShell bootstrap depend on importing Python (see the engine block above for
@@ -602,12 +691,22 @@ $intendedTenant = @($Tenant, $env:FABRIC_TENANT_ID, (Get-DotEnvValue 'FABRIC_TEN
 # would fail loudly on its own.
 $fabricResource = 'https://api.fabric.microsoft.com'
 
+$intent = Resolve-IntendedTenant $Tenant $env:FABRIC_TENANT_ID (Get-DotEnvValue 'FABRIC_TENANT_ID')
+$intendedTenant = $intent.Tenant
+$declaredAs = $intent.Tenant
 $azPresent = [bool](Get-Command az -ErrorAction SilentlyContinue)
 $scoped = if ($Subscription) { " (scoped: --subscription $Subscription)" } else { ' (default az context)' }
 $actualTenant = ''
 
-# The mint sits behind the declaration guard: no declared tenant - or one that cannot be compared -
-# means no `az` call at all, so an operator who only parses workbooks pays nothing. Preflight runs
+# A declared non-GUID gets RESOLVED before it gets given up on (see Resolve-TenantIdFromDomain).
+# Still behind the declaration guard, so an undeclared run pays nothing.
+if ($intendedTenant -and -not (Test-TenantIdShape $intendedTenant) -and $azPresent) {
+    $resolved = Resolve-TenantIdFromDomain $intendedTenant
+    if ($resolved) { $intendedTenant = $resolved }
+}
+
+# The mint sits behind the same guard: no declared tenant - or one that still cannot be compared -
+# means no token call at all, so an operator who only parses workbooks pays nothing. Preflight runs
 # before EVERY migration, so a mandatory token mint here would tax every run for a check that has
 # nothing to compare against.
 if ($intendedTenant -and (Test-TenantIdShape $intendedTenant) -and $azPresent) {
@@ -624,7 +723,7 @@ if ($intendedTenant -and (Test-TenantIdShape $intendedTenant) -and $azPresent) {
 }
 
 $verdict = Get-TenantVerdict -IntendedTenant $intendedTenant -ActualTenant $actualTenant `
-    -IntentIsExplicit $tenantIntentIsExplicit -AzPresent $azPresent -Scope $scoped
+    -IntentIsExplicit $intent.IsExplicit -AzPresent $azPresent -Scope $scoped -DeclaredAs $declaredAs
 
 # One hint per Kind. Anything that needs an extra `az` call lives in its own branch, so the failure
 # path is the only one that pays for it.
@@ -633,7 +732,7 @@ $tenantHint = switch ($verdict.Kind) {
         'Declare the tenant you deploy into and this becomes automatic: -Tenant <id> (blocking, for a run that is about to deploy), $env:FABRIC_TENANT_ID, or FABRIC_TENANT_ID in the git-ignored .env (both warn-only). Same id you pass to deploy_estate.py --tenant. Until then, a WorkspaceNotFound on a workspace you know exists may simply be a token for another tenant.'
     }
     'malformed' {
-        'A token''s `tid` claim is always a GUID, so preflight has nothing to compare a domain name or a placeholder against. Use the GUID form: az account show --query tenantId -o tsv (or Entra > Overview). Note `az --tenant` and deploy_estate.py DO accept contoso.onmicrosoft.com, so this is a preflight-only requirement - and it never blocks.'
+        'Preflight resolves a default domain (contoso.onmicrosoft.com) against `az account list --all`, so this one is either a VANITY domain, a tenant this machine has never signed in to, or a placeholder that was never filled in. Give the GUID instead: az account show --query tenantId -o tsv (or Entra > Overview). Note `az --tenant` and deploy_estate.py DO accept a domain, so this is a preflight-only requirement - and it never blocks.'
     }
     'no-az' {
         'Install the Azure CLI to verify which tenant this machine actually mints Fabric tokens for.'
@@ -674,11 +773,17 @@ foreach ($tier in @('critical', 'recommended', 'optional')) {
     }
 }
 Write-Host ''
+# The tenant verdict is one line in the middle of ~40, and the OK lines that follow it push it off
+# an 80x24 terminal: measured, a WRONG TENANT warning sat at line 22 of 38 while the only text still
+# on screen read "Ready to migrate. 3 recommended warning(s) present." A count is not a diagnosis -
+# name the tenant on the line that survives scrolling. Empty for a match, for an undeclared run, and
+# for a merely configured intent that could not be verified, so the common case stays quiet.
+$tenantNote = if ($verdict.Summary) { " $($verdict.Summary)." } else { '' }
 if ($criticalMissing -gt 0) {
     $suffix = if ($recommendedWarnings -gt 0) { " ($recommendedWarnings recommended warning(s) also present)." } else { '' }
-    Write-Host "PREFLIGHT: $criticalMissing critical item(s) missing - resolve before migrating.$suffix"
+    Write-Host "PREFLIGHT: $criticalMissing critical item(s) missing - resolve before migrating.$suffix$tenantNote"
     exit 1
 }
 $suffix = if ($recommendedWarnings -gt 0) { " $recommendedWarnings recommended warning(s) present; review before relying on affected capabilities." } else { '' }
-Write-Host "PREFLIGHT: all critical dependencies present. Ready to migrate.$suffix"
+Write-Host "PREFLIGHT: all critical dependencies present. Ready to migrate.$suffix$tenantNote"
 exit 0

--- a/tests/fixtures/dotenv-spellings.env
+++ b/tests/fixtures/dotenv-spellings.env
@@ -14,3 +14,18 @@ UNMATCHED_QUOTE="a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d
 INNER_QUOTES=ab"cd"ef
 HAS_EQUALS=a=b=c
 EMPTY=
+
+# Inline comments. Next to a GUID nobody can recognize by sight, a trailing note is the natural
+# thing to write - so it is a spelling, not an abuse. Inside quotes a '#' is DATA, and a '#' with no
+# whitespace in front of it (`abc#def`) is part of the value: over-stripping would corrupt a
+# declaration just as quietly as not stripping at all.
+COMMENTED=a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d # customer tenant, do not change
+COMMENTED_TIGHT=a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d	# after a tab
+QUOTED_AND_COMMENTED="a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d"  # both at once
+HASH_INSIDE_QUOTES="ab #cd"
+HASH_IS_DATA=abc#def
+HASH_AFTER_INNER_QUOTE="ab" #cd"
+HASH_STILL_INSIDE="a #b" c"
+ONLY_A_COMMENT= # nothing but a note
+DOUBLE_QUOTED_TWICE=""a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d""
+QUOTE_THEN_TAIL="a"b"

--- a/tests/fixtures/dotenv-spellings.env
+++ b/tests/fixtures/dotenv-spellings.env
@@ -1,0 +1,16 @@
+# Synthetic .env spellings for tests/test_preflight_contract.py. NO real credentials and NO real
+# tenant id: the GUID below is synthetic (a1b2c3d4-...), chosen to contain hex LETTERS so a
+# case-sensitivity regression cannot pass unnoticed. The file is committed on purpose - 
+# `Get-DotEnvValue` reads a PATH, so a fixture needs no temp directory, and it doubles as the
+# written-down list of spellings preflight promises to accept.
+PLAIN=a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d
+DOUBLE_QUOTED="a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d"
+SINGLE_QUOTED='a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d'
+PADDED=   a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d
+QUOTED_AND_PADDED =   "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d"
+
+# A comment, a blank line above it, and the awkward cases below.
+UNMATCHED_QUOTE="a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d
+INNER_QUOTES=ab"cd"ef
+HAS_EQUALS=a=b=c
+EMPTY=

--- a/tests/test_preflight_contract.py
+++ b/tests/test_preflight_contract.py
@@ -1,10 +1,27 @@
-"""Source-contract tests for ``scripts/preflight.ps1`` severity tiers."""
+"""Source-contract tests for ``scripts/preflight.ps1`` severity tiers.
 
+Two kinds of test live here. Most are **source contracts**: CI runs on Ubuntu while the script
+deliberately depends on Windows/Power BI Desktop primitives, so the tiers and hints are asserted by
+reading the source. The JWT-decoder tests at the bottom are **executed**, because a base64url
+padding bug is invisible to any amount of source reading and would make the wrong-tenant check
+silently answer "cannot decode" on exactly the tokens it exists to inspect.
+"""
+
+import base64
+import json
+import os
 import re
+import shutil
+import subprocess
 from pathlib import Path
+
+import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 PREFLIGHT = REPO_ROOT / "scripts" / "preflight.ps1"
+
+TENANT_CHECK = "Fabric token tenant"
+DESKTOP_PIN_CHECK = "PBI_DESKTOP_PATH (bridge exe pin)"
 
 
 def _preflight_source() -> str:
@@ -37,6 +54,11 @@ def test_known_blocking_preflight_checks_are_critical() -> None:
     The renderer exits non-zero only for CRITICAL checks. These names are source-contract tests rather
     than a full PowerShell harness because CI runs on Ubuntu, while the script intentionally depends on
     Windows/Power BI Desktop primitives.
+
+    ``PBI_DESKTOP_PATH (bridge exe pin)`` was on this list until #124 and is deliberately no longer
+    here: it is a Desktop-only pin, and the estate pipeline never opens Desktop. Its tier is pinned
+    from the other side by `test_the_desktop_pin_warns_rather_than_blocking_a_run_that_never_opens_it`,
+    so it cannot drift back to critical *or* fade to an invisible optional.
     """
     source = _preflight_source()
 
@@ -46,12 +68,63 @@ def test_known_blocking_preflight_checks_are_critical() -> None:
         "engine: plugin installed",
         "engine: single source",
         "Power BI Desktop",
-        "PBI_DESKTOP_PATH (bridge exe pin)",
     ):
         _assert_add_check_tier(source, check_name, "critical")
 
     for command in ("npx", "powerbi-desktop", "dotnet"):
         _assert_add_cli_tier(source, command, "critical")
+
+
+def test_the_desktop_pin_warns_rather_than_blocking_a_run_that_never_opens_it() -> None:
+    """A Desktop-only pin must not exit 1 on a pipeline that never opens Desktop (#124).
+
+    Measured: a machine with the engine, both plugins, both CLIs at known-good versions, Desktop
+    installed, `az`, `uv` and ODBC 18 was reported NOT READY over this one unset variable - while
+    `run_estate.py`'s own docstring says it "never opens Power BI Desktop". Spending exit 1, which the
+    runbook defines as "resolve before migrating", on an item the runbook never names is how an
+    operator learns to ignore exit 1.
+
+    ``recommended`` is the exact tier this needs: still rendered, still counted in the summary line,
+    but not a blocker. ``optional`` would be a downgrade too far - the failure it prevents (Desktop
+    auto-updates, the bridge can no longer find the exe) is real.
+    """
+    _assert_add_check_tier(_preflight_source(), DESKTOP_PIN_CHECK, "recommended")
+
+
+def test_the_desktop_pin_hint_is_actionable_in_the_shell_that_reads_it() -> None:
+    """`setx` cannot fix the session that is reading the hint, so it cannot be the only advice.
+
+    `setx` writes the user profile and is inherited only by processes started later; an agent's tool
+    shells inherit an already-running parent's environment. Following the old hint verbatim therefore
+    left preflight failing in the very session that printed it. `$env:` is the form that takes effect
+    immediately, so it must lead, and any `setx` offered alongside must say it does not affect the
+    current shell.
+    """
+    source = _preflight_source()
+    hint = source[source.index(f"Add-Check '{DESKTOP_PIN_CHECK}'") :].split("\n\n")[0]
+    assert "$env:PBI_DESKTOP_PATH = " in hint, "the hint must give the form that works in THIS shell"
+    if "setx" in hint:
+        assert re.search(r"(?i)new shells|does NOT affect this one", hint), (
+            "a `setx` hint must state that it does not affect the shell reading it"
+        )
+
+
+def test_the_correctness_floor_says_where_report_version_at_import_belongs() -> None:
+    """The floor's justification is load-bearing prose, and stating it imprecisely produced a bug (#129).
+
+    Measured against the known-good validator: `reportVersionAtImport` is REQUIRED inside each
+    `themeCollection` entry and FORBIDDEN at the top level of `report.json`, which answers
+    "must NOT have additional properties". Three documents called it "schema-required in report.json"
+    without saying where, and an agent reading exactly that added it beside `$schema` in
+    `scripts/probe_live_source.py` - a scaffold that then failed this repo's own gate. Ground truth is
+    committed at examples/shipping-kpis/fabric/ShippingKPIs.Report/definition/report.json.
+    """
+    source = _preflight_source()
+    claim = source[source.index("reportVersionAtImport") - 400 : source.index("reportVersionAtImport") + 400]
+    assert "themeCollection" in claim, "say WHERE it is required, or the next reader puts it at the top level"
+    assert re.search(r"(?i)forbidden at the top level", claim), (
+        "the top-level prohibition is the half that was actually acted on incorrectly"
+    )
 
 
 def test_the_engine_check_asks_the_one_resolver_rather_than_listing_paths_itself() -> None:
@@ -92,3 +165,215 @@ def test_the_upstream_engine_check_stays_opt_in_and_advisory() -> None:
     upstream_block = source[source.index("if ($CheckUpstream) {") :]
     assert "Add-Check 'upstream: conversion engine' 'optional'" in upstream_block
     assert "upstream_version_url" in upstream_block, "the URL belongs to engine_source.py, not to preflight"
+
+
+# --------------------------------------------------------------------------------------------------
+# The wrong-tenant check (#124). A token that MINTS successfully can still be for another tenant, and
+# Fabric then answers WorkspaceNotFound for a workspace that exists - measured four times across two
+# operators, ~15 minutes each, every time read as a 404 rather than as an identity problem.
+# --------------------------------------------------------------------------------------------------
+
+
+def _tenant_block(source: str) -> str:
+    return source[source.index("# --- Fabric token TENANT") : source.index("$odbc = ")]
+
+
+def test_the_tenant_check_is_emitted_on_every_branch() -> None:
+    """Every path must report, because a check that renders as nothing reads as a check that passed.
+
+    Four outcomes exist - nothing declared, `az` absent, no token minted, and the verdict itself -
+    and each must produce a line. This is the same rule the engine block already obeys.
+    """
+    block = _tenant_block(_preflight_source())
+    branches = block.count(f"Add-Check '{TENANT_CHECK}'")
+    assert branches == 4, f"expected all four tenant-check branches to report, found {branches}"
+
+
+def test_only_a_tenant_mismatch_is_critical() -> None:
+    """Blocking is reserved for the one outcome that is unambiguously wrong.
+
+    A mismatch can only fire after someone has explicitly declared "I intend to deploy into tenant
+    X", so it can never block a machine that never declared one - that opt-in is what makes exit 1
+    defensible here. Everything else (undeclared, no `az`, no token) is advisory: those are reasons
+    the check could not run, not evidence that anything is wrong, and the estate pipeline does not
+    touch Fabric at all.
+    """
+    block = _tenant_block(_preflight_source())
+    tiers = re.findall(rf"Add-Check '{re.escape(TENANT_CHECK)}' (\S+)", block)
+    literal = [t for t in tiers if t.startswith("'")]
+    conditional = [t for t in tiers if not t.startswith("'")]
+    assert literal == ["'optional'"] * 3, f"non-verdict branches must stay advisory, saw {literal}"
+    assert len(conditional) == 1, "the verdict branch must choose its tier from the comparison"
+    assert "$(if ($tenantOk) { 'optional' } else { 'critical' })" in block, (
+        "a mismatch must be critical and a match must not be"
+    )
+
+
+def test_the_tenant_check_costs_nothing_until_a_tenant_is_declared() -> None:
+    """No declaration, no `az` call: preflight runs before EVERY migration, including parse-only ones.
+
+    A mandatory token mint here would tax every run for a check that cannot say anything useful
+    without an intended tenant to compare against - the same reasoning that keeps `-CheckUpstream`
+    opt-in.
+    """
+    block = _tenant_block(_preflight_source())
+    guard = block.index("if (-not $intendedTenant)")
+    assert guard < block.index("'get-access-token'"), "the token mint must sit behind the declaration guard"
+    resolution = block[block.index("$intendedTenant = ") : guard]
+    assert " az " not in resolution, "resolving the intended tenant must not shell out to az"
+
+
+def test_the_wrong_tenant_hint_prefers_the_non_mutating_fix() -> None:
+    """`az account set` rewrites the CLI profile on disk; every other process on the machine follows.
+
+    That is hostile when other work is in flight, so the hint must lead with per-call scoping and
+    must not present the global mutation as the plain fix.
+
+    The `--subscription` text is asserted on `$subHint` rather than on the hint literal because the
+    hint interpolates it: on a mismatch the script looks up a subscription that actually lives in the
+    intended tenant, so the advice is copy-pasteable rather than a `<placeholder>`. Both branches of
+    that lookup - one found, none found - must still name the flag.
+    """
+    block = _tenant_block(_preflight_source())
+    sub_hint = re.search(r"\$subHint = .*", block)
+    assert sub_hint, "the mismatch hint must build a --subscription suggestion"
+    assert sub_hint.group(0).count("--subscription") == 2, (
+        "both the found-a-subscription and no-subscription-found branches must name the flag"
+    )
+    hint = block[block.index("This is an IDENTITY problem") :]
+    assert "$subHint" in hint, "the hint must actually offer the per-call, non-mutating fix"
+    assert "az account set" in hint and re.search(r"(?i)profile on disk|process on this machine", hint), (
+        "if `az account set` is mentioned it must carry the process-global caveat"
+    )
+
+
+def test_no_output_path_can_carry_the_token() -> None:
+    """The token is a bearer credential: it must reach the decoder and nothing else.
+
+    Enumerating the allowed uses (rather than grepping `Write-Host` for it) is what makes this
+    mutation-proof: any new line that touches the token - a debug print, a richer Detail string, an
+    error message echoing `az` output - is a line this test has never seen and therefore fails.
+    """
+    block = _tenant_block(_preflight_source())
+    allowed = (
+        re.compile(r"^#"),  # commentary
+        re.compile(r"^\$tokenJson = & az @azArgs 2>\$null$"),
+        re.compile(r"^if \(\$tokenJson\) \{$"),
+        re.compile(r"^try \{ \$actualTenant = Get-JwtTenantId .*accessToken.*$"),
+    )
+    for line in block.splitlines():
+        stripped = line.strip()
+        if "tokenJson" not in stripped and "accessToken" not in stripped:
+            continue
+        assert any(pattern.match(stripped) for pattern in allowed), f"the token escapes into: {stripped}"
+
+
+# --- Executed, not merely read: the base64url decode ------------------------------------------------
+# A padding or charset bug here fails CLOSED in the worst way - the check would report "could not
+# decode" for real tokens and never fire, while every source-contract test above still passed.
+
+_PS = shutil.which("pwsh") or shutil.which("powershell")
+
+# Extract the decoder from the script by AST and dot-source only that function, so running these
+# tests never executes preflight itself (which probes npm, Desktop and the plugin cache).
+_HARNESS = """
+$ErrorActionPreference = 'Stop'
+$ast = [System.Management.Automation.Language.Parser]::ParseFile($env:PREFLIGHT_PS1, [ref]$null, [ref]$null)
+$fn = $ast.Find({ param($n) $n -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+                            $n.Name -eq 'Get-JwtTenantId' }, $true)
+if (-not $fn) { Write-Output 'FUNCTION-NOT-FOUND'; exit 3 }
+. ([scriptblock]::Create($fn.Extent.Text))
+$r = Get-JwtTenantId $env:PREFLIGHT_TEST_TOKEN
+if ([string]::IsNullOrEmpty($r)) { Write-Output 'NULL' } else { Write-Output $r }
+"""
+
+_TID = "11111111-2222-3333-4444-555555555555"
+
+
+def _jwt(payload: dict) -> str:
+    """A JWT-shaped string. Only the middle segment is ever read, so header/signature are stubs."""
+    body = base64.urlsafe_b64encode(json.dumps(payload, ensure_ascii=False).encode("utf-8")).decode()
+    return f"header.{body.rstrip('=')}.signature"
+
+
+def _payload_with_stripped_padding(remainder: int) -> dict:
+    """A payload whose base64url segment is `remainder` mod 4 long once its '=' padding is stripped.
+
+    Real tokens arrive unpadded, and `FromBase64String` rejects an unpadded string, so every
+    remainder has to be reconstructed correctly - 0, 2 and 3 are the three that can occur.
+    """
+    for size in range(64):
+        payload = {"tid": _TID, "pad": "x" * size}
+        if len(_jwt(payload).split(".")[1]) % 4 == remainder:
+            return payload
+    raise AssertionError(f"no payload found with segment length {remainder} mod 4")
+
+
+def _payload_using_the_url_safe_alphabet() -> dict:
+    """A payload whose encoding actually contains '-' and '_'.
+
+    base64url substitutes those for '+' and '/', which `FromBase64String` rejects. Most ASCII
+    payloads never produce either, so a decoder that forgets the substitution passes every casual
+    test and then fails on a real token. Multi-byte UTF-8 fillers are what reliably set the high bits
+    that encode to those two characters.
+    """
+    for filler in ("\u07ff", "\u00ff", "\uffff", "\u0080"):
+        for size in range(1, 64):
+            payload = {"tid": _TID, "pad": filler * size}
+            segment = _jwt(payload).split(".")[1]
+            if "-" in segment and "_" in segment:
+                return payload
+    raise AssertionError("no payload found that exercises the base64url alphabet")
+
+
+def _decode(token: str) -> str:
+    # -EncodedCommand rather than piping to `-Command -`: PowerShell 7 consumes stdin line by line,
+    # which silently truncates a multi-line script block (measured: empty output, exit 0). Base64
+    # UTF-16LE is also the one form that needs no shell quoting on either platform.
+    encoded = base64.b64encode(_HARNESS.encode("utf-16-le")).decode()
+    result = subprocess.run(  # noqa: S603
+        [_PS, "-NoProfile", "-NonInteractive", "-EncodedCommand", encoded],
+        capture_output=True,
+        text=True,
+        check=False,
+        env={**os.environ, "PREFLIGHT_PS1": str(PREFLIGHT), "PREFLIGHT_TEST_TOKEN": token},
+    )
+    assert "FUNCTION-NOT-FOUND" not in result.stdout, "Get-JwtTenantId was renamed or removed"
+    assert result.returncode == 0, f"decoder harness failed: {result.stderr.strip()[:400]}"
+    return result.stdout.strip()
+
+
+@pytest.mark.skipif(_PS is None, reason="no PowerShell on PATH")
+@pytest.mark.parametrize(
+    ("label", "payload"),
+    [
+        ("padding 0 mod 4", _payload_with_stripped_padding(0)),
+        ("padding 2 mod 4", _payload_with_stripped_padding(2)),
+        ("padding 3 mod 4", _payload_with_stripped_padding(3)),
+        ("base64url alphabet", _payload_using_the_url_safe_alphabet()),
+    ],
+)
+def test_the_tid_survives_every_base64url_shape(label: str, payload: dict) -> None:
+    """The decoded tenant is what the whole check compares against; it must never be approximate."""
+    assert _decode(_jwt(payload)) == _TID, label
+
+
+@pytest.mark.skipif(_PS is None, reason="no PowerShell on PATH")
+@pytest.mark.parametrize(
+    "token",
+    [
+        "",
+        "not-a-jwt",
+        "header..signature",
+        "header.@@@@.signature",
+        _jwt({"aud": "https://api.fabric.microsoft.com"}),  # a real token shape, minus the tid claim
+    ],
+)
+def test_an_undecodable_token_yields_nothing_rather_than_a_wrong_answer(token: str) -> None:
+    """No tid must read as "cannot verify", never as a tenant.
+
+    An exception here would abort the check, and a garbage value would compare unequal to the
+    intended tenant and raise a WRONG TENANT alarm on a perfectly good machine. Both are worse than
+    the advisory WARN the script emits for an absent tid.
+    """
+    assert _decode(token) == "NULL"

--- a/tests/test_preflight_contract.py
+++ b/tests/test_preflight_contract.py
@@ -2,9 +2,11 @@
 
 Two kinds of test live here. Most are **source contracts**: CI runs on Ubuntu while the script
 deliberately depends on Windows/Power BI Desktop primitives, so the tiers and hints are asserted by
-reading the source. The JWT-decoder tests at the bottom are **executed**, because a base64url
-padding bug is invisible to any amount of source reading and would make the wrong-tenant check
-silently answer "cannot decode" on exactly the tokens it exists to inspect.
+reading the source. The tests at the bottom are **executed**, because the two things they cover are
+invisible to any amount of source reading: a base64url padding bug would make the wrong-tenant check
+silently answer "cannot decode" on exactly the tokens it exists to inspect, and the comparison that
+produces the verdict is one line whose two most damaging mutations (``$tenantOk = $true``; an
+inverted ``-ne``) both survived a 15-mutation sweep against source-string assertions alone.
 """
 
 import base64
@@ -178,49 +180,70 @@ def _tenant_block(source: str) -> str:
     return source[source.index("# --- Fabric token TENANT") : source.index("$odbc = ")]
 
 
-def test_the_tenant_check_is_emitted_on_every_branch() -> None:
-    """Every path must report, because a check that renders as nothing reads as a check that passed.
+def test_the_tenant_check_reports_exactly_once_whatever_happens() -> None:
+    """One unconditional emission, and a hint for every outcome the verdict can return.
 
-    Four outcomes exist - nothing declared, `az` absent, no token minted, and the verdict itself -
-    and each must produce a line. This is the same rule the engine block already obeys.
+    Four outcomes became six (a malformed intended id, and the verdict itself), and the previous
+    shape - one ``Add-Check`` per branch - meant a new outcome could be added with no emission at
+    all, which renders as nothing and reads as a check that passed. A single top-level call cannot
+    be skipped; what CAN drift is the hint switch, so every ``Kind`` the function returns must have
+    a branch there.
     """
     block = _tenant_block(_preflight_source())
-    branches = block.count(f"Add-Check '{TENANT_CHECK}'")
-    assert branches == 4, f"expected all four tenant-check branches to report, found {branches}"
+    assert block.count(f"Add-Check '{TENANT_CHECK}'") == 1, "the tenant check must be emitted from exactly one place"
+    assert re.search(rf"(?m)^Add-Check '{re.escape(TENANT_CHECK)}' ", block), (
+        "that one emission must be unconditional (top level), not nested in a branch"
+    )
+    kinds = set(re.findall(r"Kind = '([a-z-]+)'", block))
+    assert len(kinds) >= 6, f"expected every outcome to name a Kind, saw {sorted(kinds)}"
+    hint_branches = set(re.findall(r"(?m)^\s{4}'([a-z-]+)' \{", block))
+    assert kinds - {"match"} <= hint_branches, f"no hint branch for {sorted(kinds - {'match'} - hint_branches)}"
+    # And the emission must carry the VERDICT, not a constant. This one stays a source contract
+    # because the wiring can only be executed by running preflight itself, which probes npm, Desktop
+    # and the plugin cache and cannot run in CI - but it is exactly where a correct verdict can still
+    # be thrown away: rewriting `$verdict.Tier` to `'optional'` leaves every executed test green.
+    assert re.search(
+        rf"(?m)^Add-Check '{re.escape(TENANT_CHECK)}' \$verdict\.Tier \$verdict\.Ok \$verdict\.Detail \$tenantHint$",
+        block,
+    ), "the rendered tier/status/detail must come from the verdict object, not from a literal"
 
 
-def test_only_a_tenant_mismatch_is_critical() -> None:
-    """Blocking is reserved for the one outcome that is unambiguously wrong.
+def test_critical_is_reserved_for_a_mismatch_declared_on_this_run() -> None:
+    """Exit 1 must follow deploy INTENT, and only ``-Tenant`` declares it for the run in hand.
 
-    A mismatch can only fire after someone has explicitly declared "I intend to deploy into tenant
-    X", so it can never block a machine that never declared one - that opt-in is what makes exit 1
-    defensible here. Everything else (undeclared, no `az`, no token) is advisory: those are reasons
-    the check could not run, not evidence that anything is wrong, and the estate pipeline does not
-    touch Fabric at all.
+    ``FABRIC_TENANT_ID`` in ``.env`` is persisted configuration: set once for a deploy, it then
+    outlives that run and would block every later parse-only estate sweep - whose steps 1-6 never
+    call Fabric - re-creating from the other side the false blocker this change set removed (a
+    Desktop-only pin failing a run that never opens Desktop). ``-Tenant <id>`` is a statement about
+    THIS invocation, so a wrong token there is unambiguously a blocker.
+
+    The tier mapping itself is executed by `test_the_verdict_tiers_follow_where_the_intent_came_from`;
+    this pins that ``critical`` appears nowhere else in the block, so no other outcome can acquire it.
     """
     block = _tenant_block(_preflight_source())
-    tiers = re.findall(rf"Add-Check '{re.escape(TENANT_CHECK)}' (\S+)", block)
-    literal = [t for t in tiers if t.startswith("'")]
-    conditional = [t for t in tiers if not t.startswith("'")]
-    assert literal == ["'optional'"] * 3, f"non-verdict branches must stay advisory, saw {literal}"
-    assert len(conditional) == 1, "the verdict branch must choose its tier from the comparison"
-    assert "$(if ($tenantOk) { 'optional' } else { 'critical' })" in block, (
-        "a mismatch must be critical and a match must not be"
+    assigns = [ln.strip() for ln in block.splitlines() if re.search(r"\$tier\s*=", ln)]
+    assert assigns == ["$tier = if ($IntentIsExplicit) { 'critical' } else { 'recommended' }"], (
+        f"exactly one line may decide the tier, and only from explicit intent, saw {assigns}"
+    )
+    others = [ln.strip() for ln in block.splitlines() if "'critical'" in ln and not re.search(r"\$tier\s*=", ln)]
+    assert all("-eq 'critical'" in ln for ln in others), f"'critical' is assigned somewhere else too: {others}"
+    assert "$tenantIntentIsExplicit = [bool](Remove-SurroundingQuotes $Tenant)" in block, (
+        "explicit intent means the -Tenant parameter, not an ambient environment variable"
     )
 
 
-def test_the_tenant_check_costs_nothing_until_a_tenant_is_declared() -> None:
+def test_the_tenant_check_costs_nothing_until_a_comparable_tenant_is_declared() -> None:
     """No declaration, no `az` call: preflight runs before EVERY migration, including parse-only ones.
 
     A mandatory token mint here would tax every run for a check that cannot say anything useful
     without an intended tenant to compare against - the same reasoning that keeps `-CheckUpstream`
-    opt-in.
+    opt-in. The guard also skips the mint for an intended id that is not a GUID, because that one
+    cannot be compared against a `tid` either.
     """
     block = _tenant_block(_preflight_source())
-    guard = block.index("if (-not $intendedTenant)")
+    guard = block.index("if ($intendedTenant -and (Test-TenantIdShape $intendedTenant) -and $azPresent) {")
     assert guard < block.index("'get-access-token'"), "the token mint must sit behind the declaration guard"
-    resolution = block[block.index("$intendedTenant = ") : guard]
-    assert " az " not in resolution, "resolving the intended tenant must not shell out to az"
+    assert "& az" not in block[:guard], "no `az` invocation may precede the declaration guard"
 
 
 def test_the_wrong_tenant_hint_prefers_the_non_mutating_fix() -> None:
@@ -247,6 +270,18 @@ def test_the_wrong_tenant_hint_prefers_the_non_mutating_fix() -> None:
     )
 
 
+def test_a_warning_only_mismatch_says_how_to_make_it_blocking() -> None:
+    """A WARN that does not explain how to get the blocker is a downgrade, not a design.
+
+    An operator who is about to deploy needs to know that the same mismatch fails preflight once the
+    run declares `-Tenant`, or the recommended tier just reads as "we decided this matters less".
+    """
+    block = _tenant_block(_preflight_source())
+    escalation = re.search(r"\$escalation = .*", block)
+    assert escalation, "a warning-only mismatch must carry an escalation note"
+    assert "-Tenant" in escalation.group(0), "the note must name the flag that makes it blocking"
+
+
 def test_no_output_path_can_carry_the_token() -> None:
     """The token is a bearer credential: it must reach the decoder and nothing else.
 
@@ -268,26 +303,244 @@ def test_no_output_path_can_carry_the_token() -> None:
         assert any(pattern.match(stripped) for pattern in allowed), f"the token escapes into: {stripped}"
 
 
-# --- Executed, not merely read: the base64url decode ------------------------------------------------
-# A padding or charset bug here fails CLOSED in the worst way - the check would report "could not
-# decode" for real tokens and never fire, while every source-contract test above still passed.
+# --- Executed, not merely read ---------------------------------------------------------------------
+# Two things here cannot be established by reading the source:
+#   * the base64url decode - a padding or charset bug fails CLOSED in the worst way, reporting "could
+#     not decode" for real tokens so the check never fires, while every source contract still passes;
+#   * the verdict itself - `$tenantOk = $true` and an inverted comparison both survived a 15-mutation
+#     sweep, i.e. the one line that decides OK-vs-MISS was the least covered line in the file.
+# So the decision lives in `Get-TenantVerdict`, and the harness below runs it for real.
 
 _PS = shutil.which("pwsh") or shutil.which("powershell")
 
-# Extract the decoder from the script by AST and dot-source only that function, so running these
+# Extract the functions under test from the script by AST and dot-source only those, so running these
 # tests never executes preflight itself (which probes npm, Desktop and the plugin cache).
-_HARNESS = """
+_EXTRACT_FUNCS = """
 $ErrorActionPreference = 'Stop'
 $ast = [System.Management.Automation.Language.Parser]::ParseFile($env:PREFLIGHT_PS1, [ref]$null, [ref]$null)
-$fn = $ast.Find({ param($n) $n -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
-                            $n.Name -eq 'Get-JwtTenantId' }, $true)
-if (-not $fn) { Write-Output 'FUNCTION-NOT-FOUND'; exit 3 }
-. ([scriptblock]::Create($fn.Extent.Text))
-$r = Get-JwtTenantId $env:PREFLIGHT_TEST_TOKEN
-if ([string]::IsNullOrEmpty($r)) { Write-Output 'NULL' } else { Write-Output $r }
+$defs = $ast.FindAll({ param($n) $n -is [System.Management.Automation.Language.FunctionDefinitionAst] }, $true)
+foreach ($name in ($env:PREFLIGHT_FUNCS -split ',')) {
+    $fn = $defs | Where-Object { $_.Name -eq $name } | Select-Object -First 1
+    if (-not $fn) { Write-Output "FUNCTION-NOT-FOUND:$name"; exit 3 }
+    . ([scriptblock]::Create($fn.Extent.Text))
+}
 """
 
-_TID = "11111111-2222-3333-4444-555555555555"
+# Values are emitted between markers so a stray leading/trailing space is a FAILURE rather than
+# something the test quietly strips - the whole point of these cases is that whitespace and quoting
+# must be normalized by the script, not by the harness.
+_EMIT = "function Emit($v) { if ($null -eq $v) { Write-Output '<<NULL>>' } else { Write-Output ('<<' + $v + '>>') } }\n"
+
+# A synthetic tenant id that deliberately contains hex LETTERS. An all-digit GUID makes every
+# casing test vacuous - measured here: with `11111111-2222-...`, mutating the comparison to the
+# case-SENSITIVE `-ceq` survived the whole suite, because `.upper()` of a digit string is itself.
+_TID = "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d"
+_OTHER_TID = "99999999-8888-7777-6666-555555555555"
+_FIXTURE_ENV = REPO_ROOT / "tests" / "fixtures" / "dotenv-spellings.env"
+
+
+def _run_ps(functions: str, body: str, extra_env: dict[str, str]) -> str:
+    # -EncodedCommand rather than piping to `-Command -`: PowerShell 7 consumes stdin line by line,
+    # which silently truncates a multi-line script block (measured: empty output, exit 0). Base64
+    # UTF-16LE is also the one form that needs no shell quoting on either platform.
+    script = _EXTRACT_FUNCS + _EMIT + body
+    encoded = base64.b64encode(script.encode("utf-16-le")).decode()
+    result = subprocess.run(  # noqa: S603
+        [_PS, "-NoProfile", "-NonInteractive", "-EncodedCommand", encoded],
+        capture_output=True,
+        text=True,
+        check=False,
+        env={**os.environ, "PREFLIGHT_PS1": str(PREFLIGHT), "PREFLIGHT_FUNCS": functions, **extra_env},
+    )
+    assert "FUNCTION-NOT-FOUND" not in result.stdout, f"renamed or removed: {result.stdout.strip()}"
+    assert result.returncode == 0, f"harness failed: {result.stderr.strip()[:400]}"
+    return result.stdout.strip()
+
+
+def _emitted(raw: str) -> str:
+    marked = re.search(r"<<(.*)>>", raw, re.DOTALL)
+    assert marked, f"harness produced no marked value: {raw!r}"
+    return marked.group(1)
+
+
+def _verdict(
+    intended: str,
+    actual: str = _TID,
+    *,
+    explicit: bool = False,
+    az_present: bool = True,
+) -> dict:
+    raw = _run_ps(
+        "Get-TenantVerdict,Remove-SurroundingQuotes,Test-TenantIdShape",
+        "$v = Get-TenantVerdict -IntendedTenant $env:T_INTENDED -ActualTenant $env:T_ACTUAL "
+        "-IntentIsExplicit ([bool]::Parse($env:T_EXPLICIT)) -AzPresent ([bool]::Parse($env:T_AZ)) -Scope ''\n"
+        "Emit ($v | ConvertTo-Json -Compress)\n",
+        {
+            "T_INTENDED": intended,
+            "T_ACTUAL": actual,
+            "T_EXPLICIT": str(explicit),
+            "T_AZ": str(az_present),
+        },
+    )
+    return json.loads(_emitted(raw))
+
+
+@pytest.mark.skipif(_PS is None, reason="no PowerShell on PATH")
+def test_a_matching_tenant_passes_and_a_mismatched_one_does_not() -> None:
+    """The verdict line, executed in both directions.
+
+    This is the test the mutation sweep was missing: with it, `$tenantOk = $true` (the check can
+    never fire) fails on the mismatch case, and `$tenantOk = ($ActualTenant -ne $IntendedTenant)`
+    (fires on every correct machine) fails on the match case. Neither was detectable before, because
+    the verdict was asserted by matching the source string that contains it.
+    """
+    match = _verdict(_TID, _TID)
+    assert (match["Kind"], match["Ok"], match["Tier"]) == ("match", True, "optional")
+    assert _TID in match["Detail"]
+
+    mismatch = _verdict(_OTHER_TID, _TID, explicit=True)
+    assert (mismatch["Kind"], mismatch["Ok"]) == ("mismatch", False)
+    assert "WRONG TENANT" in mismatch["Detail"]
+    assert _OTHER_TID in mismatch["Detail"] and _TID in mismatch["Detail"], (
+        "both tenants must be named, or the operator cannot tell which end is wrong"
+    )
+
+
+@pytest.mark.skipif(_PS is None, reason="no PowerShell on PATH")
+@pytest.mark.parametrize(
+    ("label", "declared"),
+    [
+        ("double-quoted, as dotenv convention teaches", f'"{_TID}"'),
+        ("single-quoted", f"'{_TID}'"),
+        ("padded with whitespace", f"  {_TID}  "),
+        ("quoted AND padded", f'  "{_TID}"  '),
+        ("uppercased, as the Entra portal shows it", _TID.upper()),
+    ],
+)
+def test_a_correct_tenant_spelled_differently_is_still_correct(label: str, declared: str) -> None:
+    """Be liberal in what you accept; be strict only about what you compare.
+
+    Measured 2026-08-13 on the version this replaces: `FABRIC_TENANT_ID="72f988bf-..."` naming the
+    CORRECT tenant produced `[MISS] WRONG TENANT ... intended "72f988bf-..."` and exit 1 on a fully
+    configured machine - a hard blocker, in front of a customer, caused by a pair of quotes that
+    every dotenv consumer strips. The casing case is here for the same reason: the portal and the
+    `tid` claim disagree on it, and PowerShell's `-eq` is case-insensitive - a well-meaning "fix" to
+    `-ceq` would reintroduce exactly this class of false blocker.
+    """
+    verdict = _verdict(declared, _TID)
+    assert verdict["Ok"] is True, f"{label} must still match: {verdict['Detail']}"
+    assert verdict["Tier"] == "optional"
+    assert '"' not in verdict["Detail"] and "'" not in verdict["Detail"], (
+        "the normalized id, not the raw spelling, belongs in the output"
+    )
+
+
+@pytest.mark.skipif(_PS is None, reason="no PowerShell on PATH")
+def test_the_verdict_tiers_follow_where_the_intent_came_from() -> None:
+    """Blocking follows an in-run declaration; persisted configuration warns (#124 follow-up).
+
+    `-Tenant <id>` says "this run points at that tenant" - a token for another one is a blocker.
+    `FABRIC_TENANT_ID` in `.env` is a standing preference that outlives the deploy it was set for,
+    and a parse-only estate run (steps 1-6 never call Fabric) must not exit 1 because of it.
+    """
+    assert _verdict(_OTHER_TID, _TID, explicit=True)["Tier"] == "critical"
+    ambient = _verdict(_OTHER_TID, _TID, explicit=False)
+    assert ambient["Tier"] == "recommended", "persisted configuration must warn, not block"
+    assert re.search(r"(?i)warning only|-Tenant", ambient["Detail"]), (
+        "a warning-only mismatch must say so, or it reads as an ordinary WARN"
+    )
+
+
+@pytest.mark.skipif(_PS is None, reason="no PowerShell on PATH")
+@pytest.mark.parametrize(
+    "declared",
+    [
+        "contoso.onmicrosoft.com",  # accepted by `az --tenant` and deploy_estate.py, so plausible here
+        "<your-tenant-id>",  # copied out of a .env.example and never filled in
+        "72f988bf86f141af91ab2d7cd011db47",  # a GUID with the hyphens lost
+        "not-a-guid",
+    ],
+)
+def test_an_uncomparable_tenant_id_never_blocks(declared: str) -> None:
+    """A `tid` is always a GUID, so anything else is "cannot compare", never "wrong tenant".
+
+    Comparing a domain name or a placeholder against a GUID answers WRONG TENANT and exits 1 - the
+    same false blocker as the quoting bug, arriving by a different route. This one is not
+    hypothetical: `FABRIC_TENANT_ID` is currently documented nowhere, and the obvious fix for that
+    (a line in `.env.example`) ships a placeholder to every clone.
+    """
+    verdict = _verdict(declared, _TID)
+    assert (verdict["Kind"], verdict["Ok"], verdict["Tier"]) == ("malformed", False, "optional")
+    assert declared in verdict["Detail"], "name the value that could not be compared"
+
+
+@pytest.mark.skipif(_PS is None, reason="no PowerShell on PATH")
+@pytest.mark.parametrize(
+    ("label", "kwargs", "expected_kind"),
+    [
+        ("nothing declared", {"intended": "", "actual": _TID}, "no-intent"),
+        ("az not installed", {"intended": _TID, "actual": "", "az_present": False}, "no-az"),
+        ("declared, az present, no token", {"intended": _TID, "actual": ""}, "no-token"),
+    ],
+)
+def test_every_reason_the_check_could_not_run_is_advisory(label: str, kwargs: dict, expected_kind: str) -> None:
+    """ "Could not run" is not evidence of a problem, and must never spend exit 1.
+
+    Each still reports a line, though: a check that renders as nothing reads as a check that passed,
+    which is the false-green shape this whole script exists to prevent.
+    """
+    verdict = _verdict(**kwargs)
+    assert verdict["Kind"] == expected_kind, label
+    assert verdict["Ok"] is False, f"{label}: an unrun check is not a pass"
+    assert verdict["Tier"] == "optional", f"{label}: must not block"
+    assert verdict["Detail"], f"{label}: must still say something"
+
+
+def _dotenv(key: str) -> str:
+    raw = _run_ps(
+        "Get-DotEnvValue,Remove-SurroundingQuotes",
+        "Emit (Get-DotEnvValue $env:T_KEY $env:T_PATH)\n",
+        {"T_KEY": key, "T_PATH": str(_FIXTURE_ENV)},
+    )
+    return _emitted(raw)
+
+
+@pytest.mark.skipif(_PS is None, reason="no PowerShell on PATH")
+@pytest.mark.parametrize(
+    ("key", "expected"),
+    [
+        ("PLAIN", _TID),
+        ("DOUBLE_QUOTED", _TID),
+        ("SINGLE_QUOTED", _TID),
+        ("PADDED", _TID),
+        ("QUOTED_AND_PADDED", _TID),
+        # Only a MATCHED outer pair is a quoting convention. Everything else is the value.
+        ("UNMATCHED_QUOTE", f'"{_TID}'),
+        ("INNER_QUOTES", 'ab"cd"ef'),
+        ("HAS_EQUALS", "a=b=c"),
+        # Present-but-empty and absent are both "no value" to every caller, which filters falsy;
+        # the reader still distinguishes them ('' vs $null) rather than inventing one.
+        ("EMPTY", ""),
+        ("ABSENT_FROM_THE_FILE", "NULL"),
+    ],
+)
+def test_the_dotenv_reader_accepts_every_ordinary_spelling(key: str, expected: str) -> None:
+    """`.env` is the documented home for a customer tenant id, so its parse decides the verdict.
+
+    This is where the false blocker actually lived: the reader mirrored
+    `scripts/tableau_env.py:load_env` exactly - `value.strip()`, no quote handling - and the comment
+    saying so was the argument for keeping it. The two parsers agreed by being wrong in the same way.
+    `load_env` is owned elsewhere and should get the same treatment; nothing in Python reads
+    FABRIC_TENANT_ID today, so the divergence is inert until it does.
+    """
+    assert _dotenv(key) == expected
+
+
+# --- The base64url decode --------------------------------------------------------------------------
+
+# Its own id, unrelated to the verdict tests: what matters here is only that whatever went into the
+# payload comes back out byte-for-byte.
+_TOKEN_TID = "11111111-2222-3333-4444-555555555555"
 
 
 def _jwt(payload: dict) -> str:
@@ -303,7 +556,7 @@ def _payload_with_stripped_padding(remainder: int) -> dict:
     remainder has to be reconstructed correctly - 0, 2 and 3 are the three that can occur.
     """
     for size in range(64):
-        payload = {"tid": _TID, "pad": "x" * size}
+        payload = {"tid": _TOKEN_TID, "pad": "x" * size}
         if len(_jwt(payload).split(".")[1]) % 4 == remainder:
             return payload
     raise AssertionError(f"no payload found with segment length {remainder} mod 4")
@@ -319,7 +572,7 @@ def _payload_using_the_url_safe_alphabet() -> dict:
     """
     for filler in ("\u07ff", "\u00ff", "\uffff", "\u0080"):
         for size in range(1, 64):
-            payload = {"tid": _TID, "pad": filler * size}
+            payload = {"tid": _TOKEN_TID, "pad": filler * size}
             segment = _jwt(payload).split(".")[1]
             if "-" in segment and "_" in segment:
                 return payload
@@ -327,20 +580,11 @@ def _payload_using_the_url_safe_alphabet() -> dict:
 
 
 def _decode(token: str) -> str:
-    # -EncodedCommand rather than piping to `-Command -`: PowerShell 7 consumes stdin line by line,
-    # which silently truncates a multi-line script block (measured: empty output, exit 0). Base64
-    # UTF-16LE is also the one form that needs no shell quoting on either platform.
-    encoded = base64.b64encode(_HARNESS.encode("utf-16-le")).decode()
-    result = subprocess.run(  # noqa: S603
-        [_PS, "-NoProfile", "-NonInteractive", "-EncodedCommand", encoded],
-        capture_output=True,
-        text=True,
-        check=False,
-        env={**os.environ, "PREFLIGHT_PS1": str(PREFLIGHT), "PREFLIGHT_TEST_TOKEN": token},
+    return _emitted(
+        _run_ps(
+            "Get-JwtTenantId", "Emit (Get-JwtTenantId $env:PREFLIGHT_TEST_TOKEN)\n", {"PREFLIGHT_TEST_TOKEN": token}
+        )
     )
-    assert "FUNCTION-NOT-FOUND" not in result.stdout, "Get-JwtTenantId was renamed or removed"
-    assert result.returncode == 0, f"decoder harness failed: {result.stderr.strip()[:400]}"
-    return result.stdout.strip()
 
 
 @pytest.mark.skipif(_PS is None, reason="no PowerShell on PATH")
@@ -355,7 +599,7 @@ def _decode(token: str) -> str:
 )
 def test_the_tid_survives_every_base64url_shape(label: str, payload: dict) -> None:
     """The decoded tenant is what the whole check compares against; it must never be approximate."""
-    assert _decode(_jwt(payload)) == _TID, label
+    assert _decode(_jwt(payload)) == _TOKEN_TID, label
 
 
 @pytest.mark.skipif(_PS is None, reason="no PowerShell on PATH")

--- a/tests/test_preflight_contract.py
+++ b/tests/test_preflight_contract.py
@@ -180,6 +180,22 @@ def _tenant_block(source: str) -> str:
     return source[source.index("# --- Fabric token TENANT") : source.index("$odbc = ")]
 
 
+def test_the_tenant_variable_is_documented_where_an_operator_would_look_for_it() -> None:
+    """`FABRIC_TENANT_ID` is the one input this check has, and the hint text points at `.env`.
+
+    It was previously named only inside `preflight.ps1` itself - so the hint said "put it in .env"
+    and `.env.example`, the file that lists what goes in `.env`, did not mention it.
+
+    The value must stay EMPTY. A placeholder like `<your-tenant-id>` would be copied into every
+    clone's `.env`, where it becomes a declared-but-uncomparable intent: a permanent warning line
+    on every run, for a tenant nobody chose.
+    """
+    lines = (REPO_ROOT / ".env.example").read_text(encoding="utf-8").splitlines()
+    declarations = [ln for ln in lines if ln.startswith("FABRIC_TENANT_ID=")]
+    assert declarations == ["FABRIC_TENANT_ID="], f"expected one empty declaration, saw {declarations}"
+    assert any("deploy_estate.py" in ln for ln in lines), "say what the value is FOR, not just its name"
+
+
 def test_the_tenant_check_reports_exactly_once_whatever_happens() -> None:
     """One unconditional emission, and a hint for every outcome the verdict can return.
 
@@ -227,9 +243,10 @@ def test_critical_is_reserved_for_a_mismatch_declared_on_this_run() -> None:
     )
     others = [ln.strip() for ln in block.splitlines() if "'critical'" in ln and not re.search(r"\$tier\s*=", ln)]
     assert all("-eq 'critical'" in ln for ln in others), f"'critical' is assigned somewhere else too: {others}"
-    assert "$tenantIntentIsExplicit = [bool](Remove-SurroundingQuotes $Tenant)" in block, (
-        "explicit intent means the -Tenant parameter, not an ambient environment variable"
+    assert "IsExplicit = [bool]$candidates[0]" in block, (
+        "explicit intent means the -Tenant parameter - the FIRST channel - not an ambient environment variable"
     )
+    assert "-IntentIsExplicit $intent.IsExplicit" in block, "the verdict must be told which channel actually won"
 
 
 def test_the_tenant_check_costs_nothing_until_a_comparable_tenant_is_declared() -> None:
@@ -237,13 +254,32 @@ def test_the_tenant_check_costs_nothing_until_a_comparable_tenant_is_declared() 
 
     A mandatory token mint here would tax every run for a check that cannot say anything useful
     without an intended tenant to compare against - the same reasoning that keeps `-CheckUpstream`
-    opt-in. The guard also skips the mint for an intended id that is not a GUID, because that one
-    cannot be compared against a `tid` either.
+    opt-in. Resolving a declared DOMAIN now costs a second `az` call, so the contract is about the
+    top-level FLOW rather than the whole block: every `az` invocation the flow reaches must sit
+    inside a branch that has already established something was declared.
     """
     block = _tenant_block(_preflight_source())
-    guard = block.index("if ($intendedTenant -and (Test-TenantIdShape $intendedTenant) -and $azPresent) {")
-    assert guard < block.index("'get-access-token'"), "the token mint must sit behind the declaration guard"
-    assert "& az" not in block[:guard], "no `az` invocation may precede the declaration guard"
+    flow = block[block.index("$intent = Resolve-IntendedTenant") :]
+    first_guard = flow.index("if ($intendedTenant")
+    for line in flow.splitlines():
+        if "& az" in line and not line.strip().startswith("#"):
+            assert line.startswith((" ", "\t")), f"an unguarded `az` invocation at the top of the flow: {line}"
+    assert first_guard < flow.index("& az"), "no `az` invocation may precede the declaration guard"
+    guard = flow.index("if ($intendedTenant -and (Test-TenantIdShape $intendedTenant) -and $azPresent) {")
+    assert guard < flow.index("'get-access-token'"), "the token mint must sit behind the declaration guard"
+    # Resolution runs only for a declaration that is NOT already a GUID, so the ordinary path pays
+    # for one `az` call, not two.
+    assert "if ($intendedTenant -and -not (Test-TenantIdShape $intendedTenant) -and $azPresent) {" in flow, (
+        "domain resolution must be guarded on a declared, non-GUID intent"
+    )
+    # And its answer must be USED. The resolver itself is executed by
+    # `test_a_declared_domain_is_resolved_rather_than_given_up_on`; this one line of wiring can only
+    # be executed by running preflight, which probes npm, Desktop and the plugin cache and cannot run
+    # in CI - and it is exactly where a correct resolution can still be thrown away, silently
+    # restoring the "not compared" verdict this change removed.
+    assert "if ($resolved) { $intendedTenant = $resolved }" in flow, (
+        "a successful resolution must replace the declared spelling for comparison"
+    )
 
 
 def test_the_wrong_tenant_hint_prefers_the_non_mutating_fix() -> None:
@@ -303,7 +339,23 @@ def test_no_output_path_can_carry_the_token() -> None:
         assert any(pattern.match(stripped) for pattern in allowed), f"the token escapes into: {stripped}"
 
 
-# --- Executed, not merely read ---------------------------------------------------------------------
+def test_the_closing_line_names_the_tenant_when_something_is_wrong_with_it() -> None:
+    """A count is not a diagnosis, and the tenant line scrolls off before the verdict is read.
+
+    Measured: the WRONG TENANT warning sat at line 22 of 38 output lines, with 16 `[OK]` lines after
+    it; on an 80x24 terminal the only text still visible read "Ready to migrate. 3 recommended
+    warning(s) present." Both exit paths therefore carry the tenant summary - the failing one too,
+    because a run that is already blocking on something else must still say the tenant was wrong.
+    """
+    source = _preflight_source()
+    summary_lines = [ln for ln in source.splitlines() if 'Write-Host "PREFLIGHT:' in ln]
+    assert len(summary_lines) == 2, f"expected the two exit summaries, saw {summary_lines}"
+    assert all("$tenantNote" in ln for ln in summary_lines), (
+        f"every closing line must be able to name the tenant: {summary_lines}"
+    )
+    assert "$tenantNote = if ($verdict.Summary)" in source, "the note must come from the verdict, not be re-derived"
+
+
 # Two things here cannot be established by reading the source:
 #   * the base64url decode - a padding or charset bug fails CLOSED in the worst way, reporting "could
 #     not decode" for real tokens so the check never fires, while every source contract still passes;
@@ -369,17 +421,20 @@ def _verdict(
     *,
     explicit: bool = False,
     az_present: bool = True,
+    declared_as: str = "",
 ) -> dict:
     raw = _run_ps(
         "Get-TenantVerdict,Remove-SurroundingQuotes,Test-TenantIdShape",
         "$v = Get-TenantVerdict -IntendedTenant $env:T_INTENDED -ActualTenant $env:T_ACTUAL "
-        "-IntentIsExplicit ([bool]::Parse($env:T_EXPLICIT)) -AzPresent ([bool]::Parse($env:T_AZ)) -Scope ''\n"
+        "-IntentIsExplicit ([bool]::Parse($env:T_EXPLICIT)) -AzPresent ([bool]::Parse($env:T_AZ)) -Scope '' "
+        "-DeclaredAs $env:T_DECLARED\n"
         "Emit ($v | ConvertTo-Json -Compress)\n",
         {
             "T_INTENDED": intended,
             "T_ACTUAL": actual,
             "T_EXPLICIT": str(explicit),
             "T_AZ": str(az_present),
+            "T_DECLARED": declared_as,
         },
     )
     return json.loads(_emitted(raw))
@@ -455,7 +510,8 @@ def test_the_verdict_tiers_follow_where_the_intent_came_from() -> None:
 @pytest.mark.parametrize(
     "declared",
     [
-        "contoso.onmicrosoft.com",  # accepted by `az --tenant` and deploy_estate.py, so plausible here
+        "contoso.onmicrosoft.com",  # a real default domain, but for a tenant this machine cannot see
+        "contoso.com",  # a VANITY domain - never the default domain, so never resolvable
         "<your-tenant-id>",  # copied out of a .env.example and never filled in
         "72f988bf86f141af91ab2d7cd011db47",  # a GUID with the hyphens lost
         "not-a-guid",
@@ -465,9 +521,9 @@ def test_an_uncomparable_tenant_id_never_blocks(declared: str) -> None:
     """A `tid` is always a GUID, so anything else is "cannot compare", never "wrong tenant".
 
     Comparing a domain name or a placeholder against a GUID answers WRONG TENANT and exits 1 - the
-    same false blocker as the quoting bug, arriving by a different route. This one is not
-    hypothetical: `FABRIC_TENANT_ID` is currently documented nowhere, and the obvious fix for that
-    (a line in `.env.example`) ships a placeholder to every clone.
+    same false blocker as the quoting bug, arriving by a different route. Note the caller RESOLVES a
+    default domain before it gets here (`Resolve-TenantIdFromDomain`); what reaches this function is
+    the residue that resolution could not turn into a GUID, and for that "cannot compare" is honest.
     """
     verdict = _verdict(declared, _TID)
     assert (verdict["Kind"], verdict["Ok"], verdict["Tier"]) == ("malformed", False, "optional")
@@ -481,6 +537,7 @@ def test_an_uncomparable_tenant_id_never_blocks(declared: str) -> None:
         ("nothing declared", {"intended": "", "actual": _TID}, "no-intent"),
         ("az not installed", {"intended": _TID, "actual": "", "az_present": False}, "no-az"),
         ("declared, az present, no token", {"intended": _TID, "actual": ""}, "no-token"),
+        ("declared as an unresolvable name", {"intended": "contoso.com", "actual": _TID}, "malformed"),
     ],
 )
 def test_every_reason_the_check_could_not_run_is_advisory(label: str, kwargs: dict, expected_kind: str) -> None:
@@ -492,13 +549,174 @@ def test_every_reason_the_check_could_not_run_is_advisory(label: str, kwargs: di
     verdict = _verdict(**kwargs)
     assert verdict["Kind"] == expected_kind, label
     assert verdict["Ok"] is False, f"{label}: an unrun check is not a pass"
-    assert verdict["Tier"] == "optional", f"{label}: must not block"
+    assert verdict["Tier"] != "critical", f"{label}: must not block"
     assert verdict["Detail"], f"{label}: must still say something"
+
+
+@pytest.mark.skipif(_PS is None, reason="no PowerShell on PATH")
+@pytest.mark.parametrize(
+    ("label", "kwargs"),
+    [
+        ("unresolvable spelling", {"intended": "contoso.com", "actual": _TID}),
+        ("az not installed", {"intended": _TID, "actual": "", "az_present": False}),
+        ("no token could be minted", {"intended": _TID, "actual": ""}),
+    ],
+)
+def test_a_declared_tenant_that_could_not_be_verified_is_not_filed_under_optional(label: str, kwargs: dict) -> None:
+    """A check the operator ASKED FOR that did not run is a blank space, not a pass.
+
+    Measured: `preflight.ps1 -Tenant contoso.onmicrosoft.com` printed its one line under
+    `== OPTIONAL ==`, beneath a green "Ready to migrate" - i.e. an explicit, blocking-channel
+    declaration of intent bought exactly zero verification and said so in the tier nobody reads.
+    Provenance decides how loud that is, exactly as it does for a mismatch: `-Tenant` is a statement
+    about THIS run, `.env` is a standing preference. The generalisation past the reviewed case
+    (`malformed`) is deliberate - "az is missing" and "no token" leave a declared intent just as
+    unverified as an unresolvable name does.
+    """
+    ambient = _verdict(**kwargs, explicit=False)
+    explicit = _verdict(**kwargs, explicit=True)
+    assert ambient["Tier"] == "optional", f"{label}: configured intent stays optional"
+    assert explicit["Tier"] == "recommended", f"{label}: declared intent must be visible"
+    assert explicit["Tier"] != "critical", f"{label}: could-not-verify is still not a blocker"
+    assert "NOT VERIFIED" in explicit["Summary"], f"{label}: the closing line must say it was not verified"
+    assert ambient["Summary"] == "", f"{label}: a standing preference must not shout on every run"
+
+
+@pytest.mark.skipif(_PS is None, reason="no PowerShell on PATH")
+@pytest.mark.parametrize(
+    ("label", "kwargs", "expect_summary"),
+    [
+        ("a match says nothing", {"intended": _TID, "actual": _TID}, False),
+        ("nothing declared says nothing", {"intended": "", "actual": _TID}, False),
+        ("a mismatch always speaks", {"intended": _OTHER_TID, "actual": _TID}, True),
+        ("an explicit mismatch speaks", {"intended": _OTHER_TID, "actual": _TID, "explicit": True}, True),
+    ],
+)
+def test_the_summary_speaks_only_when_it_has_something_to_say(label: str, kwargs: dict, expect_summary: bool) -> None:
+    """The closing line is the last thing an operator reads; it must stay quiet on the happy path.
+
+    A mismatch names the tenant whatever its provenance - a WARN that scrolled off the top is the
+    exact failure mode this exists for - while a match, and a run with nothing declared, add nothing.
+    """
+    verdict = _verdict(**kwargs)
+    assert bool(verdict["Summary"]) is expect_summary, f"{label}: Summary={verdict['Summary']!r}"
+    if expect_summary:
+        assert _OTHER_TID in verdict["Summary"] and _TID in verdict["Summary"], (
+            "both ends must be named, or the summary cannot be acted on without scrolling back"
+        )
+
+
+@pytest.mark.skipif(_PS is None, reason="no PowerShell on PATH")
+def test_a_resolved_domain_is_compared_but_still_reported_the_way_it_was_written() -> None:
+    """The operator typed a domain; the verdict must be about the GUID yet legible to them.
+
+    Without `DeclaredAs`, a resolved domain produces a message naming two GUIDs the operator never
+    typed, and no way to connect either to what they wrote.
+    """
+    resolved = _verdict(_OTHER_TID, _TID, explicit=True, declared_as="contoso.onmicrosoft.com")
+    assert resolved["Kind"] == "mismatch" and resolved["Tier"] == "critical"
+    assert "declared as contoso.onmicrosoft.com" in resolved["Detail"]
+    assert "declared as contoso.onmicrosoft.com" in resolved["Summary"]
+    # When nothing was translated, the same string twice is noise.
+    plain = _verdict(_TID, _TID, declared_as=_TID)
+    assert "declared as" not in plain["Detail"], "only a RESOLVED spelling is worth repeating"
+
+
+def _resolve_intent(flag: str = "", env: str = "", dotenv: str = "") -> dict:
+    raw = _run_ps(
+        "Resolve-IntendedTenant,Remove-SurroundingQuotes",
+        "$i = Resolve-IntendedTenant $env:T_FLAG $env:T_ENV $env:T_DOTENV\nEmit ($i | ConvertTo-Json -Compress)\n",
+        {"T_FLAG": flag, "T_ENV": env, "T_DOTENV": dotenv},
+    )
+    return json.loads(_emitted(raw))
+
+
+@pytest.mark.skipif(_PS is None, reason="no PowerShell on PATH")
+@pytest.mark.parametrize(
+    ("label", "channels", "expected", "expected_explicit"),
+    [
+        ("the flag wins over both", {"flag": _TID, "env": _OTHER_TID, "dotenv": _OTHER_TID}, _TID, True),
+        ("the exported variable beats .env", {"env": _TID, "dotenv": _OTHER_TID}, _TID, False),
+        (".env is the last resort", {"dotenv": _TID}, _TID, False),
+        ("nothing declared", {}, "", False),
+        # Every channel is normalized, not just the one with a reader function of its own.
+        ("a quoted flag", {"flag": f'"{_TID}"'}, _TID, True),
+        ("a quoted exported variable", {"env": f'"{_TID}"'}, _TID, False),
+        ("a padded flag", {"flag": f"  {_TID} "}, _TID, True),
+        # An empty higher channel must not shadow a populated lower one, and must not claim intent.
+        ("an empty flag falls through", {"flag": "", "env": _TID}, _TID, False),
+        ("a whitespace-only flag falls through", {"flag": "   ", "env": _TID}, _TID, False),
+    ],
+)
+def test_the_three_channels_resolve_in_order_and_are_all_normalized(
+    label: str, channels: dict, expected: str, expected_explicit: bool
+) -> None:
+    """Precedence AND normalization, executed - the pipeline they share was previously only grepped.
+
+    Two mutations survived a sweep here: dropping the normalization step, and inverting the
+    precedence. The first is not cosmetic - a quoted `$env:FABRIC_TENANT_ID` then fails the GUID
+    guard and degrades to "no Fabric token could be minted", the quoting bug re-entering through the
+    one channel `Get-DotEnvValue` does not cover. The second silently makes a persisted `.env` beat
+    an in-run `-Tenant`, which also flips the tier from critical to recommended.
+    """
+    intent = _resolve_intent(**channels)
+    assert intent["Tenant"] == expected, label
+    assert intent["IsExplicit"] is expected_explicit, f"{label}: only -Tenant declares intent for this run"
+
+
+def _resolve_domain(domain: str, az_stdout: str) -> str:
+    # `az` is shadowed by a FUNCTION here: PowerShell resolves functions before executables, so the
+    # resolver runs against canned JSON with no CLI, no network and no credentials involved.
+    raw = _run_ps(
+        "Resolve-TenantIdFromDomain,Test-TenantIdShape",
+        "function az { $env:T_AZOUT }\n$r = Resolve-TenantIdFromDomain $env:T_DOMAIN\nEmit $r\n",
+        {"T_DOMAIN": domain, "T_AZOUT": az_stdout},
+    )
+    return _emitted(raw)
+
+
+_AZ_ACCOUNTS = json.dumps(
+    [
+        {"id": "sub-1", "tenantId": _OTHER_TID, "tenantDefaultDomain": "other.onmicrosoft.com"},
+        {"id": "sub-2", "tenantId": _TID, "tenantDefaultDomain": "contoso.onmicrosoft.com"},
+    ]
+)
+
+
+@pytest.mark.skipif(_PS is None, reason="no PowerShell on PATH")
+@pytest.mark.parametrize(
+    ("label", "domain", "az_stdout", "expected"),
+    [
+        ("the default domain resolves to its tenant", "contoso.onmicrosoft.com", _AZ_ACCOUNTS, _TID),
+        ("DNS names are case-insensitive", "CONTOSO.OnMicrosoft.COM", _AZ_ACCOUNTS, _TID),
+        ("the right row is chosen, not the first", "other.onmicrosoft.com", _AZ_ACCOUNTS, _OTHER_TID),
+        ("a vanity domain is not the default domain", "contoso.com", _AZ_ACCOUNTS, ""),
+        ("a tenant never signed in to", "fabrikam.onmicrosoft.com", _AZ_ACCOUNTS, ""),
+        ("az said nothing (not logged in)", "contoso.onmicrosoft.com", "", ""),
+        ("az said something that is not JSON", "contoso.onmicrosoft.com", "ERROR: please run az login", ""),
+        ("no domain to resolve", "", _AZ_ACCOUNTS, ""),
+    ],
+)
+def test_a_declared_domain_is_resolved_rather_than_given_up_on(
+    label: str, domain: str, az_stdout: str, expected: str
+) -> None:
+    """ "Cannot compare" was a choice, not a necessity: the CLI already holds the mapping.
+
+    `contoso.onmicrosoft.com` is accepted by `az --tenant` and by `deploy_estate.py --tenant`, so an
+    operator has every reason to use it here too - and before this, that spelling bought zero
+    verification. `az account list --all` returns `tenantDefaultDomain` beside `tenantId`, so the
+    honest answer is available for the asking.
+
+    The failure rows matter just as much: resolution is best-effort, and every way it can fail must
+    return "" (fall back to "cannot compare") rather than throw or guess. A vanity domain is the
+    common one - it is not the DEFAULT domain and will never appear in that mapping.
+    """
+    assert _resolve_domain(domain, az_stdout) == expected, label
 
 
 def _dotenv(key: str) -> str:
     raw = _run_ps(
-        "Get-DotEnvValue,Remove-SurroundingQuotes",
+        "Get-DotEnvValue,ConvertFrom-DotEnvValue,Remove-SurroundingQuotes",
         "Emit (Get-DotEnvValue $env:T_KEY $env:T_PATH)\n",
         {"T_KEY": key, "T_PATH": str(_FIXTURE_ENV)},
     )
@@ -514,10 +732,30 @@ def _dotenv(key: str) -> str:
         ("SINGLE_QUOTED", _TID),
         ("PADDED", _TID),
         ("QUOTED_AND_PADDED", _TID),
+        # An inline note next to a GUID nobody recognizes by sight is the natural thing to write.
+        ("COMMENTED", _TID),
+        ("COMMENTED_TIGHT", _TID),
+        ("QUOTED_AND_COMMENTED", _TID),
+        # ...but inside quotes a '#' is DATA, and one with no whitespace in front of it is part of
+        # the value. Over-stripping corrupts a declaration just as quietly as not stripping at all.
+        ("HASH_INSIDE_QUOTES", "ab #cd"),
+        ("HASH_IS_DATA", "abc#def"),
+        # The closer is the first quote that actually ENDS the value: here the `#` right after it
+        # opens a comment, so the value stops at `ab`...
+        ("HASH_AFTER_INNER_QUOTE", "ab"),
+        # ...whereas here the first inner quote is followed by more value, so the scan keeps going
+        # and the '#' it passed over stays data.
+        ("HASH_STILL_INSIDE", 'a #b" c'),
+        ("ONLY_A_COMMENT", ""),
         # Only a MATCHED outer pair is a quoting convention. Everything else is the value.
         ("UNMATCHED_QUOTE", f'"{_TID}'),
         ("INNER_QUOTES", 'ab"cd"ef'),
         ("HAS_EQUALS", "a=b=c"),
+        # The closing quote must END the value. These two stay visibly malformed rather than
+        # decoding to '' or to a truncated fragment - a silent downgrade to "nothing was declared"
+        # would be worse than the complaint.
+        ("DOUBLE_QUOTED_TWICE", f'"{_TID}"'),
+        ("QUOTE_THEN_TAIL", 'a"b'),
         # Present-but-empty and absent are both "no value" to every caller, which filters falsy;
         # the reader still distinguishes them ('' vs $null) rather than inventing one.
         ("EMPTY", ""),


### PR DESCRIPTION
Fixes #124

Catch a wrong-tenant Fabric token before it becomes a confusing WorkspaceNotFound, and stop blocking an estate run on a Desktop-only pin. Also corrects this file's reportVersionAtImport wording (partial #129 - siblings own the other copies).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>