### PR TITLE
Publish powerbi-playbook v0.3.0 with three bundles

### DIFF
--- a/scripts/build_plugin.py
+++ b/scripts/build_plugin.py
@@ -34,9 +34,16 @@ PUBLISH_REPO = "https://github.com/Guust-Franssens/powerbi-playbook"
 
 # Only source-tool-agnostic bundles ship. `sentinel-probe` is a diagnostic, and anything
 # Tableau-specific belongs in the migration repo's personas, not in a reusable plugin.
+#
+# `pbip-model-refresh` is HELD BACK at v0.3.0. Its persist path validates `cache.abf` as a CFBF/OLE2
+# container, which the format is not — measured against three real caches in `examples/`, the check
+# rejects every one, so AMO persistence cannot succeed. Four review rounds of hardening around that
+# wrong premise added a lock and a commit-detection fingerprint that introduced two further ways to
+# leave a project unopenable. It ships again once the persist path is simplified (see the tracking
+# issue), not before: a bundle whose headline feature cannot work is worse than an absent one,
+# because the gotcha bundles' cross-references at least fail loudly.
 SHIPPED_SKILLS = (
     "powerbi-ai-readiness",
-    "pbip-model-refresh",
     "powerbi-report-gotchas",
     "powerbi-semantic-model-gotchas",
 )

--- a/scripts/build_plugin.py
+++ b/scripts/build_plugin.py
@@ -49,13 +49,13 @@ SHIPPED_SKILLS = (
 )
 
 PLUGIN_DESCRIPTION = (
-    "Reusable Power BI skills: make a semantic model AI-ready, persist a refreshed local PBIP, and "
-    "avoid the PBIR and TMDL defects that pass validation but break at open, refresh or render. "
-    "Covers descriptions, enumerated domains, model-level AI instructions (CustomInstructions) and "
-    "the qnaEnabled switch that silently voids them; refreshing a PBIP in Power BI Desktop and "
-    "saving it headlessly to cache.abf via AMO ImageSave; and two hard-won gotcha catalogues for "
-    "report authoring and semantic modelling. Source-tool agnostic - the input is "
-    "already a Power BI model - so it applies to Tableau, Qlik and Cognos migrations alike."
+    "Reusable Power BI skills: make a semantic model AI-ready, and avoid the PBIR and TMDL defects "
+    "that pass validation but break at open, refresh or render. Covers descriptions, enumerated "
+    "domains, model-level AI instructions (CustomInstructions) and the qnaEnabled switch that "
+    "silently voids them; plus two hard-won gotcha catalogues for report authoring and semantic "
+    "modelling, each entry paid for by a real debugging cycle on a real migration. Source-tool "
+    "agnostic - the input is already a Power BI model - so it applies to Tableau, Qlik and Cognos "
+    "migrations alike."
 )
 
 KEYWORDS = [
@@ -91,7 +91,8 @@ equally to a Tableau, Qlik or Cognos migration.
 | Skill | Use it for |
 |---|---|
 | `powerbi-ai-readiness` | Descriptions, enumerated categorical domains, model-level AI instructions (`CustomInstructions`), and the `qnaEnabled` switch that silently voids all of it |
-| `pbip-model-refresh` | Refreshing a local PBIP/TMDL model in Power BI Desktop and persisting it to `.pbi/cache.abf` headlessly via AMO `ImageSave`, with strict pid binding |
+| `powerbi-report-gotchas` | PBIR authoring and Desktop verification: defects that pass `validate` but render wrong, conditional-formatting encodings, azureMap/scatter/matrix recipes |
+| `powerbi-semantic-model-gotchas` | TMDL and DAX pitfalls that crash Desktop on open, fail to bind, or throw only at query time - each one paid for by a real debugging cycle |
 
 ## Why a plugin and not a repo-local skill
 

--- a/tests/test_build_plugin.py
+++ b/tests/test_build_plugin.py
@@ -9,6 +9,7 @@ though the artifact itself is gitignored.
 from __future__ import annotations
 
 import json
+import re
 import stat
 import sys
 from pathlib import Path
@@ -91,6 +92,45 @@ def test_no_build_artifacts_are_published(built: Path) -> None:
 def test_the_diagnostic_probe_skill_is_never_published() -> None:
     """`sentinel-probe` is a context-visibility experiment, not something a consumer should install."""
     assert "sentinel-probe" not in build_plugin.SHIPPED_SKILLS
+
+
+def test_the_advertised_skills_are_the_shipped_skills(built: Path) -> None:
+    """The README table and plugin description must not promise a bundle that is not in the release.
+
+    Both are hand-written prose in `build_plugin.py`, so they drift the moment `SHIPPED_SKILLS`
+    changes. v0.3.0 published with a description still advertising "persist a refreshed local PBIP
+    ... via AMO ImageSave" for `pbip-model-refresh`, which that release had deliberately held back -
+    a marketplace listing selling a capability the plugin did not contain. Nothing caught it; the
+    build was green because the *files* were correct and only the prose lied.
+
+    Note the description never contains the skill's NAME - it sells the capability in prose - so
+    checking for the folder name catches the README and nothing else. The distinctive-identifier
+    check below is what actually covers the description: `ImageSave` and `cache.abf` appear in the
+    withheld bundle's own frontmatter and in no shipped one, so their presence in the marketplace
+    copy is exactly the lie. (Verified failing against the v0.3.0 text.)
+    """
+    readme = (built / "README.md").read_text(encoding="utf-8")
+    manifest = json.loads((built / ".claude-plugin" / "marketplace.json").read_text(encoding="utf-8"))
+    description = manifest["plugins"][0]["description"]
+
+    for name in build_plugin.SHIPPED_SKILLS:
+        assert name in readme, f"{name} ships but the README does not mention it"
+
+    def identifiers(text: str) -> set[str]:
+        """Technical tokens a marketing sentence would only carry if it meant that specific feature."""
+        return set(re.findall(r"\b[A-Za-z]+\.[a-z]{2,}\b|\b[a-z]+[A-Z][A-Za-z]+\b", text))
+
+    def frontmatter(skill: str) -> str:
+        return (build_plugin.SKILLS_DIR / skill / "SKILL.md").read_text(encoding="utf-8")[:1500]
+
+    shipped_terms = {term for name in build_plugin.SHIPPED_SKILLS for term in identifiers(frontmatter(name))}
+    withheld = {p.name for p in build_plugin.SKILLS_DIR.iterdir() if p.is_dir()} - set(build_plugin.SHIPPED_SKILLS)
+
+    for name in withheld:
+        assert name not in readme, f"{name} is NOT shipped but the README still advertises it"
+        exclusive = identifiers(frontmatter(name)) - shipped_terms
+        leaked = sorted(term for term in exclusive if term in description)
+        assert not leaked, f"{name} is NOT shipped, but the plugin description still sells it via {leaked}"
 
 
 def test_rebuilding_preserves_a_git_clone(tmp_path: Path) -> None:


### PR DESCRIPTION
Ships `powerbi-playbook` v0.3.0 with three bundles, and holds the fourth back.

## Why `pbip-model-refresh` is not in this release

`master` currently carries **five known defects** in its persist path, each found by failure-injection and each ending in the same place: `database.tmdl` declaring a compatibility level that no cache on disk corresponds to, which Desktop reports as an `Untitled` window with **no error message**.

| # | defect | how it was reproduced |
|---|---|---|
| 1 | lock timeout falls through to UI Save | contention invoked `save(pid)` while the lock was still held; `main()` returned **0** |
| 2 | stale-lock reclaim is not mutually exclusive | three processes forced into the critical section at once → 1604 + committed 1702 cache |
| 3 | commit evidence is only `(size, mtime_ns)` | a pre-created cache with matching size+mtime → rollback under the new cache |
| 4 | interrupt protection ends before commit detection | one-shot `KeyboardInterrupt` inside `_cache_committed()` → 1702, no cache |
| 5 | `TABLES_OK` verdict is an incomplete interface migration | `pbi-semantic-builder.agent.md:299-303` still requires exact `DATA_OK` |

Defects 1-4 live in code added to fix earlier rounds — the lock did not exist before round 4 and introduced two of them. That is the signal to stop hardening.

Note this is **not** a claim that master is broken for the CFBF reason I first wrote: round 4 correctly replaced that check with the real format (a `cache.abf` begins with the 100-byte UTF-16LE preamble `"This backup was created using XPress9 compression."`, verified against all 11 real caches in `examples/`). Master fixed the *premise* and kept the *machinery*; the machinery is what still has the defects.

Shipping three reviewed bundles beats blocking them on a fourth in that state. The gotcha bundles cross-reference it by name, so an agent invoking it gets "skill not found" — degraded, and **loud**, which is the right failure for something genuinely absent. Nothing is published from that path, so these defects are internal-only today.

`fix/simplify-persist` deletes the machinery rather than fixing it (net **−320 lines**, commit-detection and lock both gone, `os.replace` made the final operation so "it returned" *is* the commit). It returns in v0.3.1.

## Also: the listing advertised a bundle it does not ship

The first push of v0.3.0 still sold `pbip-model-refresh` — the description promised *"persist a refreshed local PBIP … saving it headlessly to cache.abf via AMO ImageSave"*, and the README table listed it. The build was green because the **files** were right; only the prose lied, and nothing checks prose.

The obvious guard is vacuous: asserting the withheld folder name is absent **passes on the real bug**, because the description never names the skill — it sells the capability. Verified: `"pbip-model-refresh" in <broken description>` is `False`.

So the test compares distinctive identifiers. Tokens like `ImageSave` and `cache.abf` appear in the withheld bundle's frontmatter and in no shipped one, so their presence in marketplace copy *is* the lie. Confirmed failing against the real v0.3.0 string —

```
AssertionError: pbip-model-refresh is NOT shipped, but the plugin
description still sells it via ['cache.abf']
```

— and passing after the rewrite.

## Published

```
/plugin marketplace add Guust-Franssens/powerbi-playbook
/plugin install powerbi-playbook@powerbi-playbook-collection
```

Substantially newer than the last publish (2026-08-01), which went stale partly because `build_plugin.py --check` — the drift guard itself — crashed with `TypeError` on this repo's declared Python (fixed in #134):

| bundle | was | now |
|---|---|---|
| `powerbi-report-gotchas` | 21,589 B | **41,892 B** |
| `powerbi-semantic-model-gotchas` | 31,778 B | **57,749 B** |

Verified live: version `0.3.0`, three skills, description no longer matches `cache.abf|ImageSave`.
