### PR TITLE
Emit the per-plugin manifest Claude Code needs

### DIFF
--- a/scripts/build_plugin.py
+++ b/scripts/build_plugin.py
@@ -128,11 +128,11 @@ def shipped_skill_dirs() -> list[Path]:
 
 
 def marketplace_manifest() -> dict:
-    """The `.claude-plugin/marketplace.json` contract Copilot CLI reads."""
+    """The root `.claude-plugin/marketplace.json` — the catalogue both clients read to find plugins."""
     return {
         "name": MARKETPLACE_NAME,
         "metadata": {
-            "description": "Reusable Power BI semantic-model skills for GitHub Copilot CLI",
+            "description": "Reusable Power BI semantic-model skills for GitHub Copilot CLI and Claude Code",
             "version": VERSION,
         },
         "owner": {"name": "Guust Franssens"},
@@ -149,6 +149,31 @@ def marketplace_manifest() -> dict:
                 "license": "MIT",
             }
         ],
+    }
+
+
+def plugin_manifest() -> dict:
+    """The per-plugin `plugins/<name>/.claude-plugin/plugin.json`.
+
+    **Claude Code requires this and Copilot CLI does not** - which is exactly why it was missing.
+    The root marketplace.json is the catalogue; this is the plugin's own identity, and Claude Code
+    uses it to recognise, version and update the plugin. Publishing without it yields a marketplace
+    that adds cleanly in both clients and a plugin that only one of them can install, with nothing in
+    the build output hinting at the difference.
+
+    Shape follows the published `claude-code-plugin-manifest` schema, and mirrors
+    `microsoft/skills-for-fabric`, which ships the same pair and works in both clients.
+    """
+    return {
+        "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+        "name": PLUGIN_NAME,
+        "description": PLUGIN_DESCRIPTION,
+        "version": VERSION,
+        "license": "MIT",
+        "repository": PUBLISH_REPO,
+        "keywords": KEYWORDS,
+        "skills": [f"./skills/{name}" for name in SHIPPED_SKILLS],
+        "agents": [],
     }
 
 
@@ -221,6 +246,10 @@ def build(out: Path) -> None:
     (manifest_dir / "marketplace.json").write_text(
         json.dumps(marketplace_manifest(), indent=2) + "\n", encoding="utf-8"
     )
+
+    plugin_manifest_dir = out / "plugins" / PLUGIN_NAME / ".claude-plugin"
+    plugin_manifest_dir.mkdir(parents=True, exist_ok=True)
+    (plugin_manifest_dir / "plugin.json").write_text(json.dumps(plugin_manifest(), indent=2) + "\n", encoding="utf-8")
 
     slug = PUBLISH_REPO.rsplit("github.com/", 1)[-1]
     (out / "README.md").write_text(

--- a/scripts/build_plugin.py
+++ b/scripts/build_plugin.py
@@ -70,13 +70,14 @@ KEYWORDS = [
     "fabric",
 ]
 
-README = """# Power BI migration skills
+README = """# Power BI Playbook
 
-Reusable GitHub Copilot CLI skills for getting a **Power BI semantic model** production-ready:
-making it answer natural-language questions correctly, and persisting a refreshed local PBIP.
+Reusable skills for **GitHub Copilot CLI** and **Claude Code** that get a Power BI semantic model
+production-ready: making it answer natural-language questions correctly, and avoiding the PBIR and
+TMDL defects that pass every validator and then break at open, refresh or render.
 
-Both skills are **source-tool agnostic** — the input is already a Power BI model — so they apply
-equally to a Tableau, Qlik or Cognos migration.
+Every skill is **source-tool agnostic** — the input is already a Power BI model — so they apply
+equally to a Tableau, Qlik or Cognos migration, and to greenfield Power BI work.
 
 ## Install
 
@@ -104,6 +105,16 @@ Skill "<name>" not found. Available skills: ...
 
 Plugin-provided skills *are* registered, so an agent persona can reference them **by name** instead
 of reading a file path. That is the entire reason this marketplace exists.
+
+## Client support
+
+Both clients read the root `.claude-plugin/marketplace.json` as the catalogue. Claude Code
+*additionally* requires this plugin's own `plugins/{plugin}/.claude-plugin/plugin.json`, which is
+what it uses to recognise, version and update the plugin.
+
+That asymmetry is worth knowing if you fork this: omit the per-plugin manifest and `marketplace add`
+still succeeds in both clients while `plugin install` succeeds only in Copilot CLI — a plugin half
+its audience cannot install, with nothing in the build output to show for it.
 
 ## Source
 

--- a/tests/test_build_plugin.py
+++ b/tests/test_build_plugin.py
@@ -94,6 +94,35 @@ def test_the_diagnostic_probe_skill_is_never_published() -> None:
     assert "sentinel-probe" not in build_plugin.SHIPPED_SKILLS
 
 
+def test_the_plugin_carries_its_own_manifest_for_claude_code(built: Path) -> None:
+    """Claude Code needs `plugins/<name>/.claude-plugin/plugin.json`; Copilot CLI does not.
+
+    That asymmetry is the whole hazard. The root marketplace.json is the *catalogue*, and both
+    clients read it - so a marketplace missing the per-plugin manifest still `marketplace add`s
+    cleanly in both, installs fine in Copilot CLI, and simply is not recognised by Claude Code.
+    v0.3.0 shipped exactly that way. Nothing in the build output differed, because from Copilot's
+    point of view nothing was wrong.
+
+    `microsoft/skills-for-fabric` ships both files per plugin, which is the working reference.
+    """
+    manifest_path = built / "plugins" / build_plugin.PLUGIN_NAME / ".claude-plugin" / "plugin.json"
+    assert manifest_path.is_file(), "Claude Code will not recognise a plugin without its own plugin.json"
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["name"] == build_plugin.PLUGIN_NAME
+    assert manifest["version"] == build_plugin.VERSION
+
+    # The skill paths are relative to the plugin directory, so they must resolve from there.
+    for entry in manifest["skills"]:
+        resolved = (manifest_path.parent.parent / entry).resolve()
+        assert (resolved / "SKILL.md").is_file(), f"{entry} does not resolve to a skill from the plugin root"
+
+    catalogue = json.loads((built / ".claude-plugin" / "marketplace.json").read_text(encoding="utf-8"))
+    assert manifest["skills"] == catalogue["plugins"][0]["skills"], (
+        "the plugin manifest and the marketplace catalogue disagree about which skills ship"
+    )
+
+
 def test_the_publish_target_matches_the_plugin_name() -> None:
     """The three identity constants must agree, and must be the post-rename ones.
 

--- a/tests/test_build_plugin.py
+++ b/tests/test_build_plugin.py
@@ -152,10 +152,17 @@ def test_the_advertised_skills_are_the_shipped_skills(built: Path) -> None:
     build was green because the *files* were correct and only the prose lied.
 
     Note the description never contains the skill's NAME - it sells the capability in prose - so
-    checking for the folder name catches the README and nothing else. The distinctive-identifier
-    check below is what actually covers the description: `ImageSave` and `cache.abf` appear in the
+    checking for the folder name catches the README table and nothing else. The distinctive-identifier
+    check below is what actually covers the marketing copy: `ImageSave` and `cache.abf` appear in the
     withheld bundle's own frontmatter and in no shipped one, so their presence in the marketplace
     copy is exactly the lie. (Verified failing against the v0.3.0 text.)
+
+    ⚠️ **Its reach is identifiers, not plain English.** The v0.3.0 README opened with "persisting a
+    refreshed local PBIP", which names the withheld capability in ordinary words carrying no
+    camelCase or dotted token - measured, this check returns `[]` for that sentence. Detecting that
+    class reliably needs a human reading the summary paragraph, so treat this as a floor, not a
+    guarantee: it catches the copy-paste of technical terms, which is the common failure, and it
+    will not catch a fluent English claim.
     """
     readme = (built / "README.md").read_text(encoding="utf-8")
     manifest = json.loads((built / ".claude-plugin" / "marketplace.json").read_text(encoding="utf-8"))
@@ -177,8 +184,9 @@ def test_the_advertised_skills_are_the_shipped_skills(built: Path) -> None:
     for name in withheld:
         assert name not in readme, f"{name} is NOT shipped but the README still advertises it"
         exclusive = identifiers(frontmatter(name)) - shipped_terms
-        leaked = sorted(term for term in exclusive if term in description)
-        assert not leaked, f"{name} is NOT shipped, but the plugin description still sells it via {leaked}"
+        for surface, text in (("plugin description", description), ("README", readme)):
+            leaked = sorted(term for term in exclusive if term in text)
+            assert not leaked, f"{name} is NOT shipped, but the {surface} still sells it via {leaked}"
 
 
 def test_rebuilding_preserves_a_git_clone(tmp_path: Path) -> None:


### PR DESCRIPTION
Emit the per-plugin manifest Claude Code needs

The marketplace shipped a root `.claude-plugin/marketplace.json` and no
`plugins/<name>/.claude-plugin/plugin.json`. Claude Code requires both: the root
file is the CATALOGUE, the per-plugin file is the plugin's own identity, and
Claude Code uses it to recognise, version and update the plugin. Copilot CLI
requires only the catalogue.

That asymmetry is why nothing caught it. `marketplace add` succeeds in both
clients, `plugin install` succeeds in Copilot CLI, and the build output is
identical either way - so v0.3.0 published a plugin that half its intended
audience simply cannot install. The Confluence guide this work supports is
written for Claude Code, so that half is the one being onboarded first.

`microsoft/skills-for-fabric` ships both files per plugin and works in both
clients; that is the reference this now matches.

Adds a test asserting the manifest exists, that its version/name track the
constants, that every declared skill path resolves to a real SKILL.md *from the
plugin directory* (the paths are plugin-relative, not repo-relative), and that
it agrees with the catalogue about which skills ship. Verified failing with the
emit removed - three lines deleted, and the assertion fires.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
