### PR TITLE
Fail fast on Desktop credential modals

### DIFF
--- a/.github/skills/pbip-model-refresh/SKILL.md
+++ b/.github/skills/pbip-model-refresh/SKILL.md
@@ -108,12 +108,25 @@ stay byte-identical.
 > anyway. If a model legitimately needs longer, refresh less with `--tables`. Never emit a
 > "this needs a human" stop from an unverified timeout - that phrasing names the one blocker an
 > agent must not retry, so a false positive turns a slow refresh into a permanent dead end.
+>
+> ⚠️ **Bridge errors that look technical can be a blocking Desktop dialog.** The pair
+> `powerbi-desktop status` -> **"Host is not ready to accept operations"** and
+> `powerbi-desktop screenshot` -> **"Print metadata is not available"** was measured on an otherwise
+> healthy Desktop/bridge when a data-source dialog was already open. Some connector dialogs expose no
+> readable text, so the fast check reports either `CREDENTIAL_MISSING` (signature text matched) or
+> `BLOCKED_BY_DIALOG` (visible non-main dialog, text unreadable/non-credential). In both cases a
+> human must look at Desktop before the run proceeds. Check this first before suspecting the bridge or
+> filing an upstream defect.
 
 Read-only preflight (proves credentials + source reachability without changing anything):
 
 ```
 python scripts/probe_desktop_query.py [--pid <pbidesktop-pid>] [--canaries "A" "B"]
 ```
+
+Use a model with a persisted `.pbi/cache.abf` for Desktop/bridge smoke tests. A PBIP whose live SQL
+Server source does not exist in the current tenant will always open behind a credential dialog and is
+a bad unattended smoke-test fixture, no matter how well the bridge itself is working.
 
 **Name one canary table per distinct live source** with `--canaries`. A model-level `DATA_OK` is only
 emitted when *every* named canary returns rows; with **no** table named, only the first queryable

--- a/.github/skills/pbip-model-refresh/scripts/_credential_modal.py
+++ b/.github/skills/pbip-model-refresh/scripts/_credential_modal.py
@@ -1,0 +1,406 @@
+"""Credential modal detection shared by the PBIP refresh/query scripts.
+
+The regex in ``credential_modal_signature.regex`` is the same signature used by
+``probe_desktop_credential.ps1``. Keep the detector's matching rule here and the signature in that
+resource so the fast Python checks and the PowerShell arbiter cannot drift.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import os
+import re
+import time
+from ctypes import wintypes
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+SIGNATURE_PATH = Path(__file__).resolve().with_name("credential_modal_signature.regex")
+POLL_SECONDS = 5.0
+CONNECTOR_SOURCE_RE = re.compile(
+    r"\b(?P<kind>Sql\.Database|Snowflake\.Databases|Databricks\.[A-Za-z]+|Odbc\.DataSource|Web\.Contents)\s*\("
+    r"\s*(?:\"(?P<double>[^\"]+)\"|'(?P<single>[^']+)')?",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class DesktopWindow:
+    """Visible top-level Power BI Desktop window plus descendant Win32 text."""
+
+    title: str
+    class_name: str
+    width: int
+    height: int
+    texts: tuple[str, ...] = ()
+    minimized: bool = False
+    hwnd: int = 0
+
+
+@dataclass(frozen=True)
+class CredentialModal:
+    """Evidence that Power BI Desktop is blocked on a data-source credential dialog."""
+
+    matched_text: str
+    window: DesktopWindow
+
+    @property
+    def excerpt(self) -> str:
+        """Short UI text excerpt suitable for a verdict line."""
+        return self.matched_text[:80]
+
+
+@dataclass(frozen=True)
+class BlockingDialog:
+    """Evidence that Desktop is blocked by a visible dialog whose text may be unreadable."""
+
+    window: DesktopWindow
+
+
+@dataclass(frozen=True)
+class CredentialDetection:
+    """Credential-dialog inspection result for a Desktop PID."""
+
+    modal: CredentialModal | None = None
+    blocking_dialog: BlockingDialog | None = None
+    unknown_reason: str | None = None
+    windows: tuple[DesktopWindow, ...] = ()
+
+
+class CredentialMissingError(RuntimeError):
+    """Power BI Desktop is showing a data-source credential dialog."""
+
+    def __init__(self, pid: int, modal: CredentialModal, source_hint: str | None = None) -> None:
+        self.pid = pid
+        self.modal = modal
+        self.source_hint = source_hint
+        super().__init__(describe_modal(modal, source_hint))
+
+
+class DialogBlockedError(RuntimeError):
+    """Power BI Desktop is showing an unreadable/non-credential blocking dialog."""
+
+    def __init__(self, pid: int, dialog: BlockingDialog) -> None:
+        self.pid = pid
+        self.dialog = dialog
+        super().__init__(describe_blocking_dialog(dialog))
+
+
+WindowEnumerator = Callable[[int], Iterable[DesktopWindow]]
+
+DESKTOP_MAIN_CLASS_PREFIX = "WindowsForms10.Window.8"
+MIN_DIALOG_WIDTH = 100
+MIN_DIALOG_HEIGHT = 100
+
+
+class Win32EnumerationError(RuntimeError):
+    """Win32 window enumeration failed before a reliable modal verdict could be formed."""
+
+
+def _winenumproc_type():
+    """Return the Win32 callback type lazily so the module imports on non-Windows CI."""
+    if os.name != "nt":
+        raise Win32EnumerationError("Win32 callback types are only available on Windows")
+    return ctypes.WINFUNCTYPE(wintypes.BOOL, wintypes.HWND, wintypes.LPARAM)
+
+
+def credential_signature() -> re.Pattern[str]:
+    """Compile the shared credential-dialog signature."""
+    return re.compile(SIGNATURE_PATH.read_text(encoding="utf-8").strip(), re.IGNORECASE)
+
+
+def match_credential_modal(windows: Iterable[DesktopWindow]) -> CredentialModal | None:
+    """Return the first window whose descendant text matches the shared credential signature."""
+    signature = credential_signature()
+    for window in windows:
+        for text in window.texts:
+            if text and signature.search(text):
+                return CredentialModal(matched_text=text, window=window)
+    return None
+
+
+def blocking_dialog_candidates(windows: Iterable[DesktopWindow]) -> list[BlockingDialog]:
+    """Visible non-main, non-zero-size windows that can block Desktop operations."""
+    candidates: list[BlockingDialog] = []
+    for window in windows:
+        if window.class_name.startswith(DESKTOP_MAIN_CLASS_PREFIX):
+            continue
+        if window.width < MIN_DIALOG_WIDTH or window.height < MIN_DIALOG_HEIGHT:
+            continue
+        candidates.append(BlockingDialog(window))
+    return candidates
+
+
+def _hwnd_value(hwnd) -> int:
+    """Normalize ctypes callback HWND values (plain int on this Python, ctypes object on others)."""
+    value = getattr(hwnd, "value", hwnd)
+    return int(value or 0)
+
+
+def _configure_user32(user32) -> None:
+    """Set Win32 signatures explicitly so 64-bit handles are not truncated."""
+    callback_type = _winenumproc_type()
+    user32.EnumWindows.argtypes = [callback_type, wintypes.LPARAM]
+    user32.EnumWindows.restype = wintypes.BOOL
+    user32.EnumChildWindows.argtypes = [wintypes.HWND, callback_type, wintypes.LPARAM]
+    user32.EnumChildWindows.restype = wintypes.BOOL
+    user32.GetWindowThreadProcessId.argtypes = [wintypes.HWND, ctypes.POINTER(wintypes.DWORD)]
+    user32.GetWindowThreadProcessId.restype = wintypes.DWORD
+    user32.IsWindowVisible.argtypes = [wintypes.HWND]
+    user32.IsWindowVisible.restype = wintypes.BOOL
+    user32.IsIconic.argtypes = [wintypes.HWND]
+    user32.IsIconic.restype = wintypes.BOOL
+    user32.GetWindowTextLengthW.argtypes = [wintypes.HWND]
+    user32.GetWindowTextLengthW.restype = ctypes.c_int
+    user32.GetWindowTextW.argtypes = [wintypes.HWND, wintypes.LPWSTR, ctypes.c_int]
+    user32.GetWindowTextW.restype = ctypes.c_int
+    user32.GetClassNameW.argtypes = [wintypes.HWND, wintypes.LPWSTR, ctypes.c_int]
+    user32.GetClassNameW.restype = ctypes.c_int
+    user32.GetWindowRect.argtypes = [wintypes.HWND, ctypes.POINTER(wintypes.RECT)]
+    user32.GetWindowRect.restype = wintypes.BOOL
+
+
+def _window_text(user32, hwnd: int) -> str:
+    """Best-effort Win32 text for ``hwnd``."""
+    length = user32.GetWindowTextLengthW(hwnd)
+    if length <= 0:
+        return ""
+    buffer = ctypes.create_unicode_buffer(length + 1)
+    user32.GetWindowTextW(hwnd, buffer, length + 1)
+    return buffer.value
+
+
+def _class_name(user32, hwnd: int) -> str:
+    """Win32 class name for ``hwnd``."""
+    buffer = ctypes.create_unicode_buffer(256)
+    user32.GetClassNameW(hwnd, buffer, len(buffer))
+    return buffer.value
+
+
+def _child_texts(user32, hwnd: int) -> tuple[str, ...]:
+    """Text from child HWNDs of a candidate top-level window."""
+    texts: list[str] = []
+    errors: list[BaseException] = []
+
+    def callback(child_hwnd, _lparam):
+        try:
+            text = _window_text(user32, _hwnd_value(child_hwnd))
+            if text:
+                texts.append(text)
+        except BaseException as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught
+            errors.append(exc)
+        return True
+
+    enum_child_proc = _winenumproc_type()(callback)
+    user32.EnumChildWindows(hwnd, enum_child_proc, 0)
+    if errors:
+        raise Win32EnumerationError(f"child window enumeration callback failed: {errors[0]}") from errors[0]
+    return tuple(texts)
+
+
+def _enumerate_pid_windows_with_count(pid: int) -> tuple[list[DesktopWindow], int]:
+    """Enumerate visible top-level/owned windows for ``pid`` using Win32 ``EnumWindows``.
+
+    UI Automation root-child discovery misses Power BI connector dialogs because they are owned
+    windows, not root children. Win32 ``EnumWindows`` sees that shape and still scopes by PID, so
+    concurrent Desktop instances do not cross-contaminate.
+    """
+    if os.name != "nt":
+        raise Win32EnumerationError("Win32 window enumeration is only available on Windows")
+    user32 = ctypes.WinDLL("user32", use_last_error=True)
+    _configure_user32(user32)
+    windows: list[DesktopWindow] = []
+    errors: list[BaseException] = []
+    visited = 0
+
+    def callback(hwnd, _lparam):
+        nonlocal visited
+        visited += 1
+        try:
+            hwnd_int = _hwnd_value(hwnd)
+            owner_pid = wintypes.DWORD()
+            user32.GetWindowThreadProcessId(hwnd_int, ctypes.byref(owner_pid))
+            if owner_pid.value != pid or not user32.IsWindowVisible(hwnd_int):
+                return True
+            rect = wintypes.RECT()
+            user32.GetWindowRect(hwnd_int, ctypes.byref(rect))
+            title = _window_text(user32, hwnd_int)
+            texts = tuple(text for text in (title, *_child_texts(user32, hwnd_int)) if text)
+            windows.append(
+                DesktopWindow(
+                    title=title,
+                    class_name=_class_name(user32, hwnd_int),
+                    width=max(0, rect.right - rect.left),
+                    height=max(0, rect.bottom - rect.top),
+                    texts=texts,
+                    minimized=bool(user32.IsIconic(hwnd_int)),
+                    hwnd=hwnd_int,
+                )
+            )
+        except BaseException as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught
+            errors.append(exc)
+        return True
+
+    enum_windows_proc = _winenumproc_type()(callback)
+    if not user32.EnumWindows(enum_windows_proc, 0):
+        error_code = ctypes.get_last_error()
+        raise Win32EnumerationError(f"EnumWindows failed with Win32 error {error_code}")
+    if errors:
+        raise Win32EnumerationError(f"window enumeration callback failed: {errors[0]}") from errors[0]
+    if visited == 0:
+        raise Win32EnumerationError("EnumWindows returned no callbacks")
+    return windows, visited
+
+
+def enumerate_pid_windows(pid: int) -> list[DesktopWindow]:
+    """Enumerate visible top-level/owned windows for ``pid`` using Win32 ``EnumWindows``."""
+    windows, _visited = _enumerate_pid_windows_with_count(pid)
+    return windows
+
+
+def inspect_credential_modal(
+    pid: int, enumerate_windows: WindowEnumerator = enumerate_pid_windows
+) -> CredentialDetection:
+    """Inspect ``pid`` for a credential modal, preserving indeterminate states."""
+    try:
+        windows = tuple(enumerate_windows(pid))
+    except Win32EnumerationError as exc:
+        return CredentialDetection(unknown_reason=f"window enumeration failed: {exc}")
+    candidates = blocking_dialog_candidates(windows)
+    candidate_windows = [candidate.window for candidate in candidates]
+    modal = match_credential_modal(candidate_windows)
+    if modal is not None:
+        return CredentialDetection(modal=modal, windows=windows)
+    if candidates:
+        return CredentialDetection(blocking_dialog=candidates[0], windows=windows)
+    minimized = [
+        window for window in windows if window.minimized and window.class_name.startswith(DESKTOP_MAIN_CLASS_PREFIX)
+    ]
+    if minimized:
+        return CredentialDetection(
+            unknown_reason="Power BI Desktop owner window is minimized; owned credential dialogs are hidden",
+            windows=windows,
+        )
+    return CredentialDetection(windows=windows)
+
+
+def detect_credential_modal(
+    pid: int, enumerate_windows: WindowEnumerator = enumerate_pid_windows
+) -> CredentialModal | None:
+    """Detect a currently visible credential modal for ``pid``."""
+    return inspect_credential_modal(pid, enumerate_windows).modal
+
+
+def describe_modal(modal: CredentialModal, source_hint: str | None = None) -> str:
+    """Human-readable modal evidence for the verdict line."""
+    window = modal.window
+    size = f"{window.width}x{window.height}" if window.width and window.height else "unknown size"
+    source = f" source={source_hint};" if source_hint else ""
+    title = window.title or "(empty title)"
+    return f"{source} window title={title!r}, class={window.class_name!r}, size={size}, text={modal.excerpt!r}"
+
+
+def describe_blocking_dialog(dialog: BlockingDialog) -> str:
+    """Human-readable evidence for an unreadable/non-credential blocking dialog."""
+    window = dialog.window
+    size = f"{window.width}x{window.height}" if window.width and window.height else "unknown size"
+    title = window.title or "(empty title)"
+    return f"window title={title!r}, class={window.class_name!r}, size={size}, text=<unreadable or non-credential>"
+
+
+def source_hint_from_model(model_dir: Path | None) -> str | None:
+    """Best-effort source hint from TMDL/M expressions, without requiring Desktop."""
+    if model_dir is None:
+        return None
+    definition = model_dir / "definition"
+    if not definition.is_dir():
+        return None
+    for path in sorted(definition.rglob("*.tmdl")):
+        try:
+            text = path.read_text(encoding="utf-8-sig", errors="replace")
+        except OSError:
+            continue
+        match = CONNECTOR_SOURCE_RE.search(text)
+        if not match:
+            continue
+        source = match.group("double") or match.group("single")
+        kind = match.group("kind")
+        return f"{kind}({source})" if source else kind
+    return None
+
+
+def print_refresh_banner(pid: int, timeout_sec: int, grace_sec: int | float) -> None:
+    """Print the no-dialog, self-bounded refresh warning before the wait starts."""
+    total = timeout_sec + grace_sec
+    print(
+        f"No blocking dialog on PID {pid}. Refreshing, bounded at {timeout_sec}s XMLA + "
+        f"{grace_sec}s grace ({total}s total); a long wait here is expected for a serverless cold start. "
+        "DO NOT kill this process - at the deadline it re-checks and reports CREDENTIAL_MISSING, "
+        "BLOCKED_BY_DIALOG, or SLOW_SOURCE. Killing it early yields NO verdict.",
+        flush=True,
+    )
+
+
+def print_refresh_unknown_banner(pid: int, timeout_sec: int, grace_sec: int | float, reason: str) -> None:
+    """Print the bounded-refresh warning when the t=0 modal check is indeterminate."""
+    total = timeout_sec + grace_sec
+    print(
+        f"Credential dialog check on PID {pid} is UNKNOWN ({reason}). Refreshing, bounded at "
+        f"{timeout_sec}s XMLA + {grace_sec}s grace ({total}s total); a minimized owner can hide owned "
+        "dialogs from enumeration. DO NOT kill this process - at the deadline it re-checks with the "
+        "dialog arbiter and reports CREDENTIAL_MISSING, BLOCKED_BY_DIALOG, or SLOW_SOURCE. Killing it early "
+        "yields NO verdict.",
+        flush=True,
+    )
+
+
+def print_refresh_heartbeat(elapsed: float, total: float) -> None:
+    """Print an elapsed/total countdown without claiming progress."""
+    print(f"still refreshing, {int(elapsed)}s / {int(total)}s", flush=True)
+
+
+# pylint: disable=too-many-arguments
+def join_with_credential_poll(
+    worker,
+    *,
+    pid: int,
+    total_timeout: float,
+    heartbeat_seconds: float,
+    poll_seconds: float,
+    source_hint: str | None = None,
+    detector: Callable[[int], CredentialDetection] = inspect_credential_modal,
+) -> bool:
+    """Wait for ``worker`` while polling for a late credential dialog.
+
+    Returns True when the worker finished before the wall-clock deadline, False when the deadline
+    elapsed. Raises as soon as the shared detector sees a blocking dialog.
+    """
+    started = time.monotonic()
+    next_heartbeat = heartbeat_seconds
+    while worker.is_alive():
+        elapsed = time.monotonic() - started
+        remaining = max(0.0, total_timeout - elapsed)
+        if remaining <= 0:
+            break
+        worker.join(min(remaining, poll_seconds, max(0.0, next_heartbeat - elapsed)))
+        elapsed = time.monotonic() - started
+        state = detector(pid)
+        if state.modal is not None:
+            raise CredentialMissingError(pid, state.modal, source_hint)
+        if state.blocking_dialog is not None:
+            raise DialogBlockedError(pid, state.blocking_dialog)
+        if elapsed >= next_heartbeat and worker.is_alive():
+            print_refresh_heartbeat(elapsed, total_timeout)
+            next_heartbeat += heartbeat_seconds
+    if worker.is_alive():
+        state = detector(pid)
+        if state.modal is not None:
+            raise CredentialMissingError(pid, state.modal, source_hint)
+        if state.blocking_dialog is not None:
+            raise DialogBlockedError(pid, state.blocking_dialog)
+        return False
+    return True
+
+
+# pylint: enable=too-many-arguments

--- a/.github/skills/pbip-model-refresh/scripts/credential_modal_signature.regex
+++ b/.github/skills/pbip-model-refresh/scripts/credential_modal_signature.regex
@@ -1,0 +1,1 @@
+You aren.t signed in|Personal Access Token|Databricks Client Credentials|specify how to connect|Account Key|Enter your credentials|Please specify how to connect

--- a/.github/skills/pbip-model-refresh/scripts/probe_desktop_credential.ps1
+++ b/.github/skills/pbip-model-refresh/scripts/probe_desktop_credential.ps1
@@ -47,27 +47,108 @@ param(
 )
 
 Add-Type -AssemblyName UIAutomationClient, UIAutomationTypes, WindowsBase
+Add-Type @"
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Text;
+
+public static class Win32CredentialWindows {
+  public sealed class WindowInfo {
+    public IntPtr Hwnd;
+    public string Title = "";
+    public string ClassName = "";
+    public int Width;
+    public int Height;
+    public bool Minimized;
+    public List<string> Texts = new List<string>();
+  }
+
+  private delegate bool EnumWindowsProc(IntPtr hWnd, IntPtr lParam);
+  [DllImport("user32.dll")] private static extern bool EnumWindows(EnumWindowsProc lpEnumFunc, IntPtr lParam);
+  [DllImport("user32.dll")] private static extern bool EnumChildWindows(IntPtr hWndParent, EnumWindowsProc lpEnumFunc, IntPtr lParam);
+  [DllImport("user32.dll")] private static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint processId);
+  [DllImport("user32.dll")] private static extern bool IsWindowVisible(IntPtr hWnd);
+  [DllImport("user32.dll")] private static extern bool IsIconic(IntPtr hWnd);
+  [DllImport("user32.dll")] private static extern int GetWindowTextLength(IntPtr hWnd);
+  [DllImport("user32.dll", CharSet = CharSet.Unicode)] private static extern int GetWindowText(IntPtr hWnd, StringBuilder text, int count);
+  [DllImport("user32.dll", CharSet = CharSet.Unicode)] private static extern int GetClassName(IntPtr hWnd, StringBuilder className, int count);
+  [DllImport("user32.dll")] private static extern bool GetWindowRect(IntPtr hWnd, out RECT rect);
+
+  [StructLayout(LayoutKind.Sequential)]
+  private struct RECT { public int Left; public int Top; public int Right; public int Bottom; }
+
+  private static string Text(IntPtr hWnd) {
+    int length = GetWindowTextLength(hWnd);
+    if (length <= 0) { return ""; }
+    var builder = new StringBuilder(length + 1);
+    GetWindowText(hWnd, builder, builder.Capacity);
+    return builder.ToString();
+  }
+
+  private static string ClassNameOf(IntPtr hWnd) {
+    var builder = new StringBuilder(256);
+    GetClassName(hWnd, builder, builder.Capacity);
+    return builder.ToString();
+  }
+
+  public static List<WindowInfo> GetPidWindows(int pid) {
+    var windows = new List<WindowInfo>();
+    EnumWindows(delegate (IntPtr hWnd, IntPtr lParam) {
+      uint ownerPid;
+      GetWindowThreadProcessId(hWnd, out ownerPid);
+      if (ownerPid != (uint)pid || !IsWindowVisible(hWnd)) { return true; }
+      RECT rect;
+      GetWindowRect(hWnd, out rect);
+      var info = new WindowInfo {
+        Hwnd = hWnd,
+        Title = Text(hWnd),
+        ClassName = ClassNameOf(hWnd),
+        Width = Math.Max(0, rect.Right - rect.Left),
+        Height = Math.Max(0, rect.Bottom - rect.Top),
+        Minimized = IsIconic(hWnd)
+      };
+      if (!String.IsNullOrEmpty(info.Title)) { info.Texts.Add(info.Title); }
+      EnumChildWindows(hWnd, delegate (IntPtr child, IntPtr childParam) {
+        string text = Text(child);
+        if (!String.IsNullOrEmpty(text)) { info.Texts.Add(text); }
+        return true;
+      }, IntPtr.Zero);
+      windows.Add(info);
+      return true;
+    }, IntPtr.Zero);
+    return windows;
+  }
+}
+"@
 
 $root = [System.Windows.Automation.AutomationElement]::RootElement
 $cond = New-Object System.Windows.Automation.PropertyCondition([System.Windows.Automation.AutomationElement]::ProcessIdProperty, $DesktopPid)
 
 # Connector credential-dialog signature text (covers Databricks / SQL / Snowflake / generic OAuth).
-$sig = 'You aren.t signed in|Personal Access Token|Databricks Client Credentials|specify how to connect|Account Key|Enter your credentials|Please specify how to connect'
+# Shared with the Python t=0/poll detector so the fast path and this arbiter cannot drift.
+$sig = Get-Content -LiteralPath (Join-Path $PSScriptRoot 'credential_modal_signature.regex') -Raw
 
 function Get-PidWindows {
-  # EVERY top-level window of the target process, not just the first. A credential modal is its own
-  # top-level window (a sibling of the main Desktop window, not a child), so scanning only the first
-  # would miss it - and the whole point of this arbiter is to catch that modal.
-  return $root.FindAll([System.Windows.Automation.TreeScope]::Children, $cond)
+  # EVERY visible top-level/owned window of the target process, not UIA RootElement children. A
+  # Power BI credential modal is an owned window; UIA root-child discovery misses it.
+  return [Win32CredentialWindows]::GetPidWindows($DesktopPid)
 }
 
 function Test-CredentialModal {
   foreach ($w in Get-PidWindows) {
-    $desc = $w.FindAll([System.Windows.Automation.TreeScope]::Descendants, [System.Windows.Automation.Condition]::TrueCondition)
-    foreach ($d in $desc) {
-      $n = $d.Current.Name
+    foreach ($n in $w.Texts) {
       if ($n -and $n -match $sig) { return $n }
     }
+  }
+  return $null
+}
+
+function Test-BlockingDialog {
+  foreach ($w in Get-PidWindows) {
+    if ($w.ClassName.StartsWith('WindowsForms10.Window.8')) { continue }
+    if ($w.Width -lt 100 -or $w.Height -lt 100) { continue }
+    return $w
   }
   return $null
 }
@@ -82,11 +163,24 @@ if ($hit) {
   Write-Output "VERDICT: CREDENTIAL_MISSING"
   exit 1
 }
+$blocker = Test-BlockingDialog
+if ($blocker) {
+  Write-Output ("blocking dialog already open: class={0} size={1}x{2}" -f $blocker.ClassName, $blocker.Width, $blocker.Height)
+  Write-Output "VERDICT: BLOCKED_BY_DIALOG"
+  exit 1
+}
+foreach ($w in $windows) {
+  if ($w.Minimized -and $w.ClassName.StartsWith('WindowsForms10.Window.8')) {
+    Write-Output "Power BI Desktop owner window is minimized; owned credential dialogs are hidden"
+    Write-Output "VERDICT: UNKNOWN"
+    exit 3
+  }
+}
 
 # 2. Otherwise trigger a refresh and watch for the modal (generous timeout for warehouse cold-start).
 # Search every top-level window for an invokable 'Refresh', not just the first.
 $invoked = $false
-foreach ($w in $windows) {
+foreach ($w in $root.FindAll([System.Windows.Automation.TreeScope]::Children, $cond)) {
   $all = $w.FindAll([System.Windows.Automation.TreeScope]::Descendants, [System.Windows.Automation.Condition]::TrueCondition)
   foreach ($e in $all) {
     if ($e.Current.Name -eq 'Refresh' -and (($e.GetSupportedPatterns() | ForEach-Object { $_.ProgrammaticName }) -match 'Invoke')) {
@@ -112,6 +206,12 @@ while ((Get-Date) -lt $deadline) {
   if ($hit) {
     Write-Output ("credential modal detected: '{0}'" -f $hit.Substring(0, [Math]::Min(80, $hit.Length)))
     Write-Output "VERDICT: CREDENTIAL_MISSING"
+    exit 1
+  }
+  $blocker = Test-BlockingDialog
+  if ($blocker) {
+    Write-Output ("blocking dialog detected: class={0} size={1}x{2}" -f $blocker.ClassName, $blocker.Width, $blocker.Height)
+    Write-Output "VERDICT: BLOCKED_BY_DIALOG"
     exit 1
   }
 }

--- a/.github/skills/pbip-model-refresh/scripts/probe_desktop_query.py
+++ b/.github/skills/pbip-model-refresh/scripts/probe_desktop_query.py
@@ -31,13 +31,23 @@ from __future__ import annotations
 
 import argparse
 import glob
+import inspect
 import os
 import re
 import subprocess
 import sys
+import threading
 import time
 from pathlib import Path
 from typing import NoReturn
+
+from _credential_modal import (
+    CredentialDetection,
+    CredentialModal,
+    describe_blocking_dialog,
+    describe_modal,
+    inspect_credential_modal,
+)
 
 # ADOMD.NET assembly shipped in the nuget cache (netcore build). Resolved at import time.
 _ADOMD_PKG = "microsoft.analysisservices.adomdclient.netcore*"
@@ -48,6 +58,7 @@ _ADOMD_GLOBS = [str(Path.home() / ".nuget/packages" / _ADOMD_PKG / "**" / _ADOMD
 # short retry - but a bounded one, because a miss must end in a loud failure, never a fallback.
 PORT_DISCOVERY_ATTEMPTS = 6
 PORT_DISCOVERY_INTERVAL_SECONDS = 2
+PREFLIGHT_CREDENTIAL_POLL_SECONDS = 5.0
 
 # Power BI's auto date/time scaffolding. Present in the engine, and serialized into a PBIP's
 # `definition/tables/` too when auto date/time is (or ever was) on - so a comparison of the two
@@ -284,7 +295,7 @@ def measure_names(conn) -> set[tuple[str, str]]:
     return pairs
 
 
-def _probe_one(port: int, conn, table: str) -> int:
+def _probe_one(port: int, conn, table: str, emit=print) -> int:
     """Run EVALUATE TOPN(1, '<table>') for one table, print the evidence, and return the row count."""
     dax = f"EVALUATE TOPN(1, '{table}')"
     cmd = conn.CreateCommand()
@@ -298,14 +309,14 @@ def _probe_one(port: int, conn, table: str) -> int:
         if rows == 1:
             first_values = [str(reader.GetValue(i)) for i in range(reader.FieldCount)]
     reader.Close()
-    print(f"port={port}  table='{table}'  dax={dax}")
-    print(f"  columns ({len(cols)}): {cols[:8]}")
+    emit(f"port={port}  table='{table}'  dax={dax}")
+    emit(f"  columns ({len(cols)}): {cols[:8]}")
     if rows:
-        print(f"  row: {first_values[:8]}")
+        emit(f"  row: {first_values[:8]}")
     return rows
 
 
-def probe(port: int, tables: list[str] | None) -> int:
+def probe(port: int, tables: list[str] | None, emit=print) -> int:
     """Probe each canary table with a 1-row read against localhost:<port>; return a process exit code.
 
     With an explicit canary set (one per distinct live source) an all-non-zero result earns the
@@ -320,27 +331,109 @@ def probe(port: int, tables: list[str] | None) -> int:
     try:
         implicit = not tables
         targets = list(tables) if tables else [first_table(conn)]
-        results = [(target, _probe_one(port, conn, target)) for target in targets]
+        results = [(target, _probe_one(port, conn, target, emit)) for target in targets]
         empty = [target for target, rows in results if rows <= 0]
         if empty:
-            print(
+            emit(
                 f"PREFLIGHT: NO_DATA (0 rows from: {', '.join(empty)} - source empty, "
                 "credential missing, or refresh failed)"
             )
             return 1
         if implicit:
             only = results[0][0]
-            print(f"PREFLIGHT: TABLE_OK '{only}'")
-            print(
+            emit(f"PREFLIGHT: TABLE_OK '{only}'")
+            emit(
                 f"  note: single-table probe of '{only}' only - NOT a model-level DATA_OK. A static "
                 "parameter/CSV table can return rows while a live source never loaded. Pass --canaries "
                 "<one per live source> to certify every source."
             )
             return 0
-        print("PREFLIGHT: DATA_OK")
+        emit("PREFLIGHT: DATA_OK")
         return 0
     finally:
         conn.Close()
+
+
+def _credential_missing(pid: int) -> CredentialModal | None:
+    """Return an already-open credential modal for ``pid``, if Desktop is blocked on one."""
+    return _credential_state(pid).modal
+
+
+def _credential_state(pid: int) -> CredentialDetection:
+    """Return the credential-modal inspection state for ``pid``."""
+    if os.name != "nt":
+        return CredentialDetection()
+    return inspect_credential_modal(pid)
+
+
+def _emit_credential_missing(pid: int, modal: CredentialModal) -> None:
+    """Print the distinct credential verdict."""
+    print(f"PREFLIGHT: CREDENTIAL_MISSING pid={pid}; {describe_modal(modal)}")
+
+
+def _emit_blocked_by_dialog(pid: int, dialog) -> None:
+    """Print the distinct generic blocking-dialog verdict."""
+    print(f"PREFLIGHT: BLOCKED_BY_DIALOG pid={pid}; {describe_blocking_dialog(dialog)}")
+
+
+def _emit_credential_unknown(pid: int, reason: str) -> None:
+    """Print an indeterminate credential-check verdict."""
+    print(f"PREFLIGHT: UNKNOWN pid={pid}; credential dialog check indeterminate: {reason}")
+
+
+def _probe_with_credential_poll(  # pylint: disable=too-many-return-statements
+    pid: int | None, port: int, tables: list[str] | None
+) -> int:
+    """Run ``probe`` while polling for a late credential dialog owned by ``pid``."""
+    if pid is None:
+        return probe(port, tables)
+
+    early = _credential_state(pid)
+    if early.modal is not None:
+        _emit_credential_missing(pid, early.modal)
+        return 1
+    if early.blocking_dialog is not None:
+        _emit_blocked_by_dialog(pid, early.blocking_dialog)
+        return 1
+    if early.unknown_reason:
+        _emit_credential_unknown(pid, early.unknown_reason)
+        return 3
+
+    result: dict[str, int | BaseException] = {}
+    captured: list[str] = []
+
+    def run_probe() -> None:
+        try:
+            if "emit" in inspect.signature(probe).parameters:
+                result["outcome"] = probe(port, tables, captured.append)
+            else:
+                result["outcome"] = probe(port, tables)
+        except BaseException as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught
+            result["outcome"] = exc
+
+    worker = threading.Thread(target=run_probe, name="desktop-query-probe", daemon=True)
+    worker.start()
+    while worker.is_alive():
+        worker.join(PREFLIGHT_CREDENTIAL_POLL_SECONDS)
+        state = _credential_state(pid)
+        if state.modal is not None:
+            _emit_credential_missing(pid, state.modal)
+            return 1
+        if state.blocking_dialog is not None:
+            _emit_blocked_by_dialog(pid, state.blocking_dialog)
+            return 1
+        if state.unknown_reason:
+            _emit_credential_unknown(pid, state.unknown_reason)
+            return 3
+
+    outcome = result.get("outcome")
+    if isinstance(outcome, BaseException):
+        raise outcome
+    if outcome is None:  # pragma: no cover - defensive; the worker always records something
+        raise RuntimeError("probe worker returned no result")
+    for line in captured:
+        print(line)
+    return outcome
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -371,9 +464,20 @@ def main(argv: list[str] | None = None) -> int:
     # Preference order: --canaries (the name that means the same thing in both scripts), then
     # --tables (plural), then --table as a one-name alias for old callers.
     tables = list(args.canaries or args.tables or ([args.table] if args.table else [])) or None
+    if args.pid is not None:
+        early = _credential_state(args.pid)
+        if early.modal is not None:
+            _emit_credential_missing(args.pid, early.modal)
+            return 1
+        if early.blocking_dialog is not None:
+            _emit_blocked_by_dialog(args.pid, early.blocking_dialog)
+            return 1
+        if early.unknown_reason:
+            _emit_credential_unknown(args.pid, early.unknown_reason)
+            return 3
     port = args.port or discover_port(args.pid)
     try:
-        return probe(port, tables)
+        return _probe_with_credential_poll(args.pid, port, tables)
     except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught
         print(f"PREFLIGHT: ERROR {type(exc).__name__}: {exc}")
         return 2

--- a/.github/skills/pbip-model-refresh/scripts/refresh_pbip_model.py
+++ b/.github/skills/pbip-model-refresh/scripts/refresh_pbip_model.py
@@ -76,8 +76,11 @@ tell you whose rows are in the blob; only the model's own contents can.
 
 from __future__ import annotations
 
+# pylint: disable=too-many-lines
+
 import argparse
 import hashlib
+import inspect
 import json
 import os
 import re
@@ -133,6 +136,19 @@ from _verdict import (  # noqa: F401  # pylint: disable=unused-import
     _canary_tables,
     _emit_data_verdict,
 )
+from _credential_modal import (
+    CredentialDetection,
+    CredentialMissingError,
+    CredentialModal,
+    DialogBlockedError,
+    describe_blocking_dialog,
+    describe_modal,
+    inspect_credential_modal,
+    join_with_credential_poll,
+    print_refresh_banner,
+    print_refresh_unknown_banner,
+    source_hint_from_model,
+)
 
 SAVE_SETTLE_SECONDS = 3
 SAVE_TIMEOUT_SECONDS = 120
@@ -162,6 +178,8 @@ REFRESH_TIMEOUT_SECONDS = 300
 # wall-clock abort. The outer bound only exists to catch the case XMLA provably cannot interrupt:
 # a mashup engine parked on a sign-in modal in another process.
 REFRESH_WALL_CLOCK_GRACE_SECONDS = 30
+REFRESH_CREDENTIAL_POLL_SECONDS = 5.0
+REFRESH_HEARTBEAT_SECONDS = 30.0
 
 # A TMDL table declaration sits at column 0 of `definition/tables/<Name>.tmdl`; the name is quoted
 # only when it needs to be (spaces, punctuation), so both forms have to be accepted.
@@ -181,6 +199,36 @@ GENERATED_EDIT_DECLARATIONS = Path("_build") / "generated-edit-declarations.json
 CREDENTIAL_PROBE = Path(__file__).resolve().parent / "probe_desktop_credential.ps1"
 
 
+def _credential_missing(pid: int) -> CredentialModal | None:
+    """Return an already-open credential modal for ``pid``, if Desktop is blocked on one."""
+    return _credential_state(pid).modal
+
+
+def _credential_state(pid: int) -> CredentialDetection:
+    """Return the credential-modal inspection state for ``pid``."""
+    if os.name != "nt":
+        return CredentialDetection()
+    return inspect_credential_modal(pid)
+
+
+def _raise_if_blocked(pid: int, state: CredentialDetection, source_hint: str | None = None) -> None:
+    """Raise the appropriate exception when ``state`` contains a blocking dialog."""
+    if state.modal is not None:
+        raise CredentialMissingError(pid, state.modal, source_hint)
+    if state.blocking_dialog is not None:
+        raise DialogBlockedError(pid, state.blocking_dialog)
+
+
+def _emit_credential_missing(pid: int, modal: CredentialModal, source_hint: str | None = None) -> None:
+    """Print the distinct credential verdict."""
+    print(f"REFRESH: CREDENTIAL_MISSING pid={pid}; {describe_modal(modal, source_hint)}")
+
+
+def _emit_blocked_by_dialog(pid: int, dialog) -> None:
+    """Print the distinct generic blocking-dialog verdict."""
+    print(f"REFRESH: BLOCKED_BY_DIALOG pid={pid}; {describe_blocking_dialog(dialog)}")
+
+
 def _catalog_id(conn) -> str:
     """The database GUID a TMSL command must name, read from the server's own catalog DMV."""
     cmd = conn.CreateCommand()
@@ -194,7 +242,15 @@ def _catalog_id(conn) -> str:
         reader.Close()
 
 
-def refresh(port: int, tables: list[str] | None, timeout_sec: int = REFRESH_TIMEOUT_SECONDS) -> tuple[bool, str]:
+# pylint: disable=too-many-statements
+def refresh(
+    port: int,
+    tables: list[str] | None,
+    timeout_sec: int = REFRESH_TIMEOUT_SECONDS,
+    *,
+    desktop_pid: int | None = None,
+    source_hint: str | None = None,
+) -> tuple[bool, str]:
     """Send a TMSL refresh over XMLA. Returns (ok, message).
 
     Refreshing named tables is preferred over the whole database: a full refresh can hang for
@@ -231,6 +287,16 @@ def refresh(port: int, tables: list[str] | None, timeout_sec: int = REFRESH_TIME
     as STALE.
     """
     result: dict[str, tuple[bool, str] | BaseException] = {}
+    total_timeout = timeout_sec + REFRESH_WALL_CLOCK_GRACE_SECONDS
+    if desktop_pid is not None:
+        state = _credential_state(desktop_pid)
+        _raise_if_blocked(desktop_pid, state, source_hint)
+        if state.unknown_reason:
+            print_refresh_unknown_banner(
+                desktop_pid, timeout_sec, REFRESH_WALL_CLOCK_GRACE_SECONDS, state.unknown_reason
+            )
+        else:
+            print_refresh_banner(desktop_pid, timeout_sec, REFRESH_WALL_CLOCK_GRACE_SECONDS)
 
     def _run() -> None:
         conn = None
@@ -263,10 +329,23 @@ def refresh(port: int, tables: list[str] | None, timeout_sec: int = REFRESH_TIME
 
     worker = threading.Thread(target=_run, name="xmla-refresh", daemon=True)
     worker.start()
-    worker.join(timeout_sec + REFRESH_WALL_CLOCK_GRACE_SECONDS)
+    if desktop_pid is None:
+        worker.join(total_timeout)
+    else:
+        join_with_credential_poll(
+            worker,
+            pid=desktop_pid,
+            total_timeout=total_timeout,
+            heartbeat_seconds=REFRESH_HEARTBEAT_SECONDS,
+            poll_seconds=REFRESH_CREDENTIAL_POLL_SECONDS,
+            source_hint=source_hint,
+            detector=_credential_state,
+        )
     if worker.is_alive():
+        if desktop_pid is not None:
+            _raise_if_blocked(desktop_pid, _credential_state(desktop_pid), source_hint)
         raise TimeoutError(
-            f"refresh did not return within {timeout_sec + REFRESH_WALL_CLOCK_GRACE_SECONDS}s "
+            f"refresh did not return within {total_timeout}s "
             f"(XMLA CommandTimeout was {timeout_sec}s and did not fire, which is the signature of a "
             f"mashup engine parked on a sign-in modal rather than a slow query)"
         )
@@ -277,6 +356,9 @@ def refresh(port: int, tables: list[str] | None, timeout_sec: int = REFRESH_TIME
     if outcome is None:  # pragma: no cover - defensive; the worker always records something
         raise RuntimeError("refresh worker returned no result")
     return outcome
+
+
+# pylint: enable=too-many-statements
 
 
 def _bridge_status() -> dict:
@@ -972,16 +1054,34 @@ def row_counts(port: int, tables: list[str] | None) -> tuple[list[tuple[str, int
         conn.Close()
 
 
-def _refresh_and_save(pid: int, port: int, cache: Path | None, args: argparse.Namespace) -> int | None:
+def _refresh_and_save(  # pylint: disable=too-many-return-statements,too-many-branches
+    pid: int, port: int, cache: Path | None, args: argparse.Namespace
+) -> int | None:
     """Run the refresh and (unless suppressed) persist it. Returns an exit code, or None to continue.
 
     `cache` is passed in rather than re-derived: `cache_file` is another Desktop Bridge round trip,
     and the bridge returning nothing (or something else) after the identity gate has run would mean
     writing to a destination that was never verified.
     """
+    source_hint = source_hint_from_model(cache.parent.parent if cache else None)
     try:
-        ok, message = refresh(port, args.tables, REFRESH_TIMEOUT_SECONDS)
+        if "desktop_pid" in inspect.signature(refresh).parameters:
+            ok, message = refresh(
+                port,
+                args.tables,
+                REFRESH_TIMEOUT_SECONDS,
+                desktop_pid=pid,
+                source_hint=source_hint,
+            )
+        else:
+            ok, message = refresh(port, args.tables, REFRESH_TIMEOUT_SECONDS)
     except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught
+        if isinstance(exc, CredentialMissingError):
+            _emit_credential_missing(exc.pid, exc.modal, exc.source_hint)
+            return 1
+        if isinstance(exc, DialogBlockedError):
+            _emit_blocked_by_dialog(exc.pid, exc.dialog)
+            return 1
         text = f"{type(exc).__name__}: {exc}"
         # A timeout has TWO possible causes and this code cannot tell them apart. It used to assert
         # the credential one ("THIS NEEDS A HUMAN. Do not retry"), which is the single most expensive
@@ -1156,13 +1256,27 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def main(argv: list[str] | None = None) -> int:
+def main(argv: list[str] | None = None) -> int:  # pylint: disable=too-many-return-statements
     """CLI entry point: refresh, save, and prove data is really there."""
     args = _build_arg_parser().parse_args(argv)
 
     pid = _resolve_pid(args.pid)
     if pid is None:
         return 2
+
+    # Resolve the destination before touching XMLA so a t=0 credential modal can be reported with the
+    # source hint from the model files, and before any query is issued against a blocked Desktop.
+    cache = cache_file(pid)
+    source_hint = source_hint_from_model(cache.parent.parent if cache else None)
+    credential_state = _credential_state(pid)
+    if credential_state.modal is not None:
+        _emit_credential_missing(pid, credential_state.modal, source_hint)
+        return 1
+    if credential_state.blocking_dialog is not None:
+        _emit_blocked_by_dialog(pid, credential_state.blocking_dialog)
+        return 1
+    if credential_state.unknown_reason:
+        print(f"  credential-check: UNKNOWN ({credential_state.unknown_reason})")
 
     # The port is DERIVED from the pid. A stray --port must never bypass that on this mutating path:
     # the destination cache is resolved from the pid, so a --port pointing at another instance would
@@ -1176,9 +1290,6 @@ def main(argv: list[str] | None = None) -> int:
         return 2
     port = discovered
 
-    # Resolved ONCE: the path that gets verified must be the path that gets written, and every
-    # re-derivation is another Desktop Bridge round trip that can come back empty.
-    cache = cache_file(pid)
     before_stamp = cache.stat().st_mtime if cache and cache.exists() else 0.0
 
     # Gate everything on identity: refreshing, row-counting or persisting a sibling's model is a

--- a/.github/skills/pbip-model-refresh/tests/test_credential_modal_detection.py
+++ b/.github/skills/pbip-model-refresh/tests/test_credential_modal_detection.py
@@ -1,0 +1,431 @@
+"""Offline tests for the Desktop credential-modal fast path and polling loop."""
+
+from __future__ import annotations
+
+# These tests deliberately monkeypatch module-internal seams so no Desktop, network, or Fabric
+# dependency is required.
+# pylint: disable=protected-access,too-few-public-methods,invalid-name
+
+import threading
+import time
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from _credential_modal import (
+    BlockingDialog,
+    CredentialDetection,
+    CredentialModal,
+    DialogBlockedError,
+    DesktopWindow,
+    _enumerate_pid_windows_with_count,
+    inspect_credential_modal,
+)
+import probe_desktop_query
+import refresh_pbip_model
+from refresh_pbip_model import CredentialMissingError, refresh
+
+
+class ParkedConnection:
+    """ADOMD stand-in whose command never returns until the test releases it."""
+
+    def __init__(self, released: threading.Event) -> None:
+        self.released = released
+
+    def Open(self) -> None:
+        """Match the ADOMD API surface."""
+
+    def CreateCommand(self):
+        """Return a command that blocks until released."""
+        return ParkedCommand(self.released)
+
+    def Close(self) -> None:
+        """Match the ADOMD API surface."""
+
+
+class ParkedCommand:
+    """Command stand-in that ignores CommandTimeout."""
+
+    CommandText = ""
+    CommandTimeout = 0
+
+    def __init__(self, released: threading.Event) -> None:
+        self.released = released
+
+    def ExecuteNonQuery(self) -> None:
+        """Block long enough that only the outer poll/deadline can end the test."""
+        self.released.wait(timeout=600)
+
+
+@pytest.fixture(name="parked")
+def parked_fixture(monkeypatch):
+    """Wire refresh() to a parked ADOMD connection."""
+    released = threading.Event()
+    conn = ParkedConnection(released)
+    monkeypatch.setattr(refresh_pbip_model, "_load_adomd", lambda: lambda _dsn: conn)
+    monkeypatch.setattr(refresh_pbip_model, "_catalog_id", lambda _conn: "catalog-1")
+    monkeypatch.setattr(refresh_pbip_model, "REFRESH_WALL_CLOCK_GRACE_SECONDS", 0.15)
+    yield released
+    released.set()
+
+
+def modal() -> CredentialModal:
+    """A credential dialog matching the measured incident window."""
+    return CredentialModal(
+        "Please specify how to connect to this data source",
+        DesktopWindow("", "WindowsForms10.Window.20008", 702, 355, ("Please specify how to connect",)),
+    )
+
+
+def modal_state() -> CredentialDetection:
+    """CredentialDetection containing the standard modal."""
+    return CredentialDetection(modal=modal())
+
+
+def blocking_dialog() -> BlockingDialog:
+    """Unreadable owned dialog matching the live SQL credential-dialog shape."""
+    return BlockingDialog(DesktopWindow("", "WindowsForms10.Window.20008", 702, 355, ()))
+
+
+def blocking_state() -> CredentialDetection:
+    """CredentialDetection containing an unreadable blocking dialog."""
+    return CredentialDetection(blocking_dialog=blocking_dialog())
+
+
+def explode(name: str):
+    """Return a stub that proves an operation was not reached."""
+
+    def boom(*_args, **_kwargs):
+        raise AssertionError(f"{name}() must not run once the credential modal is visible")
+
+    return boom
+
+
+def model_folder(root: Path, name: str) -> Path:
+    """Create a minimal PBIP sibling model and return its cache destination."""
+    tables_dir = root / f"{name}.SemanticModel" / "definition" / "tables"
+    tables_dir.mkdir(parents=True)
+    (tables_dir / "Orders.tmdl").write_text(
+        '/// doc\ntable \'Orders\'\n\n\tcolumn X\n\npartition p = m\n\tSource = Sql.Database("server", "db")\n',
+        encoding="utf-8",
+    )
+    (root / f"{name}.pbip").write_text("{}", encoding="utf-8")
+    return root / f"{name}.SemanticModel" / ".pbi" / "cache.abf"
+
+
+def test_win32_fixture_finds_owned_dialog_and_keeps_instances_separate() -> None:
+    """Faithful fixture: owned empty-title dialog on PID A, no dialog on concurrent PID B."""
+    windows_by_pid = {
+        111: [
+            DesktopWindow("", "WindowsForms10.Window.20008.app.0.33c0d9d", 702, 355, ("Enter your credentials",)),
+            DesktopWindow("sample-superstore", "WindowsForms10.Window.8.app.0.33c0d9d", 2011, 1298, ("Report",)),
+            DesktopWindow("", "Internet Explorer_Hidden", 0, 0, ()),
+        ],
+        222: [DesktopWindow("cached-model", "WindowsForms10.Window.8.app.0.33c0d9d", 2011, 1298, ("Report",))],
+    }
+    hit = inspect_credential_modal(111, lambda pid: windows_by_pid[pid]).modal
+    miss = inspect_credential_modal(222, lambda pid: windows_by_pid[pid])
+
+    assert hit is not None
+    assert hit.window.class_name.startswith("WindowsForms10.Window.20008")
+    assert miss.modal is None
+    assert miss.unknown_reason is None
+
+
+def test_unreadable_owned_dialog_reports_blocked_not_no_modal() -> None:
+    """Live SQL dialog shape: visible owned dialog, empty title, no readable text."""
+    windows_by_pid = {
+        58104: [
+            DesktopWindow("", "WindowsForms10.Window.20008.app.0.33c0d9d", 702, 355, ()),
+            DesktopWindow("sample-superstore", "WindowsForms10.Window.8.app.0.33c0d9d", 2011, 1298, ("sample",)),
+            DesktopWindow("", "Internet Explorer_Hidden", 0, 0, ()),
+        ],
+        46256: [DesktopWindow("cached", "WindowsForms10.Window.8.app.0.33c0d9d", 2011, 1298, ("cached",))],
+    }
+    blocked = inspect_credential_modal(58104, lambda pid: windows_by_pid[pid])
+    healthy = inspect_credential_modal(46256, lambda pid: windows_by_pid[pid])
+
+    assert blocked.modal is None
+    assert blocked.blocking_dialog is not None
+    assert blocked.blocking_dialog.window.width == 702
+    assert healthy.modal is None
+    assert healthy.blocking_dialog is None
+
+
+def test_zero_size_helper_window_does_not_block() -> None:
+    """Internet Explorer_Hidden 0x0 is present on healthy instances and must be ignored."""
+    state = inspect_credential_modal(
+        111,
+        lambda _pid: [
+            DesktopWindow("cached", "WindowsForms10.Window.8.app.0.33c0d9d", 2011, 1298, ("cached",)),
+            DesktopWindow("", "Internet Explorer_Hidden", 0, 0, ()),
+        ],
+    )
+
+    assert state.modal is None
+    assert state.blocking_dialog is None
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="real Win32 EnumWindows callback is Windows-only")
+def test_real_win32_enumeration_callback_runs_against_this_process() -> None:
+    """Execute the real ctypes callback; it must not be an empty fallback that swallowed exceptions."""
+    windows, visited = _enumerate_pid_windows_with_count(os.getpid())
+
+    assert isinstance(windows, list)
+    assert visited > 0, "EnumWindows callback did not run; an empty fallback would hide detector failures"
+
+
+def test_minimized_owner_reports_unknown_not_no_dialog() -> None:
+    """When the owner is minimized, Windows hides owned dialogs; absence is indeterminate."""
+    state = inspect_credential_modal(
+        111,
+        lambda _pid: [
+            DesktopWindow(
+                "sample-superstore",
+                "WindowsForms10.Window.8.app.0.33c0d9d",
+                2011,
+                1298,
+                ("Report",),
+                minimized=True,
+            )
+        ],
+    )
+
+    assert state.modal is None
+    assert state.unknown_reason is not None
+    assert "minimized" in state.unknown_reason
+
+
+def test_direct_refresh_returns_credential_missing_fast_at_t0(monkeypatch) -> None:
+    """A t=0 credential modal must not wait for the XMLA deadline."""
+    monkeypatch.setattr(refresh_pbip_model, "_credential_state", lambda _pid: modal_state())
+    monkeypatch.setattr(refresh_pbip_model, "_load_adomd", explode("_load_adomd"))
+
+    started = time.monotonic()
+    with pytest.raises(CredentialMissingError):
+        refresh(port=1234, tables=["Orders"], timeout_sec=5, desktop_pid=111, source_hint="Sql.Database(server)")
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 0.5, f"t=0 modal path waited {elapsed:.3f}s instead of returning immediately"
+
+
+def test_direct_refresh_returns_blocked_by_dialog_fast_at_t0(monkeypatch) -> None:
+    """Unreadable blocking dialog must stop immediately instead of waiting for XMLA."""
+    monkeypatch.setattr(refresh_pbip_model, "_credential_state", lambda _pid: blocking_state())
+    monkeypatch.setattr(refresh_pbip_model, "_load_adomd", explode("_load_adomd"))
+
+    started = time.monotonic()
+    with pytest.raises(DialogBlockedError):
+        refresh(port=1234, tables=["Orders"], timeout_sec=5, desktop_pid=111)
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 0.5
+
+
+def test_refresh_poll_catches_late_modal(monkeypatch, parked) -> None:
+    """A credential dialog appearing after XMLA starts is caught on the next poll."""
+    calls = {"count": 0}
+
+    def late_modal(_pid: int):
+        calls["count"] += 1
+        return modal() if calls["count"] >= 2 else None
+
+    monkeypatch.setattr(
+        refresh_pbip_model,
+        "_credential_state",
+        lambda pid: CredentialDetection(modal=late_modal(pid)),
+    )
+    monkeypatch.setattr(refresh_pbip_model, "REFRESH_CREDENTIAL_POLL_SECONDS", 0.05)
+
+    started = time.monotonic()
+    with pytest.raises(CredentialMissingError):
+        refresh(port=1234, tables=["Orders"], timeout_sec=10, desktop_pid=111)
+
+    assert time.monotonic() - started < 1.0, "shortened test poll interval should catch the modal quickly"
+    assert calls["count"] >= 2
+    parked.set()
+
+
+def test_refresh_banner_is_flushed_and_heartbeat_reports_elapsed_total(monkeypatch, parked, capsys) -> None:
+    """The warning arrives before the wait, then emits elapsed/total countdowns."""
+    monkeypatch.setattr(refresh_pbip_model, "_credential_state", lambda _pid: CredentialDetection())
+    monkeypatch.setattr(refresh_pbip_model, "REFRESH_CREDENTIAL_POLL_SECONDS", 0.05)
+    monkeypatch.setattr(refresh_pbip_model, "REFRESH_HEARTBEAT_SECONDS", 0.05)
+    printed: list[dict[str, object]] = []
+    original_print = print
+
+    def recording_print(*args, **kwargs):
+        printed.append({"text": " ".join(str(arg) for arg in args), "flush": kwargs.get("flush")})
+        original_print(*args, **kwargs)
+
+    monkeypatch.setattr("builtins.print", recording_print)
+
+    with pytest.raises(TimeoutError):
+        refresh(port=1234, tables=["Orders"], timeout_sec=0.1, desktop_pid=111)
+
+    out = capsys.readouterr().out
+    assert "No blocking dialog on PID 111. Refreshing, bounded at 0.1s XMLA + 0.15s grace" in out
+    assert "DO NOT kill this process" in out
+    assert "still refreshing," in out and "/ 0s" in out
+    assert printed[0]["flush"] is True
+    parked.set()
+
+
+def test_unknown_refresh_banner_does_not_claim_no_dialog(monkeypatch, parked, capsys) -> None:
+    """A minimized owner gets an UNKNOWN banner and falls through to the bounded refresh path."""
+    monkeypatch.setattr(
+        refresh_pbip_model,
+        "_credential_state",
+        lambda _pid: CredentialDetection(unknown_reason="Power BI Desktop owner window is minimized"),
+    )
+    monkeypatch.setattr(refresh_pbip_model, "REFRESH_CREDENTIAL_POLL_SECONDS", 0.05)
+    monkeypatch.setattr(refresh_pbip_model, "REFRESH_HEARTBEAT_SECONDS", 0.05)
+
+    with pytest.raises(TimeoutError):
+        refresh(port=1234, tables=["Orders"], timeout_sec=0.1, desktop_pid=111)
+
+    out = capsys.readouterr().out
+    assert "Credential dialog check on PID 111 is UNKNOWN" in out
+    assert "No blocking dialog on PID 111" not in out
+    parked.set()
+
+
+def test_refresh_main_returns_credential_missing_fast_at_t0(monkeypatch, tmp_path: Path, capsys) -> None:
+    """refresh_pbip_model.main stops before port discovery, identity checks, refresh, or row counts."""
+    model_folder(tmp_path, "MyMigration")
+    monkeypatch.setattr(
+        refresh_pbip_model,
+        "_bridge_status",
+        lambda: {"instances": [{"pid": 111, "currentFilePath": str(tmp_path / "MyMigration.pbip")}]},
+    )
+    monkeypatch.setattr(refresh_pbip_model, "_credential_state", lambda _pid: modal_state())
+    monkeypatch.setattr(refresh_pbip_model, "discover_port", explode("discover_port"))
+
+    started = time.monotonic()
+    exit_code = refresh_pbip_model.main(["--pid", "111"])
+    elapsed = time.monotonic() - started
+    out = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert elapsed < 0.5, f"t=0 credential verdict waited {elapsed:.3f}s"
+    assert "REFRESH: CREDENTIAL_MISSING" in out
+    assert "Sql.Database(server)" in out
+
+
+def test_probe_query_returns_credential_missing_fast_at_t0(monkeypatch, capsys) -> None:
+    """probe_desktop_query.main stops before port discovery or DAX when the modal is already open."""
+    monkeypatch.setattr(probe_desktop_query, "_credential_state", lambda _pid: modal_state())
+    monkeypatch.setattr(probe_desktop_query, "discover_port", explode("discover_port"))
+
+    started = time.monotonic()
+    exit_code = probe_desktop_query.main(["--pid", "111"])
+    elapsed = time.monotonic() - started
+    out = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert elapsed < 0.5, f"t=0 credential verdict waited {elapsed:.3f}s"
+    assert "PREFLIGHT: CREDENTIAL_MISSING" in out
+
+
+def test_probe_query_returns_blocked_by_dialog_fast_at_t0(monkeypatch, capsys) -> None:
+    """probe_desktop_query stops for an unreadable blocking dialog."""
+    monkeypatch.setattr(probe_desktop_query, "_credential_state", lambda _pid: blocking_state())
+    monkeypatch.setattr(probe_desktop_query, "discover_port", explode("discover_port"))
+
+    exit_code = probe_desktop_query.main(["--pid", "111"])
+    out = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert out.startswith("PREFLIGHT: BLOCKED_BY_DIALOG")
+
+
+def test_probe_query_returns_unknown_for_minimized_owner(monkeypatch, capsys) -> None:
+    """A minimized owner is indeterminate, not evidence that no credential dialog exists."""
+    monkeypatch.setattr(
+        probe_desktop_query,
+        "_credential_state",
+        lambda _pid: CredentialDetection(unknown_reason="Power BI Desktop owner window is minimized"),
+    )
+    monkeypatch.setattr(probe_desktop_query, "discover_port", explode("discover_port"))
+
+    exit_code = probe_desktop_query.main(["--pid", "111"])
+    out = capsys.readouterr().out
+
+    assert exit_code == 3
+    assert out.startswith("PREFLIGHT: UNKNOWN")
+    assert "minimized" in out
+
+
+def test_probe_query_poll_catches_late_modal(monkeypatch, capsys) -> None:
+    """probe_desktop_query catches a modal that appears after the read-only query starts."""
+    started = threading.Event()
+    release = threading.Event()
+    calls = {"count": 0}
+
+    def fake_probe(_port: int, _tables: list[str] | None, emit=print) -> int:
+        del emit
+        started.set()
+        release.wait(timeout=600)
+        return 0
+
+    def late_modal(_pid: int):
+        calls["count"] += 1
+        return modal() if started.is_set() and calls["count"] >= 2 else None
+
+    monkeypatch.setattr(
+        probe_desktop_query,
+        "_credential_state",
+        lambda pid: CredentialDetection(modal=late_modal(pid)),
+    )
+    monkeypatch.setattr(probe_desktop_query, "PREFLIGHT_CREDENTIAL_POLL_SECONDS", 0.05)
+    monkeypatch.setattr(probe_desktop_query, "discover_port", lambda _pid: 52001)
+    monkeypatch.setattr(probe_desktop_query, "probe", fake_probe)
+
+    try:
+        exit_code = probe_desktop_query.main(["--pid", "111", "--canaries", "Orders"])
+    finally:
+        release.set()
+    out = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert "PREFLIGHT: CREDENTIAL_MISSING" in out
+    assert calls["count"] >= 2
+
+
+def test_probe_query_worker_cannot_print_after_credential_verdict(monkeypatch, capsys) -> None:
+    """Reviewer's race: late worker DATA_OK text must not print after CREDENTIAL_MISSING."""
+    started = threading.Event()
+    release = threading.Event()
+    calls = {"count": 0}
+
+    def fake_probe(_port: int, _tables: list[str] | None, emit=print) -> int:
+        started.set()
+        release.wait(timeout=600)
+        emit("PREFLIGHT: DATA_OK_FROM_WORKER_AFTER_RELEASE")
+        return 0
+
+    def late_modal(_pid: int):
+        calls["count"] += 1
+        return modal() if started.is_set() and calls["count"] >= 2 else None
+
+    monkeypatch.setattr(
+        probe_desktop_query,
+        "_credential_state",
+        lambda pid: CredentialDetection(modal=late_modal(pid)),
+    )
+    monkeypatch.setattr(probe_desktop_query, "PREFLIGHT_CREDENTIAL_POLL_SECONDS", 0.05)
+    monkeypatch.setattr(probe_desktop_query, "discover_port", lambda _pid: 52001)
+    monkeypatch.setattr(probe_desktop_query, "probe", fake_probe)
+
+    exit_code = probe_desktop_query.main(["--pid", "111", "--canaries", "Orders"])
+    first_out = capsys.readouterr().out
+    release.set()
+    time.sleep(0.1)
+    later_out = capsys.readouterr().out
+
+    assert exit_code == 1
+    assert first_out.splitlines() == [first_out.splitlines()[-1]]
+    assert first_out.startswith("PREFLIGHT: CREDENTIAL_MISSING")
+    assert "DATA_OK_FROM_WORKER_AFTER_RELEASE" not in first_out
+    assert later_out == ""

--- a/.github/skills/pbip-model-refresh/tests/test_desktop_instance_binding.py
+++ b/.github/skills/pbip-model-refresh/tests/test_desktop_instance_binding.py
@@ -1180,9 +1180,9 @@ def test_credential_arbiter_enumerates_all_windows_and_fails_closed() -> None:
     """The credential arbiter (#118) must not fail OPEN, and must inspect EVERY window for the pid.
 
     It became "the arbiter" the timeout message points at, so a fail-open answer is worse than none
-    (round-2 major 5). The script needs live UIAutomation + Desktop to execute, so these two fixes are
-    pinned structurally: it must enumerate all top-level windows (`Get-PidWindows`/`FindAll`, not the
-    old single-window `FindFirst`), and when no Refresh control was ever invoked it must report
+    (round-2 major 5). The script needs live Desktop to execute, so these two fixes are
+    pinned structurally: it must enumerate all top-level/owned windows with Win32 `EnumWindows`, not
+    UIA root children, and when no Refresh control was ever invoked it must report
     UNKNOWN rather than asserting a credential is present.
 
     The not-invoked verdict is checked INSIDE the `if (-not $invoked) { ... }` block, not anywhere in
@@ -1192,7 +1192,7 @@ def test_credential_arbiter_enumerates_all_windows_and_fails_closed() -> None:
     """
     text = CREDENTIAL_PROBE_PS1.read_text(encoding="utf-8")
     assert "Get-PidWindows" in text, "must enumerate windows via the all-windows helper"
-    assert "FindAll" in text, "must use FindAll (every top-level window)"
+    assert "EnumWindows" in text, "must use Win32 EnumWindows for discovery (UIA root children miss owned dialogs)"
     assert "FindFirst" not in text, "the single-window FindFirst scan was the fail-open enumeration bug"
 
     block_match = re.search(r"if \(-not \$invoked\)\s*\{(.*?)\}", text, re.DOTALL)

--- a/.github/skills/powerbi-semantic-model-gotchas/SKILL.md
+++ b/.github/skills/powerbi-semantic-model-gotchas/SKILL.md
@@ -402,6 +402,13 @@ Cheapest honest probe: author a **canary** — one table, one live partition, `T
 open it in Desktop, refresh, require a row. If it returns data, build for real; if it does not, you
 have your answer in seconds. Cap at **~2 minutes or 3 attempts**, then stop and ask.
 
+⚠️ **Before blaming the Desktop Bridge, look for a blocking Desktop dialog.** Measured bridge symptoms
+for an already-open data-source dialog are `status` reporting **"Host is not ready to accept
+operations"** and `screenshot` reporting **"Print metadata is not available"**. That combination is
+not enough evidence for a bridge regression; run the bundled refresh/query probes, which check for
+visible non-main dialogs at t=0 and keep polling while the source wakes up. Text-readable credential
+prompts report `CREDENTIAL_MISSING`; unreadable/non-credential dialogs report `BLOCKED_BY_DIALOG`.
+
 **Independent confirmation is available and worth taking.** For a serverless warehouse, `STOPPED` with
 `num_active_sessions = 0` proves no query ever arrived, regardless of what any log claims. Prefer
 evidence from the *source system* over the absence of an error on your side.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -67,6 +67,10 @@ personas already use. Deleting them would make every persona *longer* — see
 | `set_ai_instructions.py` | `.github/skills/powerbi-ai-readiness/` — stamp `CustomInstructions`, force `qnaEnabled` |
 | `check_ai_readiness.py` | `.github/skills/powerbi-ai-readiness/` — audit description coverage + enumerated domains |
 
+For bridge/Desktop smoke tests, use a PBIP whose model has a persisted `.pbi/cache.abf`. A reference
+bundle that points at a live SQL Server unavailable in this tenant will always stop at the credential
+dialog and can make a healthy bridge look broken.
+
 ## Gates (CI and agent Definition of Done)
 
 | Script | What it enforces |

--- a/scripts/probe_live_source.py
+++ b/scripts/probe_live_source.py
@@ -415,6 +415,8 @@ def _classify_failure(text: str, network_fault_observed: bool) -> tuple[str, str
         return "BAD_TABLE", text
     if any(marker in low for marker in ACCESS_DENIED_MARKERS):
         return "ACCESS_DENIED", text
+    if "blocked_by_dialog" in low:
+        return "NO_CREDENTIAL", text
     if any(marker in low for marker in CREDENTIAL_MARKERS):
         return "NO_CREDENTIAL", text
     return (
@@ -422,6 +424,18 @@ def _classify_failure(text: str, network_fault_observed: bool) -> tuple[str, str
         "unclassified refresh failure: the probe ran, but the error did not match a credential, "
         "bad-table, or observed network fault signature. Do not report it as UNREACHABLE. Raw: " + raw,
     )
+
+
+def _has_data_ok_verdict(text: str) -> bool:
+    """True only when a machine-readable verdict line is exactly DATA_OK.
+
+    This deliberately ignores incidental text containing ``DATA_OK``. A credential-blocked
+    ``probe_desktop_query`` run once returned ``CREDENTIAL_MISSING`` while a background worker printed
+    a late ``DATA_OK``-looking string afterwards; substring matching over the whole transcript would
+    falsely clear the credential gate.
+    """
+    verdict_re = re.compile(r"^\s*(?:REFRESH|PREFLIGHT|PROBE):\s+DATA_OK(?:\s|$)")
+    return any(verdict_re.match(line) for line in text.splitlines())
 
 
 def _npx(args: list[str], timeout: int) -> tuple[int, str]:
@@ -698,7 +712,7 @@ def _refresh_and_classify(pid: int, table: str, timeout_sec: int, network_fault_
 
     log.info("refresh finished in %.0fs", time.monotonic() - started)
     text = (refresh.stdout + refresh.stderr).strip()
-    if "DATA_OK" in text:
+    if _has_data_ok_verdict(text):
         log.info("PROBE: DATA_OK 1 row(s) from %s - the source is genuinely reachable", table)
         return 0, "DATA_OK"
     verdict, detail = _classify_failure(text, network_fault_observed=network_fault_observed)

--- a/tests/test_probe_live_source_verdict.py
+++ b/tests/test_probe_live_source_verdict.py
@@ -1,0 +1,82 @@
+"""Regression tests for probe_live_source's machine-readable verdict parsing."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# pylint: disable=import-outside-toplevel,protected-access
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+def _import_probe_live_source():
+    """Import the script module from the repo-local scripts folder."""
+    scripts = str(REPO / "scripts")
+    if scripts not in sys.path:
+        sys.path.insert(0, scripts)
+    import probe_live_source  # noqa: PLC0415
+
+    return probe_live_source
+
+
+def test_requires_data_ok_verdict_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A stray DATA_OK substring after CREDENTIAL_MISSING must not clear the live-source gate."""
+    probe_live_source = _import_probe_live_source()
+    stdout = (
+        "PREFLIGHT: CREDENTIAL_MISSING pid=111; window title='(empty title)'\n"
+        "PREFLIGHT: DATA_OK_FROM_WORKER_AFTER_RELEASE\n"
+    )
+    monkeypatch.setattr(
+        probe_live_source.subprocess,
+        "run",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess(args=["refresh"], returncode=1, stdout=stdout, stderr=""),
+    )
+
+    assert probe_live_source._refresh_and_classify(123, "Orders", 1, network_fault_observed=False) == (  # noqa: SLF001
+        1,
+        "NO_CREDENTIAL",
+    )
+
+
+def test_accepts_genuine_data_ok_verdict(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep the success path: an anchored DATA_OK verdict still marks the source reachable."""
+    probe_live_source = _import_probe_live_source()
+    monkeypatch.setattr(
+        probe_live_source.subprocess,
+        "run",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess(
+            args=["refresh"],
+            returncode=0,
+            stdout="  data   : 1 row(s) in 'Orders'\nREFRESH: DATA_OK\n",
+            stderr="",
+        ),
+    )
+
+    assert probe_live_source._refresh_and_classify(123, "Orders", 1, network_fault_observed=False) == (  # noqa: SLF001
+        0,
+        "DATA_OK",
+    )
+
+
+def test_blocked_by_dialog_does_not_clear_gate(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A generic Desktop dialog is a human-blocked source, not reachable data."""
+    probe_live_source = _import_probe_live_source()
+    monkeypatch.setattr(
+        probe_live_source.subprocess,
+        "run",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess(
+            args=["refresh"],
+            returncode=1,
+            stdout="REFRESH: BLOCKED_BY_DIALOG pid=111; window title='(empty title)'\n",
+            stderr="",
+        ),
+    )
+
+    assert probe_live_source._refresh_and_classify(123, "Orders", 1, network_fault_observed=False) == (  # noqa: SLF001
+        1,
+        "NO_CREDENTIAL",
+    )


### PR DESCRIPTION
## Summary
- add a shared credential-modal signature/detector used by refresh and query probes
- fail fast with CREDENTIAL_MISSING at t=0 and poll for late modals while waiting
- print the bounded-refresh banner/elapsed countdown and document the bridge symptom + fixture hygiene

Fixes #146

## Tests
- ruff format --check scripts tests
- ruff check scripts tests
- python -m pylint scripts
- pytest -q
- pytest -q tests/test_skills.py
- pytest -q .github/skills/pbip-model-refresh/tests