### PR TITLE
fix(#152,#153): make the credential-gate verdict seam observe a successful refresh

### DIFF
--- a/.github/skills/pbip-model-refresh/scripts/_credential_modal.py
+++ b/.github/skills/pbip-model-refresh/scripts/_credential_modal.py
@@ -331,25 +331,39 @@ def source_hint_from_model(model_dir: Path | None) -> str | None:
 
 
 def print_refresh_banner(pid: int, timeout_sec: int, grace_sec: int | float) -> None:
-    """Print the no-dialog, self-bounded refresh warning before the wait starts."""
+    """Print the no-dialog, self-bounded refresh warning before the wait starts.
+
+    Deliberately does NOT name the verdict tokens it may later print. This banner is emitted on the
+    HEALTHY no-dialog path and is captured verbatim by ``probe_live_source``'s classifier; naming
+    ``CREDENTIAL_MISSING`` / ``BLOCKED_BY_DIALOG`` here (or even the bare word "credential") made the
+    reassuring message classify a successful refresh as ``NO_CREDENTIAL`` (issue #153). The classifier
+    now matches verdict LINES structurally, but keeping control tokens out of free prose is the
+    belt-and-braces half of that fix - so a future helpful edit cannot re-arm the landmine.
+    """
     total = timeout_sec + grace_sec
     print(
         f"No blocking dialog on PID {pid}. Refreshing, bounded at {timeout_sec}s XMLA + "
         f"{grace_sec}s grace ({total}s total); a long wait here is expected for a serverless cold start. "
-        "DO NOT kill this process - at the deadline it re-checks and reports CREDENTIAL_MISSING, "
-        "BLOCKED_BY_DIALOG, or SLOW_SOURCE. Killing it early yields NO verdict.",
+        "DO NOT kill this process - at the deadline it re-checks and prints one final machine-readable "
+        "verdict line. Killing it early yields NO verdict.",
         flush=True,
     )
 
 
 def print_refresh_unknown_banner(pid: int, timeout_sec: int, grace_sec: int | float, reason: str) -> None:
-    """Print the bounded-refresh warning when the t=0 modal check is indeterminate."""
+    """Print the bounded-refresh warning when the t=0 modal check is indeterminate.
+
+    Same rule as :func:`print_refresh_banner`: no control tokens - and not the bare word "credential" -
+    in prose the classifier scans (issue #153). The prefix reads "Blocking-dialog check ... UNKNOWN"
+    rather than the old "Credential dialog check", so a non-``DATA_OK`` refresh through this path is not
+    mislabelled ``NO_CREDENTIAL`` by ``CREDENTIAL_MARKERS``' free-text "credential" marker.
+    """
     total = timeout_sec + grace_sec
     print(
-        f"Credential dialog check on PID {pid} is UNKNOWN ({reason}). Refreshing, bounded at "
+        f"Blocking-dialog check on PID {pid} is UNKNOWN ({reason}). Refreshing, bounded at "
         f"{timeout_sec}s XMLA + {grace_sec}s grace ({total}s total); a minimized owner can hide owned "
         "dialogs from enumeration. DO NOT kill this process - at the deadline it re-checks with the "
-        "dialog arbiter and reports CREDENTIAL_MISSING, BLOCKED_BY_DIALOG, or SLOW_SOURCE. Killing it early "
+        "dialog arbiter and prints one final machine-readable verdict line. Killing it early "
         "yields NO verdict.",
         flush=True,
     )

--- a/.github/skills/pbip-model-refresh/scripts/_credential_modal.py
+++ b/.github/skills/pbip-model-refresh/scripts/_credential_modal.py
@@ -279,7 +279,7 @@ def inspect_credential_modal(
     ]
     if minimized:
         return CredentialDetection(
-            unknown_reason="Power BI Desktop owner window is minimized; owned credential dialogs are hidden",
+            unknown_reason="Power BI Desktop owner window is minimized; owned modal dialogs are hidden from enumeration",
             windows=windows,
         )
     return CredentialDetection(windows=windows)
@@ -333,12 +333,14 @@ def source_hint_from_model(model_dir: Path | None) -> str | None:
 def print_refresh_banner(pid: int, timeout_sec: int, grace_sec: int | float) -> None:
     """Print the no-dialog, self-bounded refresh warning before the wait starts.
 
-    Deliberately does NOT name the verdict tokens it may later print. This banner is emitted on the
-    HEALTHY no-dialog path and is captured verbatim by ``probe_live_source``'s classifier; naming
-    ``CREDENTIAL_MISSING`` / ``BLOCKED_BY_DIALOG`` here (or even the bare word "credential") made the
-    reassuring message classify a successful refresh as ``NO_CREDENTIAL`` (issue #153). The classifier
-    now matches verdict LINES structurally, but keeping control tokens out of free prose is the
-    belt-and-braces half of that fix - so a future helpful edit cannot re-arm the landmine.
+    Deliberately does NOT name the verdict tokens it may later print, and interpolates NO caller-supplied
+    text - so unlike :func:`print_refresh_unknown_banner`, this banner's marker-free guarantee is total
+    and self-contained. This banner is emitted on the HEALTHY no-dialog path and is captured verbatim by
+    ``probe_live_source``'s classifier; naming ``CREDENTIAL_MISSING`` / ``BLOCKED_BY_DIALOG`` here (or
+    even the bare word "credential") made the reassuring message classify a successful refresh as
+    ``NO_CREDENTIAL`` (issue #153). The classifier now matches verdict LINES structurally, but keeping
+    control tokens out of free prose is the belt-and-braces half of that fix - so a future helpful edit
+    cannot re-arm the landmine.
     """
     total = timeout_sec + grace_sec
     print(
@@ -353,10 +355,13 @@ def print_refresh_banner(pid: int, timeout_sec: int, grace_sec: int | float) -> 
 def print_refresh_unknown_banner(pid: int, timeout_sec: int, grace_sec: int | float, reason: str) -> None:
     """Print the bounded-refresh warning when the t=0 modal check is indeterminate.
 
-    Same rule as :func:`print_refresh_banner`: no control tokens - and not the bare word "credential" -
-    in prose the classifier scans (issue #153). The prefix reads "Blocking-dialog check ... UNKNOWN"
-    rather than the old "Credential dialog check", so a non-``DATA_OK`` refresh through this path is not
-    mislabelled ``NO_CREDENTIAL`` by ``CREDENTIAL_MARKERS``' free-text "credential" marker.
+    This banner's OWN static prose names no control tokens and not the bare word "credential" - but it
+    interpolates ``reason``, a caller-supplied string from ``inspect_credential_modal`` that the
+    classifier scans along with everything else. So the marker-free guarantee for the UNKNOWN path is
+    owned by the DETECTOR, not by this banner alone: the minimized-owner ``unknown_reason`` was reworded
+    off the word "credential" (a ``CREDENTIAL_MARKER``) for exactly this reason (issue #153) - otherwise
+    a slow/timeout refresh here was mislabelled ``NO_CREDENTIAL``. The prefix reads "Blocking-dialog
+    check ... UNKNOWN" rather than the old "Credential dialog check" as the belt-and-braces static half.
     """
     total = timeout_sec + grace_sec
     print(

--- a/.github/skills/pbip-model-refresh/scripts/_credential_modal.py
+++ b/.github/skills/pbip-model-refresh/scripts/_credential_modal.py
@@ -279,7 +279,9 @@ def inspect_credential_modal(
     ]
     if minimized:
         return CredentialDetection(
-            unknown_reason="Power BI Desktop owner window is minimized; owned modal dialogs are hidden from enumeration",
+            unknown_reason=(
+                "Power BI Desktop owner window is minimized; owned modal dialogs are hidden from enumeration"
+            ),
             windows=windows,
         )
     return CredentialDetection(windows=windows)

--- a/.github/skills/pbip-model-refresh/scripts/probe_desktop_credential.ps1
+++ b/.github/skills/pbip-model-refresh/scripts/probe_desktop_credential.ps1
@@ -171,7 +171,7 @@ if ($blocker) {
 }
 foreach ($w in $windows) {
   if ($w.Minimized -and $w.ClassName.StartsWith('WindowsForms10.Window.8')) {
-    Write-Output "Power BI Desktop owner window is minimized; owned credential dialogs are hidden"
+    Write-Output "Power BI Desktop owner window is minimized; owned modal dialogs are hidden from enumeration"
     Write-Output "VERDICT: UNKNOWN"
     exit 3
   }

--- a/.github/skills/pbip-model-refresh/tests/test_credential_modal_detection.py
+++ b/.github/skills/pbip-model-refresh/tests/test_credential_modal_detection.py
@@ -286,7 +286,7 @@ def test_unknown_refresh_banner_does_not_claim_no_dialog(monkeypatch, parked, ca
         refresh(port=1234, tables=["Orders"], timeout_sec=0.1, desktop_pid=111)
 
     out = capsys.readouterr().out
-    assert "Credential dialog check on PID 111 is UNKNOWN" in out
+    assert "Blocking-dialog check on PID 111 is UNKNOWN" in out
     assert "No blocking dialog on PID 111" not in out
     parked.set()
 

--- a/scripts/probe_live_source.py
+++ b/scripts/probe_live_source.py
@@ -136,6 +136,29 @@ ACCESS_DENIED_MARKERS = (
     "not authorized",
 )
 
+# The child (`refresh_pbip_model.py` / `probe_desktop_query.py`) speaks in machine-readable verdict
+# LINES: `REFRESH:`/`PREFLIGHT:`/`PROBE:` followed by a token. These two regexes match those lines
+# structurally so the classifier never mistakes prose that merely NAMES a token (a reassuring banner,
+# a doc excerpt, a late worker log) for the verdict itself. Kept as module constants so the seam
+# tests can import and exercise them directly.
+#
+# Success family, from `_verdict._emit_data_verdict`:
+#   REFRESH: DATA_OK[ + PERSISTED]          model-level (whole-database refresh, canaries had rows)
+#   REFRESH: TABLE_OK '<name>'[ + ...]       implicit single-table probe
+#   REFRESH: TABLES_OK '<name>'[, '<n2>']    a --tables-narrowed refresh (what THIS probe elicits)
+# The trailing `(?:\s+...)?$` keeps the anchoring lesson: `DATA_OK_FROM_WORKER` is NOT `DATA_OK`.
+DATA_OK_VERDICT_RE = re.compile(
+    r"^\s*(?:REFRESH|PREFLIGHT|PROBE):\s+(?P<token>DATA_OK|TABLE_OK|TABLES_OK)(?:\s+(?P<rest>.*))?$"
+)
+# Credential-stop family, from `_emit_credential_missing` / `_emit_blocked_by_dialog`. Anchored on
+# purpose (issue #153): a banner that lists these tokens in prose must NOT fabricate the verdict.
+# Forward-compat note for issue #154 (a SEPARATE fix, deliberately NOT implemented here): if a
+# latched-UNKNOWN outcome ever earns its own verdict token (e.g. `CREDENTIAL_UNKNOWN`), THIS
+# alternation is the parse point to extend so the structural line-matching keeps recognising it.
+CREDENTIAL_STOP_VERDICT_RE = re.compile(
+    r"^\s*(?:REFRESH|PREFLIGHT|PROBE):\s+(?:CREDENTIAL_MISSING|BLOCKED_BY_DIALOG)\b"
+)
+
 
 def _pbip_files(name: str, m_query: str, table: str, column: str) -> dict[str, str]:
     """The minimum PBIP that Power BI Desktop will open: one table, one column, one partition."""
@@ -415,8 +438,15 @@ def _classify_failure(text: str, network_fault_observed: bool) -> tuple[str, str
         return "BAD_TABLE", text
     if any(marker in low for marker in ACCESS_DENIED_MARKERS):
         return "ACCESS_DENIED", text
-    if "blocked_by_dialog" in low:
+    # A machine-readable credential-stop VERDICT line (CREDENTIAL_MISSING / BLOCKED_BY_DIALOG), matched
+    # structurally. Issue #153: the child prints a reassuring no-dialog banner on the HEALTHY path, and
+    # that banner used to NAME these tokens - an unanchored substring scan then let the "everything is
+    # fine" message fabricate its own NO_CREDENTIAL verdict. Anchoring to a verdict line removes that.
+    if _has_credential_stop_verdict(text):
         return "NO_CREDENTIAL", text
+    # Free-text connector error strings (NOT verdict tokens) stay an unanchored substring scan on
+    # purpose: a revoked Databricks PAT returns a 403/socket-reset with NO modal and NO verdict line,
+    # so CREDENTIAL_MARKERS is the only signal that catches it. Do not "structuralise" this path.
     if any(marker in low for marker in CREDENTIAL_MARKERS):
         return "NO_CREDENTIAL", text
     return (
@@ -426,16 +456,49 @@ def _classify_failure(text: str, network_fault_observed: bool) -> tuple[str, str
     )
 
 
-def _has_data_ok_verdict(text: str) -> bool:
-    """True only when a machine-readable verdict line is exactly DATA_OK.
+def _has_credential_stop_verdict(text: str) -> bool:
+    """True when a line is a machine-readable credential-stop verdict.
 
-    This deliberately ignores incidental text containing ``DATA_OK``. A credential-blocked
-    ``probe_desktop_query`` run once returned ``CREDENTIAL_MISSING`` while a background worker printed
-    a late ``DATA_OK``-looking string afterwards; substring matching over the whole transcript would
-    falsely clear the credential gate.
+    ``CREDENTIAL_MISSING`` / ``BLOCKED_BY_DIALOG`` on a ``REFRESH:``/``PREFLIGHT:``/``PROBE:`` verdict
+    line - never a substring of the transcript. Issue #153: the child's own reassuring "no blocking
+    dialog" banner used to name these tokens in prose, and an unanchored scan let that message classify
+    a successful refresh as ``NO_CREDENTIAL``. This is the structural half of the fix; the banner reword
+    (``_credential_modal.print_refresh_banner``) is the belt-and-braces half.
     """
-    verdict_re = re.compile(r"^\s*(?:REFRESH|PREFLIGHT|PROBE):\s+DATA_OK(?:\s|$)")
-    return any(verdict_re.match(line) for line in text.splitlines())
+    return any(CREDENTIAL_STOP_VERDICT_RE.match(line) for line in text.splitlines())
+
+
+def _has_data_ok_verdict(text: str, table: str) -> bool:
+    """True only when a machine-readable verdict LINE certifies real data for the probed ``table``.
+
+    Accepts the whole success family the child emitter (``_verdict._emit_data_verdict``) can print:
+
+      * ``DATA_OK``            - a model-level verdict (whole-database refresh, canaries returned rows)
+      * ``TABLE_OK '<name>'``  - an implicit single-table probe
+      * ``TABLES_OK '<name>'`` - a ``--tables``-narrowed refresh (what THIS probe ALWAYS elicits, since
+        it always passes ``--tables <table>`` and never ``--canaries``)
+
+    The last point is issue #152: before, this accepted only the literal ``DATA_OK``, which the probe's
+    own argv could never make the child produce - so no source, credential, or config ever lifted the
+    gate. ``TABLE_OK``/``TABLES_OK`` name the table(s) actually verified, so they are SCOPED: they clear
+    the gate only when ``table`` is among the named tables. #115's guarantee is preserved - a verdict
+    naming some OTHER table is a false certificate for this one and must not count.
+
+    Matching is anchored to a verdict line, never a substring. A credential-blocked run once printed
+    ``CREDENTIAL_MISSING`` while a background worker later printed a ``DATA_OK``-looking string; a
+    substring scan would have falsely cleared the gate (see ``test_requires_data_ok_verdict_token``).
+    """
+    for line in text.splitlines():
+        match = DATA_OK_VERDICT_RE.match(line)
+        if match is None:
+            continue
+        if match.group("token") == "DATA_OK":
+            return True
+        # TABLE_OK / TABLES_OK name one or more single-quoted tables; the probed table must be one.
+        named = re.findall(r"'([^']*)'", match.group("rest") or "")
+        if table in named:
+            return True
+    return False
 
 
 def _npx(args: list[str], timeout: int) -> tuple[int, str]:
@@ -712,7 +775,12 @@ def _refresh_and_classify(pid: int, table: str, timeout_sec: int, network_fault_
 
     log.info("refresh finished in %.0fs", time.monotonic() - started)
     text = (refresh.stdout + refresh.stderr).strip()
-    if _has_data_ok_verdict(text):
+    # Honour BOTH channels the child speaks in: a zero exit code AND a machine-readable success verdict
+    # for the very table we asked to refresh. Either alone is insufficient - the child prints its
+    # reassuring no-dialog banner on stdout even on failure paths (so the text can look OK while the run
+    # failed), and a non-zero exit must never be read as success even if a stale OK line is present
+    # (issue #152: this used to classify on stdout prose alone and ignore the exit code entirely).
+    if refresh.returncode == 0 and _has_data_ok_verdict(text, table):
         log.info("PROBE: DATA_OK 1 row(s) from %s - the source is genuinely reachable", table)
         return 0, "DATA_OK"
     verdict, detail = _classify_failure(text, network_fault_observed=network_fault_observed)

--- a/scripts/probe_live_source.py
+++ b/scripts/probe_live_source.py
@@ -495,6 +495,13 @@ def _has_data_ok_verdict(text: str, table: str) -> bool:
         if match.group("token") == "DATA_OK":
             return True
         # TABLE_OK / TABLES_OK name one or more single-quoted tables; the probed table must be one.
+        # Known limitation (reviewed 2026-08-14, intentionally NOT fixed here): a table name containing
+        # a literal apostrophe (e.g. "O'Brien Sales") is emitted UNESCAPED by ``_verdict``, so this
+        # findall recovers the wrong tokens and ``table in named`` is False. It FAILS SAFE - it can only
+        # ever keep the gate SHUT, never lift it wrongly - and a false lift is unreachable in the
+        # single-table probe flow (the probe asks for exactly the table it names). The ambiguity
+        # originates in the emitter's non-escaping, and the #115 scoping here is verified-correct, so the
+        # matcher is left untouched rather than risk regressing it for a fail-safe, unreachable edge.
         named = re.findall(r"'([^']*)'", match.group("rest") or "")
         if table in named:
             return True

--- a/tests/test_probe_live_source_verdict.py
+++ b/tests/test_probe_live_source_verdict.py
@@ -1,7 +1,17 @@
-"""Regression tests for probe_live_source's machine-readable verdict parsing."""
+"""Regression tests for probe_live_source's machine-readable verdict parsing.
+
+Two seams are pinned here:
+  * #152 - the parent (``probe_live_source``) must accept the verdict family the child
+    (``refresh_pbip_model`` via ``_verdict``) actually emits for the argv the parent actually builds,
+    honouring the child's exit code. The old suite hand-wrote ``REFRESH: DATA_OK`` - output the
+    production caller CANNOT produce - so it stayed green while the gate was un-liftable.
+  * #153 - the child's reassuring no-dialog banner must not classify as ``NO_CREDENTIAL``.
+"""
 
 from __future__ import annotations
 
+import contextlib
+import io
 import subprocess
 import sys
 from pathlib import Path
@@ -23,6 +33,23 @@ def _import_probe_live_source():
     return probe_live_source
 
 
+def _import_skill_modules():
+    """Import the CHILD-side modules the probe shells out to, from the SAME dir the probe resolves.
+
+    Derived from ``probe_live_source.SKILL_SCRIPTS`` so the seam test binds to the real child, not a
+    hand-picked path. Returns (refresh_pbip_model, _verdict, _credential_modal).
+    """
+    probe_live_source = _import_probe_live_source()
+    skill_scripts = str(probe_live_source.SKILL_SCRIPTS)
+    if skill_scripts not in sys.path:
+        sys.path.insert(0, skill_scripts)
+    import _credential_modal  # noqa: PLC0415
+    import _verdict  # noqa: PLC0415
+    import refresh_pbip_model  # noqa: PLC0415
+
+    return refresh_pbip_model, _verdict, _credential_modal
+
+
 def test_requires_data_ok_verdict_token(monkeypatch: pytest.MonkeyPatch) -> None:
     """A stray DATA_OK substring after CREDENTIAL_MISSING must not clear the live-source gate."""
     probe_live_source = _import_probe_live_source()
@@ -42,24 +69,168 @@ def test_requires_data_ok_verdict_token(monkeypatch: pytest.MonkeyPatch) -> None
     )
 
 
-def test_accepts_genuine_data_ok_verdict(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Keep the success path: an anchored DATA_OK verdict still marks the source reachable."""
+def test_probe_argv_fed_through_real_emitter_is_accepted_by_the_parent(monkeypatch: pytest.MonkeyPatch) -> None:
+    """SEAM (#152): the argv the probe ACTUALLY builds, parsed by refresh_pbip_model's REAL parser and
+    run through _verdict's REAL emitter on a successful single-row refresh, must produce a verdict line
+    _has_data_ok_verdict accepts.
+
+    This is the test CI was missing. The old fixture hand-wrote ``REFRESH: DATA_OK``, which the
+    production caller CANNOT elicit - it always passes ``--tables`` and never ``--canaries``, so the
+    child emits ``TABLES_OK``. Deriving the fixture from BOTH real sides is the only way to catch a
+    vocabulary desync across the parent/child seam.
+    """
+    probe_live_source = _import_probe_live_source()
+    refresh_pbip_model, verdict_mod, _ = _import_skill_modules()
+
+    # 1. Capture the EXACT argv the production caller builds, without running a real refresh.
+    captured: dict[str, list[str]] = {}
+
+    def _capture(cmd, *_a, **_k):  # noqa: ANN001, ANN002, ANN003
+        captured["argv"] = list(cmd)
+        return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(probe_live_source.subprocess, "run", _capture)
+    probe_live_source._refresh_and_classify(123, "shipment", 1, network_fault_observed=False)
+    argv = captured["argv"]
+
+    # The exact desync #152 named: the probe always narrows with --tables and never asks for --canaries.
+    assert "--tables" in argv and "--canaries" not in argv
+
+    # 2. Parse the child flags (everything after `python refresh_pbip_model.py`) with the REAL parser.
+    child_flags = argv[2:]
+    args = refresh_pbip_model._build_arg_parser().parse_args(child_flags)
+    assert args.tables == ["shipment"]
+    (table,) = args.tables
+
+    # 3. Run the REAL emitter on a successful single-row refresh; capture its verdict line verbatim.
+    implicit = not verdict_mod._canary_tables(args)
+    buffer = io.StringIO()
+    with contextlib.redirect_stdout(buffer):
+        exit_code = verdict_mod._emit_data_verdict(None, 0.0, args, [(table, 1)], implicit)
+    emitted = buffer.getvalue()
+
+    assert exit_code == 0, f"the child returns success on a good refresh; got exit {exit_code}"
+    assert "TABLES_OK" in emitted, f"sanity: the production argv elicits TABLES_OK, not DATA_OK: {emitted!r}"
+    # 4. The parent MUST accept what the child actually emits, for the table it actually probed.
+    assert probe_live_source._has_data_ok_verdict(emitted, table), (
+        f"verdict-vocabulary desync across the seam: child emitted {emitted!r}, parent rejected it"
+    )
+
+
+def test_probe_clears_gate_on_verbatim_live_databricks_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Issue #152 reproduction, VERBATIM from the 2026-08-14 live Databricks run: child exit 0 and a
+    ``TABLES_OK`` for the probed table. This exact input returned NO_CREDENTIAL at exit 1 before the fix.
+    """
+    probe_live_source = _import_probe_live_source()
+    stdout = "  refresh: refreshed shipment\n  data   : 1 row(s) in 'shipment'\nREFRESH: TABLES_OK 'shipment'\n"
+    monkeypatch.setattr(
+        probe_live_source.subprocess,
+        "run",
+        lambda *_a, **_k: subprocess.CompletedProcess(args=["refresh"], returncode=0, stdout=stdout, stderr=""),
+    )
+
+    assert probe_live_source._refresh_and_classify(123, "shipment", 1, network_fault_observed=False) == (  # noqa: SLF001
+        0,
+        "DATA_OK",
+    )
+
+
+def test_has_data_ok_verdict_accepts_model_level_data_ok() -> None:
+    """A whole-model ``DATA_OK`` stays a valid clear for any probed table (it certifies every source)."""
+    probe_live_source = _import_probe_live_source()
+    assert probe_live_source._has_data_ok_verdict("REFRESH: DATA_OK\n", "anything")
+    assert probe_live_source._has_data_ok_verdict("REFRESH: DATA_OK + PERSISTED\n", "anything")
+
+
+def test_scoped_table_verdicts_clear_only_for_the_probed_table() -> None:
+    """#152 + #115: TABLE_OK/TABLES_OK clear the gate for the table the probe asked to refresh, and ONLY
+    that one. A verdict naming some OTHER table is a false certificate and must not count."""
+    probe_live_source = _import_probe_live_source()
+    # Positive - the probed table is the one certified (single, multi-table membership, and TABLE_OK).
+    assert probe_live_source._has_data_ok_verdict("REFRESH: TABLES_OK 'shipment'\n", "shipment")
+    assert probe_live_source._has_data_ok_verdict("REFRESH: TABLES_OK 'a', 'shipment' + PERSISTED\n", "shipment")
+    assert probe_live_source._has_data_ok_verdict("REFRESH: TABLE_OK 'shipment'\n", "shipment")
+    # Negative control - a TABLES_OK naming a DIFFERENT table must NOT clear the gate for 'shipment'.
+    assert not probe_live_source._has_data_ok_verdict("REFRESH: TABLES_OK 'some_other_table'\n", "shipment")
+    # The anchoring lesson still holds: a stray verdict-looking substring in prose is not a verdict line.
+    assert not probe_live_source._has_data_ok_verdict("note: TABLES_OK 'shipment' happened earlier\n", "shipment")
+
+
+def test_nonzero_exit_is_never_read_as_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    """#152: honour the child's exit code - a non-zero exit must not clear the gate even when the text
+    carries a success-looking verdict line for the probed table."""
     probe_live_source = _import_probe_live_source()
     monkeypatch.setattr(
         probe_live_source.subprocess,
         "run",
-        lambda *_args, **_kwargs: subprocess.CompletedProcess(
-            args=["refresh"],
-            returncode=0,
-            stdout="  data   : 1 row(s) in 'Orders'\nREFRESH: DATA_OK\n",
-            stderr="",
+        lambda *_a, **_k: subprocess.CompletedProcess(
+            args=["refresh"], returncode=1, stdout="REFRESH: TABLES_OK 'shipment'\n", stderr=""
         ),
     )
 
-    assert probe_live_source._refresh_and_classify(123, "Orders", 1, network_fault_observed=False) == (  # noqa: SLF001
-        0,
-        "DATA_OK",
+    exit_code, verdict = probe_live_source._refresh_and_classify(123, "shipment", 1, network_fault_observed=False)
+    assert exit_code == 1 and verdict != "DATA_OK"
+
+
+def test_wrong_table_tables_ok_does_not_clear_the_gate(monkeypatch: pytest.MonkeyPatch) -> None:
+    """#115 end-to-end: even at exit 0, a TABLES_OK for a DIFFERENT table must leave the gate closed."""
+    probe_live_source = _import_probe_live_source()
+    monkeypatch.setattr(
+        probe_live_source.subprocess,
+        "run",
+        lambda *_a, **_k: subprocess.CompletedProcess(
+            args=["refresh"], returncode=0, stdout="REFRESH: TABLES_OK 'some_other_table'\n", stderr=""
+        ),
     )
+
+    exit_code, verdict = probe_live_source._refresh_and_classify(123, "shipment", 1, network_fault_observed=False)
+    assert exit_code == 1 and verdict != "DATA_OK"
+
+
+@pytest.mark.parametrize(
+    ("banner_func", "args", "sanity_substr"),
+    [
+        pytest.param("print_refresh_banner", (111, 180, 60), "No blocking dialog", id="healthy-no-dialog"),
+        pytest.param(
+            "print_refresh_unknown_banner",
+            (111, 180, 60, "owner window is minimized"),
+            "UNKNOWN",
+            id="indeterminate-unknown",
+        ),
+    ],
+)
+def test_refresh_banners_do_not_classify_as_no_credential(banner_func: str, args: tuple, sanity_substr: str) -> None:
+    """#153: NEITHER refresh banner may fabricate a credential stop from its own reassuring prose.
+
+    Both banners are printed on non-failure paths and captured verbatim by the classifier.
+    ``print_refresh_banner`` is the healthy no-dialog path; ``print_refresh_unknown_banner`` is the
+    minimized-owner UNKNOWN path (issue #154) and was a SECOND instance of the same self-poisoning
+    defect. Parametrized over BOTH on purpose rather than hard-coding one string: a third banner that
+    reintroduces a sentinel token in prose is caught the moment it is added to this list.
+    """
+    probe_live_source = _import_probe_live_source()
+    _, _, credential_modal = _import_skill_modules()
+
+    buffer = io.StringIO()
+    with contextlib.redirect_stdout(buffer):
+        getattr(credential_modal, banner_func)(*args)
+    banner = buffer.getvalue()
+
+    assert sanity_substr in banner, f"sanity: {banner_func} should render {sanity_substr!r}; got {banner!r}"
+    verdict, _ = probe_live_source._classify_failure(banner, network_fault_observed=False)
+    assert verdict != "NO_CREDENTIAL", f"{banner_func} must not fabricate a credential stop; got {verdict}: {banner!r}"
+
+
+def test_free_text_credential_marker_without_a_verdict_line_still_stops() -> None:
+    """A revoked Databricks PAT returns a 403/socket-reset with NO modal and NO verdict line, so the
+    deliberately-unanchored CREDENTIAL_MARKERS path is the only thing that catches it. Pin that #153's
+    structural change did NOT remove that free-text path."""
+    probe_live_source = _import_probe_live_source()
+    verdict, _ = probe_live_source._classify_failure(
+        "DataSource.Error: the connection was forcibly closed by the remote host (10054)",
+        network_fault_observed=False,
+    )
+    assert verdict == "NO_CREDENTIAL"
 
 
 def test_blocked_by_dialog_does_not_clear_gate(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_probe_live_source_verdict.py
+++ b/tests/test_probe_live_source_verdict.py
@@ -11,6 +11,7 @@ Two seams are pinned here:
 from __future__ import annotations
 
 import contextlib
+import inspect
 import io
 import subprocess
 import sys
@@ -187,38 +188,94 @@ def test_wrong_table_tables_ok_does_not_clear_the_gate(monkeypatch: pytest.Monke
     assert exit_code == 1 and verdict != "DATA_OK"
 
 
-@pytest.mark.parametrize(
-    ("banner_func", "args", "sanity_substr"),
-    [
-        pytest.param("print_refresh_banner", (111, 180, 60), "No blocking dialog", id="healthy-no-dialog"),
-        pytest.param(
-            "print_refresh_unknown_banner",
-            (111, 180, 60, "owner window is minimized"),
-            "UNKNOWN",
-            id="indeterminate-unknown",
-        ),
-    ],
-)
-def test_refresh_banners_do_not_classify_as_no_credential(banner_func: str, args: tuple, sanity_substr: str) -> None:
-    """#153: NEITHER refresh banner may fabricate a credential stop from its own reassuring prose.
+def _refresh_banner_funcs(credential_modal) -> dict:
+    """Discover every pre-wait refresh banner by naming convention (``print_refresh_*banner``).
 
-    Both banners are printed on non-failure paths and captured verbatim by the classifier.
-    ``print_refresh_banner`` is the healthy no-dialog path; ``print_refresh_unknown_banner`` is the
-    minimized-owner UNKNOWN path (issue #154) and was a SECOND instance of the same self-poisoning
-    defect. Parametrized over BOTH on purpose rather than hard-coding one string: a third banner that
-    reintroduces a sentinel token in prose is caught the moment it is added to this list.
+    Introspection, NOT a hand-list: a newly-added banner is covered the instant it lands, with no edit
+    here. ``print_refresh_heartbeat`` is intentionally excluded (it is not a ``*banner``).
+    """
+    return {
+        name: obj
+        for name, obj in vars(credential_modal).items()
+        if callable(obj) and name.startswith("print_refresh_") and name.endswith("banner")
+    }
+
+
+def _detector_unknown_reasons(credential_modal) -> list[str]:
+    """The REAL ``unknown_reason`` strings the detector emits, harvested by driving each UNKNOWN branch.
+
+    Derived from the detector, never hand-written - that is the #152/#153 lesson: a fixture the
+    production code cannot actually produce hides the very defect the test exists to catch. The old
+    #153 banner test hand-wrote ``reason='owner window is minimized'``; the string the detector really
+    emits contained the word 'credential' and self-classified as ``NO_CREDENTIAL``.
+    """
+
+    def _enumeration_raises(_pid: int):
+        raise credential_modal.Win32EnumerationError("boom")
+
+    minimized_main = credential_modal.DesktopWindow(
+        title="Report",
+        class_name=credential_modal.DESKTOP_MAIN_CLASS_PREFIX + ".app.0",
+        width=1200,
+        height=800,
+        minimized=True,
+    )
+    scenarios = (_enumeration_raises, lambda _pid: [minimized_main])
+
+    reasons: list[str] = []
+    for enumerate_windows in scenarios:
+        reason = credential_modal.inspect_credential_modal(111, enumerate_windows=enumerate_windows).unknown_reason
+        assert reason, "scenario failed to drive the detector into an UNKNOWN state"
+        reasons.append(reason)
+
+    # Backstop for 'catches a newly-added reason without editing a list': if inspect_credential_modal
+    # grows a THIRD unknown_reason branch, this trips so whoever adds it also adds a driver scenario.
+    branches = inspect.getsource(credential_modal.inspect_credential_modal).count("unknown_reason=")
+    assert branches == len(reasons), (
+        f"detector emits {branches} unknown_reason branch(es) but this harness exercised {len(reasons)}; "
+        "add a driver scenario in _detector_unknown_reasons so #153 stays covered."
+    )
+    return reasons
+
+
+def test_no_refresh_banner_and_detector_reason_classifies_as_no_credential() -> None:
+    """#153 (structural): NO refresh banner may fabricate a credential stop from its own prose - for ANY
+    ``unknown_reason`` the detector can actually emit.
+
+    Both inputs are DISCOVERED, not enumerated: the banner set from the module by naming convention, and
+    the reason set from the real detector. That is what makes this catch (a) a newly-added banner and
+    (b) a newly-added reason without anyone editing a parametrize list - the exact blind-spot class that
+    let hand-written fixtures stay green while the seam was broken. The concrete bug this pins: the
+    minimized-owner reason literally read '... owned credential dialogs are hidden'; while that word was
+    ``credential`` (a ``CREDENTIAL_MARKER``), a slow/timeout refresh through the UNKNOWN path was
+    mislabelled ``NO_CREDENTIAL`` and sent an operator to re-enter credentials for a merely-slow
+    warehouse. ``print_refresh_unknown_banner`` interpolates that reason, so the banner's own static
+    prose being clean was NOT enough - the fix is at the detector, and this test reads it from there.
     """
     probe_live_source = _import_probe_live_source()
     _, _, credential_modal = _import_skill_modules()
 
-    buffer = io.StringIO()
-    with contextlib.redirect_stdout(buffer):
-        getattr(credential_modal, banner_func)(*args)
-    banner = buffer.getvalue()
+    banners = _refresh_banner_funcs(credential_modal)
+    reasons = _detector_unknown_reasons(credential_modal)
+    assert len(banners) >= 2, f"expected to discover both refresh banners; got {sorted(banners)}"
+    assert len(reasons) >= 2, f"expected >=2 real unknown_reason strings; got {reasons}"
 
-    assert sanity_substr in banner, f"sanity: {banner_func} should render {sanity_substr!r}; got {banner!r}"
-    verdict, _ = probe_live_source._classify_failure(banner, network_fault_observed=False)
-    assert verdict != "NO_CREDENTIAL", f"{banner_func} must not fabricate a credential stop; got {verdict}: {banner!r}"
+    base = (63824, 300, 30)
+    failures: list[tuple[str, tuple, str]] = []
+    for name, banner in sorted(banners.items()):
+        takes_reason = "reason" in inspect.signature(banner).parameters
+        arg_sets = [(*base, reason) for reason in reasons] if takes_reason else [base]
+        for args in arg_sets:
+            buffer = io.StringIO()
+            with contextlib.redirect_stdout(buffer):
+                banner(*args)
+            text = buffer.getvalue()
+            verdict, _ = probe_live_source._classify_failure(text, network_fault_observed=False)
+            if verdict == "NO_CREDENTIAL":
+                failures.append((name, args[3:], text))
+    assert not failures, "banner(s) fabricated a credential stop from their own prose: " + "; ".join(
+        f"{name}{extra}: {text!r}" for name, extra, text in failures
+    )
 
 
 def test_free_text_credential_marker_without_a_verdict_line_still_stops() -> None:


### PR DESCRIPTION
## What & why

Two defects in the **live-source credential-gate verdict seam** (parent
`scripts/probe_live_source.py` ↔ child `pbip-model-refresh` skill). Both block the
Monday 2026-08-17 workshop. 1343 tests were green the whole time because the one seam
test hand-wrote a verdict line the production caller **cannot** elicit.

### Defect A — #152 (P0): the gate can never clear
- The probe **always** shells out with `--tables <table>` and **never** `--canaries`,
  so `_verdict._emit_data_verdict` emits `REFRESH: TABLES_OK '<table>'` (exit 0) — but
  `_has_data_ok_verdict` accepted **only** the literal `DATA_OK`, which that argv can
  never produce. No source/credential/config could ever lift the gate.
- `_refresh_and_classify` ignored the child's **exit code** and classified on stdout
  prose alone.

**Fix:** `_has_data_ok_verdict(text, table)` now accepts the whole success family the
child emits — `DATA_OK` (model-level, unconditional) and `TABLE_OK` / `TABLES_OK`
**scoped** to the probed table (a verdict naming some *other* table is a false
certificate — preserves #115). Matching stays **anchored** to a verdict line, never a
substring, so `DATA_OK_FROM_WORKER` still doesn't count. The table name is threaded
from `_refresh_and_classify`, which now requires **both** `returncode == 0` **and** the
scoped success verdict.

### Defect B — #153 (P1): a healthy refresh is labelled `NO_CREDENTIAL`
`_classify_failure` did `if "blocked_by_dialog" in low` over the whole stdout blob, and
the child's own reassuring banners *named* the sentinel tokens in prose, so the banner
matched itself → `NO_CREDENTIAL` + "A HUMAN MUST ACT". There are **two** such banners:

- `print_refresh_banner` — the healthy **no-dialog** path (the reported instance).
- `print_refresh_unknown_banner` — the **minimized-owner UNKNOWN** path (a **second
  instance**, confirmed by #154). Besides naming the tokens, its old `"Credential
  dialog check"` prefix contained the bare word **"credential"**, which is itself a
  `CREDENTIAL_MARKER`.

**Fix (belt-and-braces, both halves):**
1. **Structural** — credential-stop tokens are matched only on a
   `^(REFRESH|PREFLIGHT|PROBE):\s+<TOKEN>` verdict **line**.
2. **Reword both banners** so they carry no control tokens (and not the bare word
   "credential"). `print_refresh_unknown_banner`'s prefix is now `"Blocking-dialog
   check … UNKNOWN"`, so a generic `ERROR` routed through the UNKNOWN path is no longer
   mislabelled. Both banners keep their operational prose (`"No blocking dialog"` /
   `"UNKNOWN (<reason>)"`); the UNKNOWN `reason` arg is preserved untouched.

`CREDENTIAL_MARKERS` stays a **separate, deliberately-unanchored** free-text scan — a
revoked Databricks PAT returns a 403/socket-reset with **no** modal and **no** verdict
line, so those markers are the *only* signal that catches it. Only the verdict *tokens*
got the structural treatment.

## Tests (the part CI was missing)
- **Seam/contract test** derives its fixture from **both real sides**: capture the exact
  argv the probe builds → parse with `refresh_pbip_model`'s **real** `_build_arg_parser`
  → run `_verdict`'s **real** `_emit_data_verdict` on a one-row refresh → assert the
  parent accepts the emitted line. This catches a vocabulary desync across the seam; the
  old hand-written `REFRESH: DATA_OK` fixture could not.
- **Verbatim 2026-08-14 live-Databricks** success (exit 0 + `TABLES_OK 'shipment'`) now
  classifies `DATA_OK` (it returned `NO_CREDENTIAL` at exit 1 before).
- **Negative controls:** non-zero exit is never success; `TABLES_OK` for a *different*
  table doesn't clear the gate (#115).
- **#153 banner regression is PARAMETRIZED over BOTH banner functions**
  (`print_refresh_banner` + `print_refresh_unknown_banner`) rather than hard-coding one
  string, so a third banner that reintroduces a sentinel token in prose is caught the
  moment it is added to the list.
- The unanchored `CREDENTIAL_MARKERS` free-text path still stops a revoked-PAT socket
  reset with no verdict line.
- The anchoring guard `test_requires_data_ok_verdict_token` stays green.

## Relationship to #154 (NOT fixed here — separate owner)
#154 (minimized Desktop destroys credential-dialog evidence; `UNKNOWN` isn't latched, so
the verdict degrades to `SLOW_SOURCE`) is a **separate** fix in
`join_with_credential_poll`, which this PR **leaves untouched**. This PR only reworded
the banner *prose* on that path; the structured `unknown_reason`/`reason` and the poll
loop are unchanged, so #154's fix surface is intact. As a courtesy to that fix,
`CREDENTIAL_STOP_VERDICT_RE` carries a one-line forward-compat comment naming the exact
parse point to extend if a latched-`UNKNOWN` outcome ever earns its own verdict token
(e.g. `CREDENTIAL_UNKNOWN`). No behavioural change for #154 is included.

## Validation
Bare `pytest` (the `testpaths` invocation) is green — **1356 passed, 7 skipped**.

> **Pre-existing test-harness note (not caused by this change):** the explicit two-path
> form `pytest tests/ .github/skills/pbip-model-refresh/tests/` hits an
> `importmode=prepend` **name clash** between the repo's forwarding shims in `scripts/`
> (`refresh_pbip_model`, `probe_desktop_query`) and the skill's real modules — 3
> collection `ImportError`s. **Reproduced on clean `master`** (`97a033e`) with the same
> command, so it predates this PR. Validated instead by (a) bare `pytest` and (b) running
> the two suites **separately**: `tests/` → 1202 passed / 4 skipped, skill tests → 143
> passed / 3 skipped.

## Files changed
| File | Why |
|---|---|
| `scripts/probe_live_source.py` | verdict-family + scoped acceptance, exit-code honouring, structural credential-stop classification, two module regexes (+ #154 forward-compat comment) |
| `.github/skills/pbip-model-refresh/scripts/_credential_modal.py` | reword **both** refresh banners to carry no control tokens |
| `tests/test_probe_live_source_verdict.py` | seam/contract test + regressions; banner regression parametrized over both banners |
| `.github/skills/pbip-model-refresh/tests/test_credential_modal_detection.py` | one assertion updated for the reworded UNKNOWN banner prefix |

Fixes #152
Fixes #153
