### PR TITLE
Derive the probe's refresh timeout from the child's ceiling so it outlasts it (Fixes #156)

### DIFF
--- a/scripts/probe_live_source.py
+++ b/scripts/probe_live_source.py
@@ -3,7 +3,7 @@ purpose: prove a live data source is actually reachable FROM POWER BI, by buildi
          probe model, refreshing it, and requiring a real row back.
 usage:   python scripts/probe_live_source.py --spec <migration-spec.json> [--source-index 0]
          python scripts/probe_live_source.py --bundle <engine-output-dir> [--source-index 0]
-                                             [--timeout-sec 180] [--keep]
+                                             [--refresh-timeout-sec 390] [--keep]
 
 Why this exists
 ---------------
@@ -74,6 +74,37 @@ logging.basicConfig(level=logging.INFO, format="%(message)s")
 log = logging.getLogger("probe_live_source")
 
 SKILL_SCRIPTS = Path(__file__).parent.parent / ".github" / "skills" / "pbip-model-refresh" / "scripts"
+
+# The parent's supervising timeout is DERIVED from the child's own budget, never a second hand-picked
+# number that can silently invert against it (issue #156). We import the child's constants rather than
+# retype them so the two files cannot drift apart: a change to the child's ceiling moves the parent's
+# bound with it, by construction. `SKILL_SCRIPTS` must lead sys.path so the child's siblings
+# (`probe_desktop_query`, `_credential_modal`, ...) resolve to the real skill copies, not the
+# forwarding shims in this `scripts/` dir. The clr/ADOMD load is lazy inside the child, so this import
+# is cheap (~0.1s) and needs no Power BI Desktop.
+sys.path.insert(0, str(SKILL_SCRIPTS))
+# pylint cannot see the runtime sys.path.insert above (it does not execute the module), so it reports
+# no-name-in-module for these; the import is proven at runtime by the probe-timeout regression tests.
+from refresh_pbip_model import (  # noqa: E402  # pylint: disable=wrong-import-position,no-name-in-module
+    REFRESH_TIMEOUT_SECONDS,
+    REFRESH_WALL_CLOCK_GRACE_SECONDS,
+)
+
+# How far the parent (the backstop to the child's backstop) must outlast the child before SIGKILLing
+# it. The ordering is the whole point: the child's own deadline path yields a FAR better verdict than
+# a generic SIGKILL - at its ceiling it re-checks for a credential modal and, failing that, raises a
+# TimeoutError naming the diagnostic signature ("XMLA CommandTimeout was Ns and did not fire ... a
+# mashup engine parked on a sign-in modal rather than a slow query"). Kill the child before its
+# ceiling (the old default=180 did, by 150s) and that classification is dead code from the probe
+# path; the parent just substitutes a generic ERROR/UNREACHABLE. So the parent MUST fire last.
+PROBE_KILL_MARGIN_SECONDS = 60
+# Total refresh-phase budget the parent grants the child = child's XMLA ceiling (300s) + its outer
+# wall-clock grace (30s) + our margin (60s) = 390s. This also clears the measured cold-start floor:
+# a SUSPENDED Snowflake warehouse auto-resuming on a 1-row probe returned DATA_OK in 167s (warm
+# Databricks: 21-28s). Warehouse auto-resume dominates, not row count, so "a 1-row probe is fast by
+# construction" is false - the old 180s default sat only 13s (7.8%) above that cold success and would
+# report a healthy-but-cold source as a failure. 390s is comfortably clear of it.
+PROBE_TIMEOUT_SECONDS = REFRESH_TIMEOUT_SECONDS + REFRESH_WALL_CLOCK_GRACE_SECONDS + PROBE_KILL_MARGIN_SECONDS
 
 # A credential block does not surface as a clean "auth failed". Measured: the mashup engine raises
 # the credential exception and then crashes posting it back over the named pipe, so the client sees
@@ -1053,14 +1084,31 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--source-index", type=int, default=None, help="probe only this source (default: all live sources)"
     )
-    parser.add_argument("--timeout-sec", type=int, default=180)
+    # Renamed from --timeout-sec (issue #156): this bounds ONLY the refresh phase, not the whole probe.
+    # `open` (240s) and `_wait_for_catalog` (240s) run before it, so the worst-case wall clock is ~660s;
+    # a flag named --timeout-sec read like a total budget it never was. --timeout-sec is kept as a
+    # deprecated alias so existing callers keep working; a warning below nudges them to the new name.
+    parser.add_argument(
+        "--refresh-timeout-sec",
+        "--timeout-sec",
+        dest="refresh_timeout_sec",
+        type=int,
+        default=PROBE_TIMEOUT_SECONDS,
+        help=(
+            f"seconds to allow the XMLA refresh before SIGKILLing the child (default {PROBE_TIMEOUT_SECONDS}, "
+            "derived from the child's own ceiling so it always outlasts it). Bounds the refresh phase only, "
+            "not model load/open. --timeout-sec is a deprecated alias."
+        ),
+    )
     parser.add_argument("--keep", action="store_true", help="leave Desktop open for inspection")
     args = parser.parse_args(argv)
+    if any(a == "--timeout-sec" or a.startswith("--timeout-sec=") for a in (sys.argv[1:] if argv is None else argv)):
+        log.warning("--timeout-sec is a deprecated alias for --refresh-timeout-sec; please update callers.")
     bundle_path = args.spec or args.bundle
     if not bundle_path.exists():
         log.error("PROBE: ERROR no such spec or bundle: %s", bundle_path)
         return 1
-    return run_probe(bundle_path, args.source_index, args.timeout_sec, args.keep)
+    return run_probe(bundle_path, args.source_index, args.refresh_timeout_sec, args.keep)
 
 
 if __name__ == "__main__":

--- a/tests/test_probe_live_source_verdict.py
+++ b/tests/test_probe_live_source_verdict.py
@@ -128,3 +128,34 @@ def test_probe_timeout_is_derived_from_child_not_retyped() -> None:
     # The parent must reuse the child's own objects, not a private copy that could diverge.
     assert probe_live_source.REFRESH_TIMEOUT_SECONDS == child.REFRESH_TIMEOUT_SECONDS
     assert probe_live_source.REFRESH_WALL_CLOCK_GRACE_SECONDS == child.REFRESH_WALL_CLOCK_GRACE_SECONDS
+
+
+def test_probe_timeout_default_threads_all_the_way_to_run_probe(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#156 (the WIRING, not just the constant): the derived default must be the value that actually
+    reaches the refresh subprocess.
+
+    The two tests above pin the constant and its derivation, but neither observes what ``main()`` hands
+    to ``run_probe`` -> ``subprocess.run(..., timeout=timeout_sec)``. Reverting only the argparse default
+    to 180 (leaving PROBE_TIMEOUT_SECONDS=390) restores the exact inversion #156 exists to prevent while
+    both constant tests stay green. This drives ``main()`` with ``run_probe`` captured, so it fails the
+    moment the default drifts off the constant. No live Desktop or real bundle: ``run_probe`` is replaced
+    and an existing empty directory satisfies the path-exists guard.
+    """
+    probe_live_source = _import_probe_live_source()
+    captured: dict[str, int] = {}
+
+    def _capture(_bundle: Path, _source_index: int | None, timeout_sec: int, _keep: bool) -> int:
+        captured["timeout_sec"] = timeout_sec
+        return 0
+
+    monkeypatch.setattr(probe_live_source, "run_probe", _capture)
+    rc = probe_live_source.main(["--bundle", str(tmp_path)])
+
+    assert rc == 0
+    assert captured["timeout_sec"] == probe_live_source.PROBE_TIMEOUT_SECONDS, (
+        f"main() handed run_probe timeout_sec={captured.get('timeout_sec')}, but the derived default is "
+        f"{probe_live_source.PROBE_TIMEOUT_SECONDS}; the argparse default has drifted off the constant, so the "
+        "child would be SIGKILLed before its own deadline can fire (issue #156 inversion)."
+    )

--- a/tests/test_probe_live_source_verdict.py
+++ b/tests/test_probe_live_source_verdict.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-# pylint: disable=import-outside-toplevel,protected-access
+# pylint: disable=import-outside-toplevel,protected-access,no-member
 
 REPO = Path(__file__).resolve().parent.parent
 
@@ -80,3 +80,51 @@ def test_blocked_by_dialog_does_not_clear_gate(monkeypatch: pytest.MonkeyPatch) 
         1,
         "NO_CREDENTIAL",
     )
+
+
+def _import_child_refresh():
+    """Import the child refresh module from the skill's own scripts folder."""
+    scripts = str(REPO / ".github" / "skills" / "pbip-model-refresh" / "scripts")
+    if scripts not in sys.path:
+        sys.path.insert(0, scripts)
+    import refresh_pbip_model  # noqa: PLC0415
+
+    return refresh_pbip_model
+
+
+def test_probe_timeout_strictly_outlasts_child_ceiling() -> None:
+    """#156: the parent's refresh bound MUST strictly outlast the child's own deadline.
+
+    The inversion this guards against: with the old default of 180s the parent SIGKILLed the child
+    150s BEFORE the child's own ceiling (300 + 30 = 330s) could fire, so the child's far better
+    verdict (a credential re-check, then a TimeoutError naming the mashup-modal signature) was dead
+    code from the probe path. Computed by importing BOTH sides so any future change to either
+    constant re-checks the ordering - hard-coding 390/330 here would not catch a drift in the child.
+    """
+    probe_live_source = _import_probe_live_source()
+    child = _import_child_refresh()
+    child_ceiling = child.REFRESH_TIMEOUT_SECONDS + child.REFRESH_WALL_CLOCK_GRACE_SECONDS
+    assert probe_live_source.PROBE_TIMEOUT_SECONDS > child_ceiling, (
+        f"parent PROBE_TIMEOUT_SECONDS={probe_live_source.PROBE_TIMEOUT_SECONDS} must strictly exceed the "
+        f"child's own deadline {child_ceiling}s (REFRESH_TIMEOUT_SECONDS + REFRESH_WALL_CLOCK_GRACE_SECONDS), "
+        "or the child's deadline classification never fires before the parent kills it."
+    )
+
+
+def test_probe_timeout_is_derived_from_child_not_retyped() -> None:
+    """#156: the parent's bound must equal the child's constants plus the documented margin.
+
+    Enforcing derivation-by-construction is the point: a bound picked as an independent literal can
+    silently drift back into the inversion the moment someone bumps the child's ceiling.
+    """
+    probe_live_source = _import_probe_live_source()
+    child = _import_child_refresh()
+    expected = (
+        child.REFRESH_TIMEOUT_SECONDS
+        + child.REFRESH_WALL_CLOCK_GRACE_SECONDS
+        + probe_live_source.PROBE_KILL_MARGIN_SECONDS
+    )
+    assert probe_live_source.PROBE_TIMEOUT_SECONDS == expected
+    # The parent must reuse the child's own objects, not a private copy that could diverge.
+    assert probe_live_source.REFRESH_TIMEOUT_SECONDS == child.REFRESH_TIMEOUT_SECONDS
+    assert probe_live_source.REFRESH_WALL_CLOCK_GRACE_SECONDS == child.REFRESH_WALL_CLOCK_GRACE_SECONDS


### PR DESCRIPTION
## What & why

probe_live_source.py's `--timeout-sec` default of **180 s** was unsafe two ways (issue #156):

1. **Inverted against the child it supervises.** The parent `subprocess.run(..., timeout=timeout_sec)` SIGKILLed `refresh_pbip_model.py` at 180 s — **150 s before** the child's own ceiling (`REFRESH_TIMEOUT_SECONDS` 300 + `REFRESH_WALL_CLOCK_GRACE_SECONDS` 30 = **330 s**) could fire. The child's superior deadline verdict (a credential re-check, then a `TimeoutError` naming the mashup-modal signature) was therefore **dead code** from the probe path.
2. **13 s above a measured cold success.** A SUSPENDED Snowflake warehouse auto-resuming returned `DATA_OK` in **167 s** on a 1-row probe (warm Databricks: 21–28 s). Warehouse auto-resume dominates, not row count, so a slightly colder healthy source was reported as a **failure**.

Raising 180 → 300 fixes (2) but not (1), since 300 < 330.

## The fix

- **Import** `REFRESH_TIMEOUT_SECONDS` / `REFRESH_WALL_CLOCK_GRACE_SECONDS` from the child and **derive** `PROBE_TIMEOUT_SECONDS = 300 + 30 + 60 = 390`. The ordering is now enforced *by construction* — a change to the child's ceiling moves the parent's bound with it, so the two files cannot silently drift back into an inversion.
- `--timeout-sec` now defaults to 390; the self-declared-timer log line (which already interpolates the bound) announces 390 automatically.
- The child's `REFRESH_TIMEOUT_SECONDS = 300` is **untouched** (measured; deliberately un-flagged).

## Secondary (issue's optional item): flag rename

Chose the **rename** the author leaned toward — it is the lower-risk option and directly fixes the misleading name. `--timeout-sec` bounds only the refresh phase; `open` (240 s) and `_wait_for_catalog` (240 s) run before it, so the flag never controlled the ~660 s worst-case total it read like. Renamed to `--refresh-timeout-sec`, keeping `--timeout-sec` as a **deprecated alias** (via argparse multi-option) so nothing breaks — `test_engine_bundle_contract.py` still passes `--timeout-sec 1` — plus a one-line deprecation nudge when the old spelling is used.

## Scope guardrails honoured

No changes to `CREDENTIAL_MARKERS`, `ACCESS_DENIED_MARKERS`, `_classify_failure`, `_has_data_ok_verdict`, `_has_credential_stop_verdict`, `_credential_modal.py`, `join_with_credential_poll`, or `credential_gate.py`. The change lives entirely in the constants/argparse region and does not overlap the classifier region touched by PR #155. The credential gate was never re-armed, cleared, or bypassed.

## Verification (on `master`, PR #155 unmerged)

- **Regression tests** (`tests/test_probe_live_source_verdict.py`): two tests import **both** sides and assert `PROBE_TIMEOUT_SECONDS` strictly exceeds `REFRESH_TIMEOUT_SECONDS + REFRESH_WALL_CLOCK_GRACE_SECONDS` and equals the derived sum — so a future change to the child re-checks the ordering (a hard-coded 390/330 would not).
- **Full suite:** `.venv\Scripts\python.exe -m pytest -q` → **1365 passed, 0 skipped, 4 warnings** (warnings pre-existing, unrelated).
- **Lint:** `ruff format` + `ruff check` clean on both files; `pylint scripts` = **10.00/10** (the CI-gated invocation). CI does not run pylint on `tests/` by design.

Fixes #156

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
