### PR TITLE
Correct the probe's worst-case wall clock (~660s -> ~870s), stale in the commit that shipped it

### DIFF
--- a/scripts/probe_live_source.py
+++ b/scripts/probe_live_source.py
@@ -1162,17 +1162,13 @@ def main(argv: list[str] | None = None) -> int:
     # Renamed from --timeout-sec (issue #156): this bounds ONLY the refresh phase, not the whole probe;
     # a flag named --timeout-sec read like a total budget it never was. --timeout-sec is kept as a
     # deprecated alias so existing callers keep working; a warning below nudges them to the new name.
-    #
-    # `open` (240s cap, plus a pid-resolution poll on top) and `_wait_for_catalog` (240s) both run
-    # before it, so ONE open->catalog->refresh attempt costs at least 240 + 240 + PROBE_TIMEOUT_SECONDS
-    # = ~870s. Spelled as a sum on purpose: the previous "~660s" was computed against the old 180s
-    # refresh default and was already stale in the commit that shipped it.
-    #
-    # ~870s is a per-ATTEMPT figure, not a probe-wide ceiling: `_probe_one` re-runs the whole sequence
-    # per table on the BAD_TABLE fallback, and `run_probe` re-runs it per live source, so the
-    # probe-wide worst case is ~870s x (tables attempted across all live sources). Do not size a
-    # supervising timeout from this sum - measure wall clock (same floor-not-a-total caveat as
-    # docs/operator-runbook.md's note on phase-timings.json).
+    # `open` (240s cap + a pid-resolution poll) and `_wait_for_catalog` (240s) both run before it, so
+    # ONE open->catalog->refresh attempt costs at least 240 + 240 + PROBE_TIMEOUT_SECONDS = ~870s.
+    # Spelled as a sum because the previous "~660s" was computed against the old 180s refresh default
+    # and was already stale in the commit that shipped it. ~870s is PER ATTEMPT, not a probe-wide
+    # ceiling: `_probe_one` repeats the sequence per table on the BAD_TABLE fallback and `run_probe`
+    # repeats it per live source, so the true worst case is ~870s x (tables attempted across all live
+    # sources). Do not size a supervising timeout from this sum - measure wall clock.
     parser.add_argument(
         "--refresh-timeout-sec",
         "--timeout-sec",

--- a/scripts/probe_live_source.py
+++ b/scripts/probe_live_source.py
@@ -1159,12 +1159,20 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--source-index", type=int, default=None, help="probe only this source (default: all live sources)"
     )
-    # Renamed from --timeout-sec (issue #156): this bounds ONLY the refresh phase, not the whole probe.
-    # `open` (240s) and `_wait_for_catalog` (240s) both run before it, so the worst-case wall clock is
-    # 240 + 240 + PROBE_TIMEOUT_SECONDS = ~870s. Spelled as a sum on purpose: the previous "~660s" was
-    # computed against the old 180s refresh default and was already stale in the commit that shipped it.
+    # Renamed from --timeout-sec (issue #156): this bounds ONLY the refresh phase, not the whole probe;
     # a flag named --timeout-sec read like a total budget it never was. --timeout-sec is kept as a
     # deprecated alias so existing callers keep working; a warning below nudges them to the new name.
+    #
+    # `open` (240s cap, plus a pid-resolution poll on top) and `_wait_for_catalog` (240s) both run
+    # before it, so ONE open->catalog->refresh attempt costs at least 240 + 240 + PROBE_TIMEOUT_SECONDS
+    # = ~870s. Spelled as a sum on purpose: the previous "~660s" was computed against the old 180s
+    # refresh default and was already stale in the commit that shipped it.
+    #
+    # ~870s is a per-ATTEMPT figure, not a probe-wide ceiling: `_probe_one` re-runs the whole sequence
+    # per table on the BAD_TABLE fallback, and `run_probe` re-runs it per live source, so the
+    # probe-wide worst case is ~870s x (tables attempted across all live sources). Do not size a
+    # supervising timeout from this sum - measure wall clock (same floor-not-a-total caveat as
+    # docs/operator-runbook.md's note on phase-timings.json).
     parser.add_argument(
         "--refresh-timeout-sec",
         "--timeout-sec",

--- a/scripts/probe_live_source.py
+++ b/scripts/probe_live_source.py
@@ -1160,7 +1160,9 @@ def main(argv: list[str] | None = None) -> int:
         "--source-index", type=int, default=None, help="probe only this source (default: all live sources)"
     )
     # Renamed from --timeout-sec (issue #156): this bounds ONLY the refresh phase, not the whole probe.
-    # `open` (240s) and `_wait_for_catalog` (240s) run before it, so the worst-case wall clock is ~660s;
+    # `open` (240s) and `_wait_for_catalog` (240s) both run before it, so the worst-case wall clock is
+    # 240 + 240 + PROBE_TIMEOUT_SECONDS = ~870s. Spelled as a sum on purpose: the previous "~660s" was
+    # computed against the old 180s refresh default and was already stale in the commit that shipped it.
     # a flag named --timeout-sec read like a total budget it never was. --timeout-sec is kept as a
     # deprecated alias so existing callers keep working; a warning below nudges them to the new name.
     parser.add_argument(


### PR DESCRIPTION
## What

PR #157 renamed `--timeout-sec` to `--refresh-timeout-sec` and, in the same change, raised the
refresh bound from 180s to `PROBE_TIMEOUT_SECONDS` (300 + 30 + 60 = **390**).

The explanatory comment it added still quoted the **pre-change** arithmetic:

```
open (240s) + _wait_for_catalog (240s) + 180s = ~660s
```

**That sum was already wrong at the moment it was written.** The true worst case is
240 + 240 + 390 = **~870s**.

## Why it is worth a PR

The comment exists specifically to stop a caller reading `--refresh-timeout-sec` as a *total*
budget — which is the exact misreading issue #156 was about. A wrong total in the very comment that
teaches the distinction undercuts its own purpose, and it understates the probe's worst case by
**210 seconds**: enough for an operator to conclude a run had hung while it was still comfortably
inside its documented budget.

This repo already carries an issue (#129) about a documented number being wrong and that doc error
producing a code bug, so stale arithmetic in prose is not treated as cosmetic here.

## How

Spelled as an explicit sum that **names `PROBE_TIMEOUT_SECONDS`** instead of baking in a single
number, so the next change to the refresh bound makes the staleness visible rather than silently
invalidating the prose again. Same failure mode, now harder to repeat.

## Verification

- Comment-only change, `+3/-1`, no behaviour touched.
- `ruff format` clean; `ruff check` reported "All checks passed!"; **pylint 10.00/10**.
  - Note the 120-char limit here is enforced by **pylint C0301, not ruff** — this repo's ruff lint
    selection is `["E4","E7","E9","F"]`, which excludes E501. A long line passes ruff and still
    fails CI.
- `tests/test_probe_live_source_verdict.py`: **13 passed**.

Found while auditing the numbers for a separate timeout question. No issue was filed for this one,
since the report would have been larger than the fix.
