### PR TITLE
Remove four unreferenced dead credential-detector symbols

### DIFF
--- a/.github/skills/pbip-model-refresh/scripts/_credential_modal.py
+++ b/.github/skills/pbip-model-refresh/scripts/_credential_modal.py
@@ -17,7 +17,6 @@ from dataclasses import dataclass
 from pathlib import Path
 
 SIGNATURE_PATH = Path(__file__).resolve().with_name("credential_modal_signature.regex")
-POLL_SECONDS = 5.0
 CONNECTOR_SOURCE_RE = re.compile(
     r"\b(?P<kind>Sql\.Database|Snowflake\.Databases|Databricks\.[A-Za-z]+|Odbc\.DataSource|Web\.Contents)\s*\("
     r"\s*(?:\"(?P<double>[^\"]+)\"|'(?P<single>[^']+)')?",
@@ -285,13 +284,6 @@ def inspect_credential_modal(
             windows=windows,
         )
     return CredentialDetection(windows=windows)
-
-
-def detect_credential_modal(
-    pid: int, enumerate_windows: WindowEnumerator = enumerate_pid_windows
-) -> CredentialModal | None:
-    """Detect a currently visible credential modal for ``pid``."""
-    return inspect_credential_modal(pid, enumerate_windows).modal
 
 
 def describe_modal(modal: CredentialModal, source_hint: str | None = None) -> str:

--- a/.github/skills/pbip-model-refresh/scripts/probe_desktop_query.py
+++ b/.github/skills/pbip-model-refresh/scripts/probe_desktop_query.py
@@ -354,11 +354,6 @@ def probe(port: int, tables: list[str] | None, emit=print) -> int:
         conn.Close()
 
 
-def _credential_missing(pid: int) -> CredentialModal | None:
-    """Return an already-open credential modal for ``pid``, if Desktop is blocked on one."""
-    return _credential_state(pid).modal
-
-
 def _credential_state(pid: int) -> CredentialDetection:
     """Return the credential-modal inspection state for ``pid``."""
     if os.name != "nt":

--- a/.github/skills/pbip-model-refresh/scripts/refresh_pbip_model.py
+++ b/.github/skills/pbip-model-refresh/scripts/refresh_pbip_model.py
@@ -199,11 +199,6 @@ GENERATED_EDIT_DECLARATIONS = Path("_build") / "generated-edit-declarations.json
 CREDENTIAL_PROBE = Path(__file__).resolve().parent / "probe_desktop_credential.ps1"
 
 
-def _credential_missing(pid: int) -> CredentialModal | None:
-    """Return an already-open credential modal for ``pid``, if Desktop is blocked on one."""
-    return _credential_state(pid).modal
-
-
 def _credential_state(pid: int) -> CredentialDetection:
     """Return the credential-modal inspection state for ``pid``."""
     if os.name != "nt":


### PR DESCRIPTION
## What

Pure dead-code deletion — removes exactly **four unreferenced symbols** from the
`pbip-model-refresh` skill's credential-detector scripts. **18 lines removed, 0 added.** No
behaviour change, no refactor, no rename. The detector tier logic and the `t=0` pre-checks are
untouched.

| # | symbol | file | kind |
|---|---|---|---|
| 1 | `POLL_SECONDS` | `.github/skills/pbip-model-refresh/scripts/_credential_modal.py` | drift-trap duplicate constant |
| 2 | `detect_credential_modal` | `.github/skills/pbip-model-refresh/scripts/_credential_modal.py` | thin wrapper over `inspect_credential_modal(...).modal` |
| 3 | `_credential_missing` | `.github/skills/pbip-model-refresh/scripts/refresh_pbip_model.py` | private wrapper over `_credential_state(pid).modal` |
| 4 | `_credential_missing` | `.github/skills/pbip-model-refresh/scripts/probe_desktop_query.py` | private wrapper over `_credential_state(pid).modal` |

## Unreferenced proof

Searched the **whole repo** at the base commit `cd7c763` (`scripts/`, `tests/`, `.github/skills/**`
incl. every bundle's own `scripts/`+`tests/`, and `docs/`), covering both Python and string refs.

**1. `POLL_SECONDS`** — word-boundary search matches only its own definition. The other
`*_POLL_SECONDS` names in the tree (`_DEFAULT_POLL_SECONDS`, `REFRESH_CREDENTIAL_POLL_SECONDS`,
`PREFLIGHT_CREDENTIAL_POLL_SECONDS`) are distinct tokens; this constant is a second, unused
duplicate of the live ones — a drift trap.

```
$ git grep -n -w "POLL_SECONDS" cd7c763
cd7c763:.github/skills/pbip-model-refresh/scripts/_credential_modal.py:20:POLL_SECONDS = 5.0
```

**2. `detect_credential_modal`** — matches only its own definition. Live code calls
`inspect_credential_modal` / `_credential_state` directly.

```
$ git grep -n "detect_credential_modal" cd7c763
cd7c763:.github/skills/pbip-model-refresh/scripts/_credential_modal.py:290:def detect_credential_modal(
```

**3 + 4. `_credential_missing`** — negative lookbehind `(?<!emit)` excludes the distinct, **live**
`_emit_credential_missing`. The two `def` lines are the only definitions; the three remaining hits
are **descriptive test-function names**, not call sites — they monkeypatch the live
`_credential_state` and drive `refresh()` / `main()`, never the deleted wrappers.

```
$ git grep -n -P "(?<!emit)_credential_missing" cd7c763
cd7c763:.github/skills/pbip-model-refresh/scripts/probe_desktop_query.py:357:def _credential_missing(pid: int) -> CredentialModal | None:
cd7c763:.github/skills/pbip-model-refresh/scripts/refresh_pbip_model.py:202:def _credential_missing(pid: int) -> CredentialModal | None:
cd7c763:.github/skills/pbip-model-refresh/tests/test_credential_modal_detection.py:200:def test_direct_refresh_returns_credential_missing_fast_at_t0(monkeypatch) -> None:
cd7c763:.github/skills/pbip-model-refresh/tests/test_credential_modal_detection.py:294:def test_refresh_main_returns_credential_missing_fast_at_t0(monkeypatch, tmp_path: Path, capsys) -> None:
cd7c763:.github/skills/pbip-model-refresh/tests/test_credential_modal_detection.py:316:def test_probe_query_returns_credential_missing_fast_at_t0(monkeypatch, capsys) -> None:
```

Call-site search (`\(` appended) confirms **zero call sites** — only the two definitions:

```
$ git grep -n -P "(?<!emit)_credential_missing\(" cd7c763
cd7c763:.github/skills/pbip-model-refresh/scripts/probe_desktop_query.py:357:def _credential_missing(pid: int) -> CredentialModal | None:
cd7c763:.github/skills/pbip-model-refresh/scripts/refresh_pbip_model.py:202:def _credential_missing(pid: int) -> CredentialModal | None:
```

### Additional checks
- **No `__all__`** exists in any of these scripts, so none of the four is re-exported.
- **Forwarding shims** (`scripts/probe_desktop_query.py`, `scripts/refresh_pbip_model.py`) run the
  bundled scripts by path via `runpy.run_path` — they import/reference none of these names.
- **Plugin build/sync** scripts (`scripts/build_plugin.py`, `scripts/sync_installed_skills.py`)
  copy files wholesale and reference none of these names, so the republished `powerbi-playbook`
  plugin carries no separate contract. **No external contract found** for the two public symbols.
- **No imports orphaned:** `_credential_state`, `WindowEnumerator`, `enumerate_pid_windows` and
  `CredentialModal` all remain used by live code (e.g. `inspect_credential_modal`,
  `_emit_credential_missing`), so no import lines were removed.

## Scope

Nothing else was touched. Only the four symbols (and their surrounding blank lines) were removed;
no tier logic, no `t=0` pre-check, no rename, no unrelated cleanup.

## Validation
- `ruff format` / `ruff check --fix`: clean.
- `pylint` on all three changed files: **10.00/10**.
- `tests/` + `.github/skills/`: **1358 passed, 7 skipped** — identical before and after (pure deletion).
- `python scripts/sync_agent_conventions.py --check`: exit 0.
- `tests/test_skills.py`: passed (included in the run above).
