### PR TITLE
docs: record that ruff alone does not predict CI (E501 and C0302 gaps)

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -37,7 +37,7 @@ jobs:
           uv run ruff check scripts tests .github/skills
 
       - name: Static analysis (pylint)
-        # Two invocations, not one: `scripts/probe_desktop_query.py` is a forwarding shim with the
+        # Three invocations, not one: `scripts/probe_desktop_query.py` is a forwarding shim with the
         # same module name as the bundled script it forwards to, so a single `pylint scripts
         # .github/skills/...` puts both on the path and resolves the import to the shim
         # (E0611 no-name-in-module). Tests are not held to 10.00/10; the toolkit code is.

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -40,7 +40,9 @@ jobs:
         # Three invocations, not one: `scripts/probe_desktop_query.py` is a forwarding shim with the
         # same module name as the bundled script it forwards to, so a single `pylint scripts
         # .github/skills/...` puts both on the path and resolves the import to the shim
-        # (E0611 no-name-in-module). Tests are not held to 10.00/10; the toolkit code is.
+        # (E0611 no-name-in-module). That collision forces `scripts` and pbip-model-refresh/scripts
+        # apart; powerbi-ai-readiness/scripts is separate by the one-root-per-invocation convention.
+        # Tests are not held to 10.00/10; the toolkit code is.
         run: |
           uv run pylint scripts
           uv run pylint .github/skills/pbip-model-refresh/scripts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -290,6 +290,26 @@ in `tests/`, and a skill bundle keeps its own suite next to its scripts (`pyproj
 `testpaths` covers both — pytest skips dot-directories by default). **`uv.lock` is deliberately
 gitignored** — see the note in `.gitignore`.
 
+**⚠️ `ruff` alone does NOT predict CI — always run `pylint` too.** CI runs both and they do not
+overlap. This repo's ruff selection is `select = ["E4", "E7", "E9", "F"]`, which **excludes `E501`
+(line-too-long)**, while `[tool.pylint.format]` sets `max-line-length = 120`. So a 121-character line
+makes `ruff check` print **"All checks passed!"** and CI then fail with `C0301` — and `ruff format`
+cannot rescue you, because it will not split a long string literal or comment. Measured: PR #155 sat
+red for hours on exactly this (121/120, exit 16) while the mandated ruff ritual reported clean. Fix
+pattern: wrap the literal in parentheses across two lines (the runtime string stays byte-identical).
+
+**`max-module-lines = 1200` is the same trap one level up, and it is worse** — nothing hints at it
+until you cross it. Pylint scores **10.00/10** right up to the boundary, then fails with
+`C0302: Too many lines in module (1202/1200)`, exit 16: a red CI whose message has nothing to do with
+your change. Measured 2026-08-15 by controlled experiment on `scripts/probe_live_source.py`, which a
+**comment-only** PR had left at exactly 1200. Before adding lines to a long module, check its length
+against the cap; if you land within a few lines of it, buy the headroom back rather than leaving the
+landmine for the next author.
+
+So the ritual that actually predicts CI is `ruff format` → `ruff check --fix` → **`pylint`** → the
+targeted tests. Skipping the `pylint` step is the single most common way a green local run turns into
+a red PR in this repo.
+
 ### 6. Preflight — verify everything above in one command
 
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -294,21 +294,35 @@ gitignored** — see the note in `.gitignore`.
 overlap. This repo's ruff selection is `select = ["E4", "E7", "E9", "F"]`, which **excludes `E501`
 (line-too-long)**, while `[tool.pylint.format]` sets `max-line-length = 120`. So a 121-character line
 makes `ruff check` print **"All checks passed!"** and CI then fail with `C0301` — and `ruff format`
-cannot rescue you, because it will not split a long string literal or comment. Measured: PR #155 sat
-red for hours on exactly this (121/120, exit 16) while the mandated ruff ritual reported clean. Fix
-pattern: wrap the literal in parentheses across two lines (the runtime string stays byte-identical).
+cannot rescue you, because it will not split a long string literal or comment. Measured: PR #157 sat
+red ~1h50m on exactly this — `_credential_modal.py:282`, `C0301: Line too long (121/120)`, score
+9.99/10, [run 31839056611](https://github.com/Guust-Franssens/tableau-to-powerbi-migration/actions/runs/31839056611)
+— while the mandated ruff ritual reported clean. Fix pattern: wrap the literal in parentheses across
+two lines (the runtime string stays byte-identical).
+
+**And `pylint` means all THREE roots, not just `scripts/`.** [`checks.yml`](.github/workflows/checks.yml)
+invokes it three times — `scripts`, `.github/skills/pbip-model-refresh/scripts`,
+`.github/skills/powerbi-ai-readiness/scripts` — deliberately, because `scripts/probe_desktop_query.py`
+is a forwarding shim sharing a module name with the bundled script it forwards to, so a single
+combined invocation resolves the import to the shim (`E0611`). That is exactly how #157 got through:
+`pylint scripts` passed **10.00/10** and the failure came from the *second* invocation. Lint the root
+that contains the file you changed, not the one you think of first.
 
 **`max-module-lines = 1200` is the same trap one level up, and it is worse** — nothing hints at it
 until you cross it. Pylint scores **10.00/10** right up to the boundary, then fails with
 `C0302: Too many lines in module (1202/1200)`, exit 16: a red CI whose message has nothing to do with
-your change. Measured 2026-08-15 by controlled experiment on `scripts/probe_live_source.py`, which a
-**comment-only** PR had left at exactly 1200. Before adding lines to a long module, check its length
+your change. The boundary is `> 1200` — a 1200-line module passes at 10.00/10. Measured 2026-08-15 by
+controlled experiment on `scripts/probe_live_source.py`, which a **comment-only** PR (#159) pushed to
+exactly 1200 at its pre-merge head `97691af`; it was tightened to 1196 before merging, so master
+records 1196 and the near-miss is invisible in its history — squash-merge discards the intermediate
+commit. Cite a measurement against something that survives the merge, or say plainly that it does not.
+Before adding lines to a long module, check its length
 against the cap; if you land within a few lines of it, buy the headroom back rather than leaving the
 landmine for the next author.
 
-So the ritual that actually predicts CI is `ruff format` → `ruff check --fix` → **`pylint`** → the
-targeted tests. Skipping the `pylint` step is the single most common way a green local run turns into
-a red PR in this repo.
+So the ritual that actually predicts CI is `ruff format` → `ruff check --fix` → **`pylint` (all three
+roots)** → the targeted tests. Every step of that is load-bearing: skipping `pylint` hides `C0301` and
+`C0302`, and running it on only one root hides anything living in a skill bundle.
 
 ### 6. Preflight — verify everything above in one command
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -294,19 +294,21 @@ gitignored** — see the note in `.gitignore`.
 overlap. This repo's ruff selection is `select = ["E4", "E7", "E9", "F"]`, which **excludes `E501`
 (line-too-long)**, while `[tool.pylint.format]` sets `max-line-length = 120`. So a 121-character line
 makes `ruff check` print **"All checks passed!"** and CI then fail with `C0301` — and `ruff format`
-cannot rescue you, because it will not split a long string literal or comment. Measured: PR #157 sat
-red ~1h50m on exactly this — `_credential_modal.py:282`, `C0301: Line too long (121/120)`, score
-9.99/10, [run 31839056611](https://github.com/Guust-Franssens/tableau-to-powerbi-migration/actions/runs/31839056611)
+cannot rescue you, because it will not split a long string literal or comment. Measured: PR #155 sat
+red ~1h50m on exactly this — `.github/skills/pbip-model-refresh/scripts/_credential_modal.py:282`,
+`C0301: Line too long (121/120)`, score 9.99/10,
+[run 31839056611](https://github.com/Guust-Franssens/tableau-to-powerbi-migration/actions/runs/31839056611)
 — while the mandated ruff ritual reported clean. Fix pattern: wrap the literal in parentheses across
 two lines (the runtime string stays byte-identical).
 
 **And `pylint` means all THREE roots, not just `scripts/`.** [`checks.yml`](.github/workflows/checks.yml)
 invokes it three times — `scripts`, `.github/skills/pbip-model-refresh/scripts`,
-`.github/skills/powerbi-ai-readiness/scripts` — deliberately, because `scripts/probe_desktop_query.py`
-is a forwarding shim sharing a module name with the bundled script it forwards to, so a single
-combined invocation resolves the import to the shim (`E0611`). That is exactly how #157 got through:
-`pylint scripts` passed **10.00/10** and the failure came from the *second* invocation. Lint the root
-that contains the file you changed, not the one you think of first.
+`.github/skills/powerbi-ai-readiness/scripts`. They are *separate* invocations because
+`scripts/probe_desktop_query.py` is a forwarding shim sharing a module name with the bundled script it
+forwards to, so one combined invocation resolves the import to the shim (measured: 7 × `E0611`). What
+let #155 through is simpler than that mechanism: `pylint scripts` alone passes **10.00/10**, and the
+`C0301` came from the *second* invocation. Lint the root that contains the file you changed, not the
+one you reach for first.
 
 **`max-module-lines = 1200` is the same trap one level up, and it is worse** — nothing hints at it
 until you cross it. Pylint scores **10.00/10** right up to the boundary, then fails with

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -290,8 +290,10 @@ in `tests/`, and a skill bundle keeps its own suite next to its scripts (`pyproj
 `testpaths` covers both — pytest skips dot-directories by default). **`uv.lock` is deliberately
 gitignored** — see the note in `.gitignore`.
 
-**⚠️ `ruff` alone does NOT predict CI — always run `pylint` too.** CI runs both and they do not
-overlap. This repo's ruff selection is `select = ["E4", "E7", "E9", "F"]`, which **excludes `E501`
+**⚠️ `ruff` alone does NOT predict CI — always run `pylint` too.** CI runs both, and they do not
+*fully* overlap — each enforces gates the other does not. (They do agree on some checks: ruff `F401`
+≈ pylint `W0611`, `F821` ≈ `E0602`. The gate below is one neither of those covers.)
+This repo's ruff selection is `select = ["E4", "E7", "E9", "F"]`, which **excludes `E501`
 (line-too-long)**, while `[tool.pylint.format]` sets `max-line-length = 120`. So a 121-character line
 makes `ruff check` print **"All checks passed!"** and CI then fail with `C0301` — and `ruff format`
 cannot rescue you, because it will not split a long string literal or comment. Measured: PR #155 sat
@@ -305,7 +307,10 @@ two lines (the runtime string stays byte-identical).
 invokes it three times — `scripts`, `.github/skills/pbip-model-refresh/scripts`,
 `.github/skills/powerbi-ai-readiness/scripts`. They are *separate* invocations because
 `scripts/probe_desktop_query.py` is a forwarding shim sharing a module name with the bundled script it
-forwards to, so one combined invocation resolves the import to the shim (measured: 7 × `E0611`). What
+forwards to, so one combined invocation resolves the import to the shim (measured: 7 × `E0611`).
+Strictly, that collision only forces `scripts` and `pbip-model-refresh/scripts` apart;
+`powerbi-ai-readiness/scripts` has no colliding name and is separate by the one-root-per-invocation
+convention. What
 let #155 through is simpler than that mechanism: `pylint scripts` alone passes **10.00/10**, and the
 `C0301` came from the *second* invocation. Lint the root that contains the file you changed, not the
 one you reach for first.


### PR DESCRIPTION
## Problem

Two **pylint-only** CI gates have each turned a locally-green change into a red PR, and the mandated `ruff` ritual reports clean for both. Neither is written down anywhere, so each one has to be rediscovered.

### 1. `E501` — the ruff selection excludes it

`pyproject.toml` sets `select = ["E4", "E7", "E9", "F"]` for ruff (no `E501`), while `[tool.pylint.format]` sets `max-line-length = 120`. So a 121-character line makes `ruff check` print **"All checks passed!"**, and CI then fails with `C0301`.

`ruff format` does not save you either — it will not split a long string literal or comment, so there is no auto-fix path.

**Measured:** PR #155 sat red for hours on exactly this (121/120, exit 16). It was missed because `mergeable: MERGEABLE` was being read as "CI is fine"; that field only means *no merge conflict*.

### 2. `C0302` / `max-module-lines = 1200` — the same trap, one level up

This one is worse, because **nothing hints at it until you cross the line**. Pylint scores a clean **10.00/10** right up to the boundary and then fails with `C0302: Too many lines in module (1202/1200)`, exit 16 — a red CI whose message has nothing to do with the change that triggered it.

**Measured 2026-08-15 by controlled experiment.** A **comment-only** PR (#159) left `scripts/probe_live_source.py` at *exactly* 1200 lines. Appending a single line reproduced the failure:

```
scripts\probe_live_source.py:1:0: C0302: Too many lines in module (1202/1200) (too-many-lines)
Your code has been rated at 9.97/10 (previous run: 10.00/10, -0.03)
exit 16
```

So the boundary is `> 1200`, and a docs change had silently consumed the last of the file's headroom. That PR was subsequently tightened to 1196 to give the headroom back.

## Change

Adds both gaps to **`AGENTS.md` §5 (Python tooling)**, which currently says only *"Lint/format with `ruff`"* — the sentence that is, on its own, wrong about what CI enforces. States the fix pattern for each, cites the measurements, and spells out the ritual that actually predicts CI:

> `ruff format` → `ruff check --fix` → **`pylint`** → the targeted tests

## Why §5 and not the shared-conventions block

`AGENTS.md`'s `<!-- BEGIN:shared-conventions -->` block is duplicated by `scripts/sync_agent_conventions.py` into all four `.github/agents/*.agent.md` personas, and **`tableau-migrator` is already at 99% of its character cap** (29790). Adding ~1.5 KB there would push it over and force an unrelated eviction.

§5 is outside the synced block, so the personas are untouched.

## Verification

- `python scripts/sync_agent_conventions.py --check` → **exit 0**, "all 4 agent(s) carry the current shared conventions", caps unchanged (99 / 97 / 94 / 86 %).
- `pytest tests/test_sync_agent_conventions.py tests/test_credential_gate.py` → **96 passed** (the two suites that read `AGENTS.md`).

Docs-only; no runtime code touched.
