### PR TITLE
Document the C0302 waiver: shave, split or waive - and why three modules already waived

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -327,6 +327,21 @@ Before adding lines to a long module, check its length
 against the cap; if you land within a few lines of it, buy the headroom back rather than leaving the
 landmine for the next author.
 
+**But shaving is only one of three moves, and often the worst — there is a sanctioned waiver, and
+three modules already use it.** `# pylint: disable=too-many-lines` is carried today by
+`scripts/parse_tableau.py` (1709), `scripts/deploy_estate.py` (1903) and
+`.github/skills/pbip-model-refresh/scripts/refresh_pbip_model.py` (1305). So on hitting C0302 choose
+deliberately between **shave** (fine for a handful of lines), **split** (best when a genuinely
+cohesive seam exists — extracting the pure verdict-line matchers out of `probe_live_source.py` is a
+worked example) and
+**waive**. Waiving is a legitimate engineering answer when the module is one coherent procedure whose
+length is documented knowledge rather than sprawl; `parse_tableau.py`'s header argues exactly that,
+names the real fix it is deferring, and `deploy_estate.py` cites it as precedent. **A waiver MUST
+carry a one-line reason immediately above it** — a bare pragma is indistinguishable from a deadline
+hack, and one of the three has none. Know all three options *before* spending a cycle shaving:
+`probe_live_source.py` hit the cap three times in two days, and paid in CI failures and a module
+split, while a 1903-line neighbour passed on one comment line.
+
 So the ritual that actually predicts CI is `ruff format` → `ruff check --fix` → **`pylint` (all three
 roots)** → the targeted tests. Every step of that is load-bearing: skipping `pylint` hides `C0301` and
 `C0302`, and running it on only one root hides anything living in a skill bundle.


### PR DESCRIPTION
## Problem

`AGENTS.md` §5 documents the `max-module-lines = 1200` landmine well — pylint scores **10.00/10** right up to the boundary, then fails `C0302` with **exit 16**, a red CI whose message has nothing to do with your change. It ends by telling the reader to *"buy the headroom back"*.

That advice is incomplete in a way that costs real cycles: it presents **shaving as the only move**, and never mentions that `# pylint: disable=too-many-lines` is a sanctioned option **three modules in this repo already carry**.

## Evidence (measured on master, 2026-08-15)

| file | lines | in a pylint root? | outcome |
|---|---:|---|---|
| `scripts/deploy_estate.py` | 1903 | ✅ | waived, with a 3-line reason |
| `scripts/parse_tableau.py` | 1709 | ✅ | waived, with an 8-line reason |
| `.github/skills/pbip-model-refresh/scripts/refresh_pbip_model.py` | 1305 | ✅ | waived, **bare — no reason** |
| `scripts/probe_live_source.py` | 1196 | ✅ | **obeyed it** |

Repo-wide: 114 Python files, median **269** lines, 8 over 1000, 6 over 1200 (the other two are in `tests/`, which pylint does not lint at all).

**Every file in a linted root that has ever reached the cap has opted out of it — except `probe_live_source.py`**, which instead hit it three times in two days (#159 → exactly 1200; #162 → 1233), costing three red CI runs, a rebase and eventually a module split, while a 1903-line neighbour passed on one comment line. As enforced today the cap is **anti-correlated with complexity**: it disciplines the 1196-line module and ignores the 1903-line one.

## Why this is a docs fix, not a config change

The waiver is **not** a loophole being abused. `parse_tableau.py` argues the case properly — *"the honest answer here is that a Tableau parser genuinely is large"* — names the refactor it is deferring (splitting workbook/datasource/worksheet concerns), explains why that does not belong in a credential-gate change, and closes *"Suppressed deliberately, not accidentally."* `deploy_estate.py` cites it as precedent.

That reasoning is sound. It just lives in **exactly the wrong place** — a file header reachable only by someone already editing that file. An agent hitting C0302 on a *different* module finds nothing, follows §5's "buy the headroom back", and starts shaving.

## Change

15 lines in `AGENTS.md` §5, immediately after the existing landmine paragraph:

- names the waiver and the three files that carry it;
- spells out the three moves — **shave / split / waive** — with the criterion for each;
- requires a waiver to carry **a one-line reason immediately above it**, citing the bare pragma on `refresh_pbip_model.py` as the counter-example (with no stated reason it is indistinguishable from a deadline hack, and nobody can tell whether re-examining it is worthwhile).

## Verification

- `sync_agent_conventions.py --check` → **OK, all 4 agents carry the current shared conventions**; the edit is outside the `BEGIN/END:shared-conventions` block, so **no persona files change** and the cap headroom is unchanged (`tableau-migrator` stays at 99%).
- `git diff --stat` → `AGENTS.md | 15 +`, nothing else.
- Deliberately avoids naming any file that exists only on the unmerged #162 branch, so this is **merge-order independent**.

## Follow-up (not in this PR)

The *waiver-hygiene* question is separate and worth deciding deliberately: one of the three pragmas has no reason, and a waived file has **no ceiling at all** afterwards (`deploy_estate.py` reached 1903 with nothing watching). To be filed as an issue.
