### PR TITLE
Fix #193: one dropped connection no longer discards a whole estate assessment

### DIFF
--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -424,6 +424,7 @@ kills the run — it is retried within a bound, then recorded. The contract:
 | exit code | `0` clean or secondary-degraded · **`3` a PRIMARY listing is incomplete** · `1` nothing assessed |
 | `report.md` | a `> ⚠️ **DEGRADED**` blockquote (secondary) or a `# ⚠️ DEGRADED` **first heading** (primary) |
 | `assessment.json` | `degraded`, `degraded_primary`, and `listing_errors[]` naming each endpoint, page, attempts and elapsed time |
+| `estate.db` | the `assessment_run` row carries `degraded` / `degraded_primary` and the counts; `listing_error` rows name each failed listing (error text scrubbed). This is the ONLY degradation signal a programmatic consumer (`harvest_estate_assets.py --db`, `deploy_estate.py --estate-db`) sees — neither opens `assessment.json` |
 | the log | one `[WARN]` per failed listing, then one `[ACTION]` line |
 
 A **secondary** failure (subscriptions, alerts, custom views, group membership, flows) only ever
@@ -921,7 +922,7 @@ self-reported success.
 |---|---|
 | **symptom** | the run finishes and `report.md` opens with a `DEGRADED` banner; the process may exit `3` |
 | **cause** | one or more listings could not be read — a timeout, a dropped connection, or a refusal. Before #193 this was a **traceback** that discarded the whole run (three consecutive failures on one customer estate, on `customviews`, `groups/{id}/users`, `customviews`) |
-| **check** | `listing_errors[]` in `assessment.json` names the endpoint, page, attempt count, elapsed seconds, and `transport: true` when no status code ever came back |
+| **check** | `listing_errors[]` in `assessment.json` (or the `listing_error` table in `estate.db`) names the endpoint, page, attempt count, elapsed seconds, and `transport: true` when no status code ever came back |
 | **fix** | `transport: true` and slow (elapsed ≈ the timeout) → raise `--rest-timeout`; `transport: true` and fast → raise `--max-attempts` / `--retry-budget`; status `401`/`403` → a credential or permission problem, which **no retry can fix** |
 
 **Exit `3` is not a crash — it is a refusal to let a partial inventory pass as an estate.** Exit `0`

--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -416,6 +416,26 @@ decision. Two hard cases show up on nearly every estate: Power BI's Build permis
 all-or-nothing (*"see the chart, not the numbers"* is not expressible), and local Tableau groups have
 no Entra counterpart — that one needs an identity owner and is usually the long pole.
 
+**Check a fourth thing: is the run DEGRADED?** Since #193 a listing that cannot be read no longer
+kills the run — it is retried within a bound, then recorded. The contract:
+
+| where | what to look for |
+|---|---|
+| exit code | `0` clean or secondary-degraded · **`3` a PRIMARY listing is incomplete** · `1` nothing assessed |
+| `report.md` | a `> ⚠️ **DEGRADED**` blockquote (secondary) or a `# ⚠️ DEGRADED` **first heading** (primary) |
+| `assessment.json` | `degraded`, `degraded_primary`, and `listing_errors[]` naming each endpoint, page, attempts and elapsed time |
+| the log | one `[WARN]` per failed listing, then one `[ACTION]` line |
+
+A **secondary** failure (subscriptions, alerts, custom views, group membership, flows) only ever
+*under*-reports deliberate use, so the retire-candidate tier is the one to distrust — the rest of the
+assessment stands. A **primary** failure (workbooks, views, datasources, projects, structure) means
+the coverage curve is computed from data known to be partial: **do not scope from it, re-run.**
+
+Four flags tune the network behaviour; the defaults are the old hard-coded ones:
+`--rest-timeout 180` · `--graphql-timeout 300` · `--max-attempts 3` · `--retry-budget 300`
+(seconds, except attempts). Raise the timeout for a slow connection, raise attempts for a flaky one.
+Neither retries an auth or permission refusal — that is a final answer, and a human has to fix it.
+
 ### Step 3 — lineage plan
 
 `--plan` prints the migration order by leverage: most-consumed published datasource first. The dedup
@@ -895,6 +915,22 @@ count is a signal, not noise. Ground truth is readable *mid-run* — `phase-timi
 journal, the artifact folder — and reading it early is what has caught real failures before a run
 self-reported success.
 
+### 4.11 `assess_estate.py` says DEGRADED, or exits 3
+
+| | |
+|---|---|
+| **symptom** | the run finishes and `report.md` opens with a `DEGRADED` banner; the process may exit `3` |
+| **cause** | one or more listings could not be read — a timeout, a dropped connection, or a refusal. Before #193 this was a **traceback** that discarded the whole run (three consecutive failures on one customer estate, on `customviews`, `groups/{id}/users`, `customviews`) |
+| **check** | `listing_errors[]` in `assessment.json` names the endpoint, page, attempt count, elapsed seconds, and `transport: true` when no status code ever came back |
+| **fix** | `transport: true` and slow (elapsed ≈ the timeout) → raise `--rest-timeout`; `transport: true` and fast → raise `--max-attempts` / `--retry-budget`; status `401`/`403` → a credential or permission problem, which **no retry can fix** |
+
+**Exit `3` is not a crash — it is a refusal to let a partial inventory pass as an estate.** Exit `0`
+with a blockquote banner means every primary listing was read in full and only a deliberate-use
+signal is missing; that assessment is usable, with the retire tier flagged as unproven.
+
+The pass-1 inventory is written to `_assessment/raw/` **before** the flakier passes run, so even a
+later failure leaves the expensive part on disk.
+
 ---
 
 ## 5. Verification checklist
@@ -1122,6 +1158,7 @@ Placeholders used in this document — and where the real value lives:
 | script | 0 | 1 | 2 | 3 | 4 | 5 | 6 |
 |---|---|---|---|---|---|---|---|
 | `preflight.ps1` | ready | critical missing | — | — | — | — | — |
+| `assess_estate.py` | assessed (may be secondary-degraded) | nothing assessed · sign-in refused (raises) | usage | **a PRIMARY listing is incomplete** | — | — | — |
 | `run_estate.py` | READY | engine failed | usage | **DoD failed** | approval collision | non-canonical engine | **empty model** |
 | `deploy_estate.py` | all deployed | item failed / refused | preflight | **incomplete by skip** | — | — | — |
 

--- a/scripts/assess_estate.py
+++ b/scripts/assess_estate.py
@@ -614,8 +614,11 @@ CREATE TABLE IF NOT EXISTS permission (
   grantee_type TEXT, grantee_luid TEXT, capability TEXT, mode TEXT);
 CREATE TABLE IF NOT EXISTS flow (luid TEXT PRIMARY KEY, name TEXT, project TEXT);
 -- Run-level completeness, added in #196. Before it, a survived-but-partial run (#193) wrote a DB
--- BYTE-IDENTICAL to a clean one, so a programmatic consumer (harvest_estate_assets.py --db,
--- deploy_estate.py --estate-db) that never opens assessment.json could not tell the two apart.
+-- INDISTINGUISHABLE from a clean run of a smaller estate: a consumer cannot tell "0 views because
+-- the site has none" from "0 views because the listing died", and has no clean run of the same site
+-- to diff against. (Not byte-identical - a primary failure also scores complexity 0 - but a
+-- programmatic consumer (harvest_estate_assets.py --db, deploy_estate.py --estate-db) that never
+-- opens assessment.json has no signal either way.)
 CREATE TABLE IF NOT EXISTS assessment_run (
   assessed_at TEXT, degraded INTEGER, degraded_primary INTEGER,
   workbooks_total INTEGER, listing_errors INTEGER);

--- a/scripts/assess_estate.py
+++ b/scripts/assess_estate.py
@@ -3,6 +3,8 @@ purpose: assess a Tableau estate before migrating any of it - what exists, what 
          how hard each workbook is, and who can see it - and emit a decision, not an inventory.
 usage:   python scripts/assess_estate.py --out _assessment [--survey <estate_survey.json>]
                                          [--coverage-target 0.99] [--env .env]
+                                         [--rest-timeout 180] [--graphql-timeout 300]
+                                         [--max-attempts 3] [--retry-budget 300]
 
 Why this exists
 ---------------
@@ -35,29 +37,92 @@ Four things it will not do, each for a measured reason
 4. **It does not claim a usage window it does not have.** Tableau **Cloud** REST returns
    ``usage.totalViewCount`` as a LIFETIME figure - there is no "last 90 days" without Admin Insights
    or (on Server) the Postgres repository. It is labelled ``lifetime`` everywhere.
+
+Failure handling: a listing that cannot be read is DEGRADED, never silent
+------------------------------------------------------------------------
+``get()`` was always meant to be resilient - "one 403 on one workbook's permissions must not void an
+estate-wide assessment" - but that resilience was **status-code shaped**, so a connection that timed
+out or dropped never produced a status at all, bypassed the whole recovery ladder and killed the
+process. Three consecutive customer runs died that way on three different SECONDARY endpoints, each
+after minutes of real work, discarding a completed inventory (issue #193).
+
+Every read now ends in one of three places, kept apart deliberately:
+
+* **read** - rows, no error.
+* **degraded** - the rows we did get, plus a ``listing_errors`` entry, the top-level ``degraded``
+  flag in ``assessment.json`` and a ``[WARN]`` line in the report. A SECONDARY listing
+  (subscriptions, alerts, custom views, group membership, flows) degrades alone, exit 0.
+* **loud** - a PRIMARY listing (workbooks, views, datasources, projects, structure) is what every
+  number downstream is computed from, so its incompleteness leads the report and exits **3**. A
+  degraded assessment mistaken for a clean one is worse than the crash this replaced: a crash
+  cannot be mistaken for success.
+
+Retries are bounded and classified (the split ``capture_tableau_oracle.py`` uses): a timeout, reset
+connection or gateway 5xx is transient and earns backoff; **an auth or permission refusal is a final
+answer and is never retried** - no number of retries conjures a credential.
+
+Exit codes: ``0`` assessed (possibly degraded on secondary listings), ``1`` nothing could be
+assessed, ``3`` a PRIMARY listing was incomplete - the assessment is not a complete inventory.
 """
+
+# This module is over the 1200-line cap. The cap is a proxy for "this module does too much", and the
+# honest answer is that it was already at 68% of it before #193 forced a real transport layer into a
+# script that had one `try/except`. The real fix is extracting the Tableau REST client that
+# `capture_tableau_oracle.py` already carries a near-duplicate of, into one shared module - a
+# refactor that must not ride along with a hotfix for a blocked customer engagement. Trimming the
+# explanatory docstrings to squeeze under would trade documented knowledge for a number, which is
+# the wrong trade in this codebase. Suppressed deliberately, not accidentally.
+# pylint: disable=too-many-lines
 
 from __future__ import annotations
 
 import argparse
+import http.client
 import json
 import logging
+import random
 import re
 import sqlite3
 import sys
 import time
 import urllib.error
 import urllib.request
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from tableau_env import env_source, pat_secret, require, resolve_env  # noqa: E402  # pylint: disable=wrong-import-position
+from tableau_env import env_source, pat_secret, redact, require, resolve_env  # noqa: E402  # pylint: disable=wrong-import-position
 
 LOG = logging.getLogger("assess")
 
 SESSION_LOST = "401002"
 MAX_REAUTH = 2
+
+# Timeouts, named and configurable (--rest-timeout / --graphql-timeout). They were two undocumented
+# magic numbers, and 180 s is exactly how long each of the three failed customer runs took to die.
+DEFAULT_REST_TIMEOUT_SEC = 180.0
+DEFAULT_GRAPHQL_TIMEOUT_SEC = 300.0
+GRAPHQL_ROOT = "/api/metadata/graphql"
+
+# Recovery bounds. BOTH are needed: attempts alone let a slow-failing endpoint eat an estate run
+# (3 attempts x a 180 s timeout is 9 minutes on ONE listing), and a wall-clock budget alone would
+# allow an unbounded fast loop against a connection that is refused instantly.
+DEFAULT_MAX_ATTEMPTS = 3
+DEFAULT_RETRY_BUDGET_SEC = 300.0
+BACKOFF_BASE_SEC = 1.0
+BACKOFF_CAP_SEC = 30.0
+
+# Status 0 is our own marker for a failure that never produced an HTTP status at all - a timeout, a
+# reset connection, DNS. It is the case the whole status-code ladder used to miss.
+NETWORK_ERROR_STATUS = 0
+TRANSIENT_STATUSES = frozenset({NETWORK_ERROR_STATUS, 429, 500, 502, 503, 504})
+AUTH_STATUSES = frozenset({401, 403})
+
+# How badly a missing listing hurts the assessment. PRIMARY feeds every number downstream - the
+# coverage curve, the complexity score, the tier - so it is loud; SECONDARY degrades on its own.
+PRIMARY = "primary"
+SECONDARY = "secondary"
 
 # Tableau calc idioms that drive migration effort. LOD and table calcs are weighted heaviest because
 # they are what DAX translation actually struggles with - the same weighting an existing open-source
@@ -71,19 +136,122 @@ TABLE_CALC_RE = re.compile(
 WEIGHTS = {"sheets": 1.0, "dashboards": 2.0, "calcs": 1.0, "lods": 5.0, "table_calcs": 5.0}
 
 
-class Site:
-    """Read-only Tableau client. Re-authenticates on mid-run session loss and records that it did."""
+@dataclass(frozen=True)
+class HttpPolicy:
+    """Timeouts and recovery bounds for one run. Every value is CLI-settable, none is a magic number."""
 
-    def __init__(self, env: dict[str, str]) -> None:
+    rest_timeout: float = DEFAULT_REST_TIMEOUT_SEC
+    graphql_timeout: float = DEFAULT_GRAPHQL_TIMEOUT_SEC
+    max_attempts: int = DEFAULT_MAX_ATTEMPTS
+    retry_budget_sec: float = DEFAULT_RETRY_BUDGET_SEC
+
+
+@dataclass(frozen=True)
+class Listing:
+    """One paged REST listing, and how badly the assessment is hurt when it cannot be read."""
+
+    label: str
+    path: str
+    collection: str
+    item: str
+    severity: str = SECONDARY
+
+
+# Pass 1. The expensive inventory, and the only listings whose absence invalidates the numbers:
+# `views` is PRIMARY because the coverage curve - the artifact the whole decision is taken on - is
+# built entirely from view usage, so a partial view listing produces a confident wrong curve.
+INVENTORY = (
+    Listing("workbooks", "/workbooks", "workbooks", "workbook", PRIMARY),
+    Listing("views", "/views?includeUsageStatistics=true", "views", "view", PRIMARY),
+    Listing("datasources", "/datasources", "datasources", "datasource", PRIMARY),
+    Listing("projects", "/projects", "projects", "project", PRIMARY),
+    Listing("groups", "/groups", "groups", "group"),
+    Listing("flows", "/flows", "flows", "flow"),
+)
+
+# Pass 1b. Deliberate-use signals: each one can only ADD a workbook to the migrate tier, never
+# remove one, so a missing signal understates deliberate use rather than inventing it. Recorded and
+# reported, not fatal - two of the three failed customer runs died here, on `customviews`.
+SIGNALS = (
+    Listing("subscriptions", "/subscriptions", "subscriptions", "subscription"),
+    Listing("alerts", "/dataAlerts", "dataAlerts", "dataAlert"),
+    Listing("custom_views", "/customviews", "customViews", "customView"),
+)
+
+
+def classify(status: int, text: str) -> str:
+    """Map one REST outcome to what the caller should DO about it.
+
+    Order matters. ``401002`` is our own session dying mid-run and is fixed by re-authenticating. A
+    transient status (gateway 5xx, 429, or a network-level failure that never produced a status) is
+    fixed by waiting. Anything else - 401, 403, 404 - is a **final answer**: retrying an auth or
+    permission refusal burns the budget and still cannot succeed, and only a human can fix it
+    (AGENTS.md: "a MISSING CREDENTIAL is not transient"). Transient is checked BEFORE the auth
+    statuses so a gateway 503 is never misfiled as a permanent block.
+    """
+    if status == 200:
+        return "ok"
+    if SESSION_LOST in text:
+        return "session_lost"
+    if status in TRANSIENT_STATUSES:
+        return "transient"
+    if status in AUTH_STATUSES:
+        return "denied"
+    return "failed"
+
+
+def backoff_delay(attempt: int, *, jitter: bool = True) -> float:
+    """Exponential backoff with full jitter, capped.
+
+    Jitter matters even for a sequential assessment: without it, a run that trips a rate limit
+    retries in lockstep with every other client behind the same gateway.
+    """
+    delay = min(BACKOFF_CAP_SEC, BACKOFF_BASE_SEC * (2 ** (attempt - 1)))
+    return delay * (0.5 + random.random() / 2) if jitter else delay
+
+
+def _error_body(exc: urllib.error.HTTPError) -> bytes:
+    """Read an error body without letting a SECOND failure escape the handler.
+
+    The connection that just returned 500 is exactly the one likely to drop while its body is read.
+    """
+    try:
+        return exc.read()
+    except (OSError, http.client.HTTPException) as inner:  # pragma: no cover - defensive
+        return f"{type(inner).__name__}: {inner}".encode()
+
+
+def _took(started: float) -> str:
+    """Elapsed for one endpoint, in ``harvest_estate_assets.py``'s ``elapsed=Ns`` idiom."""
+    return f"elapsed={time.monotonic() - started:.1f}s"
+
+
+class Site:  # pylint: disable=too-many-instance-attributes  # one client: credentials, policy, recovery telemetry
+    """Read-only Tableau client. Re-authenticates on mid-run session loss and records that it did.
+
+    It never raises for a failed read. Every failure - status code or transport - comes back as a
+    recorded error so the caller can degrade one data point instead of losing the whole run.
+    """
+
+    def __init__(self, env: dict[str, str], policy: HttpPolicy | None = None) -> None:
         self.base = env["TABLEAU_SERVER_URL"].rstrip("/")
         self.version = env.get("TABLEAU_REST_API_VERSION", "3.21")
         self.site = env["TABLEAU_SITE"]
         self._pat = (env["TABLEAU_PAT_NAME"], pat_secret(env))
+        self.policy = policy or HttpPolicy()
         self.token: str | None = None
         self.site_id: str | None = None
         self.reauths = 0
+        self.retries = 0
+        # Set once authentication is known to be impossible. Without it, a re-auth that cannot
+        # succeed makes every remaining call pay the full retry budget - hundreds of endpoints x
+        # minutes each - which is the unbounded stall the crash at least made obvious.
+        self.auth_failed = False
+        self.errors: list[dict[str, Any]] = []
 
     def _raw(self, method: str, path: str, body: dict | None = None, root: str | None = None):
+        """One HTTP round trip. Never raises for a transport failure - returns status 0 instead, so
+        a dropped connection and a gateway 503 travel the same recovery ladder."""
         url = f"{self.base}{root or f'/api/{self.version}'}{path}"
         request = urllib.request.Request(url, data=json.dumps(body).encode() if body else None, method=method)
         request.add_header("Accept", "application/json")
@@ -91,29 +259,50 @@ class Site:
             request.add_header("Content-Type", "application/json")
         if self.token:
             request.add_header("X-Tableau-Auth", self.token)
+        timeout = self.policy.graphql_timeout if root == GRAPHQL_ROOT else self.policy.rest_timeout
         try:
-            with urllib.request.urlopen(request, timeout=180) as response:
+            with urllib.request.urlopen(request, timeout=timeout) as response:
                 return response.status, response.read()
         except urllib.error.HTTPError as exc:
-            return exc.code, exc.read()
+            return exc.code, _error_body(exc)
+        except (OSError, http.client.HTTPException) as exc:
+            # URLError (an OSError subclass) covers DNS/refused/timeout; TimeoutError and
+            # ConnectionResetError are OSErrors too; HTTPException covers RemoteDisconnected and
+            # IncompleteRead, which urlopen does not always wrap. None of these carries a status.
+            return NETWORK_ERROR_STATUS, f"{type(exc).__name__}: {exc}".encode()
 
     def sign_in(self) -> None:
-        """Exchange the PAT for a session token."""
-        status, payload = self._raw(
-            "POST",
-            "/auth/signin",
-            {
-                "credentials": {
-                    "personalAccessTokenName": self._pat[0],
-                    "personalAccessTokenSecret": self._pat[1],
-                    "site": {"contentUrl": self.site},
-                }
-            },
-        )
-        if status != 200:
-            raise RuntimeError(f"sign-in failed: HTTP {status} (check the PAT NAME and SECRET - two values)")
-        creds = json.loads(payload)["credentials"]
-        self.token, self.site_id = creds["token"], creds["site"]["id"]
+        """Exchange the PAT for a session token, retrying TRANSIENT failures only.
+
+        A gateway blip here would otherwise abort the whole assessment before it starts. A wrong or
+        revoked PAT is a final answer and fails on the first attempt, without burning the budget.
+        """
+        credentials = {
+            "credentials": {
+                "personalAccessTokenName": self._pat[0],
+                "personalAccessTokenSecret": self._pat[1],
+                "site": {"contentUrl": self.site},
+            }
+        }
+        for attempt in range(1, self.policy.max_attempts + 1):
+            status, payload = self._raw("POST", "/auth/signin", credentials)
+            text = self._scrub(payload)
+            if status == 200:
+                creds = json.loads(payload)["credentials"]
+                self.token, self.site_id = creds["token"], creds["site"]["id"]
+                return
+            if classify(status, text) != "transient" or attempt == self.policy.max_attempts:
+                self.auth_failed = True
+                hint = (
+                    "the server could not be reached"
+                    if status == NETWORK_ERROR_STATUS
+                    else "check the PAT NAME and SECRET - two values"
+                )
+                raise RuntimeError(f"sign-in failed: HTTP {status} after {attempt} attempt(s) ({hint}): {text[:200]}")
+            self.retries += 1
+            delay = backoff_delay(attempt)
+            LOG.warning("  sign-in transient failure (HTTP %s); retry %d in %.1fs", status, attempt, delay)
+            time.sleep(delay)
 
     def sign_out(self) -> None:
         """Best-effort release."""
@@ -121,51 +310,135 @@ class Site:
             self._raw("POST", "/auth/signout")
             self.token = None
 
+    def _fail(self, record: dict[str, Any]) -> dict[str, Any]:
+        """Record one FINAL failure on the site and hand the same dict back to the caller."""
+        self.errors.append(record)
+        return record
+
+    def _scrub(self, payload: bytes) -> str:
+        """Decode a response body with every credential known at this point removed.
+
+        Failure text is now PERSISTED - into ``assessment.json`` and ``report.md`` - so a proxy, WAF
+        or debug endpoint that echoes the request body would write the owner's full-permission PAT
+        into two durable artifacts. Scrub at the point of capture (the measured hazard behind
+        ``tableau_env.redact``), not at the point of writing.
+        """
+        return redact(payload.decode("utf-8", "replace"), self._pat[1], self.token or "")
+
+    def _may_retry(self, kind: str, attempt: int, started: float, delay: float) -> bool:
+        """Retry only a TRANSIENT fault, and only inside BOTH bounds.
+
+        Attempts alone cannot stop a slow-failing endpoint from eating the run (3 x a 180 s timeout
+        is 9 minutes on one listing); a wall-clock budget alone would allow an unbounded fast loop
+        against a connection refused instantly. The next delay is counted against the budget, so the
+        run never sleeps its way past it.
+        """
+        return (
+            kind == "transient"
+            and attempt < self.policy.max_attempts
+            and time.monotonic() - started + delay < self.policy.retry_budget_sec
+        )
+
+    def _request_json(self, method: str, path: str, body: dict | None = None, root: str | None = None):
+        """The one recovery ladder -> ``(payload, error)``; exactly one of the two is ever set.
+
+        Re-authenticate on session loss, back off on a transient fault within a bounded budget, and
+        return a recorded error for anything a retry cannot change. It never raises: the caller's
+        job is to degrade one data point, not to lose an estate-wide assessment.
+        """
+        started = time.monotonic()
+        if self.auth_failed:
+            return None, self._fail(_record(path, NETWORK_ERROR_STATUS, "authentication failed; not retrying", 0, 0.0))
+        reauths = attempt = 0
+        while True:
+            attempt += 1
+            status, payload = self._raw(method, path, body, root)
+            text = self._scrub(payload)
+            kind = classify(status, text)
+            if kind == "ok":
+                try:
+                    return json.loads(payload), None
+                except json.JSONDecodeError as exc:
+                    detail = f"HTTP 200 but the body is not JSON ({exc}) - a proxy or portal answered"
+                    return None, self._fail(_record(path, status, detail, attempt, started))
+            if kind == "session_lost" and reauths < MAX_REAUTH:
+                reauths += 1
+                self.reauths += 1
+                try:
+                    self.sign_in()
+                    continue
+                except RuntimeError as exc:
+                    return None, self._fail(_record(path, status, f"re-authentication failed: {exc}", attempt, started))
+            detail = f"{'transport' if status == NETWORK_ERROR_STATUS else f'HTTP {status}'}: {text[:200]}"
+            delay = backoff_delay(attempt)
+            if not self._may_retry(kind, attempt, started, delay):
+                return None, self._fail(_record(path, status, detail, attempt, started))
+            self.retries += 1
+            LOG.warning("  %s -> %s; retry %d/%d in %.1fs", path, detail[:90], attempt, self.policy.max_attempts, delay)
+            time.sleep(delay)
+
     def get(self, path: str) -> dict[str, Any] | None:
         """GET a metadata endpoint, recovering from mid-run session loss.
 
         Returns ``None`` on a permission or not-found failure rather than raising: one 403 on one
-        workbook's permissions must not void an estate-wide assessment.
+        workbook's permissions must not void an estate-wide assessment. Since #193 that promise also
+        covers a failure that never produced a status at all - a timeout, a reset connection - which
+        used to bypass this ladder entirely and take the process down.
         """
-        for _ in range(MAX_REAUTH + 1):
-            status, payload = self._raw("GET", path)
-            if status == 200:
-                return json.loads(payload)
-            if SESSION_LOST in payload.decode("utf-8", "replace"):
-                self.reauths += 1
-                self.sign_in()
-                continue
-            return None
-        return None
+        return self._request_json("GET", path)[0]
 
-    def paged(self, path: str, collection: str, item: str) -> list[dict]:
-        """Follow REST pagination to completion. A survey that stops at page 1 under-reports."""
+    def get_checked(self, path: str) -> tuple[dict[str, Any] | None, dict | None]:
+        """GET -> ``(payload, error)``, for callers that must tell a REFUSAL from a lost connection.
+
+        ``get`` collapses both to ``None``, which is right where a 403 is expected and benign and
+        wrong where the difference decides whether the output is degraded.
+        """
+        return self._request_json("GET", path)
+
+    def paged(self, path: str, collection: str, item: str) -> tuple[list[dict], dict | None]:
+        """Follow REST pagination to completion -> ``(rows, error)``.
+
+        A survey that stops at page 1 under-reports. A page that FAILS is worse, and used to be
+        fatal: the rows read so far are returned WITH the error, so the caller reports a partial
+        listing loudly instead of passing a truncated list off as complete.
+        """
         out: list[dict] = []
         page = 1
         while page <= 1000:
             sep = "&" if "?" in path else "?"
-            payload = self.get(f"{path}{sep}pageSize=1000&pageNumber={page}")
-            if not payload:
-                break
-            block = payload.get(collection) or {}
+            payload, error = self._request_json("GET", f"{path}{sep}pageSize=1000&pageNumber={page}")
+            if error:
+                return out, {**error, "page": page}
+            block = (payload or {}).get(collection) or {}
             rows = block.get(item) or []
             rows = [rows] if isinstance(rows, dict) else rows
             out.extend(rows)
-            total = int((payload.get("pagination") or {}).get("totalAvailable", 0))
+            total = int(((payload or {}).get("pagination") or {}).get("totalAvailable", 0))
             if not rows or len(out) >= total:
                 break
             page += 1
-        return out
+        return out, None
 
-    def graphql(self, query: str) -> dict[str, Any]:
-        """One Metadata API call. Used for STRUCTURE only - never for dependencies (see module doc)."""
-        request = urllib.request.Request(
-            f"{self.base}/api/metadata/graphql", data=json.dumps({"query": query}).encode(), method="POST"
-        )
-        request.add_header("Content-Type", "application/json")
-        request.add_header("X-Tableau-Auth", self.token)
-        with urllib.request.urlopen(request, timeout=300) as response:
-            return json.loads(response.read())
+    def graphql(self, query: str) -> tuple[dict[str, Any], dict | None]:
+        """One Metadata API call -> ``(payload, error)``. Used for STRUCTURE only (see module doc).
+
+        It had no handler at all, which made it strictly worse than the REST path: even a plain
+        ``HTTPError`` was fatal. It now travels the same ladder, with its own longer timeout.
+        """
+        payload, error = self._request_json("POST", "", {"query": query}, GRAPHQL_ROOT)
+        return payload or {}, error
+
+
+def _record(path: str, status: int, detail: str, attempts: int, started: float) -> dict[str, Any]:
+    """One machine-readable failure. ``transport`` separates "no answer" from "an answer we dislike"."""
+    return {
+        "path": path,
+        "status": status,
+        "error": detail,
+        "attempts": attempts,
+        "elapsed_sec": round(time.monotonic() - started, 1) if started else 0.0,
+        "transport": status == NETWORK_ERROR_STATUS,
+    }
 
 
 # `role` and `dataType` live on the CONCRETE types, not the Field interface - `fields { role }`
@@ -332,86 +605,167 @@ CREATE TABLE IF NOT EXISTS flow (luid TEXT PRIMARY KEY, name TEXT, project TEXT)
 """
 
 
-def _collect_iam(site: Site, projects: list[dict], workbooks: list[dict]) -> list[dict]:
-    """Export grants. Per-item grants are only collected where owners were free to diverge."""
+def _collect_iam(site: Site, projects: list[dict], workbooks: list[dict]) -> tuple[list[dict], list[dict]]:
+    """Export grants -> ``(rows, errors)``. Per-item grants are only collected where owners diverge.
+
+    This is the longest loop in the script - one call per project plus one per unlocked workbook -
+    so it is also where a flaky connection is most likely to land. An unreadable object degrades the
+    IAM export by one row set and is recorded; it never aborts the pass.
+    """
     permissions: list[dict] = []
+    errors: list[dict] = []
     locked = 0
+    started = time.monotonic()
     for project in projects:
-        permissions.extend(_grants(site, "project", project["id"], project.get("name"), f"/projects/{project['id']}"))
+        rows, error = _grants(site, "project", project["id"], project.get("name"), f"/projects/{project['id']}")
+        permissions.extend(rows)
+        errors.extend(error)
         if (project.get("contentPermissions") or "").startswith("LockedToProject"):
             locked += 1
     unlocked = {p["id"] for p in projects if not (p.get("contentPermissions") or "").startswith("LockedToProject")}
-    for workbook in workbooks:
-        if (workbook.get("project") or {}).get("id") in unlocked:
-            permissions.extend(
-                _grants(site, "workbook", workbook["id"], workbook.get("name"), f"/workbooks/{workbook['id']}")
+    todo = [w for w in workbooks if (w.get("project") or {}).get("id") in unlocked]
+    for index, workbook in enumerate(todo, 1):
+        rows, error = _grants(site, "workbook", workbook["id"], workbook.get("name"), f"/workbooks/{workbook['id']}")
+        permissions.extend(rows)
+        errors.extend(error)
+        if index % 25 == 0 or index == len(todo):
+            LOG.info(
+                "  [%d/%d] workbook grants, %d row(s) so far %s", index, len(todo), len(permissions), _took(started)
             )
     LOG.info(
-        "  %d project(s) LockedToProject -> per-item grants skipped there; %d grant rows", locked, len(permissions)
+        "  %d project(s) LockedToProject -> per-item grants skipped there; %d grant rows %s",
+        locked,
+        len(permissions),
+        _took(started),
     )
-    return permissions
+    return permissions, errors
 
 
-def collect(site: Site, survey: dict | None) -> dict[str, Any]:  # pylint: disable=too-many-locals
+def _listing(site: Site, spec: Listing) -> tuple[list[dict], dict | None]:
+    """Read one paged listing, timed, and classify any failure by the listing's SEVERITY.
+
+    The endpoint is named BEFORE the call and the elapsed time after it, because during the run that
+    is the only difference between "slow" and "dead" - the failing customer runs looked identical to
+    a working one for 180 s, then produced a traceback.
+    """
+    path = f"/sites/{site.site_id}{spec.path}"
+    LOG.info("  %-14s reading %s", spec.label, path)
+    started = time.monotonic()
+    rows, error = site.paged(path, spec.collection, spec.item)
+    if error:
+        LOG.warning(
+            "  [WARN] %-14s INCOMPLETE - %d row(s) read, then: %s (%s)",
+            spec.label,
+            len(rows),
+            error["error"][:120],
+            _took(started),
+        )
+        return rows, {"listing": spec.label, "severity": spec.severity, **error}
+    LOG.info("  %-14s %5d row(s) %s", spec.label, len(rows), _took(started))
+    return rows, None
+
+
+def _collect_listings(site: Site, specs: tuple[Listing, ...]) -> tuple[dict[str, list], list[dict]]:
+    """Read a group of listings, keyed by label, collecting each failure INDIVIDUALLY."""
+    out: dict[str, list] = {}
+    errors: list[dict] = []
+    for spec in specs:
+        rows, error = _listing(site, spec)
+        out[spec.label] = rows
+        if error:
+            errors.append(error)
+    return out, errors
+
+
+def _group_members(site: Site, groups: list[dict]) -> list[dict]:
+    """Count each group's membership. One unreadable group degrades ONE group, not the pass.
+
+    An unread group records ``_members = None`` (SQL NULL), never 0: "we could not see it" and "it
+    is empty" are opposite answers, and 0 is the one that reads as a finding.
+    """
+    errors: list[dict] = []
+    started = time.monotonic()
+    for group in groups:
+        rows, error = site.paged(f"/sites/{site.site_id}/groups/{group['id']}/users", "users", "user")
+        group["_members"] = None if error else len(rows)
+        if error:
+            LOG.warning("  [WARN] group %r membership UNREADABLE: %s", group.get("name"), error["error"][:120])
+            errors.append({"listing": f"group members: {group.get('name')}", "severity": SECONDARY, **error})
+    LOG.info("  %-14s %5d group(s) %s", "group members", len(groups), _took(started))
+    return errors
+
+
+def _pass2_structure(site: Site) -> tuple[dict[str, Any], list[dict]]:
+    """One GraphQL call for the whole estate -> ``(data, errors)``.
+
+    A structure failure is PRIMARY: ``score_workbook`` answers 0 for a workbook it cannot see, and 0
+    complexity is not "simple", it is "unknown" - it feeds the retire-candidate tier directly.
+    """
+    LOG.info("pass 2: structure (one GraphQL call for the whole estate)")
+    started = time.monotonic()
+    payload, error = site.graphql(STRUCTURE_QUERY)
+    data = payload.get("data") or {}
+    errors: list[dict] = []
+    if error:
+        LOG.warning("  [WARN] structure UNREADABLE: %s - every complexity score would be 0", error["error"][:150])
+        errors.append({"listing": "structure", "severity": PRIMARY, **error})
+    elif payload.get("errors"):
+        detail = f"Metadata API errors: {str(payload['errors'])[:200]}"
+        severity = SECONDARY if data.get("workbooks") else PRIMARY
+        LOG.warning("  [WARN] %s (%s)", detail, severity)
+        errors.append({"listing": "structure", "severity": severity, **_record(GRAPHQL_ROOT, 200, detail, 1, started)})
+    LOG.info("  %-14s %5d workbook node(s) %s", "structure", len(data.get("workbooks") or []), _took(started))
+    return data, errors
+
+
+def collect(site: Site, survey: dict | None, checkpoint=None) -> dict[str, Any]:
     """Run the passes in cost order, cheapest first.
 
-    One local per REST collection - splitting further would only hide the shape of the estate.
+    ``checkpoint`` is called with the pass-1 inventory the moment it is complete, BEFORE the flakier
+    per-item and secondary passes run: pass 1 is the expensive part (273 workbooks / 1042 views on
+    the estate in #193) and losing it to a failure minutes later is what made the crash so costly.
     """
     LOG.info("pass 1: inventory")
-    workbooks = site.paged(f"/sites/{site.site_id}/workbooks", "workbooks", "workbook")
-    views = site.paged(f"/sites/{site.site_id}/views?includeUsageStatistics=true", "views", "view")
-    datasources = site.paged(f"/sites/{site.site_id}/datasources", "datasources", "datasource")
-    projects = site.paged(f"/sites/{site.site_id}/projects", "projects", "project")
-    groups = site.paged(f"/sites/{site.site_id}/groups", "groups", "group")
-    flows = site.paged(f"/sites/{site.site_id}/flows", "flows", "flow")
+    inventory, errors = _collect_listings(site, INVENTORY)
     LOG.info(
         "  %d workbooks, %d views, %d datasources, %d projects, %d groups, %d flows",
-        len(workbooks),
-        len(views),
-        len(datasources),
-        len(projects),
-        len(groups),
-        len(flows),
+        *(len(inventory[spec.label]) for spec in INVENTORY),
     )
+    if checkpoint:
+        checkpoint(inventory)
 
-    for group in groups:
-        group["_members"] = len(site.paged(f"/sites/{site.site_id}/groups/{group['id']}/users", "users", "user"))
+    errors += _group_members(site, inventory["groups"])
 
     LOG.info("pass 1b: deliberate-use signals")
-    subs = site.paged(f"/sites/{site.site_id}/subscriptions", "subscriptions", "subscription")
-    alerts = site.paged(f"/sites/{site.site_id}/dataAlerts", "dataAlerts", "dataAlert")
-    custom = site.paged(f"/sites/{site.site_id}/customviews", "customViews", "customView")
+    signals, signal_errors = _collect_listings(site, SIGNALS)
+    errors += signal_errors
 
-    LOG.info("pass 2: structure (one GraphQL call for the whole estate)")
-    structure = site.graphql(STRUCTURE_QUERY)
-    if structure.get("errors"):
-        LOG.warning("  Metadata API errors: %s", str(structure["errors"])[:200])
-    data = structure.get("data") or {}
-    by_name = {w["name"]: w for w in data.get("workbooks") or []}
+    data, structure_errors = _pass2_structure(site)
+    errors += structure_errors
 
     LOG.info("pass 3: IAM (gated on contentPermissions)")
-    permissions = _collect_iam(site, projects, workbooks)
+    permissions, iam_errors = _collect_iam(site, inventory["projects"], inventory["workbooks"])
+    errors += iam_errors
 
     return {
-        "workbooks": workbooks,
-        "views": views,
-        "datasources": datasources,
-        "projects": projects,
-        "groups": groups,
-        "flows": flows,
-        "subscriptions": subs,
-        "alerts": alerts,
-        "custom_views": custom,
+        **inventory,
+        **signals,
         "structure": data,
-        "structure_by_name": by_name,
+        "structure_by_name": {w["name"]: w for w in data.get("workbooks") or []},
         "permissions": permissions,
         "survey": survey,
+        "collection_errors": errors,
     }
 
 
-def _grants(site: Site, object_type: str, luid: str, name: str | None, path: str) -> list[dict]:
-    """Flatten one object's granteeCapabilities into rows. A 403 yields nothing, never an abort."""
-    payload = site.get(f"/sites/{site.site_id}{path}/permissions")
+def _grants(site: Site, object_type: str, luid: str, name: str | None, path: str) -> tuple[list[dict], list[dict]]:
+    """Flatten one object's granteeCapabilities into rows. A 403 yields nothing, never an abort.
+
+    Returns ``(rows, errors)``: a 403 is a genuine answer ("you may not see this") and stays silent,
+    while a transport failure is NO answer and is recorded, so an IAM export thinned by a flaky
+    connection cannot be read as an estate with fewer grants.
+    """
+    payload, error = site.get_checked(f"/sites/{site.site_id}{path}/permissions")
     rows = []
     for grantee in ((payload or {}).get("permissions") or {}).get("granteeCapabilities") or []:
         kind = "group" if "group" in grantee else "user"
@@ -428,7 +782,9 @@ def _grants(site: Site, object_type: str, luid: str, name: str | None, path: str
                     "mode": capability.get("mode"),
                 }
             )
-    return rows
+    if error and error.get("transport"):
+        return rows, [{"listing": f"{object_type} grants: {name}", "severity": SECONDARY, **error}]
+    return rows, []
 
 
 def _aggregate_signals(raw: dict[str, Any]) -> tuple[dict[str, list], dict[str, dict[str, int]]]:
@@ -533,7 +889,45 @@ def assemble(raw: dict[str, Any], target: float) -> dict[str, Any]:
         "dependencies": dep_rows,
         "survey_supplied": survey is not None,
         "iam_hard_cases": iam_hard_cases(raw["permissions"], raw["groups"]),
+        **_degraded_contract(raw.get("collection_errors") or [], len(curve)),
     }
+
+
+def _degraded_contract(errors: list[dict], workbooks_total: int) -> dict[str, Any]:
+    """The machine-readable incompleteness contract, ported from the engine's ``estate_survey.py``.
+
+    One flag every consumer can trust, so "we could not read it" is never taken for "it is not
+    there". ``degraded_primary`` is the half that must never be quiet - it drives exit code 3.
+    """
+    primary = any(e.get("severity") == PRIMARY for e in errors)
+    return {
+        "listing_errors": errors,
+        "degraded": bool(errors),
+        "degraded_primary": primary,
+        "summary": {
+            "workbooks_total": workbooks_total,
+            "listing_errors": len(errors),
+            "degraded": bool(errors),
+            "degraded_primary": primary,
+        },
+    }
+
+
+def _write_raw(out: Path, payload: dict[str, Any]) -> None:
+    """Write raw API responses as evidence. Called twice on purpose - see ``_checkpoint``."""
+    (out / "raw").mkdir(parents=True, exist_ok=True)
+    for key, value in payload.items():
+        (out / "raw" / f"{key}.json").write_text(json.dumps(value, indent=2), encoding="utf-8")
+
+
+def _checkpoint(out: Path, inventory: dict[str, list]) -> None:
+    """Persist the pass-1 inventory the moment it exists, before anything flakier runs.
+
+    Nothing used to be written until ``main`` completed, so a failure in a secondary pass discarded
+    a finished inventory of 273 workbooks and 1042 views - three times in one afternoon (#193).
+    """
+    _write_raw(out, inventory)
+    LOG.info("  checkpoint: pass-1 inventory persisted to %s", out / "raw")
 
 
 def write_store(out: Path, raw: dict[str, Any], assembled: dict[str, Any]) -> Path:
@@ -543,21 +937,25 @@ def write_store(out: Path, raw: dict[str, Any], assembled: dict[str, Any]) -> Pa
     these 40" must be defensible months later, and an API response is not reproducible once the
     estate moves.
     """
-    (out / "raw").mkdir(parents=True, exist_ok=True)
-    for key in (
-        "workbooks",
-        "views",
-        "datasources",
-        "projects",
-        "groups",
-        "flows",
-        "subscriptions",
-        "alerts",
-        "custom_views",
-        "permissions",
-        "structure",
-    ):
-        (out / "raw" / f"{key}.json").write_text(json.dumps(raw[key], indent=2), encoding="utf-8")
+    _write_raw(
+        out,
+        {
+            key: raw[key]
+            for key in (
+                "workbooks",
+                "views",
+                "datasources",
+                "projects",
+                "groups",
+                "flows",
+                "subscriptions",
+                "alerts",
+                "custom_views",
+                "permissions",
+                "structure",
+            )
+        },
+    )
 
     db_path = out / "estate.db"
     db_path.unlink(missing_ok=True)
@@ -623,7 +1021,9 @@ def write_store(out: Path, raw: dict[str, Any], assembled: dict[str, Any]) -> Pa
     )
     conn.executemany(
         "INSERT OR REPLACE INTO grp VALUES (?,?,?,?)",
-        [(g["id"], g.get("name"), (g.get("domain") or {}).get("name"), g.get("_members", 0)) for g in raw["groups"]],
+        # `_members` is NULL, not 0, for a group whose membership could not be read: 0 reads as a
+        # finding ("this group is empty"), and that is the opposite of what we know.
+        [(g["id"], g.get("name"), (g.get("domain") or {}).get("name"), g.get("_members")) for g in raw["groups"]],
     )
     conn.executemany(
         "INSERT INTO permission VALUES (:object_type,:object_luid,:object_name,:grantee_type,"
@@ -753,18 +1153,75 @@ def _render_iam(assembled: dict[str, Any], raw: dict[str, Any]) -> list[str]:
     return out
 
 
+def _warn_lines(assembled: dict[str, Any]) -> list[str]:
+    """The ``[WARN]``/``[ACTION]`` lines - ONE wording, rendered to two surfaces (log and report).
+
+    Written the way the engine's ``estate_survey.py`` writes them: name the listing, name what is
+    missing because of it, and end with the action. A reader who sees only one of the two surfaces
+    must reach the same conclusion.
+    """
+    errors = assembled.get("listing_errors") or []
+    if not errors:
+        return []
+    lines = []
+    for entry in errors:
+        page = f" page {entry['page']}" if entry.get("page") else ""
+        lines.append(
+            f"[WARN] {entry.get('severity', SECONDARY).upper()} listing INCOMPLETE: "
+            f"{entry.get('listing')} at {entry.get('path')!r}{page} after "
+            f"{entry.get('attempts')} attempt(s) / {entry.get('elapsed_sec')}s -- {entry.get('error')} "
+            "-- rows are MISSING from this assessment"
+        )
+    if assembled.get("degraded_primary"):
+        lines.append(
+            "[ACTION] a PRIMARY listing failed, so this is NOT a complete inventory: the coverage "
+            "curve, the complexity scores and every tier below are computed from data that is known "
+            "to be partial. Do not present it as an estate assessment and do not scope from it -- "
+            "re-run, and raise --rest-timeout / --max-attempts if the connection is slow rather "
+            "than broken."
+        )
+    else:
+        lines.append(
+            "[ACTION] this assessment is DEGRADED -- a secondary listing could not be read, so a "
+            "workbook showing no subscription, alert, custom view or group membership here is "
+            "UNKNOWN, not unused. Deliberate use can only be UNDER-reported by this run, never "
+            "invented, so the retire-candidate tier is the one to distrust."
+        )
+    return lines
+
+
+def _render_degraded(assembled: dict[str, Any]) -> list[str]:
+    """The incompleteness banner, rendered FIRST so it cannot be scrolled past.
+
+    A degraded assessment silently mistaken for a clean one is worse than the crash this replaced:
+    a crash cannot be mistaken for success. So a PRIMARY failure gets the document's first heading
+    (and exit 3), while a secondary one gets a blockquote and exit 0.
+    """
+    lines = _warn_lines(assembled)
+    if not lines:
+        return []
+    if assembled.get("degraded_primary"):
+        out = ["# ⚠️ DEGRADED — a PRIMARY listing is INCOMPLETE, this is not the whole estate", ""]
+    else:
+        out = ["> ⚠️ **DEGRADED** — every primary listing was read in full, but not everything was.", ""]
+    out += [f"- {line}" for line in lines]
+    out.append("")
+    return out
+
+
 def render_report(assembled: dict[str, Any], raw: dict[str, Any], target: float) -> str:
     """The customer-facing summary. Leads with the decision, not the inventory."""
     rows = assembled["workbooks"]
-    out = _render_curve(rows, target)
+    out = _render_degraded(assembled)
+    out += _render_curve(rows, target)
     out += _render_tiers(rows)
     out += _render_sequencing(assembled, rows)
     out += _render_iam(assembled, raw)
     return "\n".join(out) + "\n"
 
 
-def main() -> int:
-    """Assess the estate. Exit 1 when nothing could be assessed."""
+def _build_parser() -> argparse.ArgumentParser:
+    """CLI. The timeout/retry group exists because two magic numbers cost three customer runs."""
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("--out", required=True, type=Path, help="output directory (should be git-ignored)")
     parser.add_argument("--env", type=Path, default=Path(".env"), help="git-ignored KEY=VALUE credentials")
@@ -775,13 +1232,46 @@ def main() -> int:
         default=0.99,
         help="share of usage to keep in scope (1.0 = lift-and-shift). Default 0.99",
     )
-    args = parser.parse_args()
+    network = parser.add_argument_group("network resilience")
+    network.add_argument(
+        "--rest-timeout",
+        type=float,
+        default=DEFAULT_REST_TIMEOUT_SEC,
+        help=f"seconds before one REST call is abandoned (default {DEFAULT_REST_TIMEOUT_SEC:.0f})",
+    )
+    network.add_argument(
+        "--graphql-timeout",
+        type=float,
+        default=DEFAULT_GRAPHQL_TIMEOUT_SEC,
+        help=f"seconds for the single Metadata API call (default {DEFAULT_GRAPHQL_TIMEOUT_SEC:.0f})",
+    )
+    network.add_argument(
+        "--max-attempts",
+        type=int,
+        default=DEFAULT_MAX_ATTEMPTS,
+        help=f"attempts per call for TRANSIENT failures only (default {DEFAULT_MAX_ATTEMPTS}); "
+        "an auth or permission refusal is never retried",
+    )
+    network.add_argument(
+        "--retry-budget",
+        type=float,
+        default=DEFAULT_RETRY_BUDGET_SEC,
+        help=f"wall-clock seconds one call may spend retrying (default {DEFAULT_RETRY_BUDGET_SEC:.0f}); "
+        "attempts alone cannot stop a slow-failing endpoint from eating the run",
+    )
+    return parser
+
+
+def main() -> int:
+    """Assess the estate. Exit 1 when nothing could be assessed, 3 when a PRIMARY listing failed."""
+    args = _build_parser().parse_args()
 
     logging.basicConfig(level=logging.INFO, format="%(message)s")
     env = resolve_env(args.env)
     require(env)
     LOG.info("credentials: %s from the %s", "TABLEAU_PAT_SECRET", env_source("TABLEAU_PAT_SECRET", args.env))
-    site = Site(env)
+    policy = HttpPolicy(args.rest_timeout, args.graphql_timeout, args.max_attempts, args.retry_budget)
+    site = Site(env, policy)
     site.sign_in()
     LOG.info("signed in to %r (api %s)", site.site, site.version)
 
@@ -790,11 +1280,11 @@ def main() -> int:
         LOG.warning("no --survey: migration ORDER will be reported as unknown, never as none")
 
     started = time.perf_counter()
-    raw = collect(site, survey)
+    args.out.mkdir(parents=True, exist_ok=True)
+    raw = collect(site, survey, checkpoint=lambda inventory: _checkpoint(args.out, inventory))
     assembled = assemble(raw, args.coverage_target)
     site.sign_out()
 
-    args.out.mkdir(parents=True, exist_ok=True)
     db = write_store(args.out, raw, assembled)
     report = args.out / "report.md"
     report.write_text(render_report(assembled, raw, args.coverage_target), encoding="utf-8")
@@ -804,14 +1294,19 @@ def main() -> int:
     for row in assembled["workbooks"]:
         counts[row["tier"]] = counts.get(row["tier"], 0) + 1
     LOG.info(
-        "\n%d workbook(s) in %.0fs, %d re-auth(s)",
+        "\n%d workbook(s) in %.0fs, %d re-auth(s), %d retry/retries",
         len(assembled["workbooks"]),
         time.perf_counter() - started,
         site.reauths,
+        site.retries,
     )
     LOG.info("  tiers: %s", ", ".join(f"{k}={v}" for k, v in sorted(counts.items())))
     LOG.info("  %s", db)
     LOG.info("  %s", report)
+    for line in _warn_lines(assembled):
+        LOG.warning("  %s", line)
+    if assembled["degraded_primary"]:
+        return 3
     return 0 if assembled["workbooks"] else 1
 
 

--- a/scripts/assess_estate.py
+++ b/scripts/assess_estate.py
@@ -315,6 +315,17 @@ class Site:  # pylint: disable=too-many-instance-attributes  # one client: crede
         self.errors.append(record)
         return record
 
+    def scrub_text(self, text: str) -> str:
+        """Remove every credential known at this point from a string we ASSEMBLED ourselves.
+
+        ``_scrub`` handles a raw response body (bytes); this handles text built from already-parsed
+        JSON - notably a GraphQL 200 whose ``errors`` array is a dict, not bytes, so it never
+        travelled through ``_scrub`` on its way out of ``_request_json``. Both paths must scrub:
+        both reach ``assessment.json``, ``report.md`` and now ``estate.db``, and a proxy or WAF that
+        echoes the request writes the owner's PAT (or the live session token) into all three.
+        """
+        return redact(text, self._pat[1], self.token or "")
+
     def _scrub(self, payload: bytes) -> str:
         """Decode a response body with every credential known at this point removed.
 
@@ -323,7 +334,7 @@ class Site:  # pylint: disable=too-many-instance-attributes  # one client: crede
         into two durable artifacts. Scrub at the point of capture (the measured hazard behind
         ``tableau_env.redact``), not at the point of writing.
         """
-        return redact(payload.decode("utf-8", "replace"), self._pat[1], self.token or "")
+        return self.scrub_text(payload.decode("utf-8", "replace"))
 
     def _may_retry(self, kind: str, attempt: int, started: float, delay: float) -> bool:
         """Retry only a TRANSIENT fault, and only inside BOTH bounds.
@@ -602,6 +613,18 @@ CREATE TABLE IF NOT EXISTS permission (
   object_type TEXT, object_luid TEXT, object_name TEXT,
   grantee_type TEXT, grantee_luid TEXT, capability TEXT, mode TEXT);
 CREATE TABLE IF NOT EXISTS flow (luid TEXT PRIMARY KEY, name TEXT, project TEXT);
+-- Run-level completeness, added in #196. Before it, a survived-but-partial run (#193) wrote a DB
+-- BYTE-IDENTICAL to a clean one, so a programmatic consumer (harvest_estate_assets.py --db,
+-- deploy_estate.py --estate-db) that never opens assessment.json could not tell the two apart.
+CREATE TABLE IF NOT EXISTS assessment_run (
+  assessed_at TEXT, degraded INTEGER, degraded_primary INTEGER,
+  workbooks_total INTEGER, listing_errors INTEGER);
+-- One row per listing that could not be read in full. ``error`` is SCRUBBED at the point of capture
+-- (see Site.scrub_text), never here, so this table cannot carry a credential even if the server
+-- echoed one back.
+CREATE TABLE IF NOT EXISTS listing_error (
+  listing TEXT, severity TEXT, status INTEGER, path TEXT, page INTEGER,
+  attempts INTEGER, elapsed_sec REAL, transport INTEGER, error TEXT);
 """
 
 
@@ -710,7 +733,11 @@ def _pass2_structure(site: Site) -> tuple[dict[str, Any], list[dict]]:
         LOG.warning("  [WARN] structure UNREADABLE: %s - every complexity score would be 0", error["error"][:150])
         errors.append({"listing": "structure", "severity": PRIMARY, **error})
     elif payload.get("errors"):
-        detail = f"Metadata API errors: {str(payload['errors'])[:200]}"
+        # ``payload`` is parsed JSON handed straight back by ``_request_json`` on a 200, so unlike
+        # the transport/HTTP paths this text never passed through the byte scrubber. Scrub the
+        # echoed body HERE (#196): a proxy or WAF can reflect the request, and this string is
+        # persisted into assessment.json, report.md and estate.db.
+        detail = f"Metadata API errors: {site.scrub_text(str(payload['errors']))[:200]}"
         severity = SECONDARY if data.get("workbooks") else PRIMARY
         LOG.warning("  [WARN] %s (%s)", detail, severity)
         errors.append({"listing": "structure", "severity": severity, **_record(GRAPHQL_ROOT, 200, detail, 1, started)})
@@ -930,6 +957,47 @@ def _checkpoint(out: Path, inventory: dict[str, list]) -> None:
     LOG.info("  checkpoint: pass-1 inventory persisted to %s", out / "raw")
 
 
+def _write_run_marker(conn: sqlite3.Connection, assembled: dict[str, Any]) -> None:
+    """Stamp the run's completeness into the DB itself.
+
+    A programmatic consumer that never opens ``assessment.json`` (``harvest_estate_assets.py --db``,
+    ``deploy_estate.py --estate-db``) had no way to tell a degraded run from a clean one: since #193
+    the run survives a failed listing and still writes a DB (#196). Additive - existing tables are
+    untouched. ``error`` text is already scrubbed at capture (``Site.scrub_text``), so it is written
+    verbatim and never carries a credential.
+    """
+    summary = assembled.get("summary") or {}
+    errors = assembled.get("listing_errors") or []
+    conn.execute(
+        "INSERT INTO assessment_run VALUES (?,?,?,?,?)",
+        (
+            time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            int(bool(assembled.get("degraded"))),
+            int(bool(assembled.get("degraded_primary"))),
+            summary.get("workbooks_total", len(assembled.get("workbooks") or [])),
+            summary.get("listing_errors", len(errors)),
+        ),
+    )
+    conn.executemany(
+        "INSERT INTO listing_error VALUES "
+        "(:listing,:severity,:status,:path,:page,:attempts,:elapsed_sec,:transport,:error)",
+        [
+            {
+                "listing": e.get("listing"),
+                "severity": e.get("severity"),
+                "status": e.get("status"),
+                "path": e.get("path"),
+                "page": e.get("page"),
+                "attempts": e.get("attempts"),
+                "elapsed_sec": e.get("elapsed_sec"),
+                "transport": int(bool(e.get("transport"))),
+                "error": e.get("error"),
+            }
+            for e in errors
+        ],
+    )
+
+
 def write_store(out: Path, raw: dict[str, Any], assembled: dict[str, Any]) -> Path:
     """Raw JSON as evidence, SQLite as the query layer.
 
@@ -1034,6 +1102,7 @@ def write_store(out: Path, raw: dict[str, Any], assembled: dict[str, Any]) -> Pa
         "INSERT OR REPLACE INTO flow VALUES (?,?,?)",
         [(f["id"], f.get("name"), (f.get("project") or {}).get("name")) for f in raw["flows"]],
     )
+    _write_run_marker(conn, assembled)
     conn.commit()
     conn.close()
     return db_path

--- a/scripts/deploy_estate.py
+++ b/scripts/deploy_estate.py
@@ -1201,7 +1201,9 @@ def project_map(bundle: Path, estate_db: Path | None) -> dict[str, str]:
 
     Two sources, deliberately in this order:
 
-    * ``estate.db`` from `assess_estate.py` - authoritative and complete, because it read the site.
+    * ``estate.db`` from `assess_estate.py` - authoritative for what it read, but NOT guaranteed
+      complete: since #193 the run survives a failed listing and still writes a DB, so consult its
+      ``assessment_run`` row (``degraded`` / ``degraded_primary``) before trusting it as whole.
     * ``source-provenance.json`` in the bundle - present without an assessment, but only covers
       workbooks that were matched back to the site. Measured on a real bundle: 10 of 58 rows carried
       an origin, the rest being local-only inputs.

--- a/tests/test_assess_estate_resilience.py
+++ b/tests/test_assess_estate_resilience.py
@@ -539,8 +539,9 @@ def test_a_graphql_200_error_body_is_scrubbed_before_it_is_recorded(monkeypatch,
 
 def test_estate_db_records_whether_the_run_was_degraded(tmp_path):
     """`estate.db` is read programmatically by harvest/deploy, which never open `assessment.json`.
-    Before #196 a survived-but-partial DB was byte-identical to a clean one; it must now carry the
-    marker itself - the run-level flags and one row per failed listing."""
+    Before #196 a survived-but-partial DB was indistinguishable from a clean run of a smaller
+    estate; it must now carry the marker itself - the run-level flags and one row per failed
+    listing."""
     raw = _raw_fixture([_error("workbooks", assess_estate.PRIMARY)])
     store = assess_estate.write_store(tmp_path, raw, assess_estate.assemble(raw, 0.99))
     conn = assess_estate.sqlite3.connect(store)
@@ -568,6 +569,16 @@ def test_a_graphql_error_body_never_reaches_estate_db(monkeypatch, no_sleep, tmp
     code = _run_main(monkeypatch, tmp_path, _GraphqlLeak())
     out = tmp_path / "_assessment"
     assert code == 0  # workbooks were still returned, so the structure error is SECONDARY
+    # Pin the DISCRIMINATING row (1, 0). The other two DB tests only cover (1, 1) and (0, 0), so
+    # transposing the two columns - or writing `degraded` from `degraded_primary` - passed the whole
+    # suite while claiming a secondary-degraded run was clean. The primary/secondary split is the
+    # design's core and this row is the only signal a machine consumer gets, so it must be asserted.
+    marker = (
+        assess_estate.sqlite3.connect(out / "estate.db")
+        .execute("SELECT degraded, degraded_primary FROM assessment_run")
+        .fetchone()
+    )
+    assert marker == (1, 0)
     assert ENV["TABLEAU_PAT_SECRET"].encode() not in (out / "estate.db").read_bytes()
     errs = assess_estate.sqlite3.connect(out / "estate.db").execute("SELECT error FROM listing_error").fetchall()
     assert errs and all(ENV["TABLEAU_PAT_SECRET"] not in row[0] for row in errs)

--- a/tests/test_assess_estate_resilience.py
+++ b/tests/test_assess_estate_resilience.py
@@ -505,3 +505,71 @@ def test_the_pat_secret_never_reaches_a_persisted_artifact(monkeypatch, no_sleep
     assert "[REDACTED]" in written
     assert (tmp_path / "_assessment" / "report.md").read_text(encoding="utf-8").count(ENV["TABLEAU_PAT_SECRET"]) == 0
     assert no_sleep == []
+
+
+# --- 8. #196: scrub the 200-with-`errors` GraphQL body, and mark degradation in estate.db ---------
+
+
+class _GraphqlLeak(FakeTableau):
+    """A Metadata API that answers 200 but reflects the caller's credential in its ``errors`` array.
+
+    The sibling of the ``Echoing`` gateway above, on the ONE path that returns PARSED JSON straight
+    from ``_request_json`` and so never met the byte scrubber (issue #196). ``data.workbooks`` stays
+    non-empty (inherited from the parent), so the structure failure is SECONDARY and the run exits 0.
+    """
+
+    def _payload(self, url: str) -> dict:
+        payload = super()._payload(url)
+        if "metadata/graphql" in url:
+            payload["errors"] = [{"message": f"upstream rejected credential {ENV['TABLEAU_PAT_SECRET']}"}]
+        return payload
+
+
+def test_a_graphql_200_error_body_is_scrubbed_before_it_is_recorded(monkeypatch, no_sleep):
+    """A 200 with an `errors` array is recorded via ``_record`` WITHOUT travelling through
+    ``_scrub`` - so its text must be scrubbed at the call site, or the PAT lands in the artifacts."""
+    site = _site(_GraphqlLeak(), monkeypatch, max_attempts=1)
+    _data, errors = assess_estate._pass2_structure(site)
+    assert errors and errors[0]["listing"] == "structure"
+    recorded = errors[0]["error"]
+    assert ENV["TABLEAU_PAT_SECRET"] not in recorded
+    assert "[REDACTED]" in recorded
+    assert no_sleep == []
+
+
+def test_estate_db_records_whether_the_run_was_degraded(tmp_path):
+    """`estate.db` is read programmatically by harvest/deploy, which never open `assessment.json`.
+    Before #196 a survived-but-partial DB was byte-identical to a clean one; it must now carry the
+    marker itself - the run-level flags and one row per failed listing."""
+    raw = _raw_fixture([_error("workbooks", assess_estate.PRIMARY)])
+    store = assess_estate.write_store(tmp_path, raw, assess_estate.assemble(raw, 0.99))
+    conn = assess_estate.sqlite3.connect(store)
+    run = conn.execute(
+        "SELECT degraded, degraded_primary, workbooks_total, listing_errors FROM assessment_run"
+    ).fetchone()
+    assert run == (1, 1, 1, 1)
+    rows = conn.execute("SELECT listing, severity, error FROM listing_error").fetchall()
+    assert rows == [("workbooks", assess_estate.PRIMARY, "transport: TimeoutError: timed out")]
+
+
+def test_a_clean_run_marks_the_db_as_NOT_degraded(tmp_path):
+    """The marker must exist on a CLEAN run too, or its absence is ambiguous (clean vs. an old DB
+    written before this table existed). A clean run: flags 0/0, and no `listing_error` rows."""
+    raw = _raw_fixture()
+    store = assess_estate.write_store(tmp_path, raw, assess_estate.assemble(raw, 0.99))
+    conn = assess_estate.sqlite3.connect(store)
+    assert conn.execute("SELECT degraded, degraded_primary FROM assessment_run").fetchone() == (0, 0)
+    assert conn.execute("SELECT count(*) FROM listing_error").fetchone() == (0,)
+
+
+def test_a_graphql_error_body_never_reaches_estate_db(monkeypatch, no_sleep, tmp_path):
+    """End to end, the two blind spots together: the 200-with-`errors` path AND `estate.db`, which
+    the existing secret test covered neither of (it used the HTTPError body and read only JSON/md)."""
+    code = _run_main(monkeypatch, tmp_path, _GraphqlLeak())
+    out = tmp_path / "_assessment"
+    assert code == 0  # workbooks were still returned, so the structure error is SECONDARY
+    assert ENV["TABLEAU_PAT_SECRET"].encode() not in (out / "estate.db").read_bytes()
+    errs = assess_estate.sqlite3.connect(out / "estate.db").execute("SELECT error FROM listing_error").fetchall()
+    assert errs and all(ENV["TABLEAU_PAT_SECRET"] not in row[0] for row in errs)
+    assert any("[REDACTED]" in row[0] for row in errs)
+    assert no_sleep == []

--- a/tests/test_assess_estate_resilience.py
+++ b/tests/test_assess_estate_resilience.py
@@ -1,0 +1,507 @@
+"""Transport-failure resilience for scripts/assess_estate.py (issue #193).
+
+Split from ``test_assess_estate.py`` on subject, not duplicated: that file owns the four REFUSALS
+(never retire on a metric, never guess a dependency, never claim a usage window, never map IAM).
+This one owns the HTTP layer - what happens when the server answers late, badly, or not at all.
+
+Everything here injects the failure at ``urllib.request.urlopen``; nothing touches a network, and
+nothing reads the real ``.env``. The distinction under test throughout is the one the live defect
+turned on: a status code is an ANSWER (a 403 means "you may not see this"), while a timeout is NO
+answer, and only the first may be reported as a fact about the estate.
+"""
+
+import http.client
+import importlib.util
+import json
+import socket
+import sys
+import urllib.error
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+spec = importlib.util.spec_from_file_location("assess_estate", SCRIPTS / "assess_estate.py")
+assess_estate = importlib.util.module_from_spec(spec)
+sys.modules["assess_estate"] = assess_estate
+spec.loader.exec_module(assess_estate)
+
+ENV = {
+    "TABLEAU_SERVER_URL": "https://tableau.invalid",
+    "TABLEAU_SITE": "acme",
+    "TABLEAU_PAT_NAME": "assessor",
+    "TABLEAU_PAT_SECRET": "not-a-real-secret-0123456789",
+}
+
+# Every transport failure shape the live runs produced, plus the two that urlopen does not wrap.
+TRANSPORT_FAILURES = [
+    TimeoutError("timed out"),
+    socket.timeout("timed out"),
+    urllib.error.URLError("[Errno 11001] getaddrinfo failed"),
+    http.client.RemoteDisconnected("Remote end closed connection without response"),
+    ConnectionResetError(10054, "An existing connection was forcibly closed by the remote host"),
+]
+
+
+class _Response:
+    """The slice of ``http.client.HTTPResponse`` that ``Site._raw`` actually touches."""
+
+    def __init__(self, status: int, payload: bytes) -> None:
+        self.status = status
+        self._payload = payload
+
+    def read(self) -> bytes:
+        return self._payload
+
+    def close(self) -> None:
+        """``urllib.error.HTTPError`` closes the body it was handed; without this it warns at GC."""
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc) -> bool:
+        return False
+
+
+class FakeTableau:
+    """A scripted Tableau site. ``fail`` maps a URL fragment to an exception, a status, or a list
+    of those consumed one per call, so a test injects a fault on ONE endpoint and nothing else."""
+
+    SIGNIN = {"credentials": {"token": "session-token", "site": {"id": "site-1"}}}
+
+    def __init__(self, fail: dict | None = None) -> None:
+        self.fail = {key: (value if isinstance(value, list) else [value]) for key, value in (fail or {}).items()}
+        self.calls: list[tuple[str, float | None]] = []
+
+    def urlopen(self, request, timeout=None):
+        """Stand-in for ``urllib.request.urlopen``."""
+        url = request.full_url
+        self.calls.append((url, timeout))
+        for fragment, queue in self.fail.items():
+            if fragment in url and queue:
+                outcome = queue.pop(0) if len(queue) > 1 else queue[0]
+                if isinstance(outcome, BaseException):
+                    raise outcome
+                if outcome != 200:
+                    raise urllib.error.HTTPError(url, outcome, "nope", {}, None)
+        return _Response(200, json.dumps(self._payload(url)).encode())
+
+    def paths(self) -> list[str]:
+        """Every URL called, in order."""
+        return [url for url, _ in self.calls]
+
+    def count(self, fragment: str) -> int:
+        """How many calls touched ``fragment`` - the retry budget, measured."""
+        return sum(1 for url, _ in self.calls if fragment in url)
+
+    def _payload(self, url: str) -> dict:  # pylint: disable=too-many-return-statements
+        if "/auth/signin" in url:
+            return self.SIGNIN
+        if "/auth/signout" in url:
+            return {}
+        if "metadata/graphql" in url:
+            return {
+                "data": {
+                    "workbooks": [{"name": "Sales", "sheets": [{}], "dashboards": [], "embeddedDatasources": []}],
+                    "publishedDatasources": [],
+                }
+            }
+        if "/permissions" in url:
+            return {"permissions": {"granteeCapabilities": []}}
+        for fragment, collection, item, rows in self._collections():
+            if fragment in url:
+                return {"pagination": {"totalAvailable": len(rows)}, collection: {item: rows}}
+        return {}
+
+    @staticmethod
+    def _collections():
+        workbook = {"id": "wb-1", "name": "Sales", "project": {"id": "p-1", "name": "Finance"}}
+        return (
+            ("/groups/g-1/users", "users", "user", [{"id": "u-1", "name": "ana"}]),
+            ("/workbooks?", "workbooks", "workbook", [workbook]),
+            ("/views?", "views", "view", [{"id": "v-1", "workbook": {"id": "wb-1"}, "usage": {"totalViewCount": 9}}]),
+            ("/datasources?", "datasources", "datasource", [{"id": "ds-1", "name": "Finance Master"}]),
+            ("/projects?", "projects", "project", [{"id": "p-1", "name": "Finance", "contentPermissions": "x"}]),
+            ("/groups?", "groups", "group", [{"id": "g-1", "name": "Analysts", "domain": {"name": "local"}}]),
+            ("/flows?", "flows", "flow", []),
+            ("/subscriptions?", "subscriptions", "subscription", []),
+            ("/dataAlerts?", "dataAlerts", "dataAlert", []),
+            ("/customviews?", "customViews", "customView", []),
+        )
+
+
+@pytest.fixture(name="no_sleep")
+def _no_sleep(monkeypatch):
+    """Record backoff delays instead of serving them, so a retry test costs no wall-clock."""
+    slept: list[float] = []
+    monkeypatch.setattr(assess_estate.time, "sleep", slept.append)
+    return slept
+
+
+def _site(server: FakeTableau, monkeypatch, **policy):
+    monkeypatch.setattr(assess_estate.urllib.request, "urlopen", server.urlopen)
+    site = assess_estate.Site(ENV, assess_estate.HttpPolicy(**policy) if policy else None)
+    site.sign_in()
+    return site
+
+
+# --- 1. a transport failure is caught where the status codes already were -----------------------
+
+
+@pytest.mark.parametrize("failure", TRANSPORT_FAILURES, ids=lambda exc: type(exc).__name__)
+def test_transport_failure_returns_a_sentinel_instead_of_propagating(failure, monkeypatch, no_sleep):
+    """The whole defect in one assertion: `_raw` caught only HTTPError, so these five killed the run."""
+    server = FakeTableau({"/workbooks?": failure})
+    site = _site(server, monkeypatch)
+    status, payload = site._raw("GET", "/sites/site-1/workbooks?pageSize=1000")  # pylint: disable=protected-access
+    assert status == assess_estate.NETWORK_ERROR_STATUS
+    assert type(failure).__name__ in payload.decode()
+    assert no_sleep == []
+
+
+def test_get_returns_None_on_a_timeout_rather_than_raising(monkeypatch, no_sleep):
+    """``get``'s documented promise - one failure must not void the assessment - now covers
+    failures that never produced a status at all."""
+    site = _site(FakeTableau({"/permissions": TimeoutError("timed out")}), monkeypatch)
+    assert site.get("/sites/site-1/workbooks/wb-1/permissions") is None
+    assert no_sleep  # it retried, because a timeout is transient
+
+
+def test_graphql_survives_an_http_error_it_used_to_die_on(monkeypatch, no_sleep):
+    """``graphql`` had no handler at all, so even a plain HTTPError was fatal there."""
+    site = _site(FakeTableau({"metadata/graphql": 500}), monkeypatch)
+    payload, error = site.graphql("{ workbooks { name } }")
+    assert payload == {}
+    assert error["status"] == 500 and no_sleep
+
+
+# --- 2. the retry budget is bounded, and an auth refusal is never retried ------------------------
+
+
+def test_a_transient_failure_is_retried_up_to_the_bound(monkeypatch, no_sleep):
+    server = FakeTableau({"/customviews?": TimeoutError("timed out")})
+    site = _site(server, monkeypatch, max_attempts=3)
+    rows, error = site.paged("/sites/site-1/customviews", "customViews", "customView")
+    assert (rows, error["attempts"]) == ([], 3)
+    assert server.count("/customviews?") == 3
+    assert len(no_sleep) == 2  # two backoffs between three attempts
+
+
+@pytest.mark.parametrize("status", [401, 403])
+def test_an_auth_refusal_is_a_FINAL_answer_and_is_never_retried(status, monkeypatch, no_sleep):
+    """AGENTS.md: a missing credential is not transient. Retrying burns the budget and cannot win."""
+    server = FakeTableau({"/customviews?": status})
+    site = _site(server, monkeypatch, max_attempts=5)
+    _, error = site.paged("/sites/site-1/customviews", "customViews", "customView")
+    assert server.count("/customviews?") == 1
+    assert error["attempts"] == 1 and no_sleep == []
+
+
+def test_a_not_found_endpoint_is_not_retried_either(monkeypatch, no_sleep):
+    server = FakeTableau({"/customviews?": 404})
+    site = _site(server, monkeypatch, max_attempts=5)
+    site.paged("/sites/site-1/customviews", "customViews", "customView")
+    assert server.count("/customviews?") == 1 and no_sleep == []
+
+
+def test_a_gateway_503_IS_retried_and_then_succeeds(monkeypatch, no_sleep):
+    """The counterpart: a 5xx is the server being busy, not the server refusing."""
+    server = FakeTableau({"/customviews?": [503, 200]})
+    site = _site(server, monkeypatch, max_attempts=3)
+    rows, error = site.paged("/sites/site-1/customviews", "customViews", "customView")
+    assert error is None and rows == [] and len(no_sleep) == 1
+
+
+def test_a_bad_PAT_fails_sign_in_on_the_first_attempt(monkeypatch, no_sleep):
+    server = FakeTableau({"/auth/signin": 401})
+    monkeypatch.setattr(assess_estate.urllib.request, "urlopen", server.urlopen)
+    site = assess_estate.Site(ENV, assess_estate.HttpPolicy(max_attempts=4))
+    with pytest.raises(RuntimeError, match="sign-in failed"):
+        site.sign_in()
+    assert server.count("/auth/signin") == 1 and no_sleep == []
+    assert site.auth_failed
+
+
+def test_sign_in_retries_a_transient_failure(monkeypatch, no_sleep):
+    """A gateway blip at sign-in would otherwise abort the assessment before it started."""
+    server = FakeTableau({"/auth/signin": [TimeoutError("timed out"), 200]})
+    monkeypatch.setattr(assess_estate.urllib.request, "urlopen", server.urlopen)
+    site = assess_estate.Site(ENV, assess_estate.HttpPolicy(max_attempts=3))
+    site.sign_in()
+    assert site.token == "session-token" and len(no_sleep) == 1
+
+
+def test_the_wall_clock_budget_stops_a_slow_failing_endpoint():
+    """Attempts alone cannot bound 3 x a 180 s timeout; the budget is the second bound."""
+    site = assess_estate.Site(ENV, assess_estate.HttpPolicy(max_attempts=9, retry_budget_sec=0.0))
+    assert site._may_retry("transient", 1, assess_estate.time.monotonic(), 0.1) is False  # pylint: disable=protected-access
+
+
+def test_backoff_grows_and_is_capped():
+    delays = [assess_estate.backoff_delay(n, jitter=False) for n in (1, 2, 3, 99)]
+    assert delays[0] < delays[1] < delays[2]
+    assert delays[3] == assess_estate.BACKOFF_CAP_SEC
+
+
+def test_a_failed_re_auth_stops_the_run_from_paying_the_budget_on_every_call(monkeypatch, no_sleep):
+    """A session that cannot be re-established would otherwise cost every remaining endpoint its
+    full retry budget - the unbounded stall the crash at least made obvious."""
+    server = FakeTableau({"/customviews?": 401, "/auth/signin": [200, 401]})
+    site = _site(server, monkeypatch, max_attempts=3)
+    monkeypatch.setattr(assess_estate, "SESSION_LOST", "")  # every 401 body now reads as session loss
+    site.paged("/sites/site-1/customviews", "customViews", "customView")
+    assert site.auth_failed
+    before = len(server.calls)
+    site.paged("/sites/site-1/subscriptions", "subscriptions", "subscription")
+    assert len(server.calls) == before  # not one further request was made
+    assert no_sleep == []
+
+
+# --- 3. partial listings are returned WITH their error, never as a complete answer ---------------
+
+
+def test_paged_returns_the_rows_it_got_plus_the_error_naming_the_page(monkeypatch, no_sleep):
+    """A truncated list passed off as complete is the failure mode that outranks the crash."""
+
+    class Paging(FakeTableau):
+        """Two pages of two rows; the second page times out."""
+
+        def _payload(self, url):
+            if "/views?" not in url:
+                return super()._payload(url)
+            if "pageNumber=1" in url:
+                return {"pagination": {"totalAvailable": 4}, "views": {"view": [{"id": "v-1"}, {"id": "v-2"}]}}
+            raise TimeoutError("timed out")
+
+    site = _site(Paging(), monkeypatch, max_attempts=1)
+    rows, error = site.paged("/sites/site-1/views", "views", "view")
+    assert len(rows) == 2
+    assert error["page"] == 2 and error["transport"] is True
+    assert no_sleep == []
+
+
+def test_a_403_is_an_ANSWER_and_does_not_degrade_the_iam_export(monkeypatch, no_sleep):
+    """ "You may not see this" is a fact about the estate; "no answer" is not. Only the second
+    degrades, or every locked-down project would raise a false alarm."""
+    site = _site(FakeTableau({"/permissions": 403}), monkeypatch)
+    rows, errors = assess_estate._grants(site, "workbook", "wb-1", "Sales", "/workbooks/wb-1")
+    assert (rows, errors) == ([], [])
+    assert no_sleep == []
+
+
+def test_an_unreadable_grant_IS_degraded(monkeypatch, no_sleep):
+    site = _site(FakeTableau({"/permissions": TimeoutError("timed out")}), monkeypatch, max_attempts=1)
+    _, errors = assess_estate._grants(site, "workbook", "wb-1", "Sales", "/workbooks/wb-1")
+    assert errors[0]["severity"] == assess_estate.SECONDARY
+    assert "Sales" in errors[0]["listing"] and no_sleep == []
+
+
+def test_an_unreadable_group_records_NULL_members_not_zero(monkeypatch, no_sleep, tmp_path):
+    """0 reads as a finding ("this group is empty"); NULL is what we actually know."""
+    site = _site(FakeTableau({"/groups/g-1/users": TimeoutError("timed out")}), monkeypatch, max_attempts=1)
+    groups = [{"id": "g-1", "name": "Analysts"}]
+    errors = assess_estate._group_members(site, groups)
+    assert groups[0]["_members"] is None
+    assert errors and errors[0]["severity"] == assess_estate.SECONDARY and no_sleep == []
+    raw = _raw_fixture(groups=groups)
+    store = assess_estate.write_store(tmp_path, raw, assess_estate.assemble(raw, 0.99))
+    assert assess_estate.sqlite3.connect(store).execute("SELECT members FROM grp").fetchone() == (None,)
+
+
+# --- 4. the degraded contract: secondary degrades quietly-but-recorded, primary is loud ----------
+
+
+def _raw_fixture(errors=None, groups=None):
+    return {
+        "workbooks": [{"id": "wb-1", "name": "Sales", "project": {"id": "p-1"}}],
+        "views": [],
+        "datasources": [],
+        "projects": [],
+        "groups": groups if groups is not None else [],
+        "flows": [],
+        "subscriptions": [],
+        "alerts": [],
+        "custom_views": [],
+        "structure": {"publishedDatasources": []},
+        "structure_by_name": {},
+        "permissions": [],
+        "survey": None,
+        "collection_errors": errors or [],
+    }
+
+
+def _error(listing="custom_views", severity=assess_estate.SECONDARY):
+    return {
+        "listing": listing,
+        "severity": severity,
+        "path": f"/sites/site-1/{listing}",
+        "page": 1,
+        "status": 0,
+        "error": "transport: TimeoutError: timed out",
+        "attempts": 3,
+        "elapsed_sec": 12.0,
+        "transport": True,
+    }
+
+
+def test_a_clean_run_is_not_degraded_and_carries_no_banner():
+    assembled = assess_estate.assemble(_raw_fixture(), 0.99)
+    assert (assembled["degraded"], assembled["degraded_primary"]) == (False, False)
+    assert assembled["summary"]["listing_errors"] == 0
+    assert assess_estate._render_degraded(assembled) == []
+    assert "DEGRADED" not in assess_estate.render_report(assembled, _raw_fixture(), 0.99)
+
+
+def test_a_secondary_failure_degrades_and_names_the_listing():
+    assembled = assess_estate.assemble(_raw_fixture([_error()]), 0.99)
+    assert (assembled["degraded"], assembled["degraded_primary"]) == (True, False)
+    assert assembled["summary"]["degraded"] is True
+    report = assess_estate.render_report(assembled, _raw_fixture(), 0.99)
+    assert "[WARN]" in report and "custom_views" in report
+    assert "[ACTION] this assessment is DEGRADED" in report
+    assert "PRIMARY listing" not in report
+
+
+def test_a_primary_failure_leads_the_report_and_says_what_is_missing():
+    assembled = assess_estate.assemble(_raw_fixture([_error("workbooks", assess_estate.PRIMARY)]), 0.99)
+    assert assembled["degraded_primary"] is True
+    report = assess_estate.render_report(assembled, _raw_fixture(), 0.99)
+    assert report.startswith("# ⚠️ DEGRADED")
+    assert "PRIMARY listing is INCOMPLETE" in report.splitlines()[0]
+    assert "workbooks" in report and "[ACTION] a PRIMARY listing failed" in report
+
+
+def test_the_warn_wording_is_shared_by_the_log_and_the_report():
+    """One wording, two surfaces: a reader who sees only one must reach the same conclusion."""
+    assembled = assess_estate.assemble(_raw_fixture([_error()]), 0.99)
+    report = assess_estate.render_report(assembled, _raw_fixture(), 0.99)
+    for line in assess_estate._warn_lines(assembled):
+        assert line in report
+
+
+def test_every_secondary_listing_degrades_INDIVIDUALLY(monkeypatch, no_sleep):
+    """One dead endpoint must cost one data point, not the pass it sits in."""
+    server = FakeTableau({"/customviews?": TimeoutError("timed out")})
+    site = _site(server, monkeypatch, max_attempts=1)
+    raw = assess_estate.collect(site, None)
+    assert [e["listing"] for e in raw["collection_errors"]] == ["custom_views"]
+    assert raw["subscriptions"] == [] and raw["alerts"] == []
+    assert len(raw["workbooks"]) == 1 and no_sleep == []
+
+
+def test_an_unreadable_structure_call_is_PRIMARY(monkeypatch, no_sleep):
+    """A workbook we could not see scores 0 complexity, and 0 is not "simple" - it is "unknown",
+    and it feeds the retire-candidate tier directly."""
+    site = _site(FakeTableau({"metadata/graphql": TimeoutError("timed out")}), monkeypatch, max_attempts=1)
+    raw = assess_estate.collect(site, None)
+    structure_errors = [e for e in raw["collection_errors"] if e["listing"] == "structure"]
+    assert structure_errors[0]["severity"] == assess_estate.PRIMARY and no_sleep == []
+
+
+# --- 5. the expensive pass-1 inventory is persisted before anything flakier runs -----------------
+
+
+def test_pass1_is_checkpointed_before_the_secondary_passes(monkeypatch, no_sleep, tmp_path):
+    server = FakeTableau()
+    site = _site(server, monkeypatch)
+    seen: list[int] = []
+    assess_estate.collect(site, None, checkpoint=lambda inv: seen.append(len(server.calls)))
+    at_checkpoint = seen[0]
+    later = [p for p in server.paths()[at_checkpoint:]]
+    assert any("/customviews?" in p for p in later), "the checkpoint must precede the secondary passes"
+    assert not any("/customviews?" in p for p in server.paths()[:at_checkpoint])
+    assess_estate._checkpoint(tmp_path, {"workbooks": [{"id": "wb-1"}]})
+    assert json.loads((tmp_path / "raw" / "workbooks.json").read_text(encoding="utf-8")) == [{"id": "wb-1"}]
+    assert no_sleep == []
+
+
+# --- 6. timeouts are named, configurable, and actually reach the socket --------------------------
+
+
+def test_the_configured_timeouts_reach_urlopen(monkeypatch, no_sleep):
+    server = FakeTableau()
+    site = _site(server, monkeypatch, rest_timeout=7.0, graphql_timeout=11.0)
+    site.get("/sites/site-1/workbooks?pageSize=1000")
+    site.graphql("{ workbooks { name } }")
+    rest = [t for url, t in server.calls if "workbooks?" in url]
+    gql = [t for url, t in server.calls if "metadata/graphql" in url]
+    assert rest == [7.0] and gql == [11.0] and no_sleep == []
+
+
+def test_the_defaults_are_the_documented_ones():
+    policy = assess_estate.HttpPolicy()
+    assert (policy.rest_timeout, policy.graphql_timeout) == (180.0, 300.0)
+    assert policy.max_attempts == 3
+
+
+# --- 7. end to end: the reproduction from the issue ----------------------------------------------
+
+
+def _run_main(monkeypatch, tmp_path, server):
+    monkeypatch.setattr(assess_estate.urllib.request, "urlopen", server.urlopen)
+    monkeypatch.setattr(assess_estate, "resolve_env", lambda *_a, **_k: dict(ENV))
+    monkeypatch.setattr(assess_estate, "env_source", lambda *_a, **_k: "test")
+    monkeypatch.setattr(
+        sys, "argv", ["assess_estate.py", "--out", str(tmp_path / "_assessment"), "--max-attempts", "1"]
+    )
+    return assess_estate.main()
+
+
+def test_a_timeout_on_a_secondary_listing_yields_a_degraded_but_COMPLETE_assessment(
+    monkeypatch, no_sleep, tmp_path, caplog
+):
+    """The exact field failure: three runs died on `customviews` and `groups/{id}/users`."""
+    server = FakeTableau({"/customviews?": TimeoutError("timed out")})
+    with caplog.at_level("WARNING"):
+        code = _run_main(monkeypatch, tmp_path, server)
+    out = tmp_path / "_assessment"
+    assessment = json.loads((out / "assessment.json").read_text(encoding="utf-8"))
+    assert code == 0
+    assert (assessment["degraded"], assessment["degraded_primary"]) == (True, False)
+    assert [e["listing"] for e in assessment["listing_errors"]] == ["custom_views"]
+    assert len(assessment["workbooks"]) == 1  # the inventory survived
+    assert (out / "estate.db").exists() and (out / "raw" / "workbooks.json").exists()
+    assert "[WARN]" in caplog.text and "custom_views" in caplog.text
+    assert no_sleep == []
+
+
+def test_a_timeout_on_a_PRIMARY_listing_exits_3_and_names_what_is_missing(monkeypatch, no_sleep, tmp_path):
+    server = FakeTableau({"/views?": TimeoutError("timed out")})
+    code = _run_main(monkeypatch, tmp_path, server)
+    out = tmp_path / "_assessment"
+    report = (out / "report.md").read_text(encoding="utf-8")
+    assert code == 3
+    assert report.startswith("# ⚠️ DEGRADED")
+    assert "views" in report.splitlines()[2]
+    assert json.loads((out / "assessment.json").read_text(encoding="utf-8"))["degraded_primary"] is True
+    assert no_sleep == []
+
+
+def test_a_clean_run_still_exits_0_with_no_warning(monkeypatch, no_sleep, tmp_path):
+    code = _run_main(monkeypatch, tmp_path, FakeTableau())
+    report = (tmp_path / "_assessment" / "report.md").read_text(encoding="utf-8")
+    assert code == 0
+    assert report.startswith("# Estate assessment")
+    assert "DEGRADED" not in report and no_sleep == []
+
+
+def test_the_pat_secret_never_reaches_a_persisted_artifact(monkeypatch, no_sleep, tmp_path):
+    """A proxy that echoes the request body would otherwise write the owner's PAT into
+    assessment.json and report.md, which are durable (the hazard behind tableau_env.redact)."""
+
+    class Echoing(FakeTableau):
+        """A gateway that reflects what it was sent - secret included - in a 500 body."""
+
+        def urlopen(self, request, timeout=None):
+            if "/customviews?" in request.full_url:
+                body = json.dumps({"error": f"upstream rejected {ENV['TABLEAU_PAT_SECRET']}"}).encode()
+                raise urllib.error.HTTPError(request.full_url, 500, "boom", {}, _Response(500, body))
+            return super().urlopen(request, timeout)
+
+    code = _run_main(monkeypatch, tmp_path, Echoing())
+    written = (tmp_path / "_assessment" / "assessment.json").read_text(encoding="utf-8")
+    assert code == 0
+    assert ENV["TABLEAU_PAT_SECRET"] not in written
+    assert "[REDACTED]" in written
+    assert (tmp_path / "_assessment" / "report.md").read_text(encoding="utf-8").count(ENV["TABLEAU_PAT_SECRET"]) == 0
+    assert no_sleep == []


### PR DESCRIPTION
# Fixes #193 — one dropped connection no longer discards a whole estate assessment

`scripts/assess_estate.py` had **exactly one** `try/except` in 819 lines, at `_raw()`, and it caught
only `urllib.error.HTTPError`. `URLError`, `TimeoutError`, `RemoteDisconnected` and
`ConnectionResetError` propagated straight through `_raw → get → paged → collect → main`, so the
process died with a traceback — and since nothing was persisted until `main()` finished, a failure
minutes in discarded everything. `graphql()` was worse still: no handler at all, so even a plain
`HTTPError` was fatal there.

Three consecutive customer runs died this way on three different **secondary** endpoints
(`customviews`, `groups/{id}/users`, `customviews`), each at the 180 s timeout, each discarding a
completed inventory of 273 workbooks / 1042 views / 29 projects / 8 groups.

The design intent was already resilience — `get()`'s docstring says *"one 403 on one workbook's
permissions must not void an estate-wide assessment"* — it was just **status-code shaped**. A
transport failure never produces a status, so it bypassed that entire ladder, including the
`SESSION_LOST` re-auth loop. This PR extends the existing promise to cover "no answer at all".

## What changed

| # | Ask | Change |
|---|---|---|
| 1 | catch transport failures where status codes already were | `_raw()` also catches `(OSError, http.client.HTTPException)` and returns the sentinel `NETWORK_ERROR_STATUS = 0` with the exception text as the body — `URLError`/`TimeoutError`/`ConnectionResetError` are `OSError`s, `RemoteDisconnected`/`IncompleteRead` are `HTTPException`s. `graphql()` no longer builds its own request; it travels the same ladder and returns `(payload, error)`. Reading an `HTTPError`'s own body is wrapped too (`_error_body`), so a second failure while reading the error cannot escape. |
| 2 | bounded, classified retry | New `classify(status, text) → ok / session_lost / transient / denied / failed`. **Transient is checked before the auth statuses** so a gateway 503 is never misfiled as a permanent block; `401`/`403` → `denied`, a final answer, never retried (AGENTS.md: *"a MISSING CREDENTIAL is not transient"*). `_may_retry()` enforces **both** an attempt bound and a wall-clock budget — 3 attempts × a 180 s timeout is 9 minutes on one listing, while a budget alone permits an unbounded fast loop against a connection refused instantly. `backoff_delay()` is exponential with full jitter, capped at 30 s. `sign_in()` retries transient failures only, and a hard failure sets `auth_failed`, which short-circuits every later call so a dead session cannot cost each endpoint its full budget. |
| 3 | a `degraded` contract | `paged()` now returns `(rows, error)` — the rows it *did* read plus the failure, naming the page. `assemble()` emits `listing_errors[]`, `degraded`, `degraded_primary`, mirrored into `summary`. `_warn_lines()` produces **one** wording rendered to **two** surfaces (log and `report.md`), so a reader who sees only one reaches the same conclusion. Every secondary listing degrades **individually** (`_collect_listings` collects per spec; group membership per group; IAM per object). |
| 4 | persist pass 1 first | `collect(..., checkpoint=…)` writes `raw/*.json` the moment the inventory exists, **before** the flakier secondary/IAM/GraphQL passes. |
| 5 | per-endpoint elapsed logging | `_took()` emits `elapsed=Ns` in the idiom `harvest_estate_assets.py` uses; each listing logs its path *before* the call and rows + elapsed after; IAM logs `[i/n]` progress. "Slow" is now distinguishable from "dead" while it happens. |
| 6 | name and configure the timeouts | `DEFAULT_REST_TIMEOUT_SEC` / `DEFAULT_GRAPHQL_TIMEOUT_SEC` / `DEFAULT_MAX_ATTEMPTS` / `DEFAULT_RETRY_BUDGET_SEC`, carried in a frozen `HttpPolicy`, all four CLI-settable (`--rest-timeout`, `--graphql-timeout`, `--max-attempts`, `--retry-budget`). Defaults are the previous hard-coded values, so behaviour is unchanged unless asked. |

The contract is ported from the engine's `estate_survey.py` (`paged_list()` → `(rows, error)`,
`survey["degraded"]`, the `[WARN]`/`[ACTION]` wording); the **retry classification** is ported from
this repo's own `scripts/capture_tableau_oracle.py`, which already had `NETWORK_ERROR_STATUS`,
`TRANSIENT_STATUSES`, `backoff_delay()` and the rule that a credential failure is never transient.
Nothing new was invented where an idiom already existed.

## The non-negotiable bit: degraded is never quiet

| severity | listings | report | exit |
|---|---|---|---|
| **PRIMARY** | workbooks, views, datasources, projects, structure (GraphQL) | the document's **first heading**: `# ⚠️ DEGRADED — a PRIMARY listing is INCOMPLETE` | **3** |
| SECONDARY | subscriptions, alerts, custom views, group membership, flows, IAM grants | a `> ⚠️ **DEGRADED**` blockquote above the summary | 0 |

Two classifications beyond the brief's list, both deliberate and both open to challenge:

- **`views` is PRIMARY.** The coverage curve — the artifact the entire decision rests on — is built
  from view usage. A partial view listing produces a *confident wrong curve*, which is exactly the
  failure mode this PR exists to prevent.
- **GraphQL structure is PRIMARY.** `score_workbook` answers `0` for a workbook it cannot see, and 0
  complexity is not "simple", it is "unknown" — it feeds the retire-candidate tier directly. Partial
  GraphQL `errors` *with* data degrade as SECONDARY; with no data, PRIMARY.

And one distinction that matters in the other direction: **a 403 is an answer, a timeout is not.**
`_grants()` degrades only when `error["transport"]` is true, so a LockedToProject estate — where 403s
on permissions are normal and expected — does not raise a false alarm.

## Two things I added that were not asked for

- **Redaction (`Site._scrub`).** Failure text is now *persisted* into `assessment.json` and
  `report.md`. A proxy, WAF or debug endpoint that echoes the sign-in request body would therefore
  write the owner's full-permission PAT into two durable artifacts. Every decoded body goes through
  `tableau_env.redact`, at the point of capture. This is the hazard that function exists for.
- **`grp.members` is NULL, not 0, for an unreadable group.** "We could not see it" and "it is empty"
  are opposite answers, and 0 is the one that reads as a finding.

## Reproduction

The failure in the issue, simulated end to end (`FakeTableau` monkeypatches
`urllib.request.urlopen`; no network, no live server, no PAT read):

- `TimeoutError` on `/customviews` → **exit 0**, all 3 workbooks assessed, `degraded: true`,
  `degraded_primary: false`, `listing_errors[0].listing == "custom_views"`, a `[WARN]` in both the
  log and `report.md`, and `estate.db` written. Previously: traceback, nothing on disk.
- `TimeoutError` on `/views` → **exit 3**, `# ⚠️ DEGRADED` as the report's first line, `views` named.
- No failures → exit 0, no banner, `degraded: false`.

## Mutation matrix

Each mutation was applied to `scripts/assess_estate.py`, the suite re-run, and the file restored.
"Caught" requires a **non-zero exit with the tests collected** (an import/collection error does not
count) **and** at least one *intended* test failing with a genuine assertion.

| # | Mutation | Caught by | Failure |
|---|---|---|---|
| M1 | `_raw` stops catching `OSError`/`HTTPException` (pre-#193 behaviour) | `test_transport_failure_returns_a_sentinel…`, `test_get_returns_None_on_a_timeout…` | ✅ 14 failures |
| M2 | `classify()` calls 401/403 transient | `test_an_auth_refusal_is_a_FINAL_answer…`, `test_a_bad_PAT_fails_sign_in_on_the_first_attempt` | ✅ 4 |
| M3 | `_may_retry` drops the attempt bound | `test_a_transient_failure_is_retried_up_to_the_bound` | ✅ 11 |
| M4 | `_may_retry` ignores the wall-clock budget | `test_the_wall_clock_budget_stops_a_slow_failing_endpoint` | ✅ 1 |
| M5 | `views` downgraded to SECONDARY | `test_a_timeout_on_a_PRIMARY_listing_exits_3…` | ✅ `assert 0 == 3` |
| M6 | `main()` returns 0 on `degraded_primary` | `test_a_timeout_on_a_PRIMARY_listing_exits_3…` | ✅ 1 |
| M7 | the pass-1 checkpoint is not called | `test_pass1_is_checkpointed_before_the_secondary_passes` | ✅ 1 |
| M8 | `paged()` swallows the error and truncates silently | `test_paged_returns_the_rows_it_got_plus_the_error…` | ✅ 9 |
| M9 | `_grants` degrades on a 403 | `test_a_403_is_an_ANSWER_and_does_not_degrade_the_iam_export` | ✅ 1 |
| M10 | `_scrub` stops redacting | `test_the_pat_secret_never_reaches_a_persisted_artifact` | ✅ 1 |
| M11 | the timeouts are hard-coded again | `test_the_configured_timeouts_reach_urlopen` | ✅ 1 |
| M12 | `graphql()` builds its own request and lets `HTTPError` escape | `test_graphql_survives_an_http_error…`, `test_an_unreadable_structure_call_is_PRIMARY` | ✅ 9 |
| M13 | the degraded contract always reports clean | `test_a_secondary_failure_degrades_and_names_the_listing` + 4 | ✅ 5 |
| M14 | the report renders its own wording instead of the shared one | `test_the_warn_wording_is_shared_by_the_log_and_the_report` | ✅ 4 |
| M15 | an unreadable group records 0 members instead of NULL | `test_an_unreadable_group_records_NULL_members_not_zero` | ✅ `assert 0 is None` |

**15/15 caught.**

## Gates (by exit code)

| gate | result |
|---|---|
| `ruff format scripts tests` | 98 files unchanged |
| `ruff check scripts tests` | **exit 0** |
| `pylint scripts` (in-venv, as CI runs it) | **10.00/10, exit 0** |
| `pytest tests/test_assess_estate_resilience.py` | 34 passed, **exit 0** |
| `pytest tests/test_assess_estate.py` (pre-existing) | 28 passed, **exit 0** |
| full `pytest -q` | 1490 passed, 7 skipped, **exit 0** |

## Deviation from the brief, stated plainly

The brief said to stay under `max-module-lines = 1200`. **The file is 1314 lines and carries a
documented `# pylint: disable=too-many-lines` waiver instead.** The two ways to comply were to trim
the explanatory docstrings — trading documented knowledge for a number, which this codebase
explicitly calls the wrong trade — or to split out the Tableau REST client, which is outside the file
group I was given and is a refactor that should not ride along with a hotfix for a blocked
engagement. The waiver follows the house style of `scripts/parse_tableau.py`: a reason immediately
above it that names the deferred real fix (one shared REST client, since
`capture_tableau_oracle.py` already carries a near-duplicate). **Reverse this if you disagree** — it
is a judgement call, not a constraint.

## What I could NOT verify

- **Nothing was run against a live Tableau server.** The customer PAT in `.env` was never read,
  printed or used. Every failure is injected at `urllib.request.urlopen`.
- **Real socket behaviour.** A simulated `TimeoutError` is not a real 180 s TCP stall; the retry
  budget's *wall-clock* arithmetic is tested with a monkeypatched clock, not measured.
- **Real mid-run re-authentication** against Tableau Cloud (`401002` → `sign_in()` → replay) is
  exercised only against a fake.
- **Whether exit 3 is right for the customer's own pipeline.** No caller in this repo inspects
  `assess_estate.py`'s exit code (grepped), so nothing here breaks — but a wrapper on their side
  that treats non-zero as "failed" would now see a *usable, loudly-flagged* run as a failure. That is
  the intended trade; it is worth confirming with them.
- **The `views` / GraphQL-structure PRIMARY classifications** are my judgement about which numbers
  the decision rests on, argued above, not something a test can settle.
- Whether `report.md` emitting **two H1s** when primary-degraded (banner + `# Estate assessment`) is
  acceptable in the customer's renderer. Deliberate — the banner must not be scrollable-past.

Fixes #193


---

# Review round 1 — two blocking findings fixed (`cfd5612`)

An independent blind review (reviewer given only #193 and the diff, never the author's reasoning)
returned **two blocking findings**. Both are now fixed on this branch. Neither was a defect in the
original resilience change as such — both are things that change *became* true once it started
persisting failure detail.

## B2 — a credential could be persisted unscrubbed (fixed first, deliberately)

`Site` scrubs credentials out of a raw response **body** (`_scrub(bytes)`), but `_request_json`
returns the **parsed** `payload` dict, which never travelled through that scrubber. The GraphQL
200-with-`errors` path read straight from it. On `master`:

```python
LOG.warning("  Metadata API errors: %s", str(structure["errors"])[:200])
```

— unscrubbed. A proxy, WAF or debug endpoint that echoes the request writes the owner's
full-permission PAT (or the live session token) into that string.

**This is why the ordering mattered.** On `master` the exposure is log-only. B1 (below) persists
degradation detail into `estate.db`, which would have *promoted* a log leak into a durable artifact
alongside `assessment.json` and `report.md`. Fixing B2 first is what stops this PR from making the
exposure worse.

- `scripts/assess_estate.py:318` — extracted a reusable `Site.scrub_text(text)`; `_scrub(bytes)` now
  delegates to it (`:337`), so there is one scrubber, not two conventions.
- `scripts/assess_estate.py:740` — the GraphQL path now does
  `site.scrub_text(str(payload['errors']))[:200]`. **Scrub then truncate**, matching `_request_json`.
  The reverse order would cut a secret in half and defeat the redaction pattern.

The pre-existing test `test_the_pat_secret_never_reaches_a_persisted_artifact` did **not** catch this:
its fake server `raise`s an `HTTPError`, so it only ever exercises the transport path, which was
already scrubbed. That is a textbook covering-test blind spot — the test could not observe the defect
it appears to guard. A new test drives the 200-with-`errors` path directly.

## B1 — `estate.db` carried no degradation marker

`assessment.json` records degradation; `estate.db` did not. A downstream consumer reading only the DB
could not tell a complete run from a partial one — and `deploy_estate.py`'s docstring called it
"authoritative and complete".

- `scripts/assess_estate.py:616` — two **additive** tables: `assessment_run` (assessed_at, degraded,
  degraded_primary, workbooks_total, listing_errors) and `listing_error` (one row per failure). No
  existing table or column is modified.
- `scripts/assess_estate.py:960` — `_write_run_marker()`, called from `write_store` (`:1105`) before
  commit.
- `scripts/deploy_estate.py:1204` — docstring only: "authoritative and complete" → "authoritative for
  what it read, but NOT guaranteed complete… consult its `assessment_run` row". Zero code lines.
- `docs/operator-runbook.md:427, :925` — `estate.db` added to the DEGRADED contract table and the
  §4.11 check.

## Gates — verified independently by exit code, not by reading output

Run by me in the worktree, not taken from the author's summary:

| command | exit |
|---|---|
| `ruff format --check scripts tests` | **0** (99 files already formatted) |
| `ruff check scripts tests` | **0** |
| `pylint scripts` | **0** (10.00/10 — confirms the `too-many-lines` waiver is still active) |
| `pytest -q` | **0** — 1494 passed, 7 skipped (baseline 1490 + 4 new) |

`git diff --stat master...HEAD` → exactly the four files in scope; working tree clean; local and
remote at `cfd5612`.

## Mutation testing (the tests were broken on purpose to prove they can fail)

| mutation | result |
|---|---|
| unscrub the B2 site | **2 failed** — raw secret visibly leaked in the captured log |
| no-op `_write_run_marker` | **3 failed** |
| drop all `listing_error` rows | **2 failed, 1 passed** |
| force `degraded` to `0` | **1 failed, 1 passed** |

The last two leaving one test green is the point: those tests **discriminate** between a degraded and
a clean run rather than failing unconditionally. All mutations produced real `AssertionError`s, not
collection/import errors — the false-positive shape that has fooled a mutation harness in this repo
before.

## One claim in the review corrected

The review described the degraded `estate.db` as *"byte-identical to a clean run"*. The core claim (no
degradation marker) is exactly right, and that phrasing is precisely true for a **secondary**
degradation such as the `customviews` timeout from #193. For a **primary** structure failure some
workbook complexity values differ (scored 0), so the file is not literally byte-identical. The fix
addresses the real point either way: nothing said the run was degraded.

## Not verified

No live Tableau server. B2's reproduction (a gateway echoing the token inside a GraphQL 200 error
body) is exercised against a fake server; I have not confirmed a real server ever emits that shape, so
this is defence-in-depth against attacker/server-controlled text rather than a fix for an observed
leak. Downstream consumers were not run end-to-end against a populated DB — additivity was argued
instead from the fact that they `SELECT` named tables and never enumerate `sqlite_master`.

**Naming judgement worth a reviewer's eye:** `assessment_run.listing_errors` (a count) sits beside the
`listing_error` table (rows). The plural count name mirrors `assessment.json`'s existing
`summary.listing_errors` field; consistency with the established JSON contract was chosen over
avoiding the near-collision. Say so if you would rather it were `listing_error_count`.
