### PR TITLE
Route persona screenshot capture by source, not by habit (#198)

### DIFF
--- a/.github/agents/pbi-migration-validator.agent.md
+++ b/.github/agents/pbi-migration-validator.agent.md
@@ -162,16 +162,19 @@ Refuse to do a meaningful pass without these — flag it back rather than guessi
    *spec* is never a reason to decline — a missing *ground truth* is, so say which you actually lack.
 3. **Tableau reference screenshots**, one whole-dashboard capture per dashboard at minimum, ideally
    per-worksheet crops too. **Ground truth lives at `migrations/workbooks/<slug>/reference/` (with a
-   `manifest.json`) — look there FIRST; all existing migrations already have one.** If it's empty, use
-   the repo's purpose-built, provenance-stamped capture subsystem rather than hand-rolling Playwright:
-   ```
-   python scripts/capture_tableau_reference.py migrations/workbooks/<slug> [--public-url <url> --view <view>]
-   ```
-   It has a **`manual` provider** for workbooks that are *not* on Tableau Public (the enterprise case):
-   the user drops screenshots into `reference/` and they become the immutable ground truth. See
-   `docs/reference-capture.md`. Only fall back to raw Playwright (Gotchas below) if that script can't
-   serve the case. A fidelity review without ground-truth imagery is guessing — but **"not on Tableau
-   Public" is NOT a reason to refuse**; ask for a manual capture instead.
+   `manifest.json`) — look there FIRST; all existing migrations already have one**, and the brief
+   names what the dispatcher captured in Step 1 (path, tool, grade), so you never route capture
+   yourself. A fidelity review without ground-truth imagery is guessing — but **"not on Tableau
+   Public" is NOT a reason to refuse**: ask for the dispatcher's capture, or a manual one.
+
+   ⚠️ **Grade the evidence, don't just consume it (#194).** If the brief points you at an *oracle*
+   capture (`_oracle/images/…`, from `capture_tableau_oracle.py`), those images land OUTSIDE
+   `reference/` and carry **no `capabilities` manifest** — so they are **not** a `validation_grade`
+   source. Treat an oracle image as **layout- and text-grade** native-render evidence (catch gross
+   layout/label/mark differences), for the **default state only** (no `?vf_` state-pinning). Do **not**
+   sign off visual fidelity, `state_reproducible`, or `revision_bound` parity on it alone; a signed-off
+   visual PASS still needs a `validation_grade` reference (guided manual export / user-confirmed
+   screenshot). Record the gap in `limitations_encountered`. See `docs/reference-capture.md`.
 4. **The semantic model + PBIP report location** — for your own PBI-side screenshots (Desktop Bridge
    `screenshot`/`screenshot-all`, otherwise ask the orchestrator/user for a fresh one) and for the
    numeric `EVALUATE` pass (see *Skills you use* for the offline path that works on a local PBIP).

--- a/.github/agents/tableau-migrator.agent.md
+++ b/.github/agents/tableau-migrator.agent.md
@@ -205,8 +205,8 @@ PBIR files yourself.
    `fixable` / `accepted-limitation` / `false-claim`, and **both builders consume that
    classification**. Sending a builder at the raw list instead means it repairs a deferral that was
    deliberate — measured, one such row would silently re-scope six other table calcs. Give it the
-   handover slice, the active contract (`migration-spec.json` or engine bundle) and the reference bundle
-   (`migrations/workbooks/<name>/reference/`; capture with `capture_tableau_reference.py` if empty).
+   handover slice, the active contract (`migration-spec.json` or engine bundle) and the reference
+   bundle (path/tool/grade from the brief; default `migrations/workbooks/<name>/reference/`).
    **Name the mode** — this persona has three (triage / spot-check / sign-off) and they are different
    jobs; step 10 invokes it again, independently, for the last one.
 8. **Delegate to `pbi-semantic-builder`** with: the handover slice (its `requests[]` is the work

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -450,10 +450,10 @@ installs under `~/.copilot/installed-plugins/tableau-collection/tableau-fabric-s
 second copy.
 
 **Three things about that invocation will bite you, all measured:** `--server` is required (there is
-no default); `--json` takes a **PATH**, not a bare flag; and the PAT **name** cannot come from a
-`.env` file, so pass `--pat-name` on the command line. `run_engine_survey.py` reads the one documented
-`TABLEAU_PAT_SECRET` key (or the legacy engine spelling in existing environments), exports both names
-to the engine, and supplies `--no-prompt` so a missing secret fails clearly rather than hanging.
+no default); `--json` takes a **PATH**, not a bare flag; and — via `run_engine_survey.py` — the PAT
+**name** rides through from `.env`, so the `--pat-name` above is optional: it carries the whole file
+into the engine's child env (with `--no-prompt`). Pass it **only** for a *direct* `estate_survey.py`
+call — the engine's `credential_resolver.py` reads the *secret* from `--env-file`, not the name.
 
 `harvest_estate_assets.py` is worth more than the download: it also runs **both** parsers (ours for
 fidelity, the engine's for conversion) over every asset and writes `<out>/parse-sweep.md` /

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -452,8 +452,9 @@ second copy.
 **Three things about that invocation will bite you, all measured:** `--server` is required (there is
 no default); `--json` takes a **PATH**, not a bare flag; and — via `run_engine_survey.py` — the PAT
 **name** rides through from `.env`, so the `--pat-name` above is optional: it carries the whole file
-into the engine's child env (with `--no-prompt`). Pass it **only** for a *direct* `estate_survey.py`
-call — the engine's `credential_resolver.py` reads the *secret* from `--env-file`, not the name.
+into the engine's child env (with `--no-prompt`). A *direct* `estate_survey.py` call must supply the
+name itself — `--pat-name` or an exported `TABLEAU_PAT_NAME` — because the engine's
+`credential_resolver.py` reads only the *secret* from `--env-file`, never the name.
 
 `harvest_estate_assets.py` is worth more than the download: it also runs **both** parsers (ours for
 fidelity, the engine's for conversion) over every asset and writes `<out>/parse-sweep.md` /

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -460,6 +460,33 @@ fidelity, the engine's for conversion) over every asset and writes `<out>/parse-
 `parse-sweep.json` — an estate-wide failure distribution, and exactly the evidence an upstream
 feature request needs instead of an anecdote.
 
+**Capture the Tableau reference imagery in the SAME trip — this is the dispatcher's job, not a
+subagent's.** A fidelity review later needs a picture of the *source*, and nothing downstream produces
+it: the Desktop Bridge `screenshot`/`screenshot-all` commands shoot the Power BI *output*, not
+Tableau. Capturing it now, while you are already authenticated to the site, is the difference between
+one command and a re-authentication against a server that may since have gone dark — which is why it
+belongs here and not inside a persona (issue #198: an operator had to ask for it by hand, because the
+builder/validator personas each routed capture themselves and stalled on the wrong tool). **Pick the
+tool by the source:**
+
+| Source | Capture command | Notes |
+|---|---|---|
+| **Tableau Public URL, or a local `.twb`/`.twbx`** | `python scripts/capture_tableau_reference.py migrations/workbooks/<slug> [--public-url <url> --view <view>]` | Writes a provenance-stamped `reference/manifest.json` — a `capabilities`-carrying `validation_grade` source; its `manual` provider also adopts user-dropped `tableau-*.png` in `reference/`. An **existing `reference/manifest.json` short-circuits to exit 0** — re-run with `--force`. |
+| **Tableau Server/Cloud** (`TABLEAU_SERVER_URL` configured) | `python scripts/capture_tableau_oracle.py --out _oracle --images [--workbook "<published name>"]` | The command on the left **exits 3** on an empty target when the URL is set (URL unset → 1): that is *"wrong tool for this source"*, **NOT** "capture is impossible" — misreading it is the whole of #198. Its `server_rest` provider is a `NotImplementedError` stub. Use the oracle, which does the live REST image export. |
+
+Three things about the oracle bite, all verified in `scripts/capture_tableau_oracle.py`:
+- **`--out` is required** — omit it and argparse exits 2, capturing nothing.
+- **`--workbook` is an exact, case-insensitive *published-workbook-name* filter** (`select_views`), so
+  substituting a migration slug for the published name silently matches **zero** views.
+- **Do not trust the oracle's exit 0.** It is computed from per-view *data* status only — image status
+  never reaches the exit code, and zero selected views also exits 0 — so `--images` can return 0
+  having produced no image. Confirm the capture in `_oracle/oracle-manifest.json` (a non-zero
+  `view_count`, plus each view's image status) before believing it happened. It writes renders to
+  `_oracle/images/<view>__<luid8>.png`, numbers to `_oracle/data/`, and that manifest.
+
+Credentials for either tool come from `.env` **or exported environment variables** (the latter take
+precedence), never CLI arguments.
+
 **The conversion engine has exactly ONE source: the installed plugin.** `tableau-fabric-skills@tableau-collection`,
 at `~/.copilot/installed-plugins/tableau-collection/tableau-fabric-skills/`. Not a sibling clone, not
 a checkout in `~/vscode-projects`, not "whichever one a script finds first". Every step resolves it
@@ -540,6 +567,17 @@ two reasons no persona can solve alone: it survives a **dropped session** (a clo
 this session's entire working memory with it — measured, 2026-08-08), and it is what a **stateless**
 subagent receives instead of re-deriving intent nobody wrote down. Then invoke `@tableau-migrator`
 per unit of work, handing it the brief.
+
+**Record the Step-1 capture in the brief — grade included.** A stateless subagent cannot see what you
+captured; the brief is how it learns. For each unit write down three things: **where the reference
+landed** (`migrations/workbooks/<slug>/reference/` for a `capture_tableau_reference.py` run, or
+`_oracle/images/…` for an oracle run), **which tool produced it**, and **what grade of evidence it
+is** — the load-bearing part. A `reference/` capture carries a `capabilities` manifest and is a
+`validation_grade` source; an **oracle** capture is **not** — its images land outside `reference/`,
+carry no `capabilities` manifest, and are taken in the view's **default state only** (no `?vf_` filter
+pinning), so they are **layout- and text-grade only**. Say so in the brief, and tell the consumer to
+log that ceiling in `limitations_encountered`: a visual PASS signed off on oracle imagery alone is
+overstated (issue #194). Do not quietly drop this, and do not inflate it.
 
 > **Running the pipeline by hand, or standing behind someone who is?**
 > [`docs/operator-runbook.md`](docs/operator-runbook.md) is the command-by-command version of this


### PR DESCRIPTION
Fixes #198.

## The defect

Both personas hard-coded `capture_tableau_reference.py` for grabbing a source Tableau reference image.
That script's Server/Cloud provider is a **stub** — it exits 3 whenever `TABLEAU_SERVER_URL` is set,
which is *every real customer engagement*, since those always have a configured `.env`. The agent then
stalled and a human had to name the right script by hand. That is the reported symptom.

PR #195 fixed the human-facing docs. It did not fix the **personas**, which are what the agent actually
reads. So the dead end survived the fix.

## What changed

Each persona now routes **by source**, not by habit:

| source | tool |
|---|---|
| Tableau Public URL, or a local `.twb`/`.twbx` | `capture_tableau_reference.py` (incl. its `manual` provider) |
| Tableau Server/Cloud (`TABLEAU_SERVER_URL` set) | `capture_tableau_oracle.py --out _oracle --images` |

and `exit 3` from the reference script is now documented as **"wrong tool for this source"**, not
"capture is impossible" — which is the inference that produced the stall.

## Honest about what the oracle image is NOT

This is the part I would review hardest. `capture_tableau_oracle.py --images` is a real live REST render,
but its output lands **outside** `reference/` and carries **no `capabilities` manifest**. The validator
persona now says so explicitly: treat it as **layout- and text-grade** evidence for the **default state
only** (no `?vf_` state-pinning), do **not** sign off `validation_grade`, `state_reproducible` or
`revision_bound` on it alone, and record the gap in `limitations_encountered`.

An agent that silently upgraded an ungraded image to a sign-off source would be a worse bug than the
one being fixed here.

## Verified (by command, not by reading)

- `grep -c capture_tableau_oracle .github/agents/*.agent.md` → validator `1`, migrator `1`
- `sync_agent_conventions.py --check` → **exit 0**; migrator 29,864 / validator 29,510, both under the
  30,000-char cap
- `git diff --stat master...HEAD` → **only** the two persona files
- exit-3 mechanism confirmed at `scripts/capture_tableau_reference.py:302-307` (`TABLEAU_SERVER_URL`
  set → `NotImplementedError` → `return 3`)
- the documented oracle output path is exact: `capture_tableau_oracle.py:370` builds
  `stem = f"{safe_slug(name)}__{view_luid[:8]}"`, `:401` writes it to `out_dir/"images"`, `:503` emits
  `oracle-manifest.json`, `:404` calls `/image?resolution=high`

## Cap trade (worth a look)

`tableau-migrator.agent.md` had ~190 chars of headroom. To fit the routing sentence, the redundant gloss
`` (`migration-spec.json` or engine bundle) `` on *"the active contract"* was dropped from step 7 — the
term is already defined in step 3 and detailed in step 8. Net +55 chars. If a reviewer thinks that gloss
was load-bearing, say so; the trade is the reviewable decision here, not the routing.

## Scope — deliberately NOT closed

This is the **personas half**. It does **not** close #194 item 5 (making `server_rest` a real provider on
the shared transport). The stub is untouched. A field reporter has a working implementation and has been
invited to PR it separately.

## Not verified

No live Tableau Server/Cloud site was available, so `capture_tableau_oracle.py --images` was not run
end-to-end. Flags, credential handling and output paths are verified from the code; the exit-3 routing is
verified by experiment; the oracle's live behaviour (re-auth on `401002`, real image bytes) rests on the
code plus its live-tested docstring, not a fresh run.
