### PR TITLE
docs(.env.example): correct an inverted claim about the PAT name

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,10 @@ TABLEAU_SERVER_URL=
 TABLEAU_SITE=
 
 # Personal Access Token.
+# Setting it here is enough for the engine too: run_engine_survey.py forwards the whole environment,
+# and the engine reads the NAME from it (fetch_tds.py `args.pat_name or os.environ.get(...)`). Only a
+# DIRECT call to the engine's estate_survey.py needs `--pat-name` - its credential_resolver.py
+# resolves the SECRET through the .env layer, never the name.
 TABLEAU_PAT_NAME=
 # Set this one secret key. scripts/run_engine_survey.py accepts it and silently supplies the
 # deterministic engine's historical spelling when it invokes estate_survey.py.

--- a/.env.example
+++ b/.env.example
@@ -13,11 +13,9 @@ TABLEAU_SERVER_URL=
 # Site content URL segment (the part after /site/ in a Tableau URL); empty string for Default.
 TABLEAU_SITE=
 
-# Personal Access Token.
-# Setting it here is enough for the engine too: run_engine_survey.py forwards the whole environment,
-# and the engine reads the NAME from it (fetch_tds.py `args.pat_name or os.environ.get(...)`). Only a
-# DIRECT call to the engine's estate_survey.py needs `--pat-name` - its credential_resolver.py
-# resolves the SECRET through the .env layer, never the name.
+# PAT name (not a secret). run_engine_survey.py forwards it from .env into the engine's process env,
+# so filling it in here is enough (fetch_tds.py: `os.environ.get("TABLEAU_PAT_NAME")`) - only a
+# direct call to estate_survey.py, bypassing that wrapper, still needs --pat-name explicitly.
 TABLEAU_PAT_NAME=
 # Set this one secret key. scripts/run_engine_survey.py accepts it and silently supplies the
 # deterministic engine's historical spelling when it invokes estate_survey.py.

--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -382,11 +382,13 @@ convention — see §7 for which ones actually are.
 - `scripts/run_engine_survey.py` supplies `--no-prompt` itself, converting a missing secret from a
   hidden-input block into an instant, explanatory error.
 
-`--pat-name` on the command line is the safe default. It *can* come from the process environment
-variable `TABLEAU_PAT_NAME` ✅ verified (`fetch_tds._resolve_auth`:
-`args.pat_name or os.environ.get("TABLEAU_PAT_NAME")`) — but **not** from the `.env` file, because
-the `--env-file` layer is only consulted for *secrets*. Omitting the name is harmless: it raises an
-immediate `SystemExit` naming both options ✅ verified by direct call.
+`--pat-name` on the command line is the safe default, but **through `run_engine_survey.py` it is
+optional**: the wrapper forwards the whole `.env` into the engine's child process environment, and
+the engine reads the name from there ✅ verified (`fetch_tds._resolve_auth`:
+`args.pat_name or os.environ.get("TABLEAU_PAT_NAME")`), and confirmed by a live sign-in with `.env`
+alone. It is genuinely required only for a **direct** `estate_survey.py` call that bypasses the
+wrapper — there the `--env-file` layer is consulted for *secrets* only, never the name, and omitting
+it raises an immediate `SystemExit` naming both options ✅ verified by direct call.
 
 Expect on success: `[SURVEY] N workbook(s); M depend on a published datasource; K datasource(s) must
 be fetched first.` then one `[DEPENDS]` line per dependent workbook, then `[OK] survey written to …`.


### PR DESCRIPTION
A blind review of the original version of this PR **disproved its central claim by running the code**, and ground truth confirmed the reviewer. This revision inverts the claim.

## What the original PR said (wrong)

That the deterministic engine cannot resolve `TABLEAU_PAT_NAME` from a `.env`, so an engine survey always needs `--pat-name` on the command line.

## What is actually true

```
scripts/run_engine_survey.py:61   subprocess.run(cmd, env=engine_child_env(env))
scripts/tableau_env.py:231        merged = {**dict(os.environ), **env}
<engine>/.../estate_survey.py:386 fetch_tds._resolve_auth(args)
<engine>/.../fetch_tds.py:564     args.pat_name or os.environ.get("TABLEAU_PAT_NAME")
```

`engine_child_env` forwards the **whole** `.env` dict into the child environment — it only *aliases* the secret, it does not filter which other keys pass through (already pinned by `tests/test_tableau_env.py:79-81`). The engine reads the name straight from the environment. **`--pat-name` is not required on the sanctioned path.**

## Why the original reasoning failed

It checked the engine's `credential_resolver.py`, found no PAT-name path, and concluded none existed anywhere. That is true but insufficient — the name never goes through `credential_resolver` at all. Checking one file and stopping is precisely the error, and it is worth recording because the same mistake is already baked into `AGENTS.md`.

## What survives

A **direct**, wrapper-bypassing call to `estate_survey.py` does still need `--pat-name`, because `credential_resolver.py` resolves only the SECRET through the `.env` layer. The comment now says that, and nothing more.

## Verification

- **Live sign-in against Tableau Cloud** with only `.env` populated and no `--pat-name` argument: **succeeded**.
- `tests/test_tableau_env.py`, `tests/test_preflight_contract.py`, `tests/test_deploy_estate.py` → **301 passed, exit 0**.
- Corroboration already in-repo: `harvest_estate_assets.py` invokes the sibling engine script `fetch_tds.py` and its command list never includes `--pat-name`; it works purely because `engine_child_env(env)` is passed as `env=`.

## Follow-up (deliberately not in this PR)

`AGENTS.md:452-457` and `docs/operator-runbook.md` carry the **same inverted claim** — that pre-existing error is what caused this PR in the first place. Both files are owned by an in-flight branch and are being corrected there, to avoid a conflict.
