### PR TITLE
Fix #199: preflight never checked ADOMD.NET, so a machine passed clean and failed mid-migration

### DIFF
--- a/.github/skills/pbip-model-refresh/SKILL.md
+++ b/.github/skills/pbip-model-refresh/SKILL.md
@@ -14,8 +14,8 @@ and AMO client libraries under `~/.nuget/packages`, and `npx` for
 
 The ADOMD.NET client is a *separate* nuget package from TOM/AMO, so a machine can have one and not the
 other. If `probe_desktop_query.py` prints `AdomdClient.dll not found in the nuget cache` (and
-`preflight.ps1` WARNs `ADOMD.NET client (live DAX probe)`), restore it — forcing a supported TFM so
-`dotnet add` cannot silently no-op on a net10 default:
+`preflight.ps1` WARNs `ADOMD.NET client (Desktop probe/refresh)`), restore it — forcing a supported TFM
+so `dotnet add` cannot silently no-op on a net10 default:
 `dotnet new console -o $env:TEMP\adomd --framework net8.0; dotnet add $env:TEMP\adomd package Microsoft.AnalysisServices.AdomdClient.NetCore.retail.amd64 --version 19.84.1`
 
 ## Available scripts

--- a/.github/skills/pbip-model-refresh/SKILL.md
+++ b/.github/skills/pbip-model-refresh/SKILL.md
@@ -12,6 +12,12 @@ Requirements, in full: Windows with Power BI Desktop, Python >= 3.11 with `pytho
 and AMO client libraries under `~/.nuget/packages`, and `npx` for
 `@microsoft/powerbi-desktop-bridge-cli`. No other dependency, and nothing repo-specific.
 
+The ADOMD.NET client is a *separate* nuget package from TOM/AMO, so a machine can have one and not the
+other. If `probe_desktop_query.py` prints `AdomdClient.dll not found in the nuget cache` (and
+`preflight.ps1` WARNs `ADOMD.NET client (live DAX probe)`), restore it — forcing a supported TFM so
+`dotnet add` cannot silently no-op on a net10 default:
+`dotnet new console -o $env:TEMP\adomd --framework net8.0; dotnet add $env:TEMP\adomd package Microsoft.AnalysisServices.AdomdClient.NetCore.retail.amd64 --version 19.84.1`
+
 ## Available scripts
 
 - [**`scripts/refresh_pbip_model.py`**](scripts/refresh_pbip_model.py) - refresh the open model,

--- a/.github/skills/pbip-model-refresh/scripts/probe_desktop_query.py
+++ b/.github/skills/pbip-model-refresh/scripts/probe_desktop_query.py
@@ -112,7 +112,14 @@ def _load_adomd():
             from Microsoft.AnalysisServices.AdomdClient import AdomdConnection
 
             return AdomdConnection
-    print("PREFLIGHT: ERROR Microsoft.AnalysisServices.AdomdClient.dll not found in the nuget cache")
+    print(
+        "PREFLIGHT: ERROR Microsoft.AnalysisServices.AdomdClient.dll not found in the nuget cache - "
+        "restore it (a DIFFERENT nuget package from the TOM/AMO one), forcing a supported TFM so the "
+        "add cannot silently no-op on a net10 default: "
+        r"dotnet new console -o $env:TEMP\adomd --framework net8.0; "
+        r"dotnet add $env:TEMP\adomd package Microsoft.AnalysisServices.AdomdClient.NetCore.retail.amd64 "
+        "--version 19.84.1"
+    )
     sys.exit(2)
 
 

--- a/scripts/preflight.ps1
+++ b/scripts/preflight.ps1
@@ -460,6 +460,30 @@ Add-Check 'Privacy Levels (manual)' 'optional' $true `
 # restored by the tmdl_validate project - so the real machine dependency is the .NET SDK.
 Add-Cli 'dotnet' 'critical' 'Install the .NET SDK - needed to build/run the offline TMDL structural validator (tmdl_validate).'
 
+# --- ADOMD.NET client assembly (probe_desktop_query.py's live-Desktop DAX gate) ---------------------
+# The .NET-SDK check above covers TOM/AMO (Microsoft.AnalysisServices.NetCore.retail.amd64). ADOMD.NET
+# is a SEPARATE nuget package (Microsoft.AnalysisServices.AdomdClient.NetCore.retail.amd64) - a machine
+# can have TOM and still be missing ADOMD. That was the silent field failure this check exists for: on
+# a colleague's box the AdomdClient assembly was absent, so probe_desktop_query.py could not run a live
+# EVALUATE, and nothing flagged it up front. `dotnet add package` had even printed "Restored ... 0
+# Errors" while landing ZERO PackageReference (a net10.0 scratch project silently no-op'd the add) - so
+# console text is not proof; presence of the DLL on disk is. Hence a file check, not a restore attempt.
+#
+# It resolves the EXACT path probe_desktop_query.py globs (probe_desktop_query.py:52-55:
+# Path.home()/.nuget/packages/microsoft.analysisservices.adomdclient.netcore*/**/AdomdClient.dll, NOT
+# $env:NUGET_PACKAGES) so it PREDICTS the probe's own resolution rather than a different cache location.
+#
+# Severity: recommended, not critical. ADOMD is needed ONLY by the live-Desktop data probe - the
+# credentials/reachability gate before building a report - the same Desktop-phase-only scope as the
+# PBI_DESKTOP_PATH check above. The deterministic estate pipeline, offline TMDL validation and PBIR
+# authoring/validation never touch it, so a miss must NOT block an estate/model-only run; but it must be
+# a VISIBLE warning naming the gated capability and the exact restore, because its absence was silent.
+$adomdDll = Get-ChildItem -Path (Join-Path $HOME '.nuget\packages\microsoft.analysisservices.adomdclient.netcore*') `
+    -Recurse -Filter 'Microsoft.AnalysisServices.AdomdClient.dll' -ErrorAction SilentlyContinue | Select-Object -First 1
+Add-Check 'ADOMD.NET client (live DAX probe)' 'recommended' ([bool]$adomdDll) `
+    $(if ($adomdDll) { $adomdDll.FullName } else { 'not in the nuget cache - probe_desktop_query.py cannot run a live EVALUATE against an open Desktop model' }) `
+    'Restore the ADOMD.NET client (a DIFFERENT nuget package from the TOM/AMO one the .NET-SDK check covers), forcing a supported TFM so the add cannot silently no-op on a net10 default: dotnet new console -o $env:TEMP\adomd --framework net8.0; dotnet add $env:TEMP\adomd package Microsoft.AnalysisServices.AdomdClient.NetCore.retail.amd64 --version 19.84.1  (throwaway project; the restore populates the shared ~/.nuget cache the probe reads).'
+
 Add-Cli 'uv' 'optional' 'Install uv for env/dependency management (uv venv && uv sync).'
 Add-Cli 'az' 'optional' 'Azure CLI - only for Fabric REST / token-based operations.'
 

--- a/scripts/preflight.ps1
+++ b/scripts/preflight.ps1
@@ -477,16 +477,19 @@ Add-Cli 'dotnet' 'critical' 'Install the .NET SDK - needed to build/run the offl
 # os.path.expanduser("~") resolve to the SAME base - both go through os.path.expanduser - so those two
 # cannot disagree; that NEITHER honours NUGET_PACKAGES is a separate cross-file gap - see #203.)
 #
-# Severity: recommended, not critical. ADOMD is used by the pbip-model-refresh skill's live-Desktop
-# steps - BOTH the read-only DAX probe (probe_desktop_query.py) and the refresh + cache.abf persist
-# (refresh_pbip_model.py imports _load_adomd) - i.e. the credentials/reachability gate and the model
-# refresh before building a report. That is the same Desktop-phase-only scope as the PBI_DESKTOP_PATH
-# check above: the deterministic estate pipeline, offline TMDL validation and PBIR authoring/validation
-# never touch it, so a miss must NOT block an estate/model-only run; but it must be a VISIBLE warning
-# naming the gated capability and the exact restore, because its absence was silent.
+# Severity: CRITICAL, by this file's own rule above — "critical if any persona's Definition of Done
+# depends on it, even when the dependency only fails later at handoff/validation time". It does, and
+# unconditionally: `pbi-semantic-builder`'s DoD step 8 is a HANDOFF GATE that runs
+# refresh_pbip_model.py (which imports `_load_adomd`) to refresh and SAVE `.pbi/cache.abf`, and
+# `pbi-report-builder`'s step 1 refuses to open Desktop without that file. So every migration that
+# ends in a report needs ADOMD — this is not the live-source-only scope it first appears to be.
+# Measured 2026-08-17: with only this lookup suppressed on an otherwise healthy machine, preflight
+# printed "Ready to migrate" and exited 0 while the probe exited 2 — reproducing exactly the silent
+# false-green #199 was filed to remove. Do NOT downgrade this to recommended without also removing
+# the refresh/save gate from those two personas.
 $adomdDll = Get-ChildItem -Path (Join-Path $HOME '.nuget\packages\microsoft.analysisservices.adomdclient.netcore*') `
     -Recurse -Filter 'Microsoft.AnalysisServices.AdomdClient.dll' -ErrorAction SilentlyContinue | Select-Object -First 1
-Add-Check 'ADOMD.NET client (Desktop probe/refresh)' 'recommended' ([bool]$adomdDll) `
+Add-Check 'ADOMD.NET client (Desktop probe/refresh)' 'critical' ([bool]$adomdDll) `
     $(if ($adomdDll) { $adomdDll.FullName } else { 'not in the nuget cache - probe_desktop_query.py / refresh_pbip_model.py cannot reach an open Desktop model' }) `
     'Restore the ADOMD.NET client (a DIFFERENT nuget package from the TOM/AMO one the .NET-SDK check covers), forcing a supported TFM so the add cannot silently no-op on a net10 default: dotnet new console -o $env:TEMP\adomd --framework net8.0; dotnet add $env:TEMP\adomd package Microsoft.AnalysisServices.AdomdClient.NetCore.retail.amd64 --version 19.84.1  (throwaway project; the restore populates the shared ~/.nuget cache the probe reads).'
 

--- a/scripts/preflight.ps1
+++ b/scripts/preflight.ps1
@@ -460,7 +460,7 @@ Add-Check 'Privacy Levels (manual)' 'optional' $true `
 # restored by the tmdl_validate project - so the real machine dependency is the .NET SDK.
 Add-Cli 'dotnet' 'critical' 'Install the .NET SDK - needed to build/run the offline TMDL structural validator (tmdl_validate).'
 
-# --- ADOMD.NET client assembly (probe_desktop_query.py's live-Desktop DAX gate) ---------------------
+# --- ADOMD.NET client assembly (the pbip-model-refresh skill's live-Desktop probe + refresh) --------
 # The .NET-SDK check above covers TOM/AMO (Microsoft.AnalysisServices.NetCore.retail.amd64). ADOMD.NET
 # is a SEPARATE nuget package (Microsoft.AnalysisServices.AdomdClient.NetCore.retail.amd64) - a machine
 # can have TOM and still be missing ADOMD. That was the silent field failure this check exists for: on
@@ -473,15 +473,17 @@ Add-Cli 'dotnet' 'critical' 'Install the .NET SDK - needed to build/run the offl
 # Path.home()/.nuget/packages/microsoft.analysisservices.adomdclient.netcore*/**/AdomdClient.dll, NOT
 # $env:NUGET_PACKAGES) so it PREDICTS the probe's own resolution rather than a different cache location.
 #
-# Severity: recommended, not critical. ADOMD is needed ONLY by the live-Desktop data probe - the
-# credentials/reachability gate before building a report - the same Desktop-phase-only scope as the
-# PBI_DESKTOP_PATH check above. The deterministic estate pipeline, offline TMDL validation and PBIR
-# authoring/validation never touch it, so a miss must NOT block an estate/model-only run; but it must be
-# a VISIBLE warning naming the gated capability and the exact restore, because its absence was silent.
+# Severity: recommended, not critical. ADOMD is used by the pbip-model-refresh skill's live-Desktop
+# steps - BOTH the read-only DAX probe (probe_desktop_query.py) and the refresh + cache.abf persist
+# (refresh_pbip_model.py imports _load_adomd) - i.e. the credentials/reachability gate and the model
+# refresh before building a report. That is the same Desktop-phase-only scope as the PBI_DESKTOP_PATH
+# check above: the deterministic estate pipeline, offline TMDL validation and PBIR authoring/validation
+# never touch it, so a miss must NOT block an estate/model-only run; but it must be a VISIBLE warning
+# naming the gated capability and the exact restore, because its absence was silent.
 $adomdDll = Get-ChildItem -Path (Join-Path $HOME '.nuget\packages\microsoft.analysisservices.adomdclient.netcore*') `
     -Recurse -Filter 'Microsoft.AnalysisServices.AdomdClient.dll' -ErrorAction SilentlyContinue | Select-Object -First 1
-Add-Check 'ADOMD.NET client (live DAX probe)' 'recommended' ([bool]$adomdDll) `
-    $(if ($adomdDll) { $adomdDll.FullName } else { 'not in the nuget cache - probe_desktop_query.py cannot run a live EVALUATE against an open Desktop model' }) `
+Add-Check 'ADOMD.NET client (Desktop probe/refresh)' 'recommended' ([bool]$adomdDll) `
+    $(if ($adomdDll) { $adomdDll.FullName } else { 'not in the nuget cache - probe_desktop_query.py / refresh_pbip_model.py cannot reach an open Desktop model' }) `
     'Restore the ADOMD.NET client (a DIFFERENT nuget package from the TOM/AMO one the .NET-SDK check covers), forcing a supported TFM so the add cannot silently no-op on a net10 default: dotnet new console -o $env:TEMP\adomd --framework net8.0; dotnet add $env:TEMP\adomd package Microsoft.AnalysisServices.AdomdClient.NetCore.retail.amd64 --version 19.84.1  (throwaway project; the restore populates the shared ~/.nuget cache the probe reads).'
 
 Add-Cli 'uv' 'optional' 'Install uv for env/dependency management (uv venv && uv sync).'

--- a/scripts/preflight.ps1
+++ b/scripts/preflight.ps1
@@ -472,6 +472,10 @@ Add-Cli 'dotnet' 'critical' 'Install the .NET SDK - needed to build/run the offl
 # It resolves the EXACT path probe_desktop_query.py globs (probe_desktop_query.py:52-55:
 # Path.home()/.nuget/packages/microsoft.analysisservices.adomdclient.netcore*/**/AdomdClient.dll, NOT
 # $env:NUGET_PACKAGES) so it PREDICTS the probe's own resolution rather than a different cache location.
+# Honouring NUGET_PACKAGES here would be a BUG: dotnet restores into it but the probe never reads it, so
+# preflight would PASS while the probe still failed. (probe's Path.home() and refresh_pbip_model.py:473's
+# os.path.expanduser("~") resolve to the SAME base - both go through os.path.expanduser - so those two
+# cannot disagree; that NEITHER honours NUGET_PACKAGES is a separate cross-file gap - see #203.)
 #
 # Severity: recommended, not critical. ADOMD is used by the pbip-model-refresh skill's live-Desktop
 # steps - BOTH the read-only DAX probe (probe_desktop_query.py) and the refresh + cache.abf persist


### PR DESCRIPTION
Adds the missing ADOMD.NET preflight check reported from the field.

## The gap

`scripts/preflight.ps1` checks for the .NET SDK because TOM/AMO restores via NuGet
(`Microsoft.AnalysisServices.NetCore.retail.amd64`), but there was **no equivalent check for
ADOMD.NET** — confirmed by grep, zero hits. Meanwhile
`.github/skills/pbip-model-refresh/scripts/probe_desktop_query.py` hardcodes a glob for
`microsoft.analysisservices.adomdclient.netcore*` and exits with a raw pythonnet
assembly-not-found error when it is absent.

Net effect: a machine passes preflight clean and then fails hours later, mid-migration, on a live
Desktop `EVALUATE`. That is exactly what happened on a colleague's box — TOM present, ADOMD absent.

## What this adds

- A **`recommended`**-severity preflight check globbing the same package/DLL the probe globs, with an
  install hint. Recommended rather than critical because only scripts running a live Desktop
  XMLA/ADOMD query need it — the offline TMDL path does not.
- A note in the probe and in `pbip-model-refresh/SKILL.md` recording **why the check must not honour
  `NUGET_PACKAGES`**: the check has to mirror the probe's own resolution exactly, or it would pass
  while the probe still fails. That invariant is the whole point of the check.

## Verification

| gate | exit |
|---|---|
| `ruff format --check .github/skills` | **0** |
| `ruff check .github/skills` | **0** |
| `pylint .github/skills/pbip-model-refresh/scripts` | **0** (10.00/10) |
| `preflight.ps1` PowerShell AST parse | **no syntax errors** |

Scope: 3 files, +44/-1.

Fixes #199
