### PR TITLE
Fix #201: unquoted TMDL identifiers crash Desktop for any table name with a space

### DIFF
--- a/scripts/probe_live_source.py
+++ b/scripts/probe_live_source.py
@@ -178,9 +178,35 @@ ACCESS_DENIED_MARKERS = (
 # line ceiling.
 
 
+# TMDL reserves the single quote as its identifier delimiter: an identifier containing a space (or
+# most punctuation) MUST be quoted or Power BI Desktop refuses the model with InvalidObjectHeader.
+# The deterministic engine names unresolved custom-SQL relations `Custom SQL Query`, so the un-quoted
+# probe crashed on most real estates. Quote UNCONDITIONALLY - a quoted identifier is always valid
+# TMDL even where a bare one would be legal, which kills the "which character forces quoting?" guess.
+# Ground truth (Power BI's own serializer): examples/wind-energy-utilization/.../CO2 Savings.tmdl
+# `table 'CO2 Savings'` and model.tmdl `ref table 'CO2 Savings'`; an embedded quote is doubled, per
+# examples/broadway-stage-to-screen/.../1 Films.tmdl `column 'Sondheim''s Work'`.
+def _tmdl_ident(name: str) -> str:
+    """Quote `name` as a TMDL identifier: single quotes, doubling any embedded quote."""
+    return "'" + name.replace("'", "''") + "'"
+
+
+# A table's TMDL identifier and its FILENAME are different strings. Spaces are legal in a Windows
+# filename but `< > : " / \ | ? *` and control chars are not - a source table like `dbo:staging`
+# would yield an unwritable path (a separate failure mode). Sanitise only the filename; the `table`
+# header keeps the real quoted name, and TOM matches tables by header content, not by filename.
+def _tmdl_filename_stem(name: str) -> str:
+    """A non-empty, Windows-safe filename stem for `name` (its identifier stays separate)."""
+    stem = "".join("_" if c in '<>:"/\\|?*' or ord(c) < 32 else c for c in name)
+    return stem.rstrip(" .") or "probe_table"
+
+
 def _pbip_files(name: str, m_query: str, table: str, column: str) -> dict[str, str]:
     """The minimum PBIP that Power BI Desktop will open: one table, one column, one partition."""
     indented = "\n".join("\t\t\t\t" + line for line in m_query.split("\n"))
+    table_ident = _tmdl_ident(table)
+    column_ident = _tmdl_ident(column)
+    table_stem = _tmdl_filename_stem(table)
     return {
         f"{name}.pbip": json.dumps(
             {
@@ -221,16 +247,16 @@ def _pbip_files(name: str, m_query: str, table: str, column: str) -> dict[str, s
             "\tculture: en-US\n"
             "\tdefaultPowerBIDataSourceVersion: powerBI_V3\n"
             "\tsourceQueryCulture: en-US\n\n"
-            f"ref table {table}\n"
+            f"ref table {table_ident}\n"
         ),
-        f"{name}.SemanticModel/definition/tables/{table}.tmdl": (
-            f"table {table}\n\n"
-            f"\tcolumn {column}\n"
+        f"{name}.SemanticModel/definition/tables/{table_stem}.tmdl": (
+            f"table {table_ident}\n\n"
+            f"\tcolumn {column_ident}\n"
             "\t\tdataType: string\n"
             f"\t\tlineageTag: {uuid.uuid4()}\n"
             "\t\tsummarizeBy: none\n"
             f"\t\tsourceColumn: {column}\n\n"
-            f"\tpartition {table} = m\n"
+            f"\tpartition {table_ident} = m\n"
             "\t\tmode: import\n"
             "\t\tsource =\n"
             f"{indented}\n"

--- a/scripts/probe_live_source.py
+++ b/scripts/probe_live_source.py
@@ -53,6 +53,11 @@ Outcomes (last line, machine-readable; exit 0 only on DATA_OK)
     PROBE: ACCESS_DENIED <detail>              permissions must change; signing in again is not enough
     PROBE: UNREACHABLE <detail>                refresh failed for a non-credential reason
     PROBE: ERROR <detail>                      the probe itself could not run
+
+Module-size strategy (pylint `max-module-lines = 1200`): SPLIT, not waive. The verdict-line matchers
+already live in `_verdict_lines.py`; the next extraction is the PBIP scaffold writers (`_tmdl_ident`
+/ `_tmdl_filename_stem` / `_pbip_files`). Do that before adding bulk here - a
+`# pylint: disable=too-many-lines` would only hide a module that still has a real seam left.
 """
 
 from __future__ import annotations

--- a/tests/test_probe_live_tmdl_quoting.py
+++ b/tests/test_probe_live_tmdl_quoting.py
@@ -1,0 +1,179 @@
+"""Regression tests for TMDL identifier quoting in the probe scaffold `scripts/probe_live_source.py`.
+
+The probe hand-writes a throwaway one-table TMDL model and hands it to Power BI Desktop. It used to
+interpolate the table/column name RAW into every TMDL header, so a name with a space produced
+`ref table Custom SQL Query` - which the TOM deserializer Power BI Desktop uses rejects with
+`InvalidObjectHeader` ("the object name is followed by an invalid token"). That is not an edge case:
+the deterministic conversion engine names unresolved custom-SQL relations `Custom SQL Query` (two
+spaces), a shape a live customer estate carried in ~72% of its assets, so the probe crashed Desktop
+far more often than it worked.
+
+The fix quotes every TMDL identifier unconditionally (a quoted identifier is always valid TMDL) and
+escapes an embedded single quote by doubling it - exactly what Power BI's own serializer emits. Ground
+truth these tests mirror: `examples/wind-energy-utilization/.../CO2 Savings.tmdl`
+(`table 'CO2 Savings'`, `column 'Turbine Id'`, `partition 'CO2 Savings'`), its `model.tmdl`
+(`ref table 'CO2 Savings'`), and `examples/broadway-stage-to-screen/.../1 Films.tmdl`
+(`column 'Sondheim''s Work'` - the doubled-quote escape).
+
+Two identifiers that deliberately stay UN-quoted, each with its own test below:
+* `sourceColumn:` is a plain string property (runs to end of line, e.g. `displayFolder: 01 Fleet KPIs`
+  in ground truth), and it must byte-match the raw name the partition's M query selects - quoting it
+  would break that match.
+* the on-disk FILENAME is a separate string from the identifier; it is sanitised for the characters
+  Windows forbids in a path, while the `table` header keeps the real quoted name.
+
+The authoritative structural check is TOM's `TmdlSerializer.DeserializeDatabaseFromFolder` (the offline
+`examples/*/fabric/_validation/tmdl_validate`). It was run out-of-band against the emitted models for
+each case here and returned PASS (and FAILED on the old un-quoted output), but it needs the .NET SDK +
+a Windows-only TOM package, so it is not wired into this cross-platform suite; these tests assert the
+emitted TMDL text instead.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO / "scripts"))
+
+import probe_live_source  # noqa: E402  # pylint: disable=wrong-import-position
+
+# The real 72%-of-the-estate case: the engine's unresolved custom-SQL relation name.
+TABLE = "Custom SQL Query"
+COLUMN = "Some Column"
+# A name whose own apostrophes exercise the doubling escape.
+APOS_TABLE = "O'Brien's Orders"
+APOS_COLUMN = "Sondheim's Work"
+# A name carrying characters Windows forbids in a filename (`:` and `/`).
+PATH_TABLE = "dbo:staging/tmp"
+
+TABLES_PREFIX = "Probe.SemanticModel/definition/tables/"
+MODEL_KEY = "Probe.SemanticModel/definition/model.tmdl"
+SIMPLE_M = "let\n    Source = #table({}, {})\nin\n    Source"
+
+
+def _scaffold(table: str, column: str, m: str = SIMPLE_M) -> dict[str, str]:
+    return probe_live_source._pbip_files("Probe", m, table, column)  # pylint: disable=protected-access
+
+
+def _table_key(files: dict[str, str]) -> str:
+    return next(k for k in files if k.startswith(TABLES_PREFIX))
+
+
+def _lines(text: str) -> list[str]:
+    """The TMDL as stripped lines, so an assertion pins a whole header, not a loose substring."""
+    return [ln.strip() for ln in text.splitlines()]
+
+
+# --- the four header sites, one test each (so quoting three of four is still caught) --------------
+
+
+def test_ref_table_header_is_quoted() -> None:
+    """`model.tmdl` must reference the table with a quoted identifier."""
+    lines = _lines(_scaffold(TABLE, COLUMN)[MODEL_KEY])
+    assert f"ref table '{TABLE}'" in lines
+    assert f"ref table {TABLE}" not in lines
+
+
+def test_table_header_is_quoted() -> None:
+    """The table file's `table` header must be quoted."""
+    files = _scaffold(TABLE, COLUMN)
+    lines = _lines(files[_table_key(files)])
+    assert f"table '{TABLE}'" in lines
+    assert f"table {TABLE}" not in lines
+
+
+def test_column_header_is_quoted() -> None:
+    """The `column` header must be quoted."""
+    files = _scaffold(TABLE, COLUMN)
+    lines = _lines(files[_table_key(files)])
+    assert f"column '{COLUMN}'" in lines
+    assert f"column {COLUMN}" not in lines
+
+
+def test_partition_header_is_quoted() -> None:
+    """The `partition` header must be quoted."""
+    files = _scaffold(TABLE, COLUMN)
+    lines = _lines(files[_table_key(files)])
+    assert f"partition '{TABLE}' = m" in lines
+    assert f"partition {TABLE} = m" not in lines
+
+
+def test_no_header_identifier_is_left_bare() -> None:
+    """Belt-and-suspenders: no known header may carry the raw, un-quoted name anywhere."""
+    files = _scaffold(TABLE, COLUMN)
+    model_lines = _lines(files[MODEL_KEY])
+    table_lines = _lines(files[_table_key(files)])
+    for bare in (f"ref table {TABLE}", f"table {TABLE}", f"column {COLUMN}", f"partition {TABLE} = m"):
+        assert bare not in model_lines
+        assert bare not in table_lines
+
+
+# --- escaping -------------------------------------------------------------------------------------
+
+
+def test_embedded_apostrophe_is_doubled() -> None:
+    """A name containing a single quote is wrapped and the quote doubled (`'` -> `''`)."""
+    files = _scaffold(APOS_TABLE, APOS_COLUMN)
+    model_lines = _lines(files[MODEL_KEY])
+    table_lines = _lines(files[_table_key(files)])
+    assert "ref table 'O''Brien''s Orders'" in model_lines
+    assert "table 'O''Brien''s Orders'" in table_lines
+    assert "column 'Sondheim''s Work'" in table_lines
+    assert "partition 'O''Brien''s Orders' = m" in table_lines
+
+
+def test_tmdl_ident_helper_quotes_and_escapes() -> None:
+    """Unit-level: the helper quotes unconditionally and doubles embedded quotes."""
+    ident = probe_live_source._tmdl_ident  # pylint: disable=protected-access
+    assert ident("T") == "'T'"  # unconditional: a bare-legal name is still quoted
+    assert ident("Custom SQL Query") == "'Custom SQL Query'"
+    assert ident("a'b") == "'a''b'"
+    assert ident("a'b'c") == "'a''b''c'"  # every embedded quote doubled
+
+
+# --- sourceColumn stays raw so it matches the M query --------------------------------------------
+
+
+def test_source_column_stays_raw_to_match_m_query() -> None:
+    """`sourceColumn:` must be the RAW column name; quoting it would break the M `SelectColumns` match."""
+    conn = {"class": "sqlserver", "server": "srv", "database": "db", "schema": "dbo"}
+    m_query, _ = probe_live_source.build_m_query(conn, TABLE, COLUMN)
+    files = probe_live_source._pbip_files("Probe", m_query, TABLE, COLUMN)  # pylint: disable=protected-access
+    table_lines = _lines(files[_table_key(files)])
+
+    assert f"sourceColumn: {COLUMN}" in table_lines
+    assert f"sourceColumn: '{COLUMN}'" not in table_lines
+    # The M query selects the same raw, unquoted name - that correspondence is the whole point.
+    assert f'{{"{COLUMN}"}}' in m_query
+
+
+# --- the filename is a separate, sanitised string -------------------------------------------------
+
+
+def test_table_filename_sanitised_for_path_breaking_chars() -> None:
+    """A table name with `:`/`/` must not break the file path; the header keeps the real name."""
+    files = _scaffold(PATH_TABLE, COLUMN)
+    key = _table_key(files)
+    stem = key[len(TABLES_PREFIX) : -len(".tmdl")]
+
+    assert not any(c in stem for c in '<>:"/\\|?*'), stem
+    assert f"table '{PATH_TABLE}'" in _lines(files[key])
+    assert f"ref table '{PATH_TABLE}'" in _lines(files[MODEL_KEY])
+
+
+def test_spaced_table_filename_keeps_spaces() -> None:
+    """Spaces are legal in a Windows filename, so the common case keeps a readable name."""
+    files = _scaffold(TABLE, COLUMN)
+    assert _table_key(files) == f"{TABLES_PREFIX}{TABLE}.tmdl"
+
+
+def test_tmdl_filename_stem_helper() -> None:
+    """Unit-level: forbidden characters become `_`; an empty result falls back to a constant."""
+    stem = probe_live_source._tmdl_filename_stem  # pylint: disable=protected-access
+    assert stem("Custom SQL Query") == "Custom SQL Query"
+    assert stem("dbo:staging/tmp") == "dbo_staging_tmp"
+    assert stem('a<b>c:d"e/f\\g|h?i*j') == "a_b_c_d_e_f_g_h_i_j"
+    assert stem("  ..") == "probe_table"
+    assert stem("tab\there") == "tab_here"


### PR DESCRIPTION
Quotes TMDL identifiers in the live-source probe scaffold.

## The defect

`scripts/probe_live_source.py` emitted **unquoted** TMDL headers:

```
ref table {table}
table {table}
partition {table}
```

Any table name containing a space crashes Power BI Desktop on open with `InvalidObjectHeader`.

This is not hypothetical or rare: `Custom SQL Query` is an extremely common Tableau caption. In the
customer estate that reported it, the stub marker appears in **40 tables across 33 of 46 assets
(~72%)** — so essentially every workbook backed by Snowflake custom SQL was affected.

## The fix

A `_tmdl_ident()` quoting helper applied at each of the three header sites, plus a regression test
file covering the quoting rules.

## Verification

| gate | exit |
|---|---|
| `ruff format --check scripts tests` | **0** |
| `ruff check scripts tests` | **0** |
| `pylint scripts` | **0** (10.00/10) |

⚠️ Note for reviewers: an initial `pylint` run scored 9.96 with ten findings. **All ten were in files
this PR does not touch**, and were caused by a worktree venv created without `uv sync --all-extras`
(`E0401` on `lxml`, `PIL`, `playwright`, `tableauhyperapi`). With extras installed the score is
10.00/10, exit 0.

`scripts/probe_live_source.py` is **1185 lines** — under, but close to, pylint's `C0302` cap of 1200.
Worth knowing before the next change to this module; the repo's three sanctioned responses are shave,
split, or a documented `# pylint: disable=too-many-lines` waiver.

Scope: 2 files, +210/-5.

Fixes #201
