### PR TITLE
Run the pbip-model-refresh bundle's tests on Windows in CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -69,3 +69,41 @@ jobs:
         # (`--check --strict --model <*.SemanticModel>`) and belongs in the agent hand-off, per
         # .github/skills/powerbi-ai-readiness/SKILL.md.
         run: uv run python scripts/set_ai_instructions.py --check
+
+  # The job above runs on Linux. The pbip-model-refresh bundle does not: `SKILL.md` line 8 says
+  # "Windows only." That mismatch is not cosmetic - it makes the Linux job STRUCTURALLY incapable of
+  # failing on this bundle's most important code path.
+  #
+  # Why: `_credential_state` guards on `os.name != "nt"` and returns a bare `CredentialDetection()`
+  # off Windows. Every field of that defaults to None, which is byte-identical to the state a
+  # healthy, windowed, unblocked Power BI Desktop produces. So off Windows the detector does not
+  # report "I cannot inspect this" - it reports "everything is fine", and every caller believes it.
+  #
+  # Measured (issue #182, PR #168): 17 tests drove `main(["--pid", "111", ...])` against a pid that
+  # does not exist. On ubuntu-latest that read as healthy and CI went GREEN; on Windows the same
+  # tests produced a real `process_gone` detection and exited 1. CI was green on a branch that was
+  # red on every machine that can actually run the code, and only a human reproducing it locally
+  # found out.
+  #
+  # Deliberately scoped to the bundle's own tests, NOT the whole suite: this job exists to cover the
+  # one platform the bundle runs on, not to duplicate the Linux gates on a slower runner. Measured
+  # 26.41s for 164 tests locally, so the marginal cost is small.
+  #
+  # This does not make the bundle fully covered - `_credential_state`'s own wiring to the real Win32
+  # primitives is still only exercised here, and the non-Windows return value's MEANING is still
+  # untested by construction. Issue #182 tracks those; a Windows runner is the half that no amount of
+  # dependency injection can substitute for.
+  windows-bundle:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Tests (pbip-model-refresh bundle, on the platform it actually runs on)
+        run: uv run pytest -q .github/skills/pbip-model-refresh/tests/


### PR DESCRIPTION
Closes #182.

## What this does

Adds a second CI job, `windows-bundle` (`runs-on: windows-latest`), that runs **only** the `pbip-model-refresh` bundle's tests. The existing `ubuntu-latest` job is untouched (11 steps before and after).

## Why a Windows runner, specifically

The bundle is Windows-only (`SKILL.md` line 8). That is not merely a coverage gap - it makes the Linux job **structurally incapable of failing** on the bundle's most important path.

`_credential_state` guards on `os.name != "nt"` and returns a bare `CredentialDetection()` off Windows. Every field of that defaults to `None`, which is **byte-identical to the state a healthy, windowed, unblocked Power BI Desktop produces**. So off Windows the detector does not report *"I cannot inspect this"* - it reports *"everything is fine"*, and every caller believes it.

Measured, from PR #168: 17 tests drove `main(["--pid", "111", ...])` against a pid that does not exist. On `ubuntu-latest` that read as healthy and CI went **green**; the same tests on Windows produced a real `process_gone` detection and exited 1. CI was green on a branch that was red on every machine that can actually run the code, and only a human reproducing it locally found out.

## Why NOT the issue's fix 2

Issue #182 proposes making the non-Windows return value a truthful *"unsupported"* state, on the theory that *"the CLIs would refuse"*. **Branch-order tracing shows that is false with the current callers:**

| call site | fields read, in order | effect of an "unsupported" value |
|---|---|---|
| `refresh_pbip_model.py:1352` (t=0 gate) | modal -> blocking_dialog -> process_gone -> desktop_unready -> unknown_reason | `unknown_reason` **only prints and continues** (`:1362-1364`) - startup is NOT stopped |
| `refresh_pbip_model.py:355` (worker pre-check) | modal -> blocking_dialog -> process_gone, then unknown_reason at `:358-363` | UNKNOWN banner, **does not fail**; `desktop_unready` is **not read at all** |
| `refresh_pbip_model.py:411` (timeout re-check) | modal -> blocking_dialog -> process_gone only | `unknown_reason` **unread** - unaffected |
| `probe_desktop_query.py:418/438/481` | all five | `unknown_reason` -> exit 3 |

So fix 2 would change `probe_desktop_query.py` and leave `refresh_pbip_model.py` proceeding anyway. It needs caller rewrites to work - real blast radius for no guaranteed benefit. **Declined explicitly.**

Fix 1 (resolving the detector as a module-level dependency for injection) remains a legitimate, low-risk follow-up. Not done here.

## Scope

Deliberately the bundle's tests only, not the whole suite and not the lint gates a second time. This job exists to cover the one platform the bundle runs on. Locally measured **27.09s, 161 passed / 3 skipped, exit 0**.

## Verification

- `yaml.safe_load` parses the workflow; jobs are `['checks', 'windows-bundle']`, `runs-on: windows-latest`, Linux job still 11 steps.
- `uv sync --all-extras` then `uv run pytest -q .github/skills/pbip-model-refresh/tests/` in a clean worktree -> **exit 0**.
- The real proof is this PR's own `windows-bundle` run.

## What this does NOT fix

`_credential_state`'s wiring to the real Win32 primitives is still only exercised on Windows, and the **meaning** of the non-Windows return value is still untested by construction - the autouse fixture at `tests/conftest.py:39-67` monkeypatches `_credential_state` in both entry points suite-wide, so no test observes the guard. A Windows runner is the half that no amount of dependency injection can substitute for; it is not the whole of #182's concern, and the comment in the workflow says so.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
