### PR TITLE
Fix NuGet package cache resolution

### DIFF
--- a/.github/skills/pbip-model-refresh/SKILL.md
+++ b/.github/skills/pbip-model-refresh/SKILL.md
@@ -9,8 +9,9 @@ description: Refresh a local PBIP/TMDL semantic model open in Power BI Desktop, 
 ADOMD.NET/AMO (pythonnet), plus the Desktop Bridge CLI for process to file mapping.
 
 Requirements, in full: Windows with Power BI Desktop, Python >= 3.11 with `pythonnet`, the ADOMD.NET
-and AMO client libraries under `~/.nuget/packages`, and `npx` for
-`@microsoft/powerbi-desktop-bridge-cli`. No other dependency, and nothing repo-specific.
+and AMO client libraries under the NuGet global-packages cache (`$env:NUGET_PACKAGES` when set,
+otherwise `~/.nuget/packages`), and `npx` for `@microsoft/powerbi-desktop-bridge-cli`. No other
+dependency, and nothing repo-specific.
 
 The ADOMD.NET client is a *separate* nuget package from TOM/AMO, so a machine can have one and not the
 other. If `probe_desktop_query.py` prints `AdomdClient.dll not found in the nuget cache` (and

--- a/.github/skills/pbip-model-refresh/scripts/probe_desktop_query.py
+++ b/.github/skills/pbip-model-refresh/scripts/probe_desktop_query.py
@@ -49,10 +49,20 @@ from _credential_modal import (
     inspect_credential_modal,
 )
 
-# ADOMD.NET assembly shipped in the nuget cache (netcore build). Resolved at import time.
+# ADOMD.NET assembly shipped in the nuget cache (netcore build).
 _ADOMD_PKG = "microsoft.analysisservices.adomdclient.netcore*"
 _ADOMD_DLL = "Microsoft.AnalysisServices.AdomdClient.dll"
-_ADOMD_GLOBS = [str(Path.home() / ".nuget/packages" / _ADOMD_PKG / "**" / _ADOMD_DLL)]
+
+
+def nuget_packages_root() -> Path:
+    """Return the NuGet global-packages cache root, matching dotnet's NUGET_PACKAGES precedence."""
+    return Path(os.environ.get("NUGET_PACKAGES") or (Path.home() / ".nuget" / "packages"))
+
+
+def adomd_dll_globs() -> list[str]:
+    """Glob patterns that can locate ADOMD.NET in the active NuGet global-packages cache."""
+    return [str(nuget_packages_root() / _ADOMD_PKG / "**" / _ADOMD_DLL)]
+
 
 # Desktop binds its msmdsrv port a moment AFTER the process appears, so a scoped lookup needs a
 # short retry - but a bounded one, because a miss must end in a loud failure, never a fallback.
@@ -99,7 +109,7 @@ def _load_adomd():
         print("PREFLIGHT: ERROR pythonnet not installed (uv pip install pythonnet)")
         sys.exit(2)
 
-    for pattern in _ADOMD_GLOBS:
+    for pattern in adomd_dll_globs():
         hits = glob.glob(pattern, recursive=True)
         if hits:
             dll = Path(hits[0])

--- a/.github/skills/pbip-model-refresh/scripts/refresh_pbip_model.py
+++ b/.github/skills/pbip-model-refresh/scripts/refresh_pbip_model.py
@@ -102,6 +102,7 @@ from probe_desktop_query import (
     first_table,
     is_auto_date_table_name,
     measure_names,
+    nuget_packages_root,
     table_names,
 )
 
@@ -457,6 +458,11 @@ def _instance(pid: int | None) -> dict | None:
     return instances[0] if len(instances) == 1 else None
 
 
+def amo_dll_glob() -> str:
+    """Glob pattern that can locate AMO/TOM in the active NuGet global-packages cache."""
+    return str(nuget_packages_root() / "**" / "netcoreapp*" / "Microsoft.AnalysisServices*.dll")
+
+
 def _load_amo():
     """Load AMO (Microsoft.AnalysisServices.Tabular) for the ImageSave path.
 
@@ -470,8 +476,7 @@ def _load_amo():
     load("coreclr")
     import clr
 
-    base = os.path.expanduser(r"~\.nuget\packages")
-    for dll in glob.glob(os.path.join(base, "**", "netcoreapp*", "Microsoft.AnalysisServices*.dll"), recursive=True):
+    for dll in glob.glob(amo_dll_glob(), recursive=True):
         if "resources" in dll.lower():
             continue
         try:

--- a/.github/skills/pbip-model-refresh/tests/test_nuget_cache_resolution.py
+++ b/.github/skills/pbip-model-refresh/tests/test_nuget_cache_resolution.py
@@ -1,0 +1,50 @@
+"""Regression tests for NuGet global-packages cache resolution."""
+
+import sys
+from pathlib import Path
+
+SKILL_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+if str(SKILL_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SKILL_SCRIPTS))
+
+# The path above must be in place before the skill's modules import, hence the E402 waiver.
+# pylint: disable=wrong-import-position,import-error
+import probe_desktop_query  # noqa: E402
+import refresh_pbip_model  # noqa: E402
+
+
+def _assert_cache_root(expected_root: Path) -> None:
+    assert probe_desktop_query.nuget_packages_root() == expected_root
+    assert probe_desktop_query.adomd_dll_globs() == [
+        str(
+            expected_root
+            / "microsoft.analysisservices.adomdclient.netcore*"
+            / "**"
+            / "Microsoft.AnalysisServices.AdomdClient.dll"
+        )
+    ]
+    assert refresh_pbip_model.amo_dll_glob() == str(
+        expected_root / "**" / "netcoreapp*" / "Microsoft.AnalysisServices*.dll"
+    )
+
+
+def test_nuget_packages_env_override_roots_probe_and_refresh_globs(monkeypatch) -> None:
+    """A non-empty NUGET_PACKAGES value roots both ADOMD and AMO globs."""
+    override = Path.cwd() / "_nuget_packages_for_test"
+    monkeypatch.setenv("NUGET_PACKAGES", str(override))
+
+    _assert_cache_root(override)
+
+
+def test_unset_nuget_packages_uses_home_cache(monkeypatch) -> None:
+    """An unset NUGET_PACKAGES value falls back to the default home cache."""
+    monkeypatch.delenv("NUGET_PACKAGES", raising=False)
+
+    _assert_cache_root(Path.home() / ".nuget" / "packages")
+
+
+def test_empty_nuget_packages_falls_back_to_home_cache(monkeypatch) -> None:
+    """An empty NUGET_PACKAGES value is treated like unset, not as a root path."""
+    monkeypatch.setenv("NUGET_PACKAGES", "")
+
+    _assert_cache_root(Path.home() / ".nuget" / "packages")

--- a/scripts/preflight.ps1
+++ b/scripts/preflight.ps1
@@ -469,13 +469,11 @@ Add-Cli 'dotnet' 'critical' 'Install the .NET SDK - needed to build/run the offl
 # Errors" while landing ZERO PackageReference (a net10.0 scratch project silently no-op'd the add) - so
 # console text is not proof; presence of the DLL on disk is. Hence a file check, not a restore attempt.
 #
-# It resolves the EXACT path probe_desktop_query.py globs (probe_desktop_query.py:52-55:
-# Path.home()/.nuget/packages/microsoft.analysisservices.adomdclient.netcore*/**/AdomdClient.dll, NOT
-# $env:NUGET_PACKAGES) so it PREDICTS the probe's own resolution rather than a different cache location.
-# Honouring NUGET_PACKAGES here would be a BUG: dotnet restores into it but the probe never reads it, so
-# preflight would PASS while the probe still failed. (probe's Path.home() and refresh_pbip_model.py:473's
-# os.path.expanduser("~") resolve to the SAME base - both go through os.path.expanduser - so those two
-# cannot disagree; that NEITHER honours NUGET_PACKAGES is a separate cross-file gap - see #203.)
+# It resolves the EXACT cache precedence the Python entry points use: `$env:NUGET_PACKAGES` when
+# non-empty, otherwise `$HOME/.nuget/packages`. That makes preflight predict probe_desktop_query.py's
+# ADOMD lookup and refresh_pbip_model.py's AMO/TOM lookup instead of checking a different cache. The
+# old Path.home()/os.path.expanduser("~") defaults were equivalent; the fixed gap is that none of the
+# three sites honoured dotnet's NUGET_PACKAGES override.
 #
 # Severity: CRITICAL, by this file's own rule above — "critical if any persona's Definition of Done
 # depends on it, even when the dependency only fails later at handoff/validation time". It does, and
@@ -487,11 +485,12 @@ Add-Cli 'dotnet' 'critical' 'Install the .NET SDK - needed to build/run the offl
 # printed "Ready to migrate" and exited 0 while the probe exited 2 — reproducing exactly the silent
 # false-green #199 was filed to remove. Do NOT downgrade this to recommended without also removing
 # the refresh/save gate from those two personas.
-$adomdDll = Get-ChildItem -Path (Join-Path $HOME '.nuget\packages\microsoft.analysisservices.adomdclient.netcore*') `
+$nugetPackagesRoot = if ($env:NUGET_PACKAGES) { $env:NUGET_PACKAGES } else { Join-Path $HOME '.nuget\packages' }
+$adomdDll = Get-ChildItem -Path (Join-Path $nugetPackagesRoot 'microsoft.analysisservices.adomdclient.netcore*') `
     -Recurse -Filter 'Microsoft.AnalysisServices.AdomdClient.dll' -ErrorAction SilentlyContinue | Select-Object -First 1
 Add-Check 'ADOMD.NET client (Desktop probe/refresh)' 'critical' ([bool]$adomdDll) `
     $(if ($adomdDll) { $adomdDll.FullName } else { 'not in the nuget cache - probe_desktop_query.py / refresh_pbip_model.py cannot reach an open Desktop model' }) `
-    'Restore the ADOMD.NET client (a DIFFERENT nuget package from the TOM/AMO one the .NET-SDK check covers), forcing a supported TFM so the add cannot silently no-op on a net10 default: dotnet new console -o $env:TEMP\adomd --framework net8.0; dotnet add $env:TEMP\adomd package Microsoft.AnalysisServices.AdomdClient.NetCore.retail.amd64 --version 19.84.1  (throwaway project; the restore populates the shared ~/.nuget cache the probe reads).'
+    'Restore the ADOMD.NET client (a DIFFERENT nuget package from the TOM/AMO one the .NET-SDK check covers), forcing a supported TFM so the add cannot silently no-op on a net10 default: dotnet new console -o $env:TEMP\adomd --framework net8.0; dotnet add $env:TEMP\adomd package Microsoft.AnalysisServices.AdomdClient.NetCore.retail.amd64 --version 19.84.1  (throwaway project; the restore populates the active NuGet global-packages cache the probe reads).'
 
 Add-Cli 'uv' 'optional' 'Install uv for env/dependency management (uv venv && uv sync).'
 Add-Cli 'az' 'optional' 'Azure CLI - only for Fabric REST / token-based operations.'


### PR DESCRIPTION
## Summary
- Honor `NUGET_PACKAGES` (when non-empty) for the pbip-model-refresh ADOMD probe and AMO refresh lookup.
- Make `scripts/preflight.ps1` use the same cache precedence so it predicts the Python entry points.
- Update the skill docs and add regression tests for override, unset, and empty environment values.

Fixes #203

## Validation
- `uv sync --all-extras` (exit 0)
- `uv run ruff format .github\skills\pbip-model-refresh\scripts scripts` (exit 0)
- `uv run ruff check .github\skills\pbip-model-refresh\scripts scripts --fix` (exit 0)
- `uv run pylint scripts` (exit 0)
- `uv run pylint .github\skills\pbip-model-refresh\scripts` (exit 0)
- `uv run pytest -q .github\skills\pbip-model-refresh\tests\` (exit 0; 164 passed, 3 skipped)

## Mutation matrix
- Reverted probe root to ignore `NUGET_PACKAGES` -> `test_nuget_packages_env_override_roots_probe_and_refresh_globs` failed.
- Treated empty `NUGET_PACKAGES` as the cache root -> `test_empty_nuget_packages_falls_back_to_home_cache` failed.
- Reverted ADOMD glob to hard-code `~/.nuget/packages` -> `test_nuget_packages_env_override_roots_probe_and_refresh_globs` failed.
- Reverted AMO glob to hard-code `~/.nuget/packages` -> `test_nuget_packages_env_override_roots_probe_and_refresh_globs` failed.

## Not verified
- I did not run an end-to-end `dotnet restore`/real Desktop probe against a redirected NuGet cache; the change is covered by path-resolution unit tests.
