### PR TITLE
Fix Tableau image capture exit codes

### DIFF
--- a/scripts/capture_tableau_oracle.py
+++ b/scripts/capture_tableau_oracle.py
@@ -464,7 +464,15 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("--out", required=True, type=Path, help="output directory (should be git-ignored)")
     parser.add_argument("--env", type=Path, default=Path(".env"), help="git-ignored KEY=VALUE credentials file")
-    parser.add_argument("--workbook", action="append", default=None, help="workbook name filter (repeatable)")
+    parser.add_argument(
+        "--workbook",
+        action="append",
+        default=None,
+        help=(
+            "published Tableau workbook caption filter; exact, case-insensitive match, not the migration slug "
+            "(repeatable)"
+        ),
+    )
     parser.add_argument("--images", action="store_true", help="also capture /image?resolution=high per view")
     parser.add_argument("--limit", type=int, default=0, help="stop after N views (0 = all)")
     parser.add_argument(
@@ -527,11 +535,29 @@ def log_progress(index: int, total: int, record: dict[str, Any]) -> None:
 def write_manifest(
     records: list[dict[str, Any]], session: TableauSession, env: dict[str, str], out_dir: Path, started: float
 ) -> int:
-    """Write the manifest and return the process exit code (0 ok / 1 failure / 2 credential-blocked)."""
+    """Write the manifest and return the process exit code.
+
+    Codes: 0 all selected views captured, 1 partial non-credential failure, 2 credential-blocked,
+    3 total non-credential failure, 4 no views selected.
+    """
     ok = [r for r in records if r.get("data", {}).get("status") == "ok"]
     empty = [r for r in ok if r["data"]["row_count"] == 0]
-    blocked = [r for r in records if r.get("data", {}).get("status") == "source_credential"]
-    failed = [r for r in records if r.get("data", {}).get("status") not in {"ok", "source_credential"}]
+    complete = [
+        r
+        for r in records
+        if r.get("data", {}).get("status") == "ok" and r.get("image", {"status": "ok"}).get("status") == "ok"
+    ]
+    blocked = [
+        r for r in records if "source_credential" in {r.get("data", {}).get("status"), r.get("image", {}).get("status")}
+    ]
+    failed = [
+        r
+        for r in records
+        if any(
+            status not in {"ok", "source_credential"}
+            for status in (r.get("data", {}).get("status"), r.get("image", {"status": "ok"}).get("status"))
+        )
+    ]
     manifest = {
         "schema": "tableau-oracle/1",
         "captured_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
@@ -539,6 +565,7 @@ def write_manifest(
         "site": env["TABLEAU_SITE"],
         "rest_api_version": env.get("TABLEAU_REST_API_VERSION"),
         "view_count": len(records),
+        "captured_complete": len(complete),
         "data_ok": len(ok),
         "data_empty": len(empty),
         "credential_blocked": len(blocked),
@@ -553,7 +580,7 @@ def write_manifest(
 
     LOG.info(
         "\n%d/%d captured (%d empty), %d credential-blocked, %d failed, %d re-auth(s), %d retr(ies), %.0fs -> %s",
-        len(ok),
+        len(complete),
         len(records),
         len(empty),
         len(blocked),
@@ -570,9 +597,12 @@ def write_manifest(
             len(blocked),
         )
         for record in blocked:
-            LOG.warning("  - %s (%s): %s", record["view_name"], record["workbook_name"], record["data"]["detail"])
+            blocked_detail = record.get("data", {}).get("detail") or record.get("image", {}).get("detail")
+            LOG.warning("  - %s (%s): %s", record["view_name"], record["workbook_name"], blocked_detail)
+    if not records:
+        return 4
     if failed:
-        return 1
+        return 1 if complete else 3
     return 2 if blocked else 0
 
 
@@ -606,8 +636,9 @@ def build_retry_policy(max_attempts: int, budget_sec: float) -> RetryPolicy:
 def main() -> int:
     """Capture the oracle for every selected view.
 
-    Exit codes: ``0`` all captured, ``1`` a hard failure, ``2`` some view needs a credential on the
-    Tableau side (actionable only by a human -- never by a retry).
+    Exit codes: ``0`` all selected views captured, ``1`` partial non-credential failure,
+    ``2`` some selected view needs a credential on the Tableau side (actionable only by a human --
+    never by a retry), ``3`` total non-credential failure, ``4`` no views selected.
     """
     args = build_parser().parse_args()
 

--- a/tests/test_capture_tableau_oracle.py
+++ b/tests/test_capture_tableau_oracle.py
@@ -316,13 +316,19 @@ def test_slug_is_filesystem_safe():
 # --------------------------------------------------------------------------- manifest contract
 
 
-def _record(status: str, rows: int = 1) -> dict:
+def _record(status: str, rows: int = 1, image_status: str | None = None) -> dict:
     data = {"status": status}
     if status == "ok":
         data.update({"row_count": rows, "elapsed_sec": 1.0, "reauths": 0, "retries": 0})
     else:
         data["detail"] = "adb.example.net: Tableau needs an unexpired OAuth refresh token"
-    return {"view_name": "V", "workbook_name": "W", "data": data}
+    record = {"view_name": "V", "workbook_name": "W", "data": data}
+    if image_status is not None:
+        image = {"status": image_status}
+        if image_status != "ok":
+            image["detail"] = "image export failed"
+        record["image"] = image
+    return record
 
 
 def _write(tmp_path, records):
@@ -336,14 +342,34 @@ def test_a_clean_capture_exits_zero(tmp_path):
     assert _write(tmp_path, [_record("ok")]) == 0
 
 
+def test_a_clean_image_capture_exits_zero(tmp_path):
+    """A data+image run is successful only when the image succeeded too."""
+    assert _write(tmp_path, [_record("ok", image_status="ok")]) == 0
+
+
+def test_zero_selected_views_exits_four(tmp_path):
+    """Selecting nothing is a failed invocation, not a successful capture of an empty estate."""
+    assert _write(tmp_path, []) == 4
+
+
+def test_every_image_failed_exits_three(tmp_path):
+    """Data success alone is not enough when the requested reference images all failed."""
+    assert _write(tmp_path, [_record("ok", image_status="failed"), _record("ok", image_status="failed")]) == 3
+
+
+def test_partial_image_success_exits_one(tmp_path):
+    """A caller must be able to distinguish a partial reference-image set from a clean capture."""
+    assert _write(tmp_path, [_record("ok", image_status="ok"), _record("ok", image_status="failed")]) == 1
+
+
 def test_a_credential_block_exits_two_not_one(tmp_path):
     """Exit 2 is distinct on purpose: it means 'a human must act', not 'the tool is broken'."""
     assert _write(tmp_path, [_record("ok"), _record("source_credential")]) == 2
 
 
-def test_a_hard_failure_outranks_a_credential_block(tmp_path):
-    """A broken run must not be downgraded to 'just needs a credential' by a co-occurring block."""
-    assert _write(tmp_path, [_record("failed"), _record("source_credential")]) == 1
+def test_partial_hard_failure_outranks_a_credential_block(tmp_path):
+    """A partly broken run must not be downgraded to 'just needs a credential' by a co-occurring block."""
+    assert _write(tmp_path, [_record("ok"), _record("failed"), _record("source_credential")]) == 1
 
 
 def test_manifest_records_recovery_counts(tmp_path):


### PR DESCRIPTION
## Summary
- make `capture_tableau_oracle.py` include image outcomes and zero selected views in exit-code decisions
- document the full exit-code contract and clarify `--workbook` matches the published Tableau workbook caption
- add manifest-contract tests for zero selected views, all image failures, partial image success, and full image success

## Exit codes
- `0`: all selected views captured completely
- `1`: partial non-credential failure
- `2`: credential-blocked (human action required)
- `3`: total non-credential failure
- `4`: no views selected

## Mutation matrix
| Scenario | Production mutation | Targeted test | Result |
|---|---|---|---|
| Zero views selected | `return 4` -> `return 0` | `test_zero_selected_views_exits_four` | failed, pytest exit 1 |
| Every image failed | total failure branch `else 3` -> `else 0` | `test_every_image_failed_exits_three` | failed, pytest exit 1 |
| Partial image success | partial failure branch `return 1` -> `return 0` | `test_partial_image_success_exits_one` | failed, pytest exit 1 |
| Full image success | final success `else 0` -> `else 1` | `test_a_clean_image_capture_exits_zero` | failed, pytest exit 1 |

## Verification
- `uv sync --all-extras` exit 0
- `uv run ruff format scripts\capture_tableau_oracle.py tests\test_capture_tableau_oracle.py` exit 0
- `uv run ruff check scripts\capture_tableau_oracle.py tests\test_capture_tableau_oracle.py` exit 0
- `uv run pylint scripts` exit 0
- `uv run pytest -q tests/ -k "oracle or image"` exit 0
- `git diff --check` exit 0

Fixes #204
