### PR TITLE
Document Desktop and MCP connection gotchas

### DIFF
--- a/.github/skills/pbip-model-refresh/SKILL.md
+++ b/.github/skills/pbip-model-refresh/SKILL.md
@@ -125,6 +125,40 @@ stay byte-identical.
 > human must look at Desktop before the run proceeds. Check this first before suspecting the bridge or
 > filing an upstream defect.
 
+> ⚠️ **Do not wait blindly for `NO_BRIDGE` / `not_connected` — bound the bridge wait, then prove the
+> executable by PID.** Field report, 2026-08-18, two machines: a box with two Desktop versions
+> installed silently launched the **older** one by default, and the Desktop Bridge stayed at
+> `NO_BRIDGE` for 10+ minutes with no error. `PBI_DESKTOP_PATH` does **not** fix an already-running
+> wrong instance; it is read at launch, not polled. Kill that Desktop by PID, set `PBI_DESKTOP_PATH`
+> first, then relaunch.
+>
+> Use the CLI's bounded wait instead of a human-length cold-start guess:
+>
+> ```
+> powerbi-desktop status --pid <pid> --wait-seconds 90
+> ```
+>
+> Measured in this doc pass with
+> `npx --yes @microsoft/powerbi-desktop-bridge-cli status --help`: `--wait-seconds <seconds>` is
+> documented by the CLI itself as **"Wait for bridge readiness before returning not_connected"**
+> (default `0`). Ninety seconds matches this repo's ~2-minute cap for an unresponsive external
+> system. If the bounded wait still returns `not_connected`, treat the likely cause as "wrong Desktop
+> build for this machine's bridge", not "keep waiting".
+>
+> The bridge CLI does **not** expose the Desktop exe path or version. Verified output for a connected
+> instance has exactly these fields: `pid`, `bridgeStatus`, `currentFilePath`, `hasUnsavedChanges`,
+> `reportDir`, `pages`. So the discovery primitive is OS-level: take the `pid` from `status`, then
+> run `Get-CimInstance Win32_Process -Filter "ProcessId=<pid>" | Select-Object CommandLine`.
+>
+> ⚠️ **MSIX/Store Desktop remains unresolved, not supported or unsupported.** A separate field report
+> found that the documented known-good `2.157.627.0` was not installed on a third machine; only a
+> classic per-machine build and a Store/MSIX build were present. Do not generalize from that. Open
+> [#178](https://github.com/Guust-Franssens/tableau-to-powerbi-migration/issues/178) Defect 2
+> reports `refresh_pbip_model.py` refusing an MSIX-launched Desktop with `WRONG_MODEL` because
+> pid→model-folder resolution could not follow the Store launch path, while
+> `probe_desktop_query._child_port` resolved the same pid fine. That measures a narrow
+> identity-resolution gap, not Store bridge compatibility.
+
 Read-only preflight (proves credentials + source reachability without changing anything):
 
 ```

--- a/.github/skills/powerbi-semantic-model-gotchas/SKILL.md
+++ b/.github/skills/powerbi-semantic-model-gotchas/SKILL.md
@@ -683,6 +683,31 @@ trusting a single number it returns. When they disagree, prefer the **pid-scoped
 (`probe_desktop_query.py`'s `_child_port(pid)`, which walks Desktop→child `msmdsrv` and never widens
 the lookup). A wrong-model read is far more dangerous than a failed read: it returns confident,
 plausible numbers about somebody else's data.
+
+### ⚠️ Offline `ConnectFolder` has the same implicit-connection cross-talk hazard
+
+Measured 2026-08-18 in a multi-agent build, with a sibling `pbi-semantic-builder` using the same MCP
+server for a different model. A `table_operations List` call that omitted `connectionName` silently
+returned the sibling workbook's tables (confirmed against that build's `generated-edit-declarations.json`);
+a follow-up column call then failed with "table not found." `ListConnections` also showed a stale
+two-connection snapshot for a moment right after `Disconnect`.
+
+**Rule:** after any connect call, pass the returned `connectionName` explicitly on every model-object
+operation in a multi-agent build. Never rely on the implicit "last connection." The readback pattern
+that confirmed a disconnect had landed was re-running `Disconnect` on the same name and getting
+`not found`.
+
+Nuance, verified against the MCP tool schemas in this doc pass: `connectionName` is optional and
+documented as "Uses the last connection if omitted" on `table_operations`, `column_operations`,
+`measure_operations`, `relationship_operations`, and `partition_operations`. The same schema says
+`connection_operations` **forbids** `connectionName` on `Connect`, `ConnectFabric`, `ConnectFolder`,
+and `ConnectBimFile` because the name is auto-generated; use the returned name only after the connect
+call. That is 5 checked operation types out of the broader MCP surface, not proof that all operation
+types share the same parameter.
+
+What was **not** measured: how long the stale `ListConnections` snapshot persists. The observation was
+"a moment" / seconds apart, not a bounded duration.
+
 ## 7. Legacy `.xls` navigation keys, and Desktop sessions that turn errors into hangs
 
 Measured 2026-08-08 (`book_6-1-Maps`, same Superstore BIFF8 `.xls` and same en-BE machine as §6).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -280,6 +280,12 @@ change under you with no repo diff — and several agent Gotchas encode version-
 | Python | >= 3.11 (3.11.9 tested) |
 
 If a version differs, re-verify the version-specific Gotchas in `.github/agents/` before trusting them.
+For **Power BI Desktop specifically**, treat the matrix as "the build this machine's bridge already
+answers on, discovered empirically" rather than a portable version string. Field reports on
+2026-08-18 found one machine silently launching an older side-by-side Desktop while the bridge sat at
+`NO_BRIDGE`, and another where the documented Desktop build was not installed at all. Pin the exe with
+`PBI_DESKTOP_PATH` **before launch**, then verify the running process by PID (`powerbi-desktop status`
+→ `Get-CimInstance Win32_Process ... CommandLine`); the bridge CLI reports no exe path or version.
 
 ### 5. Python tooling
 


### PR DESCRIPTION
## Summary
- Documented bounded Desktop Bridge readiness checks with `powerbi-desktop status --pid <pid> --wait-seconds 90` and the PID-level exe-discovery fallback.
- Added the AGENTS.md caveat that Desktop known-good versions are machine-discovered, not portable strings.
- Documented the modeling MCP `ConnectFolder` implicit-connection cross-talk hazard and the measured schema nuance for five operation types.

## Verification
- `npx --yes @microsoft/powerbi-desktop-bridge-cli status --help`
- `gh issue view 178 --repo Guust-Franssens/tableau-to-powerbi-migration`
- `python scripts\sync_installed_skills.py` — succeeded; updated 1 installed skill file.
- `python scripts\sync_agent_conventions.py --check` — exit 0.
- `python -m pytest tests\test_skills.py -q` — 25 passed.
- `python -m pylint scripts` — 10.00/10, exit 0.
- `powershell -ExecutionPolicy Bypass -File scripts\preflight.ps1` — critical dependencies OK; skill bundles in sync.

## What I could not verify
- Whether Store/MSIX Desktop bridges successfully in general; #178 only proves a narrow pid-to-model-folder resolution gap for one MSIX-launched case.
- How long the stale `ListConnections` snapshot persists after disconnect; the field evidence was only seconds apart.
- Whether every modeling MCP operation type accepts `connectionName`; I checked the five operation schemas named in the docs.
