### PR TITLE
Fix credential gate clear shield

### DIFF
--- a/docs/credential-gate.md
+++ b/docs/credential-gate.md
@@ -154,6 +154,20 @@ The skip is deliberately narrow, and fails closed on anything it cannot parse:
 - the source list must be **identical** (order-insensitive) — a newly added live source has no
   reachability evidence at all, so it still arms the gate.
 
+### Cleared migrations also shield themselves from unrelated ancestor markers
+
+The hook walks upward from a write target, so a marker placed too high can otherwise govern every
+migration beneath it. A migration that already earned a `probe-cleared` for the **same source list**
+is treated as its own boundary: the hook reads the nearest audit log below an ancestor marker and
+reuses the same transition/source comparison as re-arming. A bare file is never a shield, and neither
+is `manual-clear`; only an audit-backed `probe-cleared` after the latest block counts.
+
+This deliberately stays audit-backed rather than adding a new "cleared" file. A file-only token would
+repeat the override failure mode: agents already forged control files, including via string fragments
+chosen to dodge literal filename matching. The audit log is still not unforgeable at same-user
+privilege, but it is one source of truth and it preserves the ordering rule that a later block
+invalidates earlier evidence.
+
 ---
 
 ## Why it is built this way

--- a/scripts/hooks/credential_gate.py
+++ b/scripts/hooks/credential_gate.py
@@ -39,10 +39,12 @@ import json
 import os
 import re
 import sys
+import importlib.util
 from pathlib import Path
 
 MARKER = ".credential-gate-BLOCKED.json"
 OVERRIDE = ".credential-gate-AUTHORIZED"
+AUDIT = ".credential-gate-audit.log"
 
 # Artifacts whose creation IS the harm: a persisted semantic model / report for a source that was
 # never reached. Deliberately not ".json" or ".md" - the agent should stay free to write its spec
@@ -62,6 +64,8 @@ GUARDED_SUFFIXES = (".tmdl", ".pbism", ".pbir", ".pbip", ".platform")
 # Security-through-obscurity is explicitly NOT the goal - MAI reading this comment changes nothing,
 # because the denial does not depend on the agent not knowing about it.
 CONTROL_FILES = (OVERRIDE.lower(), MARKER.lower())
+
+_CORE_GATE = None
 
 # Write-capable tools, lowercased. The SAME edit surfaces as `apply_patch` on preToolUse and `edit`
 # on permissionRequest (measured), so both must be listed or one event silently allows it.
@@ -279,13 +283,78 @@ def _blocking_marker(target: Path) -> Path | None:
     Walks upward from the target: a marker governs everything beneath the directory it sits in,
     which is how one gate covers `<migration>/fabric/**` without knowing the layout.
     """
+    nearest_audit_scope: Path | None = None
     for parent in [target, *target.parents]:
         if (parent / OVERRIDE).exists():
-            return None
+            if _override_is_authentic(parent):
+                return None
         marker = parent / MARKER
         if marker.is_file():
+            if nearest_audit_scope is not None and nearest_audit_scope != parent:
+                if _earned_clear_shields(nearest_audit_scope, marker):
+                    return None
             return marker
+        if nearest_audit_scope is None and (parent / AUDIT).is_file():
+            nearest_audit_scope = parent
     return None
+
+
+def _core_gate_module():
+    """Load the gate CLI module so the hook reuses its audit ordering/source comparison."""
+    global _CORE_GATE  # pylint: disable=global-statement
+    if _CORE_GATE is not None:
+        return _CORE_GATE
+
+    scripts_dir = Path(__file__).resolve().parents[1]
+    if str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+    spec = importlib.util.spec_from_file_location("_credential_gate_core_for_hook", scripts_dir / "credential_gate.py")
+    if spec is None or spec.loader is None:
+        return None
+    module = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(module)
+    except Exception:  # pylint: disable=broad-exception-caught  # pragma: no cover - fail closed.
+        return None
+    _CORE_GATE = module
+    return module
+
+
+def _marker_sources(marker: Path) -> list[str] | None:
+    """Read the source list from a BLOCKED marker, failing closed on malformed content."""
+    try:
+        payload = json.loads(marker.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    sources = payload.get("sources")
+    if not isinstance(sources, list):
+        return None
+    return [str(source) for source in sources]
+
+
+def _override_is_authentic(scope: Path) -> bool:
+    """A local override shields the hook only when the audit log backs it."""
+    core = _core_gate_module()
+    if core is None:
+        return False
+    return bool(core._override_is_authentic(scope))  # pylint: disable=protected-access
+
+
+def _earned_clear_shields(scope: Path, marker: Path) -> bool:
+    """Whether `scope` earned a probe clearance for the same sources as `marker`.
+
+    The hook deliberately reuses `credential_gate._redundant_rearm`: it is the audited transition
+    check that already invalidates stale `probe-cleared` evidence after later block actions and
+    compares source lists membership-exactly. `authorize` is not enough here; the shield is only for
+    sources a probe actually proved reachable.
+    """
+    sources = _marker_sources(marker)
+    if sources is None:
+        return False
+    core = _core_gate_module()
+    if core is None:
+        return False
+    return core._redundant_rearm(scope, sources) == "probe-cleared"  # pylint: disable=protected-access
 
 
 def _extract_args_text(payload: dict) -> str:

--- a/tests/test_credential_gate_shield.py
+++ b/tests/test_credential_gate_shield.py
@@ -5,13 +5,17 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
+
+import pytest
 
 REPO = Path(__file__).resolve().parents[1]
 GATE = REPO / "scripts" / "credential_gate.py"
 HOOK = REPO / "scripts" / "hooks" / "credential_gate.py"
 MARKER = ".credential-gate-BLOCKED.json"
 OVERRIDE = ".credential-gate-AUTHORIZED"
+AUDIT = ".credential-gate-audit.log"
 
 
 def run_gate(*args: str) -> subprocess.CompletedProcess:
@@ -42,6 +46,18 @@ def migration_fixture(root: Path) -> Path:
 def write_marker(path: Path, sources: list[str]) -> None:
     """Write a BLOCKED marker without going through apply_block's scope guard."""
     path.write_text(json.dumps({"writes_blocked": True, "sources": sources}), encoding="utf-8")
+
+
+def append_audit(migration: Path, action: str, detail: str) -> None:
+    """Append one audit entry for states that are awkward to create through the CLI."""
+    entry = {
+        "ts": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "action": action,
+        "detail": detail,
+        "user": "test",
+    }
+    with (migration / AUDIT).open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(entry) + "\n")
 
 
 def hook_for_model_write(root: Path, migration: Path) -> dict:
@@ -82,6 +98,24 @@ def test_manual_clear_does_not_shield_from_an_ancestor_marker(tmp_path: Path) ->
     assert out.get("permissionDecision") == "deny", "manual-clear earns no exemption from ancestor blocks"
 
 
+def test_authorize_audit_entry_without_override_does_not_shield_from_ancestor_marker(tmp_path: Path) -> None:
+    """Pin the stricter shield: only a probe-cleared source, not build-only authorization, counts.
+
+    The normal `authorize` command creates the override file, which `_blocking_marker` handles before
+    the audit-shield path. Removing the local marker and writing the audit entry directly isolates
+    the reachable state where `_redundant_rearm` would return `authorize`.
+    """
+    migration = migration_fixture(tmp_path)
+    assert run_gate("block", str(migration), "--sources", "warehouse").returncode == 0
+    (migration / MARKER).unlink()
+    append_audit(migration, "authorize", "by=test; chain=[]")
+    write_marker(tmp_path / MARKER, ["warehouse"])
+
+    out = hook_for_model_write(tmp_path, migration)
+
+    assert out.get("permissionDecision") == "deny", "authorize is build-only permission, not source proof"
+
+
 def test_probe_clear_for_one_source_does_not_cover_a_later_two_source_block(tmp_path: Path) -> None:
     migration = migration_fixture(tmp_path)
     assert run_gate("block", str(migration), "--sources", "warehouse_a").returncode == 0
@@ -104,3 +138,22 @@ def test_probe_clear_before_later_rearm_does_not_count_as_current_shield(tmp_pat
     out = hook_for_model_write(tmp_path, migration)
 
     assert out.get("permissionDecision") == "deny", "a later block must invalidate earlier probe evidence"
+
+
+@pytest.mark.parametrize("marker_text", ['{"writes_blocked": true}', "not-json"])
+def test_marker_without_parseable_sources_fails_closed_even_after_empty_source_clear(
+    tmp_path: Path, marker_text: str
+) -> None:
+    """Malformed markers must not be converted into an empty-source shield.
+
+    The edge case is a prior empty-source block: if `_marker_sources(marker)` is treated as `[]` on
+    parse failure, `_redundant_rearm` sees matching empty source lists and incorrectly shields.
+    """
+    migration = migration_fixture(tmp_path)
+    assert run_gate("block", str(migration)).returncode == 0
+    assert run_gate("clear", str(migration), "--reason", "DATA_OK", "--earned").returncode == 0
+    (tmp_path / MARKER).write_text(marker_text, encoding="utf-8")
+
+    out = hook_for_model_write(tmp_path, migration)
+
+    assert out.get("permissionDecision") == "deny", "unparseable marker sources must fail closed"

--- a/tests/test_credential_gate_shield.py
+++ b/tests/test_credential_gate_shield.py
@@ -1,0 +1,106 @@
+"""Tests for audit-backed credential-gate shielding in the hook."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+GATE = REPO / "scripts" / "credential_gate.py"
+HOOK = REPO / "scripts" / "hooks" / "credential_gate.py"
+MARKER = ".credential-gate-BLOCKED.json"
+OVERRIDE = ".credential-gate-AUTHORIZED"
+
+
+def run_gate(*args: str) -> subprocess.CompletedProcess:
+    """Run the gate CLI in a subprocess."""
+    return subprocess.run([sys.executable, str(GATE), *args], capture_output=True, text=True, check=False)
+
+
+def run_hook(payload: dict) -> dict:
+    """Run the hook with a Copilot-style payload."""
+    proc = subprocess.run(
+        [sys.executable, str(HOOK)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return json.loads(proc.stdout or "{}")
+
+
+def migration_fixture(root: Path) -> Path:
+    """Create a minimal migration-shaped directory."""
+    migration = root / "mig"
+    (migration / "fabric").mkdir(parents=True)
+    (migration / "migration-spec.json").write_text("{}", encoding="utf-8")
+    return migration
+
+
+def write_marker(path: Path, sources: list[str]) -> None:
+    """Write a BLOCKED marker without going through apply_block's scope guard."""
+    path.write_text(json.dumps({"writes_blocked": True, "sources": sources}), encoding="utf-8")
+
+
+def hook_for_model_write(root: Path, migration: Path) -> dict:
+    """Ask the hook whether a model write under migration/fabric is allowed."""
+    target = migration / "fabric" / "Model.tmdl"
+    return run_hook({"toolName": "create", "toolArgs": json.dumps({"path": str(target)}), "cwd": str(root)})
+
+
+def test_probe_cleared_directory_shields_against_later_ancestor_marker(tmp_path: Path) -> None:
+    migration = migration_fixture(tmp_path)
+    assert run_gate("block", str(migration), "--sources", "warehouse").returncode == 0
+    assert run_gate("clear", str(migration), "--reason", "DATA_OK", "--earned").returncode == 0
+    write_marker(tmp_path / MARKER, ["warehouse"])
+
+    out = hook_for_model_write(tmp_path, migration)
+
+    assert out.get("permissionDecision") != "deny", "earned local clearance must stop an unrelated ancestor block"
+
+
+def test_forged_bare_override_does_not_shield_from_an_ancestor_marker(tmp_path: Path) -> None:
+    migration = migration_fixture(tmp_path)
+    (migration / OVERRIDE).write_text("forged by agent", encoding="utf-8")
+    write_marker(tmp_path / MARKER, ["warehouse"])
+
+    out = hook_for_model_write(tmp_path, migration)
+
+    assert out.get("permissionDecision") == "deny", "a bare file with no audit backing must not become a shield"
+
+
+def test_manual_clear_does_not_shield_from_an_ancestor_marker(tmp_path: Path) -> None:
+    migration = migration_fixture(tmp_path)
+    assert run_gate("block", str(migration), "--sources", "warehouse").returncode == 0
+    assert run_gate("clear", str(migration), "--reason", "manual teardown").returncode == 0
+    write_marker(tmp_path / MARKER, ["warehouse"])
+
+    out = hook_for_model_write(tmp_path, migration)
+
+    assert out.get("permissionDecision") == "deny", "manual-clear earns no exemption from ancestor blocks"
+
+
+def test_probe_clear_for_one_source_does_not_cover_a_later_two_source_block(tmp_path: Path) -> None:
+    migration = migration_fixture(tmp_path)
+    assert run_gate("block", str(migration), "--sources", "warehouse_a").returncode == 0
+    assert run_gate("clear", str(migration), "--reason", "DATA_OK", "--earned").returncode == 0
+    write_marker(tmp_path / MARKER, ["warehouse_a", "warehouse_b"])
+
+    out = hook_for_model_write(tmp_path, migration)
+
+    assert out.get("permissionDecision") == "deny", "a new live source must still be blocked"
+
+
+def test_probe_clear_before_later_rearm_does_not_count_as_current_shield(tmp_path: Path) -> None:
+    migration = migration_fixture(tmp_path)
+    assert run_gate("block", str(migration), "--sources", "warehouse_a").returncode == 0
+    assert run_gate("clear", str(migration), "--reason", "DATA_OK", "--earned").returncode == 0
+    assert run_gate("block", str(migration), "--sources", "warehouse_a", "warehouse_b").returncode == 0
+    assert run_gate("clear", str(migration), "--reason", "teardown after rearm").returncode == 0
+    write_marker(tmp_path / MARKER, ["warehouse_a", "warehouse_b"])
+
+    out = hook_for_model_write(tmp_path, migration)
+
+    assert out.get("permissionDecision") == "deny", "a later block must invalidate earlier probe evidence"


### PR DESCRIPTION
## Summary
- Makes the hook treat an earned `probe-cleared` audit entry as a scoped boundary against unrelated ancestor markers.
- Reuses `credential_gate._redundant_rearm` so source-list comparison and later-block invalidation stay identical to the existing re-arm logic.
- Stops honoring bare override files in the hook unless `_override_is_authentic` backs them with audit evidence.
- Documents the audit-backed shield threat model.

Fixes #222

## Behavior change to review
A bare `.credential-gate-AUTHORIZED` file no longer shields writes in the hook. That is deliberate: the CLI gate already treats a bare override as forged unless the audit log records `authorize`, and the hook now matches that stricter behavior. A user who needs build-only authorization should use `python scripts/credential_gate.py authorize <migration> --who "<name>"` from a non-Copilot terminal rather than only dropping the file by hand.

## Validation
- `ruff format tests\test_credential_gate_shield.py`
- `ruff check tests\test_credential_gate_shield.py --fix`
- `C:\Users\gfranssens\vscode-projects\tableau-to-pbi-migration\.venv\Scripts\python.exe -m pylint scripts` -> exit 0
- `C:\Users\gfranssens\vscode-projects\tableau-to-pbi-migration\.venv\Scripts\python.exe -m pytest tests -k "credential or gate" -q` -> 188 passed, 1 skipped, 1251 deselected

## Mutation checks
Original mutation set, all caught:
- disable ancestor shield -> `test_probe_cleared_directory_shields_against_later_ancestor_marker` failed
- honor forged override -> `test_forged_bare_override_does_not_shield_from_an_ancestor_marker` failed
- treat manual clear as a shield -> `test_manual_clear_does_not_shield_from_an_ancestor_marker` failed
- ignore source comparison -> `test_probe_clear_for_one_source_does_not_cover_a_later_two_source_block` failed
- ignore later block invalidation -> `test_probe_clear_before_later_rearm_does_not_count_as_current_shield` failed

Reviewer mutation set, all caught after the follow-up tests:
- forged override shields -> `test_forged_bare_override_does_not_shield_from_an_ancestor_marker` failed
- accept `authorize` too (`== "probe-cleared"` -> `bool(...)`) -> `test_authorize_audit_entry_without_override_does_not_shield_from_ancestor_marker` failed
- ignore marker sources (`_marker_sources(marker)` -> `_marker_sources(marker) or []`) -> `test_marker_without_parseable_sources_fails_closed_even_after_empty_source_clear` failed

## Hook cost
Baseline comparison supplied by review, 10 subprocess invocations each:
- master: 102.3 ms/call
- this branch: 107.9 ms/call
- added cost: ~5.6 ms/call (~5%), with the hook dominated by interpreter startup

My earlier standalone measurement, for context:
- first in-process shield lookup, including lazy core import: 91.6142 ms
- warm in-process lookup average over 5000 runs: 2.1721 ms
- end-to-end hook subprocess average over 50 runs: 193.14 ms

## What I could not verify
- I did not run the full repository test suite; I ran the requested gate-focused selector.
- I did not test inside a live Copilot hook runtime; tests exercise the hook subprocess with representative payloads.
