### PR TITLE
Add provenance-tagged row-count hints to migration specs

### DIFF
--- a/docs/migration-spec.schema.json
+++ b/docs/migration-spec.schema.json
@@ -294,16 +294,20 @@
   },
   "definitions": {
     "rowCountHint": {
-      "description": "Provenance-tagged row-count hint. Unknown deliberately has no value so consumers cannot mistake absence for zero/small.",
+      "description": "Provenance-tagged row-count hint. Unknown deliberately has no value so consumers cannot mistake absence for zero/small. observed_at is when WE READ the count, not when it became true - the underlying extract may be far older, and nothing here records its refresh time.",
       "oneOf": [
         {
           "type": "object",
-          "required": ["value", "source", "as_of"],
+          "required": ["value", "source", "observed_at"],
           "additionalProperties": false,
           "properties": {
             "value": { "type": "integer", "minimum": 0 },
             "source": { "type": "string", "enum": ["hyper", "live"] },
-            "as_of": { "type": "string", "format": "date-time" }
+            "observed_at": {
+              "type": "string",
+              "format": "date-time",
+              "description": "RFC 3339 timestamp of when this count was READ. format:date-time is annotation-only under jsonschema without the format-nongpl extra, so parse_tableau._schema_contract_errors enforces it with datetime.fromisoformat instead."
+            }
           }
         },
         {

--- a/docs/migration-spec.schema.json
+++ b/docs/migration-spec.schema.json
@@ -80,7 +80,11 @@
                 "id": { "type": "string" },
                 "name": { "type": "string" },
                 "source_relation": { "type": "string", "enum": ["table", "custom-sql", "join", "text", "pivot", "collection", "union"] },
-                "custom_sql": { "type": ["string", "null"] }
+                "custom_sql": { "type": ["string", "null"] },
+                "row_count": {
+                  "$ref": "#/definitions/rowCountHint",
+                  "description": "Best-effort volume hint for this physical/logical table. Hyper counts are credential-free but reflect Tableau's cached extract as of its refresh time; live counts are current but credentialed; unknown is a normal outcome for sources with no credential-free count."
+                }
               }
             }
           },
@@ -289,6 +293,30 @@
     }
   },
   "definitions": {
+    "rowCountHint": {
+      "description": "Provenance-tagged row-count hint. Unknown deliberately has no value so consumers cannot mistake absence for zero/small.",
+      "oneOf": [
+        {
+          "type": "object",
+          "required": ["value", "source", "as_of"],
+          "additionalProperties": false,
+          "properties": {
+            "value": { "type": "integer", "minimum": 0 },
+            "source": { "type": "string", "enum": ["hyper", "live"] },
+            "as_of": { "type": "string", "format": "date-time" }
+          }
+        },
+        {
+          "type": "object",
+          "required": ["source"],
+          "additionalProperties": false,
+          "properties": {
+            "source": { "type": "string", "const": "unknown" }
+          },
+          "not": { "required": ["value"] }
+        }
+      ]
+    },
     "shelfField": {
       "type": "object",
       "properties": {
@@ -320,3 +348,5 @@
     }
   }
 }
+
+

--- a/docs/migration-spec.schema.json
+++ b/docs/migration-spec.schema.json
@@ -306,7 +306,7 @@
             "observed_at": {
               "type": "string",
               "format": "date-time",
-              "description": "RFC 3339 timestamp of when this count was READ. format:date-time is annotation-only under jsonschema without the format-nongpl extra, so parse_tableau._schema_contract_errors enforces it with datetime.fromisoformat instead."
+              "description": "RFC 3339 timestamp of when this count was READ. format:date-time is annotation-only under jsonschema without the format-nongpl extra, so parse_tableau._schema_contract_errors enforces it with a shape check plus datetime.fromisoformat instead. KNOWN EXCEPTION: a seconds field of 60 (a leap second, which RFC 3339 permits) is REJECTED. Python's datetime cannot represent one at all, so accepting it would mean recording a different instant than the one written; fixing it faithfully needs the rfc3339-validator dependency this fallback exists to work without. Disclosed here so the schema does not advertise a format it knowingly does not fully accept."
             }
           }
         },

--- a/scripts/extract_hyper_data.py
+++ b/scripts/extract_hyper_data.py
@@ -177,8 +177,10 @@ def extract_data_sources(
             connection_info = ds["connection"]
             if connection_info["mode"] != "extract":
                 continue
-            hyper_file_name = Path(connection_info.get("hyper_file", "")).name
-            hyper_path = _resolve_hyper_path(hyper_files, connection_info.get("hyper_file") or "")
+            # Normalise once: the spec schema allows a null hyper_file, and Path(None) raises.
+            hyper_file_value = connection_info.get("hyper_file") or ""
+            hyper_file_name = Path(hyper_file_value).name
+            hyper_path = _resolve_hyper_path(hyper_files, hyper_file_value)
             if hyper_path is None:
                 logger.warning("Hyper file not found for %s: %s", ds["id"], hyper_file_name)
                 manifest[ds["id"]] = {"error": f"hyper file not found: {hyper_file_name}"}
@@ -257,7 +259,7 @@ def _row_count_by_table_name(relations: list[dict[str, Any]]) -> dict[str, dict[
     ambiguous: set[str] = set()
     for relation in relations:
         key = _normalise_table_name(relation.get("table"))
-        if not key or key in ambiguous:
+        if not key or key in ambiguous or key in counts:
             ambiguous.add(key)
             counts.pop(key, None)
             continue
@@ -342,7 +344,7 @@ def main() -> None:
     args = parser.parse_args()
 
     if args.schema:
-        with tempfile.TemporaryDirectory(prefix="hyper_schema_", dir=args.workbook.parent) as scratch:
+        with tempfile.TemporaryDirectory(prefix="hyper_schema_") as scratch:
             tables = describe_schema(args.workbook, Path(scratch))
         print(json.dumps({"hyper_tables": tables}, indent=2))
         logger.info(
@@ -357,7 +359,7 @@ def main() -> None:
         if args.migration_spec is None:
             parser.error("migration_spec is required with --enrich-spec")
         migration_spec = json.loads(args.migration_spec.read_text(encoding="utf-8"))
-        with tempfile.TemporaryDirectory(prefix="hyper_schema_", dir=args.workbook.parent) as scratch:
+        with tempfile.TemporaryDirectory(prefix="hyper_schema_") as scratch:
             hyper_files = extract_hyper_files(args.workbook, Path(scratch))
             enriched, updated = enrich_spec_with_hyper_counts(migration_spec, hyper_files)
         target = args.enriched_output or args.migration_spec

--- a/scripts/extract_hyper_data.py
+++ b/scripts/extract_hyper_data.py
@@ -27,6 +27,7 @@ import re
 import shutil
 import tempfile
 import zipfile
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -67,6 +68,16 @@ def _quote_ident(name: str) -> str:
     return '"' + name.replace('"', '""') + '"'
 
 
+def _utc_now_z() -> str:
+    """Return a JSON-schema date-time timestamp with a literal UTC Z suffix."""
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _hyper_row_count(value: object, as_of: str) -> dict[str, Any]:
+    """Wrap a Hyper count with provenance so stale extract counts are never mistaken for live facts."""
+    return {"value": int(value), "source": "hyper", "as_of": as_of}
+
+
 def _copy_sql(table: object, columns: list[str], csv_path: Path) -> str:
     """Build the Hyper COPY command for a table export."""
     quoted_cols = ", ".join(_quote_ident(c) for c in columns)
@@ -74,8 +85,11 @@ def _copy_sql(table: object, columns: list[str], csv_path: Path) -> str:
     return f"COPY (SELECT {quoted_cols} FROM {table}) TO '{escaped_path}' WITH (FORMAT CSV, HEADER TRUE, DELIMITER ',')"
 
 
-def export_tables_to_csv(connection: Connection, output_dir: Path) -> dict[str, dict[str, Any]]:
+def export_tables_to_csv(
+    connection: Connection, output_dir: Path, as_of: str | None = None
+) -> dict[str, dict[str, Any]]:
     """Export every table in one Hyper file to CSV, keyed by qualified table name."""
+    as_of = as_of or _utc_now_z()
     results: dict[str, dict[str, Any]] = {}
     output_dir.mkdir(parents=True, exist_ok=True)
     for schema in connection.catalog.get_schema_names():
@@ -88,7 +102,7 @@ def export_tables_to_csv(connection: Connection, output_dir: Path) -> dict[str, 
             results[str(table)] = {
                 "csv_path": str(csv_path.resolve()),
                 "columns": columns,
-                "row_count": connection.execute_scalar_query(f"SELECT COUNT(*) FROM {table}"),
+                "row_count": _hyper_row_count(connection.execute_scalar_query(f"SELECT COUNT(*) FROM {table}"), as_of),
             }
     if not results:
         raise ValueError("No tables found in any schema")
@@ -134,11 +148,12 @@ def _export_hyper_file(
     output_dir: Path,
     ds_id: str,
     hyper: HyperProcess,
+    as_of: str,
 ) -> dict[str, dict[str, Any]]:
     """Export one data source's Hyper file without deduping across other extracts."""
     with tempfile.TemporaryDirectory(prefix="hyper_csv_", dir=output_dir) as stage:
         with Connection(endpoint=hyper.endpoint, database=str(hyper_path)) as connection:
-            staged = export_tables_to_csv(connection, Path(stage))
+            staged = export_tables_to_csv(connection, Path(stage), as_of)
         exported: dict[str, dict[str, Any]] = {}
         for qualified_name, info in staged.items():
             final_csv = _relation_csv_path(output_dir, ds_id, qualified_name, len(staged))
@@ -155,6 +170,7 @@ def extract_data_sources(
     """Export every relation in every extract-backed data source and return a manifest by data source."""
     output_dir.mkdir(parents=True, exist_ok=True)
     manifest: dict[str, Any] = {}
+    as_of = _utc_now_z()
 
     with HyperProcess(telemetry=Telemetry.DO_NOT_SEND_USAGE_DATA_TO_TABLEAU) as hyper:
         for ds in migration_spec["data_sources"]:
@@ -162,20 +178,20 @@ def extract_data_sources(
             if connection_info["mode"] != "extract":
                 continue
             hyper_file_name = Path(connection_info.get("hyper_file", "")).name
-            hyper_path = _resolve_hyper_path(hyper_files, connection_info.get("hyper_file", ""))
+            hyper_path = _resolve_hyper_path(hyper_files, connection_info.get("hyper_file") or "")
             if hyper_path is None:
                 logger.warning("Hyper file not found for %s: %s", ds["id"], hyper_file_name)
                 manifest[ds["id"]] = {"error": f"hyper file not found: {hyper_file_name}"}
                 continue
 
-            exported = _export_hyper_file(hyper_path, output_dir, ds["id"], hyper)
+            exported = _export_hyper_file(hyper_path, output_dir, ds["id"], hyper, as_of)
             relations = [_manifest_relation(name, info) for name, info in sorted(exported.items())]
             _assert_no_silent_loss(ds["id"], len(exported), relations)
             manifest[ds["id"]] = {
                 "hyper_file": connection_info.get("hyper_file"),
                 "joins": ds.get("joins", []),
                 "relation_count": len(relations),
-                "total_row_count": sum(relation["row_count"] for relation in relations),
+                "total_row_count": sum(relation["row_count"]["value"] for relation in relations),
                 "relations": relations,
             }
             logger.info(
@@ -188,6 +204,29 @@ def extract_data_sources(
     return manifest
 
 
+def _describe_hyper_file(connection: Connection, hyper_file: str, as_of: str) -> list[dict[str, Any]]:
+    """Describe every table in one open Hyper file with provenance-tagged row counts."""
+    tables: list[dict[str, Any]] = []
+    for schema in connection.catalog.get_schema_names():
+        for table in connection.catalog.get_table_names(schema=schema):
+            definition = connection.catalog.get_table_definition(table)
+            rows = connection.execute_scalar_query(f"SELECT COUNT(*) FROM {table}")
+            tables.append(
+                {
+                    "hyper_file": hyper_file,
+                    "schema": str(schema),
+                    "table": str(table.name),
+                    "qualified_name": str(table),
+                    "row_count": _hyper_row_count(rows, as_of),
+                    "columns": [
+                        {"name": c.name.unescaped, "type": str(c.type), "nullable": str(c.nullability)}
+                        for c in definition.columns
+                    ],
+                }
+            )
+    return tables
+
+
 def describe_schema(workbook_path: Path, hyper_dir: Path) -> list[dict[str, Any]]:
     """Every table + column in the packaged .hyper files, WITHOUT exporting a single row.
 
@@ -198,26 +237,79 @@ def describe_schema(workbook_path: Path, hyper_dir: Path) -> list[dict[str, Any]
     """
     tables: list[dict[str, Any]] = []
     hyper_files = extract_hyper_files(workbook_path, hyper_dir)
+    as_of = _utc_now_z()
     with HyperProcess(telemetry=Telemetry.DO_NOT_SEND_USAGE_DATA_TO_TABLEAU) as hyper:
         for name, path in sorted(hyper_files.items()):
             with Connection(endpoint=hyper.endpoint, database=path) as connection:
-                for schema in connection.catalog.get_schema_names():
-                    for table in connection.catalog.get_table_names(schema=schema):
-                        definition = connection.catalog.get_table_definition(table)
-                        rows = connection.execute_scalar_query(f"SELECT COUNT(*) FROM {table}")
-                        tables.append(
-                            {
-                                "hyper_file": name,
-                                "schema": str(schema),
-                                "table": str(table.name),
-                                "row_count": rows,
-                                "columns": [
-                                    {"name": c.name.unescaped, "type": str(c.type), "nullable": str(c.nullability)}
-                                    for c in definition.columns
-                                ],
-                            }
-                        )
+                tables.extend(_describe_hyper_file(connection, name, as_of))
     return tables
+
+
+def _normalise_table_name(value: str | None) -> str:
+    """Normalise Tableau relation names and Hyper table names for best-effort matching."""
+    cleaned = (value or "").replace('"', "").replace("[", "").replace("]", "").strip()
+    return re.sub(r"\s+", " ", cleaned).casefold()
+
+
+def _row_count_by_table_name(relations: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    """Return unique Hyper counts keyed by unqualified table name; ambiguous names are omitted."""
+    counts: dict[str, dict[str, Any]] = {}
+    ambiguous: set[str] = set()
+    for relation in relations:
+        key = _normalise_table_name(relation.get("table"))
+        if not key or key in ambiguous:
+            ambiguous.add(key)
+            counts.pop(key, None)
+            continue
+        counts[key] = relation["row_count"]
+    return counts
+
+
+def _apply_hyper_counts_to_tables(ds: dict[str, Any], relations: list[dict[str, Any]]) -> int:
+    """Attach Hyper counts to spec tables and return the number of tables updated."""
+    tables = ds.get("tables") or []
+    if not tables or not relations:
+        return 0
+    if len(tables) == 1 and len(relations) == 1:
+        tables[0]["row_count"] = relations[0]["row_count"]
+        return 1
+
+    by_name = _row_count_by_table_name(relations)
+    updated = 0
+    for table in tables:
+        row_count = by_name.get(_normalise_table_name(table.get("name")))
+        if row_count is None:
+            continue
+        table["row_count"] = row_count
+        updated += 1
+    return updated
+
+
+def enrich_spec_with_hyper_counts(
+    migration_spec: dict[str, Any],
+    hyper_files: dict[str, Path],
+) -> tuple[dict[str, Any], int]:
+    """Return a copy of migration_spec enriched with per-table Hyper row-count hints.
+
+    This is deliberately opt-in rather than part of parse_tableau.py: opening every packaged `.hyper`
+    during every parse would make the offline parser slower and dependent on tableauhyperapi.
+    """
+    enriched = json.loads(json.dumps(migration_spec))
+    updated = 0
+    as_of = _utc_now_z()
+    with HyperProcess(telemetry=Telemetry.DO_NOT_SEND_USAGE_DATA_TO_TABLEAU) as hyper:
+        for ds in enriched.get("data_sources", []):
+            connection_info = ds.get("connection") or {}
+            if connection_info.get("mode") != "extract":
+                continue
+            hyper_path = _resolve_hyper_path(hyper_files, connection_info.get("hyper_file") or "")
+            if hyper_path is None:
+                logger.warning("Hyper file not found for %s: %s", ds.get("id"), connection_info.get("hyper_file"))
+                continue
+            with Connection(endpoint=hyper.endpoint, database=str(hyper_path)) as connection:
+                relations = _describe_hyper_file(connection, connection_info.get("hyper_file") or "", as_of)
+            updated += _apply_hyper_counts_to_tables(ds, relations)
+    return enriched, updated
 
 
 def main() -> None:
@@ -237,10 +329,20 @@ def main() -> None:
         help="Describe tables/columns/row-counts only, exporting NO rows. Use this for a live_source "
         "migration, where the .hyper is Tableau's cache and the model must connect upstream instead.",
     )
+    parser.add_argument(
+        "--enrich-spec",
+        action="store_true",
+        help="Update migration-spec.json with per-table Hyper row-count hints, exporting NO rows.",
+    )
+    parser.add_argument(
+        "--enriched-output",
+        type=Path,
+        help="Where to write --enrich-spec output. Defaults to overwriting migration_spec in place.",
+    )
     args = parser.parse_args()
 
     if args.schema:
-        with tempfile.TemporaryDirectory(prefix="hyper_schema_") as scratch:
+        with tempfile.TemporaryDirectory(prefix="hyper_schema_", dir=args.workbook.parent) as scratch:
             tables = describe_schema(args.workbook, Path(scratch))
         print(json.dumps({"hyper_tables": tables}, indent=2))
         logger.info(
@@ -249,6 +351,18 @@ def main() -> None:
             "these cached rows are a validation baseline, not the model's source.",
             len(tables),
         )
+        return
+
+    if args.enrich_spec:
+        if args.migration_spec is None:
+            parser.error("migration_spec is required with --enrich-spec")
+        migration_spec = json.loads(args.migration_spec.read_text(encoding="utf-8"))
+        with tempfile.TemporaryDirectory(prefix="hyper_schema_", dir=args.workbook.parent) as scratch:
+            hyper_files = extract_hyper_files(args.workbook, Path(scratch))
+            enriched, updated = enrich_spec_with_hyper_counts(migration_spec, hyper_files)
+        target = args.enriched_output or args.migration_spec
+        target.write_text(json.dumps(enriched, indent=2, ensure_ascii=False), encoding="utf-8")
+        logger.info("Wrote %s with %d table row-count hint(s)", target, updated)
         return
 
     if args.migration_spec is None or args.output is None:

--- a/scripts/extract_hyper_data.py
+++ b/scripts/extract_hyper_data.py
@@ -73,9 +73,9 @@ def _utc_now_z() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
 
-def _hyper_row_count(value: object, as_of: str) -> dict[str, Any]:
+def _hyper_row_count(value: object, observed_at: str) -> dict[str, Any]:
     """Wrap a Hyper count with provenance so stale extract counts are never mistaken for live facts."""
-    return {"value": int(value), "source": "hyper", "as_of": as_of}
+    return {"value": int(value), "source": "hyper", "observed_at": observed_at}
 
 
 def _copy_sql(table: object, columns: list[str], csv_path: Path) -> str:
@@ -86,10 +86,10 @@ def _copy_sql(table: object, columns: list[str], csv_path: Path) -> str:
 
 
 def export_tables_to_csv(
-    connection: Connection, output_dir: Path, as_of: str | None = None
+    connection: Connection, output_dir: Path, observed_at: str | None = None
 ) -> dict[str, dict[str, Any]]:
     """Export every table in one Hyper file to CSV, keyed by qualified table name."""
-    as_of = as_of or _utc_now_z()
+    observed_at = observed_at or _utc_now_z()
     results: dict[str, dict[str, Any]] = {}
     output_dir.mkdir(parents=True, exist_ok=True)
     for schema in connection.catalog.get_schema_names():
@@ -102,7 +102,9 @@ def export_tables_to_csv(
             results[str(table)] = {
                 "csv_path": str(csv_path.resolve()),
                 "columns": columns,
-                "row_count": _hyper_row_count(connection.execute_scalar_query(f"SELECT COUNT(*) FROM {table}"), as_of),
+                "row_count": _hyper_row_count(
+                    connection.execute_scalar_query(f"SELECT COUNT(*) FROM {table}"), observed_at
+                ),
             }
     if not results:
         raise ValueError("No tables found in any schema")
@@ -148,12 +150,12 @@ def _export_hyper_file(
     output_dir: Path,
     ds_id: str,
     hyper: HyperProcess,
-    as_of: str,
+    observed_at: str,
 ) -> dict[str, dict[str, Any]]:
     """Export one data source's Hyper file without deduping across other extracts."""
     with tempfile.TemporaryDirectory(prefix="hyper_csv_", dir=output_dir) as stage:
         with Connection(endpoint=hyper.endpoint, database=str(hyper_path)) as connection:
-            staged = export_tables_to_csv(connection, Path(stage), as_of)
+            staged = export_tables_to_csv(connection, Path(stage), observed_at)
         exported: dict[str, dict[str, Any]] = {}
         for qualified_name, info in staged.items():
             final_csv = _relation_csv_path(output_dir, ds_id, qualified_name, len(staged))
@@ -170,7 +172,7 @@ def extract_data_sources(
     """Export every relation in every extract-backed data source and return a manifest by data source."""
     output_dir.mkdir(parents=True, exist_ok=True)
     manifest: dict[str, Any] = {}
-    as_of = _utc_now_z()
+    observed_at = _utc_now_z()
 
     with HyperProcess(telemetry=Telemetry.DO_NOT_SEND_USAGE_DATA_TO_TABLEAU) as hyper:
         for ds in migration_spec["data_sources"]:
@@ -186,7 +188,7 @@ def extract_data_sources(
                 manifest[ds["id"]] = {"error": f"hyper file not found: {hyper_file_name}"}
                 continue
 
-            exported = _export_hyper_file(hyper_path, output_dir, ds["id"], hyper, as_of)
+            exported = _export_hyper_file(hyper_path, output_dir, ds["id"], hyper, observed_at)
             relations = [_manifest_relation(name, info) for name, info in sorted(exported.items())]
             _assert_no_silent_loss(ds["id"], len(exported), relations)
             manifest[ds["id"]] = {
@@ -206,7 +208,7 @@ def extract_data_sources(
     return manifest
 
 
-def _describe_hyper_file(connection: Connection, hyper_file: str, as_of: str) -> list[dict[str, Any]]:
+def _describe_hyper_file(connection: Connection, hyper_file: str, observed_at: str) -> list[dict[str, Any]]:
     """Describe every table in one open Hyper file with provenance-tagged row counts."""
     tables: list[dict[str, Any]] = []
     for schema in connection.catalog.get_schema_names():
@@ -219,7 +221,7 @@ def _describe_hyper_file(connection: Connection, hyper_file: str, as_of: str) ->
                     "schema": str(schema),
                     "table": str(table.name),
                     "qualified_name": str(table),
-                    "row_count": _hyper_row_count(rows, as_of),
+                    "row_count": _hyper_row_count(rows, observed_at),
                     "columns": [
                         {"name": c.name.unescaped, "type": str(c.type), "nullable": str(c.nullability)}
                         for c in definition.columns
@@ -239,11 +241,11 @@ def describe_schema(workbook_path: Path, hyper_dir: Path) -> list[dict[str, Any]
     """
     tables: list[dict[str, Any]] = []
     hyper_files = extract_hyper_files(workbook_path, hyper_dir)
-    as_of = _utc_now_z()
+    observed_at = _utc_now_z()
     with HyperProcess(telemetry=Telemetry.DO_NOT_SEND_USAGE_DATA_TO_TABLEAU) as hyper:
         for name, path in sorted(hyper_files.items()):
             with Connection(endpoint=hyper.endpoint, database=path) as connection:
-                tables.extend(_describe_hyper_file(connection, name, as_of))
+                tables.extend(_describe_hyper_file(connection, name, observed_at))
     return tables
 
 
@@ -298,7 +300,7 @@ def enrich_spec_with_hyper_counts(
     """
     enriched = json.loads(json.dumps(migration_spec))
     updated = 0
-    as_of = _utc_now_z()
+    observed_at = _utc_now_z()
     with HyperProcess(telemetry=Telemetry.DO_NOT_SEND_USAGE_DATA_TO_TABLEAU) as hyper:
         for ds in enriched.get("data_sources", []):
             connection_info = ds.get("connection") or {}
@@ -309,7 +311,7 @@ def enrich_spec_with_hyper_counts(
                 logger.warning("Hyper file not found for %s: %s", ds.get("id"), connection_info.get("hyper_file"))
                 continue
             with Connection(endpoint=hyper.endpoint, database=str(hyper_path)) as connection:
-                relations = _describe_hyper_file(connection, connection_info.get("hyper_file") or "", as_of)
+                relations = _describe_hyper_file(connection, connection_info.get("hyper_file") or "", observed_at)
             updated += _apply_hyper_counts_to_tables(ds, relations)
     return enriched, updated
 

--- a/scripts/parse_tableau.py
+++ b/scripts/parse_tableau.py
@@ -1669,6 +1669,11 @@ def _unavailable_schema_result(message: str, require_jsonschema: bool, cause: Ex
     return []
 
 
+_RFC3339_DATE_TIME = re.compile(
+    r"^\d{4}-\d{2}-\d{2}[Tt]\d{2}:\d{2}:\d{2}(\.\d+)?([Zz]|[+-]\d{2}:\d{2})$",
+)
+
+
 def _observed_at_errors(spec: dict[str, Any]) -> list[str]:
     """Return errors for row_count.observed_at values jsonschema's format:date-time cannot catch.
 
@@ -1678,9 +1683,16 @@ def _observed_at_errors(spec: dict[str, Any]) -> list[str]:
     `""` and `"2026-13-45T99:99:99Z"` are all ACCEPTED even with `format_checker=` passed. Adding
     that kwarg would look like a fix, pass every gate, and change nothing.
 
-    `datetime.fromisoformat` needs no dependency, cannot silently degrade, and is strictly stronger
-    than a regex (it rejects month 13 and 30 February, which a shape pattern accepts). It requires
-    Python 3.11+ to accept a trailing `Z`, which `requires-python` already guarantees.
+    Two checks, because neither alone matches the advertised contract:
+
+    * **Shape** (`_RFC3339_DATE_TIME`) - `datetime.fromisoformat` is much broader than RFC 3339. It
+      accepts a SPACE separator (`2026-08-19 10:04:00+00:00`) and the basic format
+      (`20260819T100400+00:00`); RFC 3339's ABNF is `full-date "T" full-time`, extended format only.
+      Silently accepting them weakens the contract the schema advertises, in the very fallback whose
+      job is to make that contract deterministic. Lowercase `t`/`z` ARE valid RFC 3339.
+    * **Semantics** (`datetime.fromisoformat`) - strictly stronger than any shape pattern: it
+      rejects month 13 and 30 February, which a regex happily matches. It needs no dependency and
+      requires Python 3.11+ to accept a trailing `Z`, which `requires-python` already guarantees.
     """
     errors = []
     for ds_index, data_source in enumerate(spec.get("data_sources") or []):
@@ -1693,8 +1705,17 @@ def _observed_at_errors(spec: dict[str, Any]) -> list[str]:
             if not isinstance(raw, str):
                 errors.append(f"{location}: expected an RFC 3339 string, got {type(raw).__name__}")
                 continue
+            if not _RFC3339_DATE_TIME.match(raw):
+                errors.append(
+                    f"{location}: {raw!r} is not RFC 3339 date-time (expected YYYY-MM-DDThh:mm:ss[.fff](Z|±hh:mm))"
+                )
+                continue
             try:
-                parsed = datetime.fromisoformat(raw)
+                # Safe because the regex above already constrained `raw` to digits and
+                # `- : . + T t Z z`: upper-casing cannot alter a digit or a separator, and
+                # `fromisoformat` accepts only the uppercase `T`/`Z` that RFC 3339 also allows
+                # in lowercase.
+                parsed = datetime.fromisoformat(raw.upper())
             except ValueError as exc:
                 errors.append(f"{location}: {raw!r} is not a valid RFC 3339 timestamp ({exc})")
                 continue

--- a/scripts/parse_tableau.py
+++ b/scripts/parse_tableau.py
@@ -280,6 +280,16 @@ def _describe_named_connection(conn_el: etree._Element, mode: str) -> dict[str, 
 _CONTAINER_RELATION_TYPES = {"collection", "join", "union"}
 
 
+def _unknown_row_count() -> dict[str, str]:
+    """Return the normal no-volume-yet marker.
+
+    Parse remains offline and fast: it records table-level unknowns rather than opening packaged
+    `.hyper` files. `extract_hyper_data.py --enrich-spec` is the opt-in step that replaces these
+    with `{value, source: "hyper", as_of}` hints after it pays the Hyper-read cost.
+    """
+    return {"source": "unknown"}
+
+
 def _published_ds_name(repo: etree._Element, connection: dict[str, Any]) -> tuple[str | None, str]:
     """Resolve the published datasource's real name, and say which attribute it came from.
 
@@ -398,6 +408,7 @@ def _parse_tables(ds_el: etree._Element, ids: IdRegistry) -> list[dict[str, Any]
                     "name": name,
                     "source_relation": "custom-sql" if rel_type == "text" else rel_type,
                     "custom_sql": rel.text if rel_type == "text" else None,
+                    "row_count": _unknown_row_count(),
                 }
             )
     return tables
@@ -1592,6 +1603,47 @@ _SPEC_CONTRACT_BAD_CANARIES: tuple[tuple[str, dict[str, Any]], ...] = (
                     "severtiy": "critical",
                 }
             ],
+        },
+    ),
+    (
+        "bare integer row_count",
+        {
+            "migration_spec_version": "1.0",
+            "source": {"file_name": "canary.twb"},
+            "data_sources": [
+                {
+                    "id": "ds.sales",
+                    "connection": {"class": "hyper", "mode": "extract"},
+                    "tables": [{"id": "tbl.sales", "name": "Sales", "source_relation": "table", "row_count": 42}],
+                    "fields": [],
+                }
+            ],
+            "worksheets": [],
+            "dashboards": [],
+        },
+    ),
+    (
+        "unknown row_count with value",
+        {
+            "migration_spec_version": "1.0",
+            "source": {"file_name": "canary.twb"},
+            "data_sources": [
+                {
+                    "id": "ds.sales",
+                    "connection": {"class": "hyper", "mode": "extract"},
+                    "tables": [
+                        {
+                            "id": "tbl.sales",
+                            "name": "Sales",
+                            "source_relation": "table",
+                            "row_count": {"source": "unknown", "value": 0},
+                        }
+                    ],
+                    "fields": [],
+                }
+            ],
+            "worksheets": [],
+            "dashboards": [],
         },
     ),
 )

--- a/scripts/parse_tableau.py
+++ b/scripts/parse_tableau.py
@@ -285,7 +285,7 @@ def _unknown_row_count() -> dict[str, str]:
 
     Parse remains offline and fast: it records table-level unknowns rather than opening packaged
     `.hyper` files. `extract_hyper_data.py --enrich-spec` is the opt-in step that replaces these
-    with `{value, source: "hyper", as_of}` hints after it pays the Hyper-read cost.
+    with `{value, source: "hyper", observed_at}` hints after it pays the Hyper-read cost.
     """
     return {"source": "unknown"}
 
@@ -1669,6 +1669,40 @@ def _unavailable_schema_result(message: str, require_jsonschema: bool, cause: Ex
     return []
 
 
+def _observed_at_errors(spec: dict[str, Any]) -> list[str]:
+    """Return errors for row_count.observed_at values jsonschema's format:date-time cannot catch.
+
+    `"format": "date-time"` is ANNOTATION-ONLY unless jsonschema is installed with the
+    `format-nongpl` extra (which pulls `rfc3339-validator`). Measured in this venv: FORMAT_CHECKER
+    enforces only date/email/idn-email/idn-hostname/ipv4/ipv6/regex, so `observed_at: "yesterday"`,
+    `""` and `"2026-13-45T99:99:99Z"` are all ACCEPTED even with `format_checker=` passed. Adding
+    that kwarg would look like a fix, pass every gate, and change nothing.
+
+    `datetime.fromisoformat` needs no dependency, cannot silently degrade, and is strictly stronger
+    than a regex (it rejects month 13 and 30 February, which a shape pattern accepts). It requires
+    Python 3.11+ to accept a trailing `Z`, which `requires-python` already guarantees.
+    """
+    errors = []
+    for ds_index, data_source in enumerate(spec.get("data_sources") or []):
+        for tbl_index, table in enumerate((data_source or {}).get("tables") or []):
+            row_count = (table or {}).get("row_count")
+            if not isinstance(row_count, dict) or "observed_at" not in row_count:
+                continue
+            location = f"$.data_sources[{ds_index}].tables[{tbl_index}].row_count.observed_at"
+            raw = row_count["observed_at"]
+            if not isinstance(raw, str):
+                errors.append(f"{location}: expected an RFC 3339 string, got {type(raw).__name__}")
+                continue
+            try:
+                parsed = datetime.fromisoformat(raw)
+            except ValueError as exc:
+                errors.append(f"{location}: {raw!r} is not a valid RFC 3339 timestamp ({exc})")
+                continue
+            if parsed.tzinfo is None:
+                errors.append(f"{location}: {raw!r} has no UTC offset; a bare local time is ambiguous")
+    return errors
+
+
 def collect_spec_validation_errors(
     spec: dict[str, Any], schema_path: Path, *, require_jsonschema: bool = False
 ) -> list[str]:
@@ -1696,7 +1730,7 @@ def collect_spec_validation_errors(
         context = _limitation_context(spec, path_parts)
         expectation = _expectation(error)
         errors.append(f"{location}{context}: {error.message};{expectation}")
-    return errors
+    return errors + _observed_at_errors(spec)
 
 
 def validate_spec(spec: dict[str, Any], schema_path: Path) -> None:

--- a/scripts/parse_tableau.py
+++ b/scripts/parse_tableau.py
@@ -1717,14 +1717,16 @@ def _observed_at_errors(spec: dict[str, Any]) -> list[str]:
                 # in lowercase.
                 parsed = datetime.fromisoformat(raw.upper())
             except ValueError as exc:
-                # RFC 3339 permits a leap second (`23:59:60`), and Python's `datetime` cannot
-                # represent one at all ("second must be in 0..59") - so this is a stdlib ceiling,
-                # not a choice, and it predates the shape check. Name it, or the generic message
-                # sends the reader hunting for a typo in a timestamp that is actually valid.
+                # RFC 3339 permits a seconds field of 60 only at an ACTUAL leap second, and Python's
+                # `datetime` cannot represent one either way ("second must be in 0..59"). So this is
+                # a stdlib ceiling, not a choice, and it predates the shape check. Deliberately does
+                # NOT assert the value IS a leap second: `23:58:60Z` is not one, and no validator can
+                # tell without a leap-second table. Name the seconds field instead of guessing.
                 if raw[17:19] == "60":
                     errors.append(
-                        f"{location}: {raw!r} is a leap second; Python's datetime cannot represent "
-                        "one, so it cannot be stored or compared here"
+                        f"{location}: {raw!r} has a seconds field of 60. RFC 3339 allows that only at "
+                        "a leap second, and Python's datetime cannot represent one, so it cannot be "
+                        "stored or compared here"
                     )
                     continue
                 errors.append(f"{location}: {raw!r} is not a valid RFC 3339 timestamp ({exc})")

--- a/scripts/parse_tableau.py
+++ b/scripts/parse_tableau.py
@@ -1717,6 +1717,16 @@ def _observed_at_errors(spec: dict[str, Any]) -> list[str]:
                 # in lowercase.
                 parsed = datetime.fromisoformat(raw.upper())
             except ValueError as exc:
+                # RFC 3339 permits a leap second (`23:59:60`), and Python's `datetime` cannot
+                # represent one at all ("second must be in 0..59") - so this is a stdlib ceiling,
+                # not a choice, and it predates the shape check. Name it, or the generic message
+                # sends the reader hunting for a typo in a timestamp that is actually valid.
+                if raw[17:19] == "60":
+                    errors.append(
+                        f"{location}: {raw!r} is a leap second; Python's datetime cannot represent "
+                        "one, so it cannot be stored or compared here"
+                    )
+                    continue
                 errors.append(f"{location}: {raw!r} is not a valid RFC 3339 timestamp ({exc})")
                 continue
             if parsed.tzinfo is None:

--- a/tests/test_extract_hyper_data.py
+++ b/tests/test_extract_hyper_data.py
@@ -110,7 +110,9 @@ def test_default_export_writes_every_relation_across_every_extract(tmp_path: Pat
     assert manifest["ds.big"]["total_row_count"] == 5
     assert manifest["ds.big"]["joins"] == [{"left": "Orders.csv_FACT", "right": "Products.csv_DIM", "type": "inner"}]
     assert len(all_relations) == 3
-    assert big_relations["ds.big.Extract.Orders.csv_FACT.csv"]["row_count"] == 3
+    assert big_relations["ds.big.Extract.Orders.csv_FACT.csv"]["row_count"]["value"] == 3
+    assert big_relations["ds.big.Extract.Orders.csv_FACT.csv"]["row_count"]["source"] == "hyper"
+    assert big_relations["ds.big.Extract.Orders.csv_FACT.csv"]["row_count"]["as_of"].endswith("Z")
     assert _csv_row_count(output_dir / "ds.big.Extract.Orders.csv_FACT.csv") == 3
     assert _csv_row_count(output_dir / "ds.big.Extract.Products.csv_DIM.csv") == 2
     assert _csv_row_count(output_dir / "ds.small.csv") == 4
@@ -165,7 +167,62 @@ def test_same_qualified_table_name_in_distinct_extracts_keeps_both_datasources(t
     assert manifest["ds.annotations"]["relation_count"] == 1
     assert manifest["ds.orders"]["relations"][0]["qualified_name"] == '"Extract"."Extract"'
     assert manifest["ds.annotations"]["relations"][0]["qualified_name"] == '"Extract"."Extract"'
-    assert manifest["ds.orders"]["relations"][0]["row_count"] == 3
-    assert manifest["ds.annotations"]["relations"][0]["row_count"] == 1
+    assert manifest["ds.orders"]["relations"][0]["row_count"]["value"] == 3
+    assert manifest["ds.orders"]["relations"][0]["row_count"]["source"] == "hyper"
+    assert manifest["ds.annotations"]["relations"][0]["row_count"]["value"] == 1
     assert _csv_row_count(output_dir / "ds.orders.csv") == 3
     assert _csv_row_count(output_dir / "ds.annotations.csv") == 1
+
+
+def test_enrich_spec_writes_table_level_hyper_row_counts(tmp_path: Path) -> None:
+    """The post-parse enrichment step persists the count where consumers can use it: tables[]."""
+    orders_hyper = tmp_path / "orders.hyper"
+    _create_hyper(
+        orders_hyper,
+        {"Orders.csv_FACT": (["Order ID", "Sales"], [("o1", "10"), ("o2", "20"), ("o3", "30")])},
+    )
+
+    workbook = tmp_path / "orders.twbx"
+    with zipfile.ZipFile(workbook, "w") as archive:
+        archive.write(orders_hyper, "Data/orders/orders.hyper")
+
+    spec = tmp_path / "migration-spec.json"
+    spec.write_text(
+        json.dumps(
+            {
+                "migration_spec_version": "1.0",
+                "source": {"file_name": "orders.twbx"},
+                "data_sources": [
+                    {
+                        "id": "ds.orders",
+                        "connection": {"class": "hyper", "mode": "extract", "hyper_file": "Data/orders/orders.hyper"},
+                        "tables": [
+                            {
+                                "id": "tbl.orders",
+                                "name": "Orders.csv_FACT",
+                                "source_relation": "table",
+                                "row_count": {"source": "unknown"},
+                            }
+                        ],
+                        "fields": [],
+                    }
+                ],
+                "worksheets": [],
+                "dashboards": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    enriched = tmp_path / "enriched.json"
+    subprocess.run(
+        [sys.executable, str(SCRIPT), str(workbook), str(spec), "--enrich-spec", "--enriched-output", str(enriched)],
+        check=True,
+        cwd=SCRIPT.parents[1],
+    )
+
+    table = json.loads(enriched.read_text(encoding="utf-8"))["data_sources"][0]["tables"][0]
+
+    assert table["row_count"]["value"] == 3
+    assert table["row_count"]["source"] == "hyper"
+    assert table["row_count"]["as_of"].endswith("Z")

--- a/tests/test_extract_hyper_data.py
+++ b/tests/test_extract_hyper_data.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import csv
+import importlib.util
 import json
 import subprocess
 import sys
@@ -226,3 +227,50 @@ def test_enrich_spec_writes_table_level_hyper_row_counts(tmp_path: Path) -> None
     assert table["row_count"]["value"] == 3
     assert table["row_count"]["source"] == "hyper"
     assert table["row_count"]["as_of"].endswith("Z")
+
+
+def _load_script_module():
+    """Import scripts/extract_hyper_data.py directly; scripts/ is not an importable package."""
+    spec = importlib.util.spec_from_file_location("extract_hyper_data_under_test", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_duplicate_unqualified_table_names_are_omitted_rather_than_last_write_wins() -> None:
+    """Two schemas holding the same table name must yield no count, not a confidently wrong one."""
+    module = _load_script_module()
+    relations = [
+        {"table": "Orders", "row_count": {"value": 3, "source": "hyper", "as_of": "Z"}},
+        {"table": "Orders", "row_count": {"value": 42104338, "source": "hyper", "as_of": "Z"}},
+        {"table": "Products", "row_count": {"value": 7, "source": "hyper", "as_of": "Z"}},
+    ]
+
+    counts = module._row_count_by_table_name(relations)
+
+    assert "orders" not in counts, "an ambiguous name must be omitted, not resolved by iteration order"
+    assert counts["products"]["value"] == 7
+
+
+def test_a_null_hyper_file_is_reported_not_raised(tmp_path: Path) -> None:
+    """parse_tableau emits hyper_file: null when <extract><connection> carries no dbname."""
+    module = _load_script_module()
+    migration_spec = {
+        "data_sources": [
+            {"id": "ds.orders", "connection": {"class": "hyper", "mode": "extract", "hyper_file": None}, "tables": []}
+        ]
+    }
+
+    manifest = module.extract_data_sources(migration_spec, {}, tmp_path / "out")
+
+    assert "hyper file not found" in manifest["ds.orders"]["error"]
+
+
+def test_schema_scratch_never_lands_beside_the_workbook() -> None:
+    """Extracted .hyper residue under migrations/<tree>/<slug>/source/ is NOT gitignored (issue #125)."""
+    source = SCRIPT.read_text(encoding="utf-8")
+
+    assert "dir=args.workbook.parent" not in source, (
+        "scratch extraction must stay in the OS temp dir: a TemporaryDirectory beside the workbook "
+        "leaves customer .hyper data in an unignored path, and it is not cleaned up if the process is killed"
+    )

--- a/tests/test_extract_hyper_data.py
+++ b/tests/test_extract_hyper_data.py
@@ -7,6 +7,7 @@ import importlib.util
 import json
 import subprocess
 import sys
+import tempfile
 import zipfile
 from pathlib import Path
 
@@ -113,7 +114,7 @@ def test_default_export_writes_every_relation_across_every_extract(tmp_path: Pat
     assert len(all_relations) == 3
     assert big_relations["ds.big.Extract.Orders.csv_FACT.csv"]["row_count"]["value"] == 3
     assert big_relations["ds.big.Extract.Orders.csv_FACT.csv"]["row_count"]["source"] == "hyper"
-    assert big_relations["ds.big.Extract.Orders.csv_FACT.csv"]["row_count"]["as_of"].endswith("Z")
+    assert big_relations["ds.big.Extract.Orders.csv_FACT.csv"]["row_count"]["observed_at"].endswith("Z")
     assert _csv_row_count(output_dir / "ds.big.Extract.Orders.csv_FACT.csv") == 3
     assert _csv_row_count(output_dir / "ds.big.Extract.Products.csv_DIM.csv") == 2
     assert _csv_row_count(output_dir / "ds.small.csv") == 4
@@ -226,7 +227,7 @@ def test_enrich_spec_writes_table_level_hyper_row_counts(tmp_path: Path) -> None
 
     assert table["row_count"]["value"] == 3
     assert table["row_count"]["source"] == "hyper"
-    assert table["row_count"]["as_of"].endswith("Z")
+    assert table["row_count"]["observed_at"].endswith("Z")
 
 
 def _load_script_module():
@@ -238,18 +239,74 @@ def _load_script_module():
 
 
 def test_duplicate_unqualified_table_names_are_omitted_rather_than_last_write_wins() -> None:
-    """Two schemas holding the same table name must yield no count, not a confidently wrong one."""
+    """Two schemas holding the same table name must yield no count, not a confidently wrong one.
+
+    THREE duplicates, not two, on purpose. With exactly two, `counts.pop` alone produces the right
+    answer and deleting `ambiguous.add(key)` leaves the suite green - the third occurrence is what
+    proves the `ambiguous` set is load-bearing, because without it the name resurrects with the
+    third value (mutation D2 in the re-review of PR #232).
+    """
     module = _load_script_module()
     relations = [
-        {"table": "Orders", "row_count": {"value": 3, "source": "hyper", "as_of": "Z"}},
-        {"table": "Orders", "row_count": {"value": 42104338, "source": "hyper", "as_of": "Z"}},
-        {"table": "Products", "row_count": {"value": 7, "source": "hyper", "as_of": "Z"}},
+        {"table": "Orders", "row_count": {"value": 3, "source": "hyper", "observed_at": "Z"}},
+        {"table": "Orders", "row_count": {"value": 42104338, "source": "hyper", "observed_at": "Z"}},
+        {"table": "Orders", "row_count": {"value": 99, "source": "hyper", "observed_at": "Z"}},
+        {"table": "Products", "row_count": {"value": 7, "source": "hyper", "observed_at": "Z"}},
     ]
 
     counts = module._row_count_by_table_name(relations)
 
     assert "orders" not in counts, "an ambiguous name must be omitted, not resolved by iteration order"
     assert counts["products"]["value"] == 7
+
+
+def test_a_multi_table_datasource_gets_every_count_matched_by_name(tmp_path: Path) -> None:
+    """The by-name path, not the 1x1 shortcut - previously untested, so disabling it stayed green.
+
+    Mutations E6 (`by_name = {}`) and E8 (`_row_count_by_table_name` -> `{}`) both survived the
+    original suite because the only enrichment test had exactly one table and one relation, which
+    the shortcut answers without ever consulting the name map.
+
+    The quoted relation names are the REAL producer shape, not decoration: `_describe_hyper_file`
+    writes `str(table.name)`, and stringifying a Hyper `Name` escapes it, so the value carries
+    literal double quotes. That is why `_normalise_table_name` strips them. A first draft of this
+    test used `"Extract.Orders"` and failed - the schema lives in `qualified_name`, never here.
+    """
+    module = _load_script_module()
+    data_source = {
+        "id": "ds.sales",
+        "tables": [
+            {"id": "tbl.orders", "name": "Orders", "row_count": {"source": "unknown"}},
+            {"id": "tbl.products", "name": "Products", "row_count": {"source": "unknown"}},
+        ],
+    }
+    relations = [
+        {"table": '"Orders"', "row_count": {"value": 3, "source": "hyper", "observed_at": "Z"}},
+        {"table": '"Products"', "row_count": {"value": 7, "source": "hyper", "observed_at": "Z"}},
+    ]
+
+    updated = module._apply_hyper_counts_to_tables(data_source, relations)
+
+    assert updated == 2
+    assert data_source["tables"][0]["row_count"]["value"] == 3
+    assert data_source["tables"][1]["row_count"]["value"] == 7
+
+
+def test_a_lone_table_is_matched_to_a_lone_relation_even_when_the_names_differ() -> None:
+    """The 1x1 shortcut exists because Tableau's table name need not equal the Hyper relation name."""
+    module = _load_script_module()
+    data_source = {
+        "id": "ds.sales",
+        "tables": [{"id": "tbl.sales", "name": "Sales", "row_count": {"source": "unknown"}}],
+    }
+    relations = [
+        {"table": "Extract.Orders_csv_FACT", "row_count": {"value": 9994, "source": "hyper", "observed_at": "Z"}}
+    ]
+
+    updated = module._apply_hyper_counts_to_tables(data_source, relations)
+
+    assert updated == 1, "a single table and a single relation must match positionally, not by name"
+    assert data_source["tables"][0]["row_count"]["value"] == 9994
 
 
 def test_a_null_hyper_file_is_reported_not_raised(tmp_path: Path) -> None:
@@ -266,11 +323,39 @@ def test_a_null_hyper_file_is_reported_not_raised(tmp_path: Path) -> None:
     assert "hyper file not found" in manifest["ds.orders"]["error"]
 
 
-def test_schema_scratch_never_lands_beside_the_workbook() -> None:
-    """Extracted .hyper residue under migrations/<tree>/<slug>/source/ is NOT gitignored (issue #125)."""
-    source = SCRIPT.read_text(encoding="utf-8")
+def test_schema_scratch_never_lands_beside_the_workbook(tmp_path: Path, monkeypatch) -> None:
+    """Extracted .hyper residue under migrations/<tree>/<slug>/source/ is NOT gitignored (issue #125).
 
-    assert "dir=args.workbook.parent" not in source, (
-        "scratch extraction must stay in the OS temp dir: a TemporaryDirectory beside the workbook "
-        "leaves customer .hyper data in an unignored path, and it is not cleaned up if the process is killed"
+    Observes the scratch path WHILE IT EXISTS rather than asserting on source text. The source-text
+    form shipped first and was measured worthless in the re-review: `dir =args.workbook.parent`
+    (one space), `dir=Path(args.workbook).parent` and a local-variable indirection all survived it,
+    while merely adding a COMMENT naming the literal string made it fail - it punished the most
+    natural way to stop the mistake recurring. Listing the directory after the run is equally
+    vacuous, because TemporaryDirectory cleans up on success; the hazard is the kill path.
+    """
+    module = _load_script_module()
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    hyper = tmp_path / "orders.hyper"
+    _create_hyper(hyper, {"Orders": (["id"], [("1",), ("2",), ("3",)])})
+    workbook = source_dir / "wb.twbx"
+    with zipfile.ZipFile(workbook, "w") as archive:
+        archive.write(hyper, "Data/orders/orders.hyper")
+
+    created: list[Path] = []
+
+    class _Recording(tempfile.TemporaryDirectory):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            created.append(Path(self.name).resolve())
+
+    monkeypatch.setattr(module.tempfile, "TemporaryDirectory", _Recording)
+    monkeypatch.setattr(sys, "argv", ["extract_hyper_data.py", str(workbook), "--schema"])
+    module.main()
+
+    assert created, "no scratch dir was created - the test proved nothing"
+    assert all(not scratch.is_relative_to(workbook.parent.resolve()) for scratch in created), (
+        f"scratch extraction must stay in the OS temp dir, got {created}: a TemporaryDirectory "
+        "beside the workbook leaves customer .hyper data in an unignored path, and it is not "
+        "cleaned up if the process is killed"
     )

--- a/tests/test_parse_tableau.py
+++ b/tests/test_parse_tableau.py
@@ -179,6 +179,13 @@ def test_collection_relation_descends_to_leaf_tables():
     assert all(t["source_relation"] == "table" for t in tables if t["name"] in {"Cities", "Regions"})
 
 
+def test_parser_emits_unknown_table_row_count_without_guessing_zero():
+    """Parse is offline and does not open .hyper files, so the normal generated hint is unknown."""
+    table = parse_workbook(FIXTURE)["data_sources"][0]["tables"][0]
+    assert table["row_count"] == {"source": "unknown"}
+    assert "value" not in table["row_count"]
+
+
 def test_metadata_only_physical_column_recovered():
     """Physical/extract columns that appear only in <metadata-records> (no <column> element) must be
     recovered into fields[] with from_metadata_record=True, deduped against existing <column> fields,

--- a/tests/test_spec_contract.py
+++ b/tests/test_spec_contract.py
@@ -157,24 +157,28 @@ def test_schema_accepts_a_real_rfc3339_observed_at(tmp_path: Path) -> None:
         assert errors == [], f"{good!r} was rejected: {errors}"
 
 
-def test_a_leap_second_is_rejected_with_an_HONEST_reason(tmp_path: Path) -> None:
+def test_a_seconds_field_of_60_is_rejected_WITHOUT_claiming_it_is_a_leap_second(tmp_path: Path) -> None:
     """A pre-existing stdlib ceiling, pinned so it stays documented rather than mysterious.
 
-    RFC 3339 permits `23:59:60`, so rejecting it IS a deviation from the advertised format. It is
-    not one this repo can fix: `datetime.fromisoformat` raises "second must be in 0..59", and
-    `datetime` has no leap-second representation, so there is nothing to store or compare even if
-    parsing succeeded. The previous `fromisoformat`-only check rejected it identically, so the
-    shape regex did not introduce this.
+    RFC 3339 permits `:60` at an actual leap second, so rejecting it IS a deviation from the
+    advertised format (now disclosed in the schema's own `observed_at` description). It is not one
+    this repo can fix: `datetime.fromisoformat` raises "second must be in 0..59", and `datetime` has
+    no leap-second representation, so there would be nothing to store or compare even if parsing
+    succeeded. The previous `fromisoformat`-only check rejected it identically, so the shape regex
+    did not introduce this.
 
-    What IS fixable is the message: a generic "not a valid RFC 3339 timestamp" sends the reader
-    hunting for a typo in a timestamp that is genuinely valid.
+    The message must NOT assert the value *is* a leap second. `23:58:60Z` is not one, and no
+    validator can tell without a leap-second table - so both are reported by naming the seconds
+    field, which is true of each.
     """
-    errors = _validation_errors_for_spec(
-        tmp_path,
-        _spec_with_first_table_row_count({"value": 42, "source": "hyper", "observed_at": "2026-12-31T23:59:60Z"}),
-    )
+    for value in ("2026-12-31T23:59:60Z", "2026-08-19T23:58:60Z"):
+        errors = _validation_errors_for_spec(
+            tmp_path,
+            _spec_with_first_table_row_count({"value": 42, "source": "hyper", "observed_at": value}),
+        )
 
-    assert any("leap second" in error for error in errors), f"expected a leap-second-specific reason, got {errors}"
+        assert any("seconds field of 60" in error for error in errors), f"{value!r}: got {errors}"
+        assert not any("is a leap second" in error for error in errors), f"{value!r} must not be CALLED a leap second"
 
 
 def test_malformed_appended_limitation_names_the_bad_field(tmp_path: Path) -> None:

--- a/tests/test_spec_contract.py
+++ b/tests/test_spec_contract.py
@@ -110,6 +110,8 @@ def test_existing_spec_without_row_count_still_validates(tmp_path: Path) -> None
         "2026-02-30T00:00:00Z",
         "2026-08-19",
         "2026-08-19T10:04:00",
+        "2026-08-19 10:04:00+00:00",
+        "20260819T100400+00:00",
     ],
 )
 def test_schema_rejects_an_observed_at_that_is_not_a_real_utc_timestamp(tmp_path: Path, bad: str) -> None:
@@ -119,8 +121,13 @@ def test_schema_rejects_an_observed_at_that_is_not_a_real_utc_timestamp(tmp_path
     date/email/idn-email/idn-hostname/ipv4/ipv6/regex - `date-time` is absent because
     `rfc3339-validator` is not installed (pyproject declares `jsonschema>=4.22` with no
     `format-nongpl` extra). Passing `format_checker=` would accept every value below while looking
-    like a fix. The last two cases are why a shape regex is not enough either: a date-only value and
-    a naive local time are both well-formed and both ambiguous.
+    like a fix. `2026-08-19` and `2026-08-19T10:04:00` are why a shape regex is not enough either: a
+    date-only value and a naive local time are both well-formed and both ambiguous.
+
+    The last two are the converse - why `fromisoformat` alone is not enough. It is far broader than
+    RFC 3339: it accepts a SPACE separator and the basic (hyphen-less) format, neither of which is
+    the `full-date "T" full-time` the schema advertises. Accepting them would let the fallback
+    silently weaken the very contract it exists to make deterministic.
     """
     errors = _validation_errors_for_spec(
         tmp_path, _spec_with_first_table_row_count({"value": 42, "source": "hyper", "observed_at": bad})
@@ -130,8 +137,19 @@ def test_schema_rejects_an_observed_at_that_is_not_a_real_utc_timestamp(tmp_path
 
 
 def test_schema_accepts_a_real_rfc3339_observed_at(tmp_path: Path) -> None:
-    """Both a Z suffix and an explicit offset are valid; the stdlib check must not over-reject."""
-    for good in ("2026-08-19T10:04:00Z", "2026-08-19T10:04:00+02:00", "2026-08-19T10:04:00.123456Z"):
+    """Both a Z suffix and an explicit offset are valid; the stdlib check must not over-reject.
+
+    Lowercase `t`/`z` are explicitly permitted by RFC 3339, but `datetime.fromisoformat` rejects
+    them - so the shape check and the semantic check disagree unless the value is normalised
+    between them. Pinned here because getting it wrong fails a VALID timestamp, which is worse
+    than the over-acceptance this pair of checks was added to fix.
+    """
+    for good in (
+        "2026-08-19T10:04:00Z",
+        "2026-08-19T10:04:00+02:00",
+        "2026-08-19T10:04:00.123456Z",
+        "2026-08-19t10:04:00z",
+    ):
         errors = _validation_errors_for_spec(
             tmp_path, _spec_with_first_table_row_count({"value": 42, "source": "hyper", "observed_at": good})
         )

--- a/tests/test_spec_contract.py
+++ b/tests/test_spec_contract.py
@@ -157,6 +157,26 @@ def test_schema_accepts_a_real_rfc3339_observed_at(tmp_path: Path) -> None:
         assert errors == [], f"{good!r} was rejected: {errors}"
 
 
+def test_a_leap_second_is_rejected_with_an_HONEST_reason(tmp_path: Path) -> None:
+    """A pre-existing stdlib ceiling, pinned so it stays documented rather than mysterious.
+
+    RFC 3339 permits `23:59:60`, so rejecting it IS a deviation from the advertised format. It is
+    not one this repo can fix: `datetime.fromisoformat` raises "second must be in 0..59", and
+    `datetime` has no leap-second representation, so there is nothing to store or compare even if
+    parsing succeeded. The previous `fromisoformat`-only check rejected it identically, so the
+    shape regex did not introduce this.
+
+    What IS fixable is the message: a generic "not a valid RFC 3339 timestamp" sends the reader
+    hunting for a typo in a timestamp that is genuinely valid.
+    """
+    errors = _validation_errors_for_spec(
+        tmp_path,
+        _spec_with_first_table_row_count({"value": 42, "source": "hyper", "observed_at": "2026-12-31T23:59:60Z"}),
+    )
+
+    assert any("leap second" in error for error in errors), f"expected a leap-second-specific reason, got {errors}"
+
+
 def test_malformed_appended_limitation_names_the_bad_field(tmp_path: Path) -> None:
     """The observed failure was an appended severity outside the schema enum."""
     spec = _fixture_spec()

--- a/tests/test_spec_contract.py
+++ b/tests/test_spec_contract.py
@@ -22,6 +22,20 @@ def _fixture_spec() -> dict:
     return json.loads(FIXTURE_SPEC.read_text(encoding="utf-8"))
 
 
+def _spec_with_first_table_row_count(row_count: object) -> dict:
+    spec = _fixture_spec()
+    if not spec["data_sources"][0].get("tables"):
+        spec["data_sources"][0]["tables"] = [{"id": "tbl.sales", "name": "Sales", "source_relation": "table"}]
+    spec["data_sources"][0]["tables"][0]["row_count"] = row_count
+    return spec
+
+
+def _validation_errors_for_spec(tmp_path: Path, spec: dict) -> list[str]:
+    path = tmp_path / "migration-spec.json"
+    path.write_text(json.dumps(spec), encoding="utf-8")
+    return collect_spec_validation_errors(path)
+
+
 def _run_cli_with_schema(spec_path: Path, schema_path: Path) -> subprocess.CompletedProcess:
     script = """
 import sys
@@ -40,6 +54,49 @@ raise SystemExit(validate_spec.main([sys.argv[1]]))
         errors="replace",
         check=False,
     )
+
+
+def test_schema_rejects_bare_integer_row_count(tmp_path: Path) -> None:
+    """row_count must carry provenance; a bare number is unsafe because it can be stale or absent."""
+    errors = _validation_errors_for_spec(tmp_path, _spec_with_first_table_row_count(42))
+
+    assert any("row_count" in error and "42" in error for error in errors)
+
+
+def test_schema_rejects_unknown_row_count_with_value(tmp_path: Path) -> None:
+    """Unknown is a normal state, but it must not carry a fake zero/small value."""
+    errors = _validation_errors_for_spec(tmp_path, _spec_with_first_table_row_count({"source": "unknown", "value": 0}))
+
+    assert any("row_count" in error and "not valid under any" in error for error in errors)
+
+
+def test_schema_rejects_unknown_row_count_source(tmp_path: Path) -> None:
+    """Consumers branch on source, so unrecognised provenance must fail validation."""
+    errors = _validation_errors_for_spec(
+        tmp_path,
+        _spec_with_first_table_row_count({"value": 42, "source": "spreadsheet-guess", "as_of": "2026-08-19T10:04:00Z"}),
+    )
+
+    assert any("row_count" in error and "spreadsheet-guess" in error for error in errors)
+
+
+def test_schema_accepts_unknown_row_count_without_value(tmp_path: Path) -> None:
+    """Unknown round-trips explicitly and cannot be confused with zero."""
+    errors = _validation_errors_for_spec(tmp_path, _spec_with_first_table_row_count({"source": "unknown"}))
+
+    assert errors == []
+
+
+def test_existing_spec_without_row_count_still_validates(tmp_path: Path) -> None:
+    """Back-compat: committed specs produced before this field remains valid."""
+    spec = _fixture_spec()
+    for data_source in spec["data_sources"]:
+        for table in data_source.get("tables", []):
+            table.pop("row_count", None)
+
+    errors = _validation_errors_for_spec(tmp_path, spec)
+
+    assert errors == []
 
 
 def test_malformed_appended_limitation_names_the_bad_field(tmp_path: Path) -> None:
@@ -232,8 +289,9 @@ def test_legitimate_appended_limitation_passes_and_is_not_rewritten(tmp_path: Pa
 
 
 def test_every_committed_spec_validates_against_the_schema() -> None:
-    """The example corpus carries real appended limitations and must stay valid."""
+    """The example/migration corpus carries real appended limitations and must stay valid."""
     specs = sorted((REPO_ROOT / "examples").glob("*/migration-spec.json"))
+    specs.extend(sorted((REPO_ROOT / "migrations").glob("*/*/migration-spec.json")))
     assert specs
     invalid = {path: collect_spec_validation_errors(path) for path in specs}
     assert not {path: errors for path, errors in invalid.items() if errors}

--- a/tests/test_spec_contract.py
+++ b/tests/test_spec_contract.py
@@ -74,7 +74,9 @@ def test_schema_rejects_unknown_row_count_source(tmp_path: Path) -> None:
     """Consumers branch on source, so unrecognised provenance must fail validation."""
     errors = _validation_errors_for_spec(
         tmp_path,
-        _spec_with_first_table_row_count({"value": 42, "source": "spreadsheet-guess", "as_of": "2026-08-19T10:04:00Z"}),
+        _spec_with_first_table_row_count(
+            {"value": 42, "source": "spreadsheet-guess", "observed_at": "2026-08-19T10:04:00Z"}
+        ),
     )
 
     assert any("row_count" in error and "spreadsheet-guess" in error for error in errors)
@@ -97,6 +99,44 @@ def test_existing_spec_without_row_count_still_validates(tmp_path: Path) -> None
     errors = _validation_errors_for_spec(tmp_path, spec)
 
     assert errors == []
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "yesterday",
+        "",
+        "2026-13-45T99:99:99Z",
+        "2026-02-30T00:00:00Z",
+        "2026-08-19",
+        "2026-08-19T10:04:00",
+    ],
+)
+def test_schema_rejects_an_observed_at_that_is_not_a_real_utc_timestamp(tmp_path: Path, bad: str) -> None:
+    """jsonschema's format:date-time is annotation-only here, so a stdlib check does the work.
+
+    Measured in this venv: Draft7Validator.FORMAT_CHECKER enforces only
+    date/email/idn-email/idn-hostname/ipv4/ipv6/regex - `date-time` is absent because
+    `rfc3339-validator` is not installed (pyproject declares `jsonschema>=4.22` with no
+    `format-nongpl` extra). Passing `format_checker=` would accept every value below while looking
+    like a fix. The last two cases are why a shape regex is not enough either: a date-only value and
+    a naive local time are both well-formed and both ambiguous.
+    """
+    errors = _validation_errors_for_spec(
+        tmp_path, _spec_with_first_table_row_count({"value": 42, "source": "hyper", "observed_at": bad})
+    )
+
+    assert any("observed_at" in error for error in errors), f"{bad!r} was accepted"
+
+
+def test_schema_accepts_a_real_rfc3339_observed_at(tmp_path: Path) -> None:
+    """Both a Z suffix and an explicit offset are valid; the stdlib check must not over-reject."""
+    for good in ("2026-08-19T10:04:00Z", "2026-08-19T10:04:00+02:00", "2026-08-19T10:04:00.123456Z"):
+        errors = _validation_errors_for_spec(
+            tmp_path, _spec_with_first_table_row_count({"value": 42, "source": "hyper", "observed_at": good})
+        )
+
+        assert errors == [], f"{good!r} was rejected: {errors}"
 
 
 def test_malformed_appended_limitation_names_the_bad_field(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Adds table-level `row_count` hints with `{value, source, as_of}` for `hyper`/`live` and explicit `{source: "unknown"}` for unknown.
- Keeps `parse_tableau.py` offline/fast by emitting unknown table hints during parse; adds `extract_hyper_data.py --enrich-spec` as the opt-in Hyper-reading enrichment step.
- Updates schema and tests so bare integers, unknown sources, and `source: "unknown"` with a value are rejected while old specs without `row_count` remain valid.

## Design decisions
1. **Placement:** `data_sources[].tables[].row_count`. The Hyper count is inherently per Hyper relation/table, and the spec already exposes parsed physical/logical tables there. I did not add a datasource total because joins/unions make a datasource aggregate easy to misread.
2. **How parse learns it:** parse does not open Hyper files. It writes `{source: "unknown"}` and the separate `extract_hyper_data.py --enrich-spec` path replaces matching table hints with Hyper counts. This avoids making every parse slower and dependent on tableauhyperapi.
3. **Backwards compatibility:** `row_count` is optional in the schema. Existing specs without it still validate.

## Validation
- `powershell -ExecutionPolicy Bypass -File scripts/preflight.ps1 -Update -CheckUpstream` (exit 0)
- `...\.venv\Scripts\python.exe -m ruff format ...` and `-m ruff check ... --fix` (exit 0)
- `...\.venv\Scripts\python.exe -m pytest tests\test_spec_contract.py tests\test_parse_tableau.py tests\test_extract_hyper_data.py -q` (67 passed)
- `...\.venv\Scripts\python.exe -m pylint scripts` (exit 0, 10.00/10)
- `...\.venv\Scripts\python.exe scripts\validate_spec.py --all` (16 specs valid)
- `...\.venv\Scripts\python.exe -m pytest -q` (1629 passed, 7 skipped, 4 warnings)

## Mutation results
Deliberately broke each new behavior and confirmed the relevant test failed:
- Allowed bare integer `row_count` in the schema -> `test_schema_rejects_bare_integer_row_count` failed.
- Made parser emit unknown as `{"source":"unknown","value":0}` -> unknown round-trip test failed.
- Made `row_count` required on tables -> existing-spec back-compat test failed.
- Changed Hyper enrichment to add 1 to the count -> enrichment persistence test failed.

## What I could not verify
- No live-source row count path was implemented or verified; `live` is schema-supported for future credentialed enrichment only.
- I did not validate ambiguous multi-table Hyper/spec name matching against a real customer TWBX; unmatched/ambiguous tables remain `unknown` by design.
