### PR TITLE
docs(agents): name check_field_bindings.py where binding failures appear

### DIFF
--- a/.github/agents/pbi-migration-validator.agent.md
+++ b/.github/agents/pbi-migration-validator.agent.md
@@ -235,6 +235,13 @@ Run these passes **in order** — cheap structural checks first, expensive judgm
    time on aesthetic judgment.
    `powerbi-report-author preview-pages <report>` and `preview-visuals <report>` emit this inventory as
    structured JSON — use them instead of reading every `visual.json` by hand.
+   `python scripts/check_field_bindings.py <bundle>` is the matching **cross-layer** check: every PBIR
+   field reference resolved against the TMDL. Run it here — it is offline and sweeps a whole estate, so
+   it costs nothing next to opening Desktop. Report its two classes **separately, because they route to
+   different owners**: **case-only** mismatches (`Flight_Duration` in PBIR vs `FLIGHT_DURATION` in TMDL)
+   are a mechanical rename for `pbi-report-builder`; **genuinely missing** columns/measures are a
+   modelling gap for `pbi-semantic-builder`. A broken binding renders blank on a report that
+   `validate` passes clean, so no other pass you run will catch it.
 2. **Whole-dashboard pass** (do this *before* drilling into individual visuals, not after). Compare
    the full-page PBI screenshot against the full Tableau dashboard screenshot as a gestalt: overall
    layout density/proportions, visual hierarchy (what draws the eye first), color usage, spacing,

--- a/.github/agents/pbi-report-builder.agent.md
+++ b/.github/agents/pbi-report-builder.agent.md
@@ -162,32 +162,12 @@ every `visual.json`). Three properties make it a patch rather than an edit:
 Worth actually doing once per migration: re-run the engine, re-run your scripts, confirm you land on
 the same report. If you cannot, you do not have a patch — you have an edit.
 
-⚠️ **A `_build/` script is only half of it — DECLARE the edit, or sign-off blocks.** Every file under
-a `*.Report` folder is hash-baselined by the engine run, and the orchestrator's pre-sign-off
-`check_migration_progress.py --bundle <b> --tamper` exits **1** on any that changed without a matching
-declaration. `scripts/declare_generated_edit.py` is the **only** thing that writes one: it runs your
-script for you and records the before/after hashes into `_build/generated-edit-declarations.json`.
-
-```bash
-python scripts/declare_generated_edit.py --bundle <b> \
-  --target pbip/<WB>/<WB>.Report/definition/pages/<p>/visuals/<id>/visual.json \
-  --script <b>/_build/fix_axis_title.py \
-  -- --only pbip/<WB>/<WB>.Report/definition/pages/<p>/visuals/<id>/visual.json
-# DECLARE: RECORDED pbip/.../visual.json -> <b>/_build/generated-edit-declarations.json
-```
-
-Measured — each of these leaves the gate RED while looking like it worked:
-
-- **One `--target` per run.** A second run of an idempotent script prints `DECLARE: NO_CHANGE` and
-  records nothing, so a whole-tree emitter leaves every file but one UNDECLARED. Give the script an
-  `--only <bundle-relative path>` scope argument, pass it after `--`, and run the wrapper per target.
-- **Never hand-edit first.** The wrapper hashes the target *before* running your script and the gate
-  only accepts a declaration whose baseline is the engine's hash, so a retro-declaration is never
-  accepted. Restore the target by re-running the engine — `reports/` is a **different file**, not a
-  copy of `pbip/` (gotchas §3).
-- **Declare last.** Touching the target again afterwards invalidates its declaration.
-
-Self-check before reporting done: `--tamper` must exit 0 (`DECLARED_DRIFT` passes, `DRIFT` does not).
+⚠️ **A `_build/` script is only half of it — DECLARE the edit, or sign-off blocks.**
+`check_migration_progress.py --bundle <b> --tamper` exits **1** on any `*.Report` file that changed
+without a declaration, and `scripts/declare_generated_edit.py` is the only thing that writes one — it
+runs your script for you and records the before/after hashes. Its three failure modes (one `--target`
+per run, never hand-edit first, declare last) and the exact invocation are in
+`powerbi-report-gotchas` §3. Self-check: `--tamper` must exit 0.
 
 ### Visual encoding — only when you must change an encoding
 
@@ -260,6 +240,13 @@ it is slow, and `validate` will not catch a wrong encoding.
    minutes *before* the cache was written loaded an EMPTY model; and a refresh on a live source hits a
    modal credential prompt no automation can fill. Consequence for step 1: an empty render is then an
    **unrefreshed-model artifact, not a binding defect** — never "fix" bindings that are already correct.
+   When bindings genuinely **are** broken ("Fields that need to be fixed", blank visuals on a report
+   that validates clean), run `python scripts/check_field_bindings.py <bundle>` **before** any Desktop
+   archaeology. It splits **case-only** mismatches (`Flight_Duration` in PBIR vs `FLIGHT_DURATION` in
+   TMDL — a mechanical rename, yours to fix) from **genuinely missing** columns/measures (a modelling
+   gap — route to `pbi-semantic-builder`, never invent the field). Measured on a 12-workbook estate:
+   it replaced ~an afternoon of per-workbook Desktop archaeology and found the same defect on 4 items
+   nobody had opened.
    **Read the baseline before changing anything.** Open the rebuilt report and screenshot every page
    against `reference/`. **Judge the GESTALT first** - proportions, density, header/slicer bands,
    where the eye lands - before looking at any single visual. This is the highest-value step and the

--- a/.github/skills/powerbi-report-gotchas/SKILL.md
+++ b/.github/skills/powerbi-report-gotchas/SKILL.md
@@ -290,7 +290,37 @@ idioms see `.github/pbi.kb/visuals/table-cond-format.md`.
   that the source had a chart there. So before concluding a field is missing, grep the model for a
   `= BLANK()` measure matching the worksheet's shelf.
 
+### Declaring a generated PBIR edit, or sign-off blocks
+
+Every file under a `*.Report` folder is hash-baselined by the engine run, and the orchestrator's
+pre-sign-off `check_migration_progress.py --bundle <b> --tamper` exits **1** on any that changed
+without a matching declaration. `scripts/declare_generated_edit.py` is the **only** thing that writes
+one: it runs your `_build/` script for you and records the before/after hashes into
+`_build/generated-edit-declarations.json`.
+
+```bash
+python scripts/declare_generated_edit.py --bundle <b> \
+  --target pbip/<WB>/<WB>.Report/definition/pages/<p>/visuals/<id>/visual.json \
+  --script <b>/_build/fix_axis_title.py \
+  -- --only pbip/<WB>/<WB>.Report/definition/pages/<p>/visuals/<id>/visual.json
+# DECLARE: RECORDED pbip/.../visual.json -> <b>/_build/generated-edit-declarations.json
+```
+
+Measured — each of these leaves the gate RED while looking like it worked:
+
+- **One `--target` per run.** A second run of an idempotent script prints `DECLARE: NO_CHANGE` and
+  records nothing, so a whole-tree emitter leaves every file but one UNDECLARED. Give the script an
+  `--only <bundle-relative path>` scope argument, pass it after `--`, and run the wrapper per target.
+- **Never hand-edit first.** The wrapper hashes the target *before* running your script and the gate
+  only accepts a declaration whose baseline is the engine's hash, so a retro-declaration is never
+  accepted. Restore the target by re-running the engine — `reports/` is a **different file**, not a
+  copy of `pbip/` (see the `byPath` entry above).
+- **Declare last.** Touching the target again afterwards invalidates its declaration.
+
+Self-check before reporting done: `--tamper` must exit 0 (`DECLARED_DRIFT` passes, `DRIFT` does not).
+
 ## 4. Crosstabs and tables — a recurring fragility class
+
 
 Two distinct failure modes, both seen in production:
 


### PR DESCRIPTION
Closes #247 - `check_field_bindings.py` was named by **no persona**, so no subagent would ever run it.

## What changed

| file | change |
|---|---|
| `pbi-report-builder.agent.md` | names the script at workflow step 1, where the persona *already* distinguishes an unrefreshed model from a real binding defect - the exact moment the question arises |
| `pbi-migration-validator.agent.md` | names it in the cheap mechanical inventory pass, with the two output classes reported **separately because they route to different owners** |
| `powerbi-report-gotchas/SKILL.md` | received the relocated `declare_generated_edit.py` mechanics (new subsection inside section 3, PBIR mechanics) |

Both personas state the cut that makes the output actionable: **case-only** mismatches (`Flight_Duration` in PBIR vs `FLIGHT_DURATION` in TMDL) are a mechanical rename owned by `pbi-report-builder`; **genuinely missing** columns/measures are a modelling gap routed to `pbi-semantic-builder`.

## The character cap was the actual work

`pbi-report-builder` sat at 29,946 / 30,000 - **27 chars of headroom** after PR #243's +27. DoD item 3 required a net removal, and there was no way to trim 340 chars of guidance out of prose that is already dense.

Applied the documented remedy instead (`AGENTS.md`: *"New craft learnings belong in these bundles, not back in a persona - that is what keeps it that way"*): moved the `declare_generated_edit.py` invocation + its three failure modes into `powerbi-report-gotchas` section 3, leaving a 6-line pointer.

**Net -604 chars.** The persona is now at 97.8% of cap with 658 chars headroom - 631 even after #243 lands.

## Conflict note

⚠️ I initially also compacted the "judge the GESTALT first" paragraph, then found **PR #243 had already made a near-identical compaction** at the same lines. Reverted it - that saving is already banked on the other branch, and duplicating it would have produced a guaranteed conflict for zero gain. This branch now touches no line #243 touches in that file.

## Verification

| gate | result |
|---|---|
| `python scripts/sync_agent_conventions.py --check` | **exit 0** - all 4 agents carry current conventions, all under cap |
| `python scripts/sync_installed_skills.py` | exit 0 - published bundle refreshed |
| `pytest tests/test_skills.py` | **exit 0** - 25 passed |
| `check_field_bindings` named in personas | `pbi-migration-validator.agent.md:238`, `pbi-report-builder.agent.md:244` (was: zero hits) |

## Out of scope, deliberately

Wiring the script into `checks.yml`, per the issue's own scope note - CI has no bundle to run it against (bundles are gitignored), so that needs a committed fixture first and is a genuinely separate concern.

## Provenance

The cloud coding agent could not do this: PR #249 came back with **zero files changed** and *"the required `.github/agents/` files are restricted in this sandbox."* Persona work is local-only - the same constraint applies to #245.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
