### PR TITLE
docs(skills): scope the AI-metadata refresh claims to what was measured, and fix an ordering rule that loses the cache

### DIFF
--- a/.github/skills/pbip-model-refresh/SKILL.md
+++ b/.github/skills/pbip-model-refresh/SKILL.md
@@ -232,18 +232,29 @@ Desktop **discards `cache.abf` when the model definition is newer than the cache
 whose `definition/*.tmdl` were touched after the cache was written opened `NO_DATA` despite a 113 KB
 cache sitting right there. So:
 
-> make **all** TMDL edits, then refresh, then save.
+> make **all** TMDL edits, **reopen Desktop so it loads them**, then refresh, then save.
+
+That middle step is not optional, and it is the easiest one to drop: `powerbi-desktop reload` does
+**not** re-read edited TMDL (measured below). Refresh without reopening and you refresh the *old*
+in-memory definition, then persist a cache that does not match what is on disk — which opens
+`NO_DATA` and looks like the cache-invalidation problem rather than the operator error it is.
 
 Anything that rewrites TMDL afterwards invalidates it, including the host repo's own sanitize step
 (here, `set_data_folder.py --sanitize`, which must run before committing). If you sanitize last, you
 have thrown the cache away; re-run this script after.
 
-**It is the CONTENT that invalidates it, not the mtime — you cannot win this by ordering.** Measured
+**A cache newer than the definition can still be invalid — you cannot win this by ordering.** Measured
 2026-08-01 on `logistics-live-dbx`: sanitize rewrote `expressions.tmdl` at 12:24:08, `ImageSave` wrote
 `cache.abf` at 12:24:23 (15 s *newer*, 57.5 KB) — and a cold reopen still came back `NO_DATA`.
 Re-localizing, reopening, refreshing and saving again produced a cache that **did** survive a
 `Stop-Process -Force` + reopen (`PREFLIGHT: DATA_OK`, no refresh). So "refresh last, after sanitize"
 does not rescue the cache: Desktop keys the cache to the definition it was built from.
+
+⚠️ **Scope this measurement honestly.** It changed `expressions.tmdl` — a *data-affecting* file.
+Whether a culture-only edit (AI instructions), a description-only `ExportToTmdlFolder` or a
+byte-identical rewrite also invalidates the cache is **UNMEASURED**; do not cite this paragraph for
+those. What it does establish — and all the warning below needs — is that a favourable mtime proves
+nothing.
 
 > ⚠️ **Do NOT gate on `cache.abf` mtime ≥ newest definition-file mtime.** Proposed independently on
 > 2026-08-19 by a field team hitting the post-ship-edit case above, and it is a **false-green

--- a/.github/skills/powerbi-ai-readiness/SKILL.md
+++ b/.github/skills/powerbi-ai-readiness/SKILL.md
@@ -66,8 +66,14 @@ definition/cultures/<lcid>.tmdl
   `definition.pbism`'s version — a different schema. (Measured 2026-07-30: a model published with
   `4.2.0` still round-tripped intact, so this is correctness hygiene, not a fix for observed data loss.)
 - **The Modeling-MCP culture `Update` surface cannot reach this key** (it exposes name / annotations /
-  extendedProperties). Editing the TMDL directly is therefore the mechanism, not a shortcut — and it
-  has a second benefit: no XMLA refresh is required to apply it.
+  extendedProperties). Editing the TMDL directly is therefore the mechanism, not a shortcut.
+- ⚠️ **"No XMLA refresh is required" is a claim about the WRITE, not about the cost.** Stamping needs
+  no XMLA call to land on disk — but it does **not** update an already-open Desktop model
+  (`pbip-model-refresh`: `reload` does not re-read edited TMDL, measured 2026-08-01), and whether it
+  leaves the persisted `.pbi/cache.abf` valid is **UNMEASURED**. The one dated cache experiment we
+  have changed `expressions.tmdl`, not a culture file, so it does not cover this case. Until that is
+  settled, treat stamping as a **final** `definition/` edit — stamp, *then* reopen Desktop, refresh
+  and save — so you pay any reload once at most.
 - The markdown source is the editable artifact (`<migration>/ai-instructions.md`, two levels above the
   `.SemanticModel` folder); the culture TMDL is **generated**. Edit the markdown, re-stamp.
 

--- a/.github/skills/powerbi-ai-readiness/scripts/set_ai_instructions.py
+++ b/.github/skills/powerbi-ai-readiness/scripts/set_ai_instructions.py
@@ -2,7 +2,10 @@
 purpose: sync a semantic model's AI instructions (an editable markdown file) into the model's
          culture linguisticMetadata.CustomInstructions key. That key is what Power BI Copilot and
          Fabric data agents read as model-level AI instructions ("Prep data for AI" > AI instructions).
-         Writing the TMDL directly avoids an XMLA refresh (and the LCID-4096 refresh bug on this box).
+         Writing the TMDL directly needs no XMLA call to land (and dodges the LCID-4096 refresh bug
+         on this box). That is about the WRITE only: it does not update an already-open Desktop
+         model, and whether it invalidates .pbi/cache.abf is UNMEASURED. Stamp BEFORE the final
+         reopen + refresh + save, not after.
 usage:   python .github/skills/powerbi-ai-readiness/scripts/set_ai_instructions.py
              --model <*.SemanticModel> [--md <file.md>]
              --all             # stamp every migration that has an ai-instructions.md


### PR DESCRIPTION
Two of our own skill bundles implied different answers to a question a customer is paying real money for: **does stamping AI metadata into a PBIP model force a full data reload?** A blind review established that **neither bundle had actually measured that case** — so this PR replaces the overclaims with honestly-scoped statements, and fixes a data-losing gap it surfaced along the way.

No behaviour changes. Documentation and one docstring.

## 1. "No XMLA refresh is required" was true about the write, misleading about the cost

`powerbi-ai-readiness/SKILL.md` and `set_ai_instructions.py`s docstring both said writing the TMDL directly *"avoids an XMLA refresh"*. That is **true** — stamping needs no XMLA call to land on disk. It was read as *"stamping is cheap"*, which does not follow: it says nothing about whether the persisted `.pbi/cache.abf` stays valid, and it does **not** update an already-open Desktop model.

Now scoped, and it points at the mitigation that holds regardless of how the measurement lands: **treat stamping as a final `definition/` edit** — stamp, *then* reopen, refresh and save — so any reload is paid once at most.

## 2. The ordering rule omitted a step, and following it literally produces NO_DATA

`pbip-model-refresh/SKILL.md` said:

> make **all** TMDL edits, then refresh, then save.

Missing the close/reopen. Desktop does not re-read edited TMDL on an in-place reload — **which this same bundle already measures 30 lines further down** (2026-08-01: `reload` returned `{"success": true}` and `INFO.MEASURES()` still showed the old expressions). The rule simply never pointed at it.

Follow it literally and you refresh the **old in-memory definition**, then persist a cache that does not match disk. Cold reopen returns `NO_DATA` — and it presents as the cache-invalidation bug rather than the operator error it is, which is what makes it expensive.

## 3. The dated cache measurement was over-generalised

The 2026-08-01 experiment changed **`expressions.tmdl`** — a *data-affecting* file. It was being cited as though it settled culture-only and description-only edits too. It does not. Scoped to what it measured; the part that carries the load (a favourable cache mtime proves nothing) is untouched and still supports the warning below it.

## Why scoping rather than measuring

The measurement is worth running and was designed, but the wording fix is **strictly better than what is there now** whether the result is "invalidates" or "does not" — one claim is misleading and one is missing a step that loses data. Landing it does not depend on the experiment.

⚠️ Honest gap: **the underlying question is still unmeasured.** The four-variant experiment (no-op / mtime-only / `CustomInstructions`-only / description-via-MCP, each cold-opened with the source disabled) was dispatched and lost when the host CLI OOM-crashed. This PR deliberately says "unmeasured" rather than guessing.

## Gates (exit codes, not printed text)

| gate | exit |
|---|---|
| `ruff format .github/skills/powerbi-ai-readiness/scripts` | 0 |
| `ruff check .github/skills/powerbi-ai-readiness/scripts` | 0 |
| `pylint .github/skills/powerbi-ai-readiness/scripts` | 0 (10.00/10) |
| `pylint .github/skills/pbip-model-refresh/scripts` | 0 (10.00/10) |

Related: #245 (no measures-only refresh path — `refresh_pbip_model.py:377` hardcodes `"type": "full"`, verified; there is no `Calculate` path anywhere in the bundle).
