### PR TITLE
Fix AMO preflight and refresh fallback

### DIFF
--- a/.github/skills/pbip-model-refresh/scripts/refresh_pbip_model.py
+++ b/.github/skills/pbip-model-refresh/scripts/refresh_pbip_model.py
@@ -169,8 +169,8 @@ REFRESH_TYPE_FULL = "full"
 REFRESH_TYPE_CALCULATE = "calculate"
 REFRESH_TYPES = {REFRESH_TYPE_FULL, REFRESH_TYPE_CALCULATE}
 
-# Legacy XMLA refresh ceiling used when progress tracing is disabled or unavailable. Keep this path
-# intact as the safe degradation mode: a progress feature must never make refresh less reliable.
+# Legacy XMLA refresh ceiling used when progress tracing is explicitly disabled or for calculate-only
+# refreshes. Trace setup failures keep the absolute wall-clock backstop instead of returning here.
 REFRESH_TIMEOUT_SECONDS = 300
 
 # A server-level AMO trace observes ProgressReport* events from the separate ADOMD refresh session.
@@ -392,7 +392,8 @@ def refresh(
     minutes on a large table that no report even uses. ``refresh_type='calculate'`` is an opt-in
     DAX-only path: it recalculates formulas/relationships/hierarchies without re-reading source rows.
     For full refreshes, the server-level AMO progress trace reports row-count evidence and non-fatal
-    silence warnings; if it cannot start, this function falls back to the legacy XMLA timeout path.
+    silence warnings; if it cannot start, this function keeps the absolute wall-clock backstop and
+    loses only trace-dependent row-count and liveness output.
 
     **The legacy timeout is real, but it does NOT bound the case it was added for.** Measured 2026-08-01,
     both halves, each with the timeout verified on readback:
@@ -431,15 +432,18 @@ def refresh(
     progress_monitor: RefreshProgressMonitor | None = None
     command_timeout = timeout_sec
     total_timeout = timeout_sec + REFRESH_WALL_CLOCK_GRACE_SECONDS
+    untraced_absolute_backstop = False
     if desktop_pid is not None:
         state = initial_state or _credential_state(desktop_pid)
         _raise_if_blocked(desktop_pid, state, source_hint)
         initial_state = state
     if progress_enabled and refresh_type == REFRESH_TYPE_FULL:
+        command_timeout = max(1, int(absolute_timeout_sec))
+        total_timeout = absolute_timeout_sec
+        untraced_absolute_backstop = True
         try:
             progress_monitor = _start_refresh_progress_trace(port, progress_liveness_sec)
-            command_timeout = max(1, int(absolute_timeout_sec))
-            total_timeout = absolute_timeout_sec
+            untraced_absolute_backstop = False
             print(
                 f"[progress] enabled: no progress event for {progress_liveness_sec:.1f}s prints a warning "
                 f"(absolute backstop {absolute_timeout_sec:.0f}s)",
@@ -447,15 +451,36 @@ def refresh(
             )
         except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught
             print(
-                f"[progress] unavailable ({type(exc).__name__}: {exc}); "
-                f"falling back to legacy {timeout_sec}s XMLA timeout",
+                f"[progress] unavailable ({type(exc).__name__}: {exc}). Row counts and the liveness "
+                "warning are OFF for this run; you cannot tell a slow refresh from a stuck one. "
+                f"The {absolute_timeout_sec:.0f}s absolute backstop still applies. To regain visibility: "
+                "restore the AMO package (Microsoft.AnalysisServices.NetCore.retail.amd64), or use "
+                "the operator refresh strategy and watch Desktop's own row counter.",
                 file=sys.stderr,
                 flush=True,
             )
     if desktop_pid is not None:
         state = initial_state or CredentialDetection()
         if progress_monitor is None:
-            if state.unknown_reason:
+            if untraced_absolute_backstop:
+                if state.unknown_reason:
+                    print(
+                        f"Blocking-dialog check on PID {desktop_pid} is UNKNOWN ({state.unknown_reason}). "
+                        f"Refreshing without progress trace, bounded by absolute backstop "
+                        f"{absolute_timeout_sec:.0f}s. DO NOT kill this process - at the deadline it "
+                        "re-checks and prints one final machine-readable verdict line. Killing it early "
+                        "yields NO verdict.",
+                        flush=True,
+                    )
+                else:
+                    print(
+                        f"No blocking dialog on PID {desktop_pid}. Refreshing without progress trace, "
+                        f"bounded by absolute backstop {absolute_timeout_sec:.0f}s. DO NOT kill this "
+                        "process - at the deadline it re-checks and prints one final machine-readable "
+                        "verdict line. Killing it early yields NO verdict.",
+                        flush=True,
+                    )
+            elif state.unknown_reason:
                 print_refresh_unknown_banner(
                     desktop_pid, timeout_sec, REFRESH_WALL_CLOCK_GRACE_SECONDS, state.unknown_reason
                 )
@@ -1618,10 +1643,7 @@ def _refresh_and_save(  # pylint: disable=too-many-return-statements,too-many-br
         # So: report the observation, offer both hypotheses, and name the arbiter that settles it.
         # Never emit a stop-word instruction from an unverified heuristic.
         if "timeout" in text.lower() or "timed out" in text.lower():
-            print(
-                f"REFRESH: TIMEOUT - no result within "
-                f"{REFRESH_TIMEOUT_SECONDS + REFRESH_WALL_CLOCK_GRACE_SECONDS}s ({text})"
-            )
+            print(f"REFRESH: TIMEOUT - no result within configured refresh deadline ({text})")
             print(
                 "  CAUSE UNKNOWN - this script cannot distinguish these two, and they need\n"
                 "  opposite responses:\n"

--- a/.github/skills/pbip-model-refresh/tests/test_credential_modal_detection.py
+++ b/.github/skills/pbip-model-refresh/tests/test_credential_modal_detection.py
@@ -398,7 +398,7 @@ def test_refresh_banner_is_flushed_and_heartbeat_reports_elapsed_total(monkeypat
     monkeypatch.setattr("builtins.print", recording_print)
 
     with pytest.raises(TimeoutError):
-        refresh(port=1234, tables=["Orders"], timeout_sec=0.1, desktop_pid=111)
+        refresh(port=1234, tables=["Orders"], timeout_sec=0.1, desktop_pid=111, progress_enabled=False)
 
     out = capsys.readouterr().out
     assert "No blocking dialog on PID 111. Refreshing, bounded at 0.1s XMLA + 0.15s grace" in out
@@ -424,7 +424,7 @@ def test_unknown_refresh_banner_does_not_claim_no_dialog(monkeypatch, parked, ca
     monkeypatch.setattr(refresh_pbip_model, "REFRESH_HEARTBEAT_SECONDS", 0.05)
 
     with pytest.raises(CredentialUnknownError) as excinfo:
-        refresh(port=1234, tables=["Orders"], timeout_sec=0.1, desktop_pid=111)
+        refresh(port=1234, tables=["Orders"], timeout_sec=0.1, desktop_pid=111, progress_enabled=False)
 
     assert excinfo.value.reason == reason
     out = capsys.readouterr().out
@@ -445,7 +445,7 @@ def test_refresh_latches_unknown_seen_only_by_initial_precheck(monkeypatch, park
     monkeypatch.setattr(refresh_pbip_model, "REFRESH_CREDENTIAL_POLL_SECONDS", 0.05)
 
     with pytest.raises(CredentialUnknownError) as excinfo:
-        refresh(port=1234, tables=["Orders"], timeout_sec=0.1, desktop_pid=111)
+        refresh(port=1234, tables=["Orders"], timeout_sec=0.1, desktop_pid=111, progress_enabled=False)
 
     assert excinfo.value.reason == reason
     parked.set()
@@ -472,7 +472,7 @@ def test_refresh_latches_desktop_unready_seen_only_by_initial_precheck(monkeypat
     monkeypatch.setattr(refresh_pbip_model, "REFRESH_CREDENTIAL_POLL_SECONDS", 0.05)
 
     with pytest.raises(DesktopUnreadyError) as excinfo:
-        refresh(port=1234, tables=["Orders"], timeout_sec=0.1, desktop_pid=111)
+        refresh(port=1234, tables=["Orders"], timeout_sec=0.1, desktop_pid=111, progress_enabled=False)
 
     assert excinfo.value.reason == reason
     parked.set()

--- a/.github/skills/pbip-model-refresh/tests/test_refresh_wall_clock.py
+++ b/.github/skills/pbip-model-refresh/tests/test_refresh_wall_clock.py
@@ -82,7 +82,7 @@ def test_a_command_that_never_returns_still_yields_a_verdict(parked) -> None:
     _conn, _released = parked
     started = time.monotonic()
     with pytest.raises(TimeoutError) as excinfo:
-        refresh(port=1234, tables=["Orders"], timeout_sec=1)
+        refresh(port=1234, tables=["Orders"], timeout_sec=1, progress_enabled=False)
     elapsed = time.monotonic() - started
 
     assert elapsed < 15, f"refresh took {elapsed:.1f}s - the wall clock did not bound it"
@@ -95,7 +95,7 @@ def test_the_worker_is_a_daemon_so_a_parked_engine_cannot_outlive_the_process(pa
     """A non-daemon worker would keep the interpreter alive after the verdict, re-hanging the caller."""
     _conn, _released = parked
     with pytest.raises(TimeoutError):
-        refresh(port=1234, tables=["Orders"], timeout_sec=1)
+        refresh(port=1234, tables=["Orders"], timeout_sec=1, progress_enabled=False)
 
     workers = [t for t in threading.enumerate() if t.name == "xmla-refresh"]
     assert workers, "expected the parked worker to still be running - that is the scenario"
@@ -369,8 +369,8 @@ def test_progress_liveness_warns_but_does_not_kill_a_quiet_refresh(monkeypatch, 
     assert "[progress] no progress event" in capsys.readouterr().out
 
 
-def test_progress_trace_failure_degrades_to_the_legacy_refresh_path(monkeypatch, capsys) -> None:
-    """A trace setup failure must not break refresh; it falls back to the old CommandTimeout path."""
+def test_amo_trace_import_failure_keeps_the_absolute_backstop(monkeypatch, capsys) -> None:
+    """AMO trace loss removes progress evidence, not the long timeout that replaced the 300s ceiling."""
     executed: list[tuple[str, int]] = []
 
     class _Cmd:  # pylint: disable=too-few-public-methods,invalid-name
@@ -397,19 +397,26 @@ def test_progress_trace_failure_degrades_to_the_legacy_refresh_path(monkeypatch,
             """Match the ADOMD API surface."""
 
     def trace_denied(*_args):
-        raise RuntimeError("trace denied")
+        raise ImportError("No module named Microsoft.AnalysisServices")
 
     monkeypatch.setattr(refresh_pbip_model, "_start_refresh_progress_trace", trace_denied)
     monkeypatch.setattr(refresh_pbip_model, "_load_adomd", lambda: lambda _dsn: _Conn())
     monkeypatch.setattr(refresh_pbip_model, "_catalog_id", lambda _conn: "catalog-1")
 
-    ok, message = refresh(port=1234, tables=["Orders"], timeout_sec=5, progress_enabled=True)
+    ok, message = refresh(port=1234, tables=["Orders"], progress_enabled=True, absolute_timeout_sec=17.2)
 
     assert ok is True
     assert "Orders" in message
-    assert executed and executed[0][1] == 5
+    assert executed and executed[0][1] == 17
+    assert executed[0][1] != REFRESH_TIMEOUT_SECONDS
     captured = capsys.readouterr()
     assert "[progress] unavailable" in captured.err
+    assert "Row counts and the liveness warning are OFF" in captured.err
+    assert "you cannot tell a slow refresh from a stuck one" in captured.err
+    assert "The 17s absolute backstop still applies" in captured.err
+    assert "restore the AMO package (Microsoft.AnalysisServices.NetCore.retail.amd64)" in captured.err
+    assert "operator refresh strategy" in captured.err
+    assert "legacy" not in captured.err
     assert "[progress] unavailable" not in captured.out
 
 

--- a/scripts/preflight.ps1
+++ b/scripts/preflight.ps1
@@ -481,16 +481,35 @@ Add-Check 'Privacy Levels (manual)' 'optional' $true `
 # --- .NET SDK (builds scripts/tmdl_validate for offline TMDL deserialization) ---
 # NOTE: this replaced an older check for Microsoft.AnalysisServices.Tabular.dll under
 # ~/.copilot/installed-plugins. The powerbi-authoring plugin no longer bundles Tabular Editor, so that
-# check could never pass. TOM now comes from the NuGet package Microsoft.AnalysisServices.NetCore.retail.amd64,
-# restored by the tmdl_validate project - so the real machine dependency is the .NET SDK.
+# check could never pass. The .NET SDK is still needed to build/run the offline validator, but it does
+# NOT prove AMO/TOM or ADOMD assemblies exist in the NuGet cache; those file checks live below.
 Add-Cli 'dotnet' 'critical' 'Install the .NET SDK - needed to build/run the offline TMDL structural validator (tmdl_validate).'
 
+# --- AMO/TOM client assembly (the pbip-model-refresh skill's progress trace + ImageSave persist) ---
+# `dotnet` being on PATH proves only that a restore COULD run. It does not prove the restored package is
+# already present on a firewalled machine. Mirror the ADOMD lesson below: console text is not proof;
+# presence of the DLL on disk is. Hence a file check, not a restore attempt.
+#
+# Severity: RECOMMENDED, not critical. AMO/TOM is needed for the Desktop refresh/save phase: without it
+# scripted refresh loses row-count progress and non-fatal liveness warnings, and ImageSave falls back
+# to the UI save path. The estate pipeline's parse/convert steps never open Desktop, so failing the
+# whole run here would recreate #124's false-blocker shape for a Desktop-only dependency. After #283,
+# the refresh still keeps its 3600s absolute backstop when AMO trace setup fails; the missing
+# capability is scripted observability and AMO ImageSave, not the timeout fix. This warning exists so
+# the operator chooses before work starts: restore AMO first, or choose the operator refresh strategy.
+$nugetPackagesRoot = if ($env:NUGET_PACKAGES) { $env:NUGET_PACKAGES } else { Join-Path $HOME '.nuget\packages' }
+$amoDll = Get-ChildItem -Path (Join-Path $nugetPackagesRoot 'microsoft.analysisservices.netcore.retail.amd64*') `
+    -Recurse -Filter 'Microsoft.AnalysisServices.Tabular.dll' -ErrorAction SilentlyContinue | Select-Object -First 1
+Add-Check 'AMO/TOM client (Desktop progress/ImageSave)' 'recommended' ([bool]$amoDll) `
+    $(if ($amoDll) { $amoDll.FullName } else { 'not in the nuget cache - progress reporting and liveness are unavailable, so scripted refresh runs blind; ImageSave falls back to UI; the 3600s absolute refresh backstop remains active' }) `
+    'Before a scripted refresh, restore AMO/TOM into the active NuGet global-packages cache, or prefer the operator refresh strategy and watch Desktop''s own row counter: dotnet new console -o $env:TEMP\amo --framework net8.0; dotnet add $env:TEMP\amo package Microsoft.AnalysisServices.NetCore.retail.amd64 --version 19.84.1  (throwaway project; the restore populates the cache this preflight and refresh_pbip_model.py read).'
+
 # --- ADOMD.NET client assembly (the pbip-model-refresh skill's live-Desktop probe + refresh) --------
-# The .NET-SDK check above covers TOM/AMO (Microsoft.AnalysisServices.NetCore.retail.amd64). ADOMD.NET
-# is a SEPARATE nuget package (Microsoft.AnalysisServices.AdomdClient.NetCore.retail.amd64) - a machine
-# can have TOM and still be missing ADOMD. That was the silent field failure this check exists for: on
-# a colleague's box the AdomdClient assembly was absent, so probe_desktop_query.py could not run a live
-# EVALUATE, and nothing flagged it up front. `dotnet add package` had even printed "Restored ... 0
+# AMO/TOM (Microsoft.AnalysisServices.NetCore.retail.amd64) and ADOMD.NET
+# (Microsoft.AnalysisServices.AdomdClient.NetCore.retail.amd64) are SEPARATE nuget packages - a machine
+# can have one and still be missing the other. That was the silent field failure this check exists for:
+# on a colleague's box the AdomdClient assembly was absent, so probe_desktop_query.py could not run a
+# live EVALUATE, and nothing flagged it up front. `dotnet add package` had even printed "Restored ... 0
 # Errors" while landing ZERO PackageReference (a net10.0 scratch project silently no-op'd the add) - so
 # console text is not proof; presence of the DLL on disk is. Hence a file check, not a restore attempt.
 #

--- a/tests/test_preflight_contract.py
+++ b/tests/test_preflight_contract.py
@@ -31,6 +31,8 @@ import deploy_estate as de  # noqa: E402  # pylint: disable=wrong-import-positio
 
 TENANT_CHECK = "Fabric token tenant"
 DESKTOP_PIN_CHECK = "PBI_DESKTOP_PATH (bridge exe pin)"
+AMO_CHECK = "AMO/TOM client (Desktop progress/ImageSave)"
+ADOMD_CHECK = "ADOMD.NET client (Desktop probe/refresh)"
 
 
 def _preflight_source() -> str:
@@ -98,6 +100,49 @@ def test_the_desktop_pin_warns_rather_than_blocking_a_run_that_never_opens_it() 
     auto-updates, the bridge can no longer find the exe) is real.
     """
     _assert_add_check_tier(_preflight_source(), DESKTOP_PIN_CHECK, "recommended")
+
+
+def test_amo_warns_rather_than_blocking_a_run_that_never_opens_desktop() -> None:
+    """AMO/TOM absence affects Desktop refresh/save, not the parse/convert estate pipeline (#283).
+
+    This mirrors the #124 Desktop-pin decision: the failure is real and must be visible, but not every
+    migration phase opens Desktop. ``recommended`` keeps the line in the WARN summary without spending
+    preflight's exit 1 on a dependency that is needed later.
+    """
+    _assert_add_check_tier(_preflight_source(), AMO_CHECK, "recommended")
+
+
+def test_amo_is_checked_by_dll_presence_not_by_the_dotnet_cli() -> None:
+    """`dotnet` on PATH is not proof that the AMO/TOM package exists in the active cache (#283)."""
+    source = _preflight_source()
+    amo_block = source[source.index("# --- AMO/TOM client assembly") : source.index("# --- ADOMD.NET")]
+    assert "Add-Cli 'dotnet'" not in amo_block, "AMO must be a file check, not another CLI check"
+    assert "microsoft.analysisservices.netcore.retail.amd64*" in amo_block
+    assert "Microsoft.AnalysisServices.Tabular.dll" in amo_block
+    assert "$env:NUGET_PACKAGES" in amo_block and "Join-Path $HOME '.nuget\\packages'" in amo_block
+    assert "console text is not proof" in amo_block
+
+
+def test_amo_warning_names_the_runtime_consequence_after_the_timeout_fix() -> None:
+    """The message must move the decision before work: scripted is blind; operator is visible."""
+    source = _preflight_source()
+    amo_block = source[source.index(f"Add-Check '{AMO_CHECK}'") : source.index("# --- ADOMD.NET")]
+    assert "progress reporting and liveness are unavailable" in amo_block
+    assert "scripted refresh runs blind" in amo_block
+    assert "ImageSave falls back to UI" in amo_block
+    assert "3600s absolute refresh backstop remains active" in amo_block
+    assert "operator refresh strategy" in amo_block
+    assert "Desktop''s own row counter" in amo_block
+    assert "falling back to legacy" not in amo_block
+
+
+def test_adomd_remains_separate_from_amo() -> None:
+    """The new AMO check must not weaken or replace the existing ADOMD gate."""
+    source = _preflight_source()
+    _assert_add_check_tier(source, ADOMD_CHECK, "critical")
+    adomd_block = source[source.index("# --- ADOMD.NET") : source.index("Add-Cli 'uv'")]
+    assert "microsoft.analysisservices.adomdclient.netcore*" in adomd_block
+    assert "Microsoft.AnalysisServices.AdomdClient.dll" in adomd_block
 
 
 def test_the_desktop_pin_hint_is_actionable_in_the_shell_that_reads_it() -> None:


### PR DESCRIPTION
## Summary
- keep the absolute refresh backstop when AMO progress tracing is unavailable; lose only row-count/liveness output
- make the AMO-unavailable runtime stderr state the consequence/remedy: scripted refresh is blind, restore AMO or use operator strategy
- add a recommended preflight AMO/TOM DLL check using the same NuGet cache precedence as runtime, with refresh-strategy guidance
- pin regressions for timeout fallback and preflight contract

Fixes #283

## Verification
- ruff format/check on changed Python files
- pylint scripts; pylint .github/skills/pbip-model-refresh/scripts; pylint .github/skills/powerbi-ai-readiness/scripts
- pytest .github/skills/pbip-model-refresh/tests -q (175 passed, 3 skipped)
- targeted preflight contract tests
- mutation checks: 4/4 caught by assertion failures
- preflight present/empty-NuGet AMO modes
- checks.yml run 32526097541: success before refinement; rerun pending for fbabac9

## Follow-up
- AGENTS.md intake question 5 says scripted refresh shows per-table row counts; on machines without AMO that is false. Per owner guidance, this PR does not edit AGENTS.md/personas; follow-up should adjust that wording separately.