### PR TITLE
test(fixtures): minimal reproductions for upstream engine issues, and a triage of all 10

### DIFF
--- a/fixtures/upstream-repros/README.md
+++ b/fixtures/upstream-repros/README.md
@@ -1,0 +1,19 @@
+# Upstream engine repro fixtures
+
+Small, text-only Tableau workbook fixtures for upstream `Yarbrdab000/tableau-fabric-skills` issues. These are intentionally minimal inputs for the deterministic engine; generated `migration-spec.json` and engine output are not committed.
+
+Tested with canonical engine 2.260.0 via:
+
+```powershell
+$py = ".\.venv\Scripts\python.exe"
+$json = & $py scripts\engine_source.py --json | ConvertFrom-Json
+& $py ($json.scripts + "\migrate_estate.py") -i fixtures\upstream-repros -o _repro_runs\engine-b
+```
+
+## Fixtures
+
+| Issue | Fixture | 2.260.0 result |
+|---:|---|---|
+| #166 / #164 | `issue-166-custom-sql-disambiguation` | Meaningful negative: model tables disambiguate, but report fails closed/skips fields; no wrong PBIR binding emitted. |
+| #168 | `issue-168-case-one-bad-branch` | Reproduces: one unresolved CASE branch stubs the whole dispatcher measure to `BLANK()`. |
+| #171 | `issue-171-measure-names-parameter` | Partial: parameter calc translates, but virtual Measure Names remains unresolved/deferred and no field parameter is emitted. |

--- a/fixtures/upstream-repros/issue-166-custom-sql-disambiguation/README.md
+++ b/fixtures/upstream-repros/issue-166-custom-sql-disambiguation/README.md
@@ -1,0 +1,17 @@
+# Issue #166 / #164 — custom-SQL disambiguated report binding
+
+Upstream:
+
+- https://github.com/Yarbrdab000/tableau-fabric-skills/issues/166
+- related/consolidated: https://github.com/Yarbrdab000/tableau-fabric-skills/issues/164
+
+This minimal `.twb` encodes two custom-SQL relations in one datasource:
+
+- `Custom SQL Query`
+- `Custom SQL Query (Upgrade Aircraft Installs)`
+
+Both expose overlapping field captions (`TAIL`, `TECHNOLOGY`). The worksheet deliberately binds the disambiguated `TAIL (Custom SQL Query (Upgrade Aircraft Installs))` and `NEW_TECHNOLOGY` fields. The repro question is whether PBIR binds those fields to the disambiguated model table or falls back to the base `Custom SQL Query` table.
+
+Measured on canonical engine 2.260.0: **does not reproduce the wrong-binding symptom with this synthetic shape**. The model emits both tables, including `Custom SQL Query (Upgrade Aircraft Installs)` with `TAIL`, `NEW_TECHNOLOGY`, and `OLD_TECHNOLOGY`, but the report layer fails closed: `report.json` records `could not resolve field 'none:TAIL (Custom SQL Query (Upgrade Aircraft Installs)):nk' (skipped)` and `could not resolve field 'none:NEW_TECHNOLOGY:nk' (skipped)`. No PBIR visual was emitted with a wrong `SourceRef.Entity`.
+
+This is still a useful negative fixture: it bounds #166/#164 to a Tableau XML shape narrower than merely "two custom-SQL relations with overlapping column names".

--- a/fixtures/upstream-repros/issue-166-custom-sql-disambiguation/issue-166-custom-sql-disambiguation.twb
+++ b/fixtures/upstream-repros/issue-166-custom-sql-disambiguation/issue-166-custom-sql-disambiguation.twb
@@ -1,0 +1,50 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<workbook source-build='2019.2.2 (20192.19.0718.1543)' source-platform='win' version='18.1' xmlns:user='http://www.tableausoftware.com/xml/user'>
+  <datasources>
+    <datasource caption='Aircraft Installs' inline='true' name='federated.customsql' version='18.1'>
+      <connection class='federated'>
+        <named-connections>
+          <named-connection caption='Snowflake' name='snowflake.aircraft'>
+            <connection authentication='Username Password' class='snowflake' dbname='AIRCRAFT' schema='PUBLIC' server='example.snowflakecomputing.com' username='TABLEAU_SVC' warehouse='COMPUTE_WH' />
+          </named-connection>
+        </named-connections>
+        <relation type='collection'>
+          <relation connection='snowflake.aircraft' name='Custom SQL Query' type='text'>SELECT tail, technology, install_status FROM base_installs</relation>
+          <relation connection='snowflake.aircraft' name='Custom SQL Query (Upgrade Aircraft Installs)' type='text'>SELECT tail, technology AS new_technology, old_technology FROM upgrade_installs</relation>
+        </relation>
+      </connection>
+      <column caption='TAIL' datatype='string' name='[TAIL]' role='dimension' type='nominal' />
+      <column caption='TECHNOLOGY' datatype='string' name='[TECHNOLOGY]' role='dimension' type='nominal' />
+      <column caption='INSTALL_STATUS' datatype='string' name='[INSTALL_STATUS]' role='dimension' type='nominal' />
+      <column caption='TAIL (Custom SQL Query (Upgrade Aircraft Installs))' datatype='string' name='[TAIL (Custom SQL Query (Upgrade Aircraft Installs))]' role='dimension' type='nominal' />
+      <column caption='NEW_TECHNOLOGY' datatype='string' name='[NEW_TECHNOLOGY]' role='dimension' type='nominal' />
+      <column caption='OLD_TECHNOLOGY' datatype='string' name='[OLD_TECHNOLOGY]' role='dimension' type='nominal' />
+      <column-instance column='[TAIL]' derivation='None' name='[none:TAIL:nk]' pivot='key' type='nominal' />
+      <column-instance column='[TECHNOLOGY]' derivation='None' name='[none:TECHNOLOGY:nk]' pivot='key' type='nominal' />
+      <column-instance column='[TAIL (Custom SQL Query (Upgrade Aircraft Installs))]' derivation='None' name='[none:TAIL (Custom SQL Query (Upgrade Aircraft Installs)):nk]' pivot='key' type='nominal' />
+      <column-instance column='[NEW_TECHNOLOGY]' derivation='None' name='[none:NEW_TECHNOLOGY:nk]' pivot='key' type='nominal' />
+      <metadata-records>
+        <metadata-record class='column'><remote-name>TAIL</remote-name><local-name>[TAIL]</local-name><parent-name>[Custom SQL Query]</parent-name><local-type>string</local-type></metadata-record>
+        <metadata-record class='column'><remote-name>TECHNOLOGY</remote-name><local-name>[TECHNOLOGY]</local-name><parent-name>[Custom SQL Query]</parent-name><local-type>string</local-type></metadata-record>
+        <metadata-record class='column'><remote-name>INSTALL_STATUS</remote-name><local-name>[INSTALL_STATUS]</local-name><parent-name>[Custom SQL Query]</parent-name><local-type>string</local-type></metadata-record>
+        <metadata-record class='column'><remote-name>TAIL</remote-name><local-name>[TAIL (Custom SQL Query (Upgrade Aircraft Installs))]</local-name><parent-name>[Custom SQL Query (Upgrade Aircraft Installs)]</parent-name><local-type>string</local-type></metadata-record>
+        <metadata-record class='column'><remote-name>NEW_TECHNOLOGY</remote-name><local-name>[NEW_TECHNOLOGY]</local-name><parent-name>[Custom SQL Query (Upgrade Aircraft Installs)]</parent-name><local-type>string</local-type></metadata-record>
+        <metadata-record class='column'><remote-name>OLD_TECHNOLOGY</remote-name><local-name>[OLD_TECHNOLOGY]</local-name><parent-name>[Custom SQL Query (Upgrade Aircraft Installs)]</parent-name><local-type>string</local-type></metadata-record>
+      </metadata-records>
+    </datasource>
+  </datasources>
+  <worksheets>
+    <worksheet name='Upgrade Aircraft Installs'>
+      <table>
+        <view><datasources><datasource caption='Aircraft Installs' name='federated.customsql' /></datasources></view>
+        <panes><pane><mark class='Bar' /><encodings><color column='[federated.customsql].[none:NEW_TECHNOLOGY:nk]' /></encodings></pane></panes>
+        <rows>[federated.customsql].[none:TAIL (Custom SQL Query (Upgrade Aircraft Installs)):nk]</rows>
+        <cols>[federated.customsql].[none:NEW_TECHNOLOGY:nk]</cols>
+      </table>
+      <simple-id uuid='{16600000-0000-0000-0000-000000000001}' />
+    </worksheet>
+  </worksheets>
+  <dashboards>
+    <dashboard name='Dashboard'><size maxheight='800' maxwidth='1000' /><zones><zone h='100000' id='1' name='Upgrade Aircraft Installs' w='100000' x='0' y='0' /></zones></dashboard>
+  </dashboards>
+</workbook>

--- a/fixtures/upstream-repros/issue-168-case-one-bad-branch/README.md
+++ b/fixtures/upstream-repros/issue-168-case-one-bad-branch/README.md
@@ -1,0 +1,7 @@
+# Issue #168 — CASE dispatcher with one bad branch
+
+Upstream: https://github.com/Yarbrdab000/tableau-fabric-skills/issues/168
+
+This minimal `.twb` encodes the reported shape: a parameter-driven `CASE` dispatcher where several branches return valid aggregate measures and one branch references an unresolved field. The purpose is to observe whether the engine preserves the valid branches or stubs the entire dispatcher.
+
+Measured on canonical engine 2.260.0: **reproduces**. The generated semantic model contains `measure 'Selected KPI' = BLANK()`, while `report.json` records exactly one `model_translation_handoff.requests[]` entry with `fallback_reason: "unresolved/ambiguous field [MISSING_METRIC]"`. The three valid branches are not preserved in the emitted measure.

--- a/fixtures/upstream-repros/issue-168-case-one-bad-branch/issue-168-case-one-bad-branch.twb
+++ b/fixtures/upstream-repros/issue-168-case-one-bad-branch/issue-168-case-one-bad-branch.twb
@@ -1,0 +1,60 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<workbook source-build='2019.2.2 (20192.19.0718.1543)' source-platform='win' version='18.1' xmlns:user='http://www.tableausoftware.com/xml/user'>
+  <datasources>
+    <datasource hasconnection='false' inline='true' name='Parameters' version='18.1'>
+      <column caption='Select KPI' datatype='string' name='[Parameter 1]' param-domain-type='list' role='measure' type='nominal' value='&quot;Sales&quot;'>
+        <calculation class='tableau' formula='&quot;Sales&quot;' />
+        <members>
+          <member value='&quot;Sales&quot;' />
+          <member value='&quot;Profit&quot;' />
+          <member value='&quot;Quantity&quot;' />
+          <member value='&quot;Bad Branch&quot;' />
+        </members>
+      </column>
+    </datasource>
+    <datasource caption='Orders' inline='true' name='federated.casefixture' version='18.1'>
+      <connection class='federated'>
+        <named-connections>
+          <named-connection caption='orders' name='excel-direct.orders'>
+            <connection class='excel-direct' />
+          </named-connection>
+        </named-connections>
+        <relation connection='excel-direct.orders' name='Orders' table='[Orders$]' type='table' />
+      </connection>
+      <column caption='Category' datatype='string' name='[CATEGORY]' role='dimension' type='nominal' />
+      <column caption='Sales' datatype='real' name='[SALES]' role='measure' type='quantitative' />
+      <column caption='Profit' datatype='real' name='[PROFIT]' role='measure' type='quantitative' />
+      <column caption='Quantity' datatype='integer' name='[QUANTITY]' role='measure' type='quantitative' />
+      <column caption='Selected KPI' datatype='real' name='[Selected KPI]' role='measure' type='quantitative'>
+        <calculation class='tableau' formula='CASE [Parameters].[Parameter 1] WHEN &quot;Sales&quot; THEN SUM([SALES]) WHEN &quot;Profit&quot; THEN SUM([PROFIT]) WHEN &quot;Quantity&quot; THEN SUM([QUANTITY]) WHEN &quot;Bad Branch&quot; THEN SUM([MISSING_METRIC]) END' />
+      </column>
+      <column-instance column='[CATEGORY]' derivation='None' name='[none:CATEGORY:nk]' pivot='key' type='nominal' />
+      <column-instance column='[Selected KPI]' derivation='Sum' name='[sum:Selected KPI:qk]' pivot='key' type='quantitative' />
+      <metadata-records>
+        <metadata-record class='column'><remote-name>CATEGORY</remote-name><local-name>[CATEGORY]</local-name><parent-name>[Orders]</parent-name><local-type>string</local-type></metadata-record>
+        <metadata-record class='column'><remote-name>SALES</remote-name><local-name>[SALES]</local-name><parent-name>[Orders]</parent-name><local-type>real</local-type></metadata-record>
+        <metadata-record class='column'><remote-name>PROFIT</remote-name><local-name>[PROFIT]</local-name><parent-name>[Orders]</parent-name><local-type>real</local-type></metadata-record>
+        <metadata-record class='column'><remote-name>QUANTITY</remote-name><local-name>[QUANTITY]</local-name><parent-name>[Orders]</parent-name><local-type>integer</local-type></metadata-record>
+      </metadata-records>
+    </datasource>
+  </datasources>
+  <worksheets>
+    <worksheet name='Selected KPI by Category'>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption='Orders' name='federated.casefixture' />
+            <datasource name='Parameters' />
+          </datasources>
+        </view>
+        <panes><pane><mark class='Bar' /><encodings /></pane></panes>
+        <rows>[federated.casefixture].[sum:Selected KPI:qk]</rows>
+        <cols>[federated.casefixture].[none:CATEGORY:nk]</cols>
+      </table>
+      <simple-id uuid='{16800000-0000-0000-0000-000000000001}' />
+    </worksheet>
+  </worksheets>
+  <dashboards>
+    <dashboard name='Dashboard'><size maxheight='800' maxwidth='1000' /><zones><zone h='100000' id='1' name='Selected KPI by Category' w='100000' x='0' y='0' /></zones></dashboard>
+  </dashboards>
+</workbook>

--- a/fixtures/upstream-repros/issue-171-measure-names-parameter/README.md
+++ b/fixtures/upstream-repros/issue-171-measure-names-parameter/README.md
@@ -1,0 +1,11 @@
+# Issue #171 — parameter-driven `:Measure Names` swap
+
+Upstream: https://github.com/Yarbrdab000/tableau-fabric-skills/issues/171
+
+This minimal `.twb` encodes a Tableau Measure Names/Measure Values view with an explicit workbook parameter `Select Measure`. It is intentionally small and text-only; it does not try to reverse-engineer the customer workbook.
+
+The repro question is whether the engine emits a Power BI field parameter / equivalent selector, or instead leaves the virtual `:Measure Names` binding unresolved/deferred.
+
+Measured on canonical engine 2.260.0: **partially reproduces / bounds the issue**. The parameter-driven calculated measure itself translates successfully to an `IF(EXACT([Select Measure Value], ...))` measure, and a parameter table/value measure is emitted. However, no Power BI field parameter table is emitted (`NAMEOF` / `ParameterMetadata` absent in TMDL), and the Measure Names/Values worksheet is not rebuilt: `report.json` records `Measure Values shelf could not be enumerated to member measures (no member list found; skipped)` plus a dashboard zone left empty.
+
+This fixture does not prove the exact customer parameter-driven Measure Names idiom, but it does provide a small regression input for the current gap: virtual Measure Names remains a manual/deferred report binding rather than a generated field parameter.

--- a/fixtures/upstream-repros/issue-171-measure-names-parameter/issue-171-measure-names-parameter.twb
+++ b/fixtures/upstream-repros/issue-171-measure-names-parameter/issue-171-measure-names-parameter.twb
@@ -1,0 +1,62 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<workbook source-build='2019.2.2 (20192.19.0718.1543)' source-platform='win' version='18.1' xmlns:user='http://www.tableausoftware.com/xml/user'>
+  <datasources>
+    <datasource hasconnection='false' inline='true' name='Parameters' version='18.1'>
+      <column caption='Select Measure' datatype='string' name='[Parameter 1]' param-domain-type='list' role='measure' type='nominal' value='&quot;Sales&quot;'>
+        <calculation class='tableau' formula='&quot;Sales&quot;' />
+        <members>
+          <member value='&quot;Sales&quot;' />
+          <member value='&quot;Profit&quot;' />
+        </members>
+      </column>
+    </datasource>
+    <datasource caption='Orders' inline='true' name='federated.measurenames' version='18.1'>
+      <connection class='federated'>
+        <named-connections>
+          <named-connection caption='orders' name='excel-direct.orders'>
+            <connection class='excel-direct' />
+          </named-connection>
+        </named-connections>
+        <relation connection='excel-direct.orders' name='Orders' table='[Orders$]' type='table' />
+      </connection>
+      <column caption='Category' datatype='string' name='[CATEGORY]' role='dimension' type='nominal' />
+      <column caption='Sales' datatype='real' name='[SALES]' role='measure' type='quantitative' />
+      <column caption='Profit' datatype='real' name='[PROFIT]' role='measure' type='quantitative' />
+      <column caption='Selected Measure Value' datatype='real' name='[Selected Measure Value]' role='measure' type='quantitative'>
+        <calculation class='tableau' formula='CASE [Parameters].[Parameter 1] WHEN &quot;Sales&quot; THEN SUM([SALES]) WHEN &quot;Profit&quot; THEN SUM([PROFIT]) END' />
+      </column>
+      <column-instance column='[CATEGORY]' derivation='None' name='[none:CATEGORY:nk]' pivot='key' type='nominal' />
+      <column-instance column='[SALES]' derivation='Sum' name='[sum:SALES:qk]' pivot='key' type='quantitative' />
+      <column-instance column='[PROFIT]' derivation='Sum' name='[sum:PROFIT:qk]' pivot='key' type='quantitative' />
+      <column-instance column='[Selected Measure Value]' derivation='Sum' name='[sum:Selected Measure Value:qk]' pivot='key' type='quantitative' />
+      <metadata-records>
+        <metadata-record class='column'><remote-name>CATEGORY</remote-name><local-name>[CATEGORY]</local-name><parent-name>[Orders]</parent-name><local-type>string</local-type></metadata-record>
+        <metadata-record class='column'><remote-name>SALES</remote-name><local-name>[SALES]</local-name><parent-name>[Orders]</parent-name><local-type>real</local-type></metadata-record>
+        <metadata-record class='column'><remote-name>PROFIT</remote-name><local-name>[PROFIT]</local-name><parent-name>[Orders]</parent-name><local-type>real</local-type></metadata-record>
+      </metadata-records>
+    </datasource>
+  </datasources>
+  <worksheets>
+    <worksheet name='Parameter Measure Names Swap'>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption='Orders' name='federated.measurenames' />
+            <datasource name='Parameters' />
+          </datasources>
+          <filter class='categorical' column='[:Measure Names]'>
+            <groupfilter function='member' member='&quot;[federated.measurenames].[sum:SALES:qk]&quot;' />
+            <groupfilter function='member' member='&quot;[federated.measurenames].[sum:PROFIT:qk]&quot;' />
+          </filter>
+        </view>
+        <panes><pane><mark class='Bar' /><encodings /></pane></panes>
+        <rows>[federated.measurenames].[Multiple Values]</rows>
+        <cols>[federated.measurenames].[:Measure Names]</cols>
+      </table>
+      <simple-id uuid='{17100000-0000-0000-0000-000000000001}' />
+    </worksheet>
+  </worksheets>
+  <dashboards>
+    <dashboard name='Dashboard'><size maxheight='800' maxwidth='1000' /><zones><zone h='100000' id='1' name='Parameter Measure Names Swap' w='100000' x='0' y='0' /><zone h='8000' id='2' param='[Parameters].[Parameter 1]' type='paramctrl' w='25000' x='0' y='0' /></zones></dashboard>
+  </dashboards>
+</workbook>


### PR DESCRIPTION
Converts customer field reports into runnable fixtures — the concrete form of #87 (*"repeated migration failures do not trigger a minimal repro and regression harness"*).

## Triage across 10 open upstream issues

| bucket | issues | outcome |
|---|---|---|
| **A** — checkable from artifacts we already hold | #167, #170, #174 | all three **verified**, posted upstream |
| **B** — needs a constructed `.twb` | #164, #166, #168, #171 | 1 reproduced, 1 partial, 2 meaningful negatives |
| **C** — blocked without customer artifacts | #172, #173 | no reproduction possible here |
| **D** — not a bug | #163 | feature request; needs row-count *data*, which we now have from both contacts |

Getting the triage right was most of the value: three issues turned out to be answerable by reading artifacts we already had, which would otherwise have cost hours of fixture construction.

## #168 reproduced outright

A minimal `CASE` with three valid branches (`SUM([SALES])`, `SUM([PROFIT])`, `SUM([QUANTITY])`) and one referencing an unresolved field emits, on canonical engine **2.260.0**:

```
measure 'Selected KPI' = BLANK()
```

The three working branches are discarded. `report.json` carries exactly one `model_translation_handoff.requests[]` entry with `fallback_reason: "unresolved/ambiguous field [MISSING_METRIC]"`.

That is the reported shape — *"14 working branches discarded"* — at minimum size.

## #166 / #164 produced meaningful negatives

Reported as negatives rather than buried. A fixture that does **not** reproduce still bounds the defect, and saying so is more useful to the engine author than silence.

## Why these are committed

They are permanent regression material. When the engine author fixes one, we re-run the fixture and verify rather than trusting a release note. Each is small, text-only, and carries a README citing its upstream issue.

CI green: run 32535548761.
