### PR TITLE
fix(gates): stop reporting PASS when there was nothing to examine

### DIFF
--- a/.github/skills/powerbi-ai-readiness/scripts/check_ai_readiness.py
+++ b/.github/skills/powerbi-ai-readiness/scripts/check_ai_readiness.py
@@ -40,6 +40,10 @@ OBJECT_RE = re.compile(r"^(?P<indent>\t*)(?P<kind>table|column|measure)\s+(?P<na
 # A hint that a description enumerates its domain (e.g. "One of: A, B, C" or "values: X, Y").
 DOMAIN_HINT_RE = re.compile(r"(one of|values?:|categories|domain|:contains|e\.g\.)", re.IGNORECASE)
 
+EXIT_OK = 0
+EXIT_FINDINGS = 1
+EXIT_SKIPPED = 3
+
 
 def _iter_tmdl(model_dir: Path):
     yield from model_dir.glob("definition/*.tmdl")
@@ -77,23 +81,26 @@ def _model_dirs(target: Path):
     return sorted(target.glob("fabric/*.SemanticModel"))
 
 
-def _print_model(slug: str, model_dir: Path, result: dict) -> bool:
+def _print_model(slug: str, model_dir: Path, result: dict) -> str:
     counts = result["counts"]
     total = sum(c["total"] for c in counts.values())
     described = sum(c["described"] for c in counts.values())
-    pct = 100.0 * described / total if total else 100.0
+    pct = 100.0 * described / total if total else 0.0
     print(f"\n=== {slug} / {model_dir.name} ===")
     for kind in ("table", "column", "measure"):
         c = counts[kind]
-        p = 100.0 * c["described"] / c["total"] if c["total"] else 100.0
+        p = 100.0 * c["described"] / c["total"] if c["total"] else 0.0
         print(f"  {kind + 's':<9} {c['described']:>3}/{c['total']:<3} described ({p:5.1f}%)")
     print(f"  {'overall':<9} {described:>3}/{total:<3} described ({pct:5.1f}%)")
+    if total == 0:
+        print("  SKIPPED - nothing measured (no tables, columns, or measures found)")
+        return "SKIPPED"
     gaps = result["categorical_gaps"]
     if gaps:
         print(f"  categorical columns missing enumerated domain values ({len(gaps)}):")
         for g in gaps[:25]:
             print(f"    - {g}")
-    return pct >= 100.0 and not gaps
+    return "OK" if pct >= 100.0 and not gaps else "FINDINGS"
 
 
 def main() -> None:
@@ -114,18 +121,21 @@ def main() -> None:
         parser.error("provide a <tree>/<slug> path or --all")
         return
 
-    all_ok = True
+    statuses = []
     for target in targets:
         model_dirs = _model_dirs(target)
         if not model_dirs:
-            print(f"(no semantic model under {target.name}/fabric/)")
+            print(f"(no semantic model under {target.name}/fabric/) SKIPPED - nothing measured")
+            statuses.append("SKIPPED")
             continue
         for model_dir in model_dirs:
-            ok = _print_model(target.name, model_dir, audit_model(model_dir))
-            all_ok = all_ok and ok
+            statuses.append(_print_model(target.name, model_dir, audit_model(model_dir)))
 
-    if args.strict and not all_ok:
-        sys.exit(1)
+    if any(status == "FINDINGS" for status in statuses):
+        if args.strict:
+            sys.exit(EXIT_FINDINGS)
+    elif not statuses or any(status == "SKIPPED" for status in statuses):
+        sys.exit(EXIT_SKIPPED)
 
 
 if __name__ == "__main__":

--- a/scripts/check_blank_placeholders.py
+++ b/scripts/check_blank_placeholders.py
@@ -305,13 +305,27 @@ def _blank_objects_in_tmdl(tmdl: Path, model_dir: Path, root: Path) -> list[dict
     return objects
 
 
+def _model_tmdl_documents(root: Path) -> list[Path]:
+    """TMDL table files from shipping models, used to distinguish clean from unmeasured."""
+    if root.name.endswith(".SemanticModel"):
+        model_dirs = [root]
+    else:
+        base = root / "pbip" if (root / "pbip").is_dir() else root
+        model_dirs = [path for path in base.rglob("*.SemanticModel") if path.is_dir()]
+    return sorted(
+        tmdl
+        for model_dir in model_dirs
+        for tmdl in (model_dir / "definition" / "tables").glob("*.tmdl")
+        if tmdl.is_file()
+    )
+
+
 def blank_objects(root: Path) -> list[dict]:
     """Every BLANK()-only calculated object under the shipping PBIP models."""
-    base = root / "pbip" if (root / "pbip").is_dir() else root
     objects: list[dict] = []
-    for model_dir in sorted(p for p in base.rglob("*.SemanticModel") if p.is_dir()):
-        for tmdl in sorted((model_dir / "definition" / "tables").glob("*.tmdl")):
-            objects.extend(_blank_objects_in_tmdl(tmdl, model_dir, root))
+    for tmdl in _model_tmdl_documents(root):
+        model_dir = tmdl.parents[2]
+        objects.extend(_blank_objects_in_tmdl(tmdl, model_dir, root))
     return objects
 
 
@@ -495,6 +509,7 @@ def scan(root: Path) -> dict:
     """Scan a bundle and return the machine-readable report."""
     root = root.resolve()
     evidence = handover_candidates(root)
+    documents = _model_tmdl_documents(root)
     objects = blank_objects(root)
     findings = correlated_placeholders(root, evidence, objects)
     attach_dependencies(root, findings)
@@ -505,7 +520,8 @@ def scan(root: Path) -> dict:
         unchecked_workbooks.append({**workbook, "blank_objects": blank_count})
     skipped_owners = sorted({obj["owner"] for obj in objects} - set(evidence.report_workbook_owners))
     skipped_datasources = _owner_blank_summaries(objects, skipped_owners) if evidence.report_workbook_owners else []
-    incomplete = bool(unchecked_workbooks or skipped_datasources)
+    nothing_measured = not documents and not evidence.entries and not evidence.report_workbook_owners
+    incomplete = bool(unchecked_workbooks or skipped_datasources or nothing_measured)
     status = (
         STATUS_REFERENCED
         if referenced
@@ -519,6 +535,8 @@ def scan(root: Path) -> dict:
         "placeholders_referenced": len(referenced),
         "handover_unreadable": len(evidence.unreadable),
         "handover_unreadable_paths": evidence.unreadable,
+        "model_tmdl_documents": len(documents),
+        "nothing_measured": nothing_measured,
         "workbooks_reported": len(evidence.report_workbook_owners),
         "workbooks_unchecked": len(unchecked_workbooks),
         "workbooks_unchecked_blank_objects": sum(item["blank_objects"] for item in unchecked_workbooks),
@@ -565,9 +583,12 @@ def render(report: dict) -> str:
         lines.append("  OK - no handover-backed BLANK() placeholder survived into the model.")
         return "\n".join(lines)
     if report["status"] == STATUS_INCOMPLETE and not report["findings"]:
-        lines.append(
-            "  INCOMPLETE - no handover-backed placeholders were proven, but part of the estate was not checked."
-        )
+        if report.get("nothing_measured"):
+            lines.append("  INCOMPLETE - nothing measured (no handover evidence or model TMDL files found).")
+        else:
+            lines.append(
+                "  INCOMPLETE - no handover-backed placeholders were proven, but part of the estate was not checked."
+            )
         return "\n".join(lines)
     lines.append(
         "  Severity model: unreferenced placeholders are documented gaps; references from filters or "
@@ -621,6 +642,8 @@ def main(argv: list[str] | None = None) -> int:
         "placeholders_referenced": 0,
         "handover_unreadable": 0,
         "handover_unreadable_paths": [],
+        "model_tmdl_documents": 0,
+        "nothing_measured": False,
         "workbooks_reported": 0,
         "workbooks_unchecked": 0,
         "workbooks_unchecked_blank_objects": 0,
@@ -635,6 +658,8 @@ def main(argv: list[str] | None = None) -> int:
         merged["placeholders_referenced"] += report["placeholders_referenced"]
         merged["handover_unreadable"] += report["handover_unreadable"]
         merged["handover_unreadable_paths"].extend(report["handover_unreadable_paths"])
+        merged["model_tmdl_documents"] += report["model_tmdl_documents"]
+        merged["nothing_measured"] = merged["nothing_measured"] or report["nothing_measured"]
         merged["workbooks_reported"] += report["workbooks_reported"]
         merged["workbooks_unchecked"] += report["workbooks_unchecked"]
         merged["workbooks_unchecked_blank_objects"] += report["workbooks_unchecked_blank_objects"]
@@ -643,7 +668,9 @@ def main(argv: list[str] | None = None) -> int:
         merged["skipped_shared_datasource_blank_objects"] += report["skipped_shared_datasource_blank_objects"]
         merged["skipped_shared_datasource_details"].extend(report["skipped_shared_datasource_details"])
         merged["findings"].extend(report["findings"])
-    incomplete = bool(merged["workbooks_unchecked"] or merged["skipped_shared_datasources"])
+    incomplete = bool(
+        merged["workbooks_unchecked"] or merged["skipped_shared_datasources"] or merged["nothing_measured"]
+    )
     merged["status"] = (
         STATUS_REFERENCED
         if merged["placeholders_referenced"]

--- a/scripts/check_empty_model.py
+++ b/scripts/check_empty_model.py
@@ -142,9 +142,14 @@ CATEGORY_EMPTY = "empty_file"
 BLOCKING_CATEGORIES = (CATEGORY_MISSING, CATEGORY_FOREIGN, CATEGORY_EMPTY)
 JUDGED_CATEGORIES = BLOCKING_CATEGORIES + (CATEGORY_FILE_OK,)
 
+STATUS_OK = "OK"
+STATUS_EMPTY_MODELS = "EMPTY_MODELS"
+STATUS_SKIPPED = "SKIPPED"
+
 EXIT_OK = 0
 EXIT_EMPTY_MODEL = 5
 EXIT_USAGE = 2
+EXIT_SKIPPED = 3
 
 # The host this check is running on, read ONCE into a module global so a test can exercise the other
 # host without a second CI runner. `os.name` is not read anywhere else in this module.
@@ -428,6 +433,13 @@ def classify_partition(block: dict, model_dir: Path, params: dict[str, str] | No
     return {**verdict, **decided}
 
 
+def _has_tmdl_documents(model_dir: Path) -> bool:
+    """Whether this model has any TMDL document for the checker to inspect."""
+    definition = model_dir / "definition"
+    root = definition if definition.is_dir() else model_dir
+    return any(path.is_file() for path in root.rglob("*.tmdl"))
+
+
 def scan_model(model_dir: Path, root: Path) -> dict:
     """Classify every partition of one `.SemanticModel` folder."""
     params = model_parameters(model_dir)
@@ -449,7 +461,7 @@ def scan_model(model_dir: Path, root: Path) -> dict:
         "partitions_total": len(partitions),
         "categories": _counts(partitions),
         "findings": findings,
-        "status": "EMPTY" if findings else "OK",
+        "status": "EMPTY" if findings else (STATUS_OK if _has_tmdl_documents(model_dir) else STATUS_SKIPPED),
     }
 
 
@@ -487,13 +499,16 @@ def scan(root: Path) -> dict:
     """Scan a bundle (or a single model) and return the machine-readable report."""
     models = [scan_model(model, root) for model in find_models(root)]
     empty = [m for m in models if m["status"] == "EMPTY"]
+    skipped = [m for m in models if m["status"] == STATUS_SKIPPED]
+    status = STATUS_EMPTY_MODELS if empty else (STATUS_SKIPPED if skipped or not models else STATUS_OK)
     return {
         "version": REPORT_VERSION,
         "root": str(root),
         "host": "windows" if HOST_OS == "nt" else "posix",
         "models_scanned": len(models),
         "models_empty": len(empty),
-        "status": "EMPTY_MODELS" if empty else "OK",
+        "models_skipped": len(skipped),
+        "status": status,
         "models": models,
     }
 
@@ -516,8 +531,11 @@ def category_totals(report: dict, categories: tuple[str, ...], invert: bool = Fa
 def render(report: dict) -> str:
     """Human-readable verdict: what is empty, which artifact says so, and what to do about it."""
     lines = [f"EMPTY-MODEL CHECK: {report['models_scanned']} model(s) under {report['root']}"]
-    if not report["models_scanned"]:
-        lines.append("  no .SemanticModel folders found - nothing to judge")
+    if report["status"] == STATUS_SKIPPED:
+        if not report["models_scanned"]:
+            lines.append("  SKIPPED - nothing measured (no .SemanticModel folders found)")
+        else:
+            lines.append(f"  SKIPPED - nothing measured ({report['models_skipped']} model(s) contain no TMDL files)")
         return "\n".join(lines)
 
     # Both lines print on every run, pass or fail: a gate whose false-positive posture is invisible is
@@ -582,7 +600,11 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.warn_only:
         return EXIT_OK
-    return EXIT_EMPTY_MODEL if any(r["status"] == "EMPTY_MODELS" for r in reports) else EXIT_OK
+    if any(r["status"] == STATUS_EMPTY_MODELS for r in reports):
+        return EXIT_EMPTY_MODEL
+    if any(r["status"] == STATUS_SKIPPED for r in reports):
+        return EXIT_SKIPPED
+    return EXIT_OK
 
 
 if __name__ == "__main__":

--- a/scripts/check_relationship_health.py
+++ b/scripts/check_relationship_health.py
@@ -195,6 +195,14 @@ def _stranded_date_tables(model: cfb.ModelFields, census: dict[str, TableInfo]) 
     return findings
 
 
+def _has_tmdl_documents(model_dir: Path) -> bool:
+    """Whether this model has any TMDL document for the checker to inspect."""
+    root = model_dir / "definition"
+    if not root.is_dir():
+        root = model_dir
+    return any(path.is_file() for path in root.rglob("*.tmdl"))
+
+
 def scan_model(model_dir: Path) -> dict[str, Any]:
     """Scan one `.SemanticModel` for sparse Date relationship gaps."""
     model = cfb.parse_model(model_dir)
@@ -202,7 +210,7 @@ def scan_model(model_dir: Path) -> dict[str, Any]:
     active_relationships = sum(1 for rel in model.relationships if rel.is_active)
     relationshipable = _relationshipable_tables(model)
     findings = _stranded_date_tables(model, census)
-    status = STATUS_MISSING if findings else STATUS_OK
+    status = STATUS_MISSING if findings else (STATUS_OK if _has_tmdl_documents(model_dir) else STATUS_SKIPPED)
     date_tables = [name for name, info in census.items() if name in relationshipable and _is_date_table(name, info)]
     return {
         "model": model_dir.name,
@@ -230,10 +238,11 @@ def scan(root: Path) -> dict[str, Any]:
 def merge(models: list[dict[str, Any]]) -> dict[str, Any]:
     """Fold per-model reports into one verdict."""
     failing = [model for model in models if model["status"] == STATUS_MISSING]
+    skipped = [model for model in models if model["status"] == STATUS_SKIPPED]
     if not models:
         status = STATUS_SKIPPED
     else:
-        status = STATUS_MISSING if failing else STATUS_OK
+        status = STATUS_MISSING if failing else (STATUS_SKIPPED if skipped else STATUS_OK)
     return {
         "status": status,
         "models_scanned": len(models),
@@ -248,7 +257,7 @@ def merge(models: list[dict[str, Any]]) -> dict[str, Any]:
 def render(report: dict[str, Any]) -> str:
     """Human-readable verdict, matching sibling offline gates."""
     if report["status"] == STATUS_SKIPPED:
-        return "RELATIONSHIP HEALTH CHECK: SKIPPED - nothing measured (no semantic model found)"
+        return "RELATIONSHIP HEALTH CHECK: SKIPPED - nothing measured (no semantic model or TMDL files found)"
     if report["status"] == STATUS_OK:
         sparse = sum(1 for model in report["models"] if model["sparse_relationship_graph"])
         tail = f" {sparse} sparse graph(s) reported for review." if sparse else ""

--- a/scripts/check_sqlproxy_connections.py
+++ b/scripts/check_sqlproxy_connections.py
@@ -184,14 +184,22 @@ def _finding(pair: Pair, model_dir: Path, expressions_path: Path) -> dict[str, A
     }
 
 
+def _has_tmdl_documents(model_dir: Path) -> bool:
+    """Whether this model has any TMDL document for the checker to inspect."""
+    definition = model_dir / "definition"
+    root = definition if definition.is_dir() else model_dir
+    return any(path.is_file() for path in root.rglob("*.tmdl"))
+
+
 def scan_model(model_dir: Path) -> dict[str, Any]:
     """Scan one semantic model for sqlproxy-derived expression parameters."""
     expressions_path = model_dir / "definition" / "expressions.tmdl"
     findings = [_finding(pair, model_dir, expressions_path) for pair in _pairs(parse_expressions(expressions_path))]
+    measured = _has_tmdl_documents(model_dir)
     return {
         "model": model_dir.name,
         "path": str(model_dir),
-        "status": STATUS_SQLPROXY if findings else STATUS_OK,
+        "status": STATUS_SQLPROXY if findings else (STATUS_OK if measured else STATUS_SKIPPED),
         "connections": len(findings),
         "incomplete_connections": sum(1 for finding in findings if not finding["complete"]),
         "findings": findings,
@@ -211,10 +219,11 @@ def merge(models: list[dict[str, Any]], risks: list[RiskSignal] | None = None) -
     """Fold per-model reports into one verdict."""
     risks = risks or []
     failing = [model for model in models if model["status"] == STATUS_SQLPROXY]
+    skipped = [model for model in models if model["status"] == STATUS_SKIPPED]
     if not models:
         status = STATUS_SKIPPED
     else:
-        status = STATUS_SQLPROXY if failing else STATUS_OK
+        status = STATUS_SQLPROXY if failing else (STATUS_SKIPPED if skipped else STATUS_OK)
     return {
         "status": status,
         "models_scanned": len(models),
@@ -264,7 +273,7 @@ def _workbooks(value: Any) -> list[dict[str, Any]]:
 def render(report: dict[str, Any]) -> str:
     """Human-readable verdict, matching the sibling offline gates."""
     if report["status"] == STATUS_SKIPPED:
-        return "SQLPROXY CONNECTION CHECK: SKIPPED - nothing measured (no semantic model found)"
+        return "SQLPROXY CONNECTION CHECK: SKIPPED - nothing measured (no semantic model or TMDL files found)"
     warning_tail = _warning_tail(report)
     if report["status"] == STATUS_OK:
         return (

--- a/scripts/check_unit.py
+++ b/scripts/check_unit.py
@@ -169,6 +169,8 @@ GATES = (
         frozenset({0}),
         frozenset({"EMPTY_MODELS"}),
         frozenset({1, 5}),
+        frozenset({"SKIPPED"}),
+        frozenset({3}),
     ),
     Gate(
         "pbir-valid",
@@ -190,6 +192,8 @@ GATES = (
         frozenset({"DISPLACED_MAIN_COLUMN"}),
         frozenset({1}),
     ),
+    # Deliberate: the native census is non-gating by default for mid-migration use, but check_unit is
+    # the completion facade. A unit claimed ready must not silently carry unresolved BLANK() stubs.
     Gate(
         "stub-measures",
         "check_stub_measures.py",
@@ -688,15 +692,23 @@ def check_ai_descriptions(target: Path) -> dict[str, Any]:
                 "total": total,
                 "described": described,
                 "categorical_gaps": gaps,
-                "status": "OK" if described == total and not gaps else "FINDINGS",
+                "status": "SKIPPED" if total == 0 else ("OK" if described == total and not gaps else "FINDINGS"),
             }
         )
-    failing = [row for row in rows if row["status"] != "OK"]
+    failing = [row for row in rows if row["status"] == "FINDINGS"]
+    skipped = [row for row in rows if row["status"] == "SKIPPED"]
+    if failing:
+        status, native_status, native_exit = STATUS_FINDINGS, "FINDINGS", 1
+    elif skipped:
+        status, native_status, native_exit = STATUS_NOT_CHECKED, "SKIPPED", 3
+    else:
+        status, native_status, native_exit = STATUS_PASS, "OK", 0
     return {
         "id": "ai-descriptions",
-        "status": STATUS_FINDINGS if failing else STATUS_PASS,
-        "native_status": "FINDINGS" if failing else "OK",
-        "native_exit": 1 if failing else 0,
+        "status": status,
+        "native_status": native_status,
+        "native_exit": native_exit,
+        "detail": "nothing measured (no tables, columns, or measures found)" if skipped and not failing else None,
         "models": rows,
     }
 
@@ -1032,6 +1044,30 @@ def _count_suffix(missing: int) -> str:
     return f"   [{missing} MISSING]" if missing else ""
 
 
+def _summary_line(report: dict[str, Any]) -> str:
+    """Stable one-line aggregate for comparing repeated gate runs."""
+    owner_findings: dict[str, int] = {}
+    structural = 0
+    missing_input = 0
+    for check in report["checks"]:
+        owner = OWNER_HINTS.get(check["id"], "unknown")
+        if check["status"] in {STATUS_FINDINGS, STATUS_PRECONDITION_FAILED}:
+            owner_findings[owner] = owner_findings.get(owner, 0) + 1
+        if check["status"] == STATUS_NOT_CHECKED:
+            if check.get("verification") == "CLAIMED_ONLY":
+                structural += 1
+            else:
+                missing_input += 1
+    findings = ",".join(f"{owner}={count}" for owner, count in sorted(owner_findings.items())) or "none"
+    return (
+        "SUMMARY: "
+        f"findings_by_owner={findings}; "
+        f"not_checked_structural={structural}; "
+        f"not_checked_missing_input={missing_input}; "
+        f"ladder={report['status']} exit={report['exit_code']}"
+    )
+
+
 def render(report: dict[str, Any]) -> str:
     """Human-readable unit verdict."""
     scope = report.get("scope", SCOPE_ALL)
@@ -1079,6 +1115,7 @@ def render(report: dict[str, Any]) -> str:
     ex = report["exemptions"]
     if ex["accepted"] or ex["invalid"]:
         lines.append(f"  documented why-not exemptions: {ex['accepted']} accepted, {ex['invalid']} invalid")
+    lines.append(_summary_line(report))
     return "\n".join(lines)
 
 

--- a/scripts/run_estate.py
+++ b/scripts/run_estate.py
@@ -94,6 +94,7 @@ from pathlib import Path
 from typing import NamedTuple
 
 from check_empty_model import REPORT_NAME as EMPTY_MODEL_REPORT
+from check_empty_model import STATUS_EMPTY_MODELS
 from check_empty_model import render as render_empty_model
 from check_empty_model import scan as scan_for_empty_models
 from check_blank_placeholders import REPORT_NAME as BLANK_PLACEHOLDER_REPORT
@@ -592,7 +593,7 @@ def final_verdict(gates: GateResults, out_dir: Path) -> int:
             f"Details: {out_dir / BLANK_PLACEHOLDER_REPORT}"
         )
         return EXIT_BLANK_PLACEHOLDER
-    if gates.empty_models["status"] != "OK":
+    if gates.empty_models["status"] == STATUS_EMPTY_MODELS:
         print(
             f"\nESTATE: EMPTY_MODEL - {gates.empty_models['models_empty']} of "
             f"{gates.empty_models['models_scanned']} model(s) would open and load NO ROWS\n"

--- a/tests/test_check_ai_readiness.py
+++ b/tests/test_check_ai_readiness.py
@@ -1,0 +1,28 @@
+"""Tests for the skill-owned AI readiness checker."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = REPO_ROOT / ".github" / "skills" / "powerbi-ai-readiness" / "scripts" / "check_ai_readiness.py"
+
+
+def test_empty_semantic_model_is_skipped_not_clean(tmp_path: Path) -> None:
+    """A `.SemanticModel` with no TMDL objects must not be reported as 100% described."""
+    unit = tmp_path / "unit"
+    (unit / "fabric" / "CacheOnly.SemanticModel").mkdir(parents=True)
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), str(unit), "--strict"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 3, result.stdout + result.stderr
+    assert "SKIPPED - nothing measured" in result.stdout
+    assert "100.0%" not in result.stdout

--- a/tests/test_check_blank_placeholders.py
+++ b/tests/test_check_blank_placeholders.py
@@ -472,6 +472,18 @@ def test_an_unreadable_input_alone_does_not_invent_a_placeholder(tmp_path: Path)
     assert cbp.main([str(bundle), "--quiet"]) == cbp.EXIT_OK
 
 
+def test_existing_model_with_no_tmdl_is_incomplete_not_ok(tmp_path: Path) -> None:
+    """A cache-only `.SemanticModel` measures no placeholder evidence and must not pass."""
+    model = tmp_path / "CacheOnly.SemanticModel"
+    model.mkdir()
+
+    report = cbp.scan(model)
+
+    assert report["status"] == cbp.STATUS_INCOMPLETE
+    assert report["nothing_measured"] is True
+    assert cbp.main([str(model), "--quiet"]) == cbp.EXIT_INCOMPLETE
+
+
 def test_cli_exit_codes_distinguish_clean_gap_incomplete_and_material_dependency(tmp_path: Path) -> None:
     """The process status is the gate: clean, documented gap, incomplete scope, material dependency."""
     clean = _bundle(tmp_path / "clean")

--- a/tests/test_check_empty_model.py
+++ b/tests/test_check_empty_model.py
@@ -532,15 +532,17 @@ def test_a_quoted_partition_name_is_unquoted(tmp_path: Path) -> None:
     assert cem.scan(bundle)["models"][0]["findings"][0]["partition"] == "Orders$"
 
 
-def test_a_model_with_no_tables_folder_is_not_a_finding(tmp_path: Path) -> None:
-    """An empty scan target must produce OK, not a crash and not a false alarm."""
+def test_a_model_with_no_tables_folder_is_skipped_not_ok(tmp_path: Path) -> None:
+    """An empty scan target is missing input, not a clean empty-model verdict."""
     bundle = tmp_path / "bundle"
     (bundle / "pbip" / "wb" / "Empty.SemanticModel" / "definition").mkdir(parents=True)
 
     report = cem.scan(bundle)
 
     assert report["models_scanned"] == 1
-    assert report["status"] == "OK"
+    assert report["models_skipped"] == 1
+    assert report["status"] == cem.STATUS_SKIPPED
+    assert cem.main([str(bundle)]) == cem.EXIT_SKIPPED
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_check_relationship_health.py
+++ b/tests/test_check_relationship_health.py
@@ -156,3 +156,13 @@ def test_no_models_is_skipped_not_ok(tmp_path, capsys) -> None:
     """An affirmative verdict requires at least one model to be measured."""
     assert crh.main([str(tmp_path)]) == crh.EXIT_SKIPPED
     assert "SKIPPED" in capsys.readouterr().out
+
+
+def test_existing_model_with_no_tmdl_is_skipped_not_ok(tmp_path, capsys) -> None:
+    """A cache-only `.SemanticModel` is a missing input state, not a clean relationship scan."""
+    model = tmp_path / "CacheOnly.SemanticModel"
+    model.mkdir()
+
+    assert crh.main([str(model)]) == crh.EXIT_SKIPPED
+    out = capsys.readouterr().out
+    assert "SKIPPED" in out and "OK" not in out

--- a/tests/test_check_sqlproxy_connections.py
+++ b/tests/test_check_sqlproxy_connections.py
@@ -132,6 +132,16 @@ def test_no_models_is_skipped_not_ok(tmp_path, capsys) -> None:
     assert "SKIPPED" in out and "OK" not in out
 
 
+def test_existing_model_with_no_tmdl_is_skipped_not_ok(tmp_path, capsys) -> None:
+    """A cache-only `.SemanticModel` is a missing input state, not a clean sqlproxy scan."""
+    model = tmp_path / "CacheOnly.SemanticModel"
+    model.mkdir()
+
+    assert csc.main([str(model)]) == csc.EXIT_SKIPPED
+    out = capsys.readouterr().out
+    assert "SKIPPED" in out and "OK" not in out
+
+
 def test_json_output_carries_pairs_and_warning_signal(tmp_path) -> None:
     """The machine-readable output must contain the action queue and non-blocking risk telemetry."""
     bundle = _write_bundle(tmp_path, REAL_ENGINE_SQLPROXY_EXPRESSIONS)

--- a/tests/test_check_unit.py
+++ b/tests/test_check_unit.py
@@ -282,6 +282,36 @@ def test_native_gate_skipped_is_not_a_pass(tmp_path: Path, monkeypatch: pytest.M
     assert report["exit_code"] == cu.EXIT_NOT_CHECKED
 
 
+def test_summary_line_counts_findings_and_not_checked_classes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The final line gives reviewers one stable aggregate to compare between runs."""
+    _write_spec(tmp_path, ["Executive"])
+    _write_report(tmp_path, ["Executive"])
+    _write_reference_manifest(tmp_path, ["Executive"])
+    monkeypatch.setattr(cu, "GATES", (_gate("sqlproxy-connections", "unused.py"),))
+    monkeypatch.setattr(
+        cu,
+        "_run_cli_gate",
+        lambda gate, *_args: {
+            "id": gate.check_id,
+            "status": cu.STATUS_FINDINGS,
+            "native_status": "STUBS",
+            "native_exit": 1,
+        },
+    )
+    monkeypatch.setattr(
+        cu,
+        "claimed_only_checks",
+        lambda: [{"id": "finalized", "status": cu.STATUS_NOT_CHECKED, "verification": "CLAIMED_ONLY"}],
+    )
+
+    rendered = cu.render(cu.run_all(tmp_path))
+
+    assert rendered.splitlines()[-1] == (
+        "SUMMARY: findings_by_owner=model=1; not_checked_structural=1; "
+        "not_checked_missing_input=0; ladder=FINDINGS exit=1"
+    )
+
+
 def _gate(check_id: str = "x", script: str = "x.py") -> cu.Gate:
     return cu.Gate(
         check_id,
@@ -560,10 +590,12 @@ def test_gate_registrations_match_native_exit_constants() -> None:
     assert gate.not_checked_exit_codes == {blank.EXIT_INCOMPLETE}
 
     gate = _gate_by_id("empty-model")
-    assert gate.pass_statuses == {"OK"}
+    assert gate.pass_statuses == {empty.STATUS_OK}
     assert gate.pass_exit_codes == {empty.EXIT_OK}
-    assert gate.finding_statuses == {"EMPTY_MODELS"}
+    assert gate.finding_statuses == {empty.STATUS_EMPTY_MODELS}
     assert empty.EXIT_EMPTY_MODEL in gate.finding_exit_codes
+    assert gate.not_checked_statuses == {empty.STATUS_SKIPPED}
+    assert gate.not_checked_exit_codes == {empty.EXIT_SKIPPED}
 
     for check_id, module, finding_status, finding_exit in (
         ("sqlproxy-connections", sqlproxy, sqlproxy.STATUS_SQLPROXY, sqlproxy.EXIT_SQLPROXY),
@@ -576,6 +608,9 @@ def test_gate_registrations_match_native_exit_constants() -> None:
         assert gate.pass_exit_codes == {module.EXIT_OK}
         assert gate.finding_statuses == {finding_status}
         assert gate.finding_exit_codes == {finding_exit}
+        if hasattr(module, "STATUS_SKIPPED"):
+            assert module.STATUS_SKIPPED in gate.not_checked_statuses
+            assert module.EXIT_SKIPPED in gate.not_checked_exit_codes
 
     gate = _gate_by_id("data-model")
     assert gate.pass_statuses == {"OK"}
@@ -615,6 +650,27 @@ def test_cli_integration_scope_exits_zero_on_committed_clean_fixture() -> None:
     assert result.returncode == cu.EXIT_OK, result.stdout + result.stderr
     assert "AUTOMATED_CHECKS_PASS" in result.stdout
     assert "omitted checks:" in result.stdout
+
+
+def test_cli_model_scope_empty_semantic_model_is_not_a_vacuous_pass(tmp_path: Path) -> None:
+    """Subprocess regression for a customer folder containing a cache-only semantic model."""
+    model = tmp_path / "CacheOnly.SemanticModel"
+    model.mkdir()
+    result = subprocess.run(
+        [sys.executable, str(REPO_ROOT / "scripts" / "check_unit.py"), str(model), "--scope", "model"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == cu.EXIT_FINDINGS, result.stdout + result.stderr
+    assert "blank-placeholders: NOT_CHECKED" in result.stdout
+    assert "sqlproxy-connections: NOT_CHECKED" in result.stdout
+    assert "relationship-health: NOT_CHECKED" in result.stdout
+    assert "empty-model: NOT_CHECKED" in result.stdout
+    assert "ai-descriptions: NOT_CHECKED" in result.stdout
+    assert "SUMMARY:" in result.stdout
 
 
 def test_cli_missing_path_is_usage_not_a_mutation_success(tmp_path: Path) -> None:


### PR DESCRIPTION
Fixes a **false green** found by independent review: `check_unit.py` reported **five PASSes on a directory containing zero files** - including `empty-model`, the gate named for exactly that condition. It exited 1 only because `ai-instructions` happened to fail, and reproduced on a real deliverable.

## Why this mattered more than it looks

This is the failure mode a customer hits first. They have ~46 assets already migrated in **their own folder structure**; pointing our gates at it returned PASS rather than *"this is not the shape I expected"*.

The doctrine was already written in this repo and four gates did not honour it - `check_stub_measures.py:68-69`:

> *"SKIPPED: nothing was measured. Distinct from 0 on purpose - **'no stubs' and 'no model' must never print or exit the same way**."*

## Before / after, empty `.SemanticModel`

```
BEFORE   PASS: blank-placeholders, sqlproxy-connections, relationship-health,
               empty-model, ai-descriptions

AFTER    blank-placeholders   NOT_CHECKED (native INCOMPLETE exit 3)
         field-bindings       NOT_CHECKED (native SKIPPED)
         sqlproxy-connections NOT_CHECKED (native SKIPPED exit 3)
         relationship-health  NOT_CHECKED (native SKIPPED exit 3)
         -> zero PASSes
```

**The exit ladder is unchanged** - it was already correct (`PRECONDITION_FAILED > FINDINGS > NOT_CHECKED > OK`). The defect was that gates returned a clean verdict for *"nothing to examine"*, and the rendering gave an agent no way to notice.

## New summary line, and why it is the brownfield signal

```
empty folder:  SUMMARY: findings_by_owner=model=1; not_checked_structural=0;
                        not_checked_missing_input=9; ladder=FINDINGS exit=1

real bundle:   SUMMARY: findings_by_owner=...model=6,orchestrator=1,report=1;
                        not_checked_structural=3; not_checked_missing_input=3; ladder=FINDINGS exit=1
```

It separates **structurally unverifiable** (no artifact exists for this, ever) from **missing input** (this run lacked something). `not_checked_missing_input=9` is an agent's cue that it is pointed at the wrong shape. It also makes a rerun **one line to compare** instead of ~25.

## No regression

`examples/`, `_bundle-208`, `_bundle-op` and the dirty fixture keep their genuine findings and passes - `data-model`, `pbir-layout` and `occlusion` still PASS on the real bundle. **No golden diffs.** 1974 passed / 7 skipped; mutation 5/5; pylint 10.00/10 on all three roots.

`--strict` kept, deliberately: appropriate for a completion facade, though the author's warning that `check_stub_measures` is *"deliberately NOT a gate by default"* is on record and worth revisiting if `--scope model` proves unsatisfiable mid-migration.
