### PR TITLE
Surface measure filter handover risk

### DIFF
--- a/scripts/read_handover.py
+++ b/scripts/read_handover.py
@@ -33,7 +33,10 @@ The problem is not that the data is unreachable. It is that reading it costs mor
   clean. There are **15** in the worked example and **26 across 9 of the 38 workbooks**, sitting
   beside a 170-item worklist that does not rank them. No persona or skill surfaced them before this
   tool; whether a human ever looked is not something this file can know, and the earlier "nobody had
-  looked at them" is narrowed accordingly.
+  looked at them" is narrowed accordingly. ``measure_filters_needs_review`` is the same class of
+  buried report-side signal, but worse for sign-off: the visual renders and the values are wrong.
+  This reader turns each dropped aggregate/calculated measure filter into a blocking work item so
+  a severity-scoped triage sees the invisible numeric-fidelity risk beside visible report defects.
 
 ⚠️ **What this tool is NOT.** An earlier version of this docstring claimed that reading the slice
 directly failed *silently* - that a truncated read returned ``needs_review[]`` (the same calcs with
@@ -121,6 +124,17 @@ CATEGORY_ORDER = [
 ]
 
 SEVERITY_ORDER = ["blocking", "high", "medium", "low"]
+
+MEASURE_FILTER_CATEGORY = "measure_filter_needs_review"
+MEASURE_FILTER_MISSING = "not_recorded"
+MEASURE_FILTER_NONE = "none"
+MEASURE_FILTER_PRESENT = "present"
+MEASURE_FILTER_INVALID = "invalid"
+MEASURE_FILTER_DEFAULT_NOTE = (
+    "worksheet filter on an aggregate/calculated measure was left to review (no faithful slicer "
+    "mapping); it changes the values shown -- re-apply it as a visual-level filter in Power BI"
+)
+MEASURE_FILTER_RISK = "INVISIBLE NUMERIC FIDELITY RISK: visual renders, values are wrong until filter is re-applied."
 
 
 class HandoverError(RuntimeError):
@@ -526,22 +540,99 @@ def _emptied_visuals(wb: dict) -> list[dict]:
     return [d for d in drops if isinstance(d, dict) and d.get("emptied")]
 
 
+def measure_filter_status(wb: dict) -> tuple[str, dict]:
+    """Return whether the engine recorded the measure-filter audit, without treating missing as zero."""
+    if "measure_filters_needs_review" not in wb:
+        return MEASURE_FILTER_MISSING, {}
+    payload = wb.get("measure_filters_needs_review")
+    if not isinstance(payload, dict):
+        return MEASURE_FILTER_INVALID, {}
+    count = payload.get("count")
+    worksheets = payload.get("worksheets")
+    if not count and not worksheets:
+        return MEASURE_FILTER_NONE, payload
+    return MEASURE_FILTER_PRESENT, payload
+
+
+def _measure_filter_note(payload: dict) -> str:
+    note = (payload.get("note") or "").strip()
+    return note or MEASURE_FILTER_DEFAULT_NOTE
+
+
+def _measure_filter_work_items(wb: dict) -> list[dict]:
+    """Synthesize dropped measure filters as report worklist items, because they change numbers."""
+    status, payload = measure_filter_status(wb)
+    if status != MEASURE_FILTER_PRESENT:
+        return []
+
+    note = _measure_filter_note(payload)
+    worksheets = payload.get("worksheets")
+    rows = [r for r in worksheets if isinstance(r, dict)] if isinstance(worksheets, list) else []
+    count = payload.get("count")
+    if not rows and count:
+        rows = [{"worksheet": f"{count} worksheet filter(s)", "reason": note}]
+
+    out = []
+    for row in rows:
+        reason = (row.get("reason") or note).strip()
+        out.append(
+            {
+                "category": MEASURE_FILTER_CATEGORY,
+                "severity": "blocking",
+                "reason": f"{MEASURE_FILTER_RISK} {reason}",
+                "remediation": f"{note} ({MEASURE_FILTER_RISK})",
+                "worksheet": row.get("worksheet") or "?",
+            }
+        )
+    return out
+
+
+def report_items_of(wb: dict) -> list[dict]:
+    """Report-side work queue, including invisible numeric-fidelity measure filter drops."""
+    raw = worklist_of(wb).get("items") or []
+    items = [i for i in raw if isinstance(i, dict)] if isinstance(raw, list) else []
+    return items + _measure_filter_work_items(wb)
+
+
+def _severity_counts(items: list[dict]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for item in items:
+        sev = str(item.get("severity") or "?")
+        counts[sev] = counts.get(sev, 0) + 1
+    return counts
+
+
+def _measure_filter_summary_line(wb: dict) -> str | None:
+    status, payload = measure_filter_status(wb)
+    if status == MEASURE_FILTER_PRESENT:
+        count = payload.get("count") or len(_measure_filter_work_items(wb))
+        return (
+            f"        !! {count} dropped aggregate/calculated measure filter(s) - "
+            "INVISIBLE numeric-fidelity risk; values change while visuals still render"
+        )
+    if status == MEASURE_FILTER_MISSING:
+        return "        measure filters: NOT RECORDED (key missing; this is not a zero-dropped signal)"
+    if status == MEASURE_FILTER_INVALID:
+        return "        measure filters: INVALID SHAPE (key present but not an object; inspect raw handover)"
+    return None
+
+
 def _report_section(wb: dict) -> list[str]:
-    rw = worklist_of(wb)
-    items = rw.get("items") if isinstance(rw.get("items"), list) else []
-    summary = rw.get("summary") if isinstance(rw.get("summary"), dict) else {}
+    items = report_items_of(wb)
     fidelity = wb.get("viz_fidelity") if isinstance(wb.get("viz_fidelity"), list) else []
     emptied = _emptied_visuals(wb)
+    measure_line = _measure_filter_summary_line(wb)
 
-    if not items and not fidelity:
+    if not items and not fidelity and not measure_line:
         return ["REPORT: no remediation worklist in this handover.", ""]
 
     out = []
+    summary = worklist_of(wb).get("summary") if isinstance(worklist_of(wb).get("summary"), dict) else {}
     flagged = summary.get("visuals_flagged", "?")
     clean = summary.get("visuals_clean", "?")
     out.append(f"REPORT: {len(items)} remediation item(s), {flagged} visual(s) flagged, {clean} clean")
 
-    by_sev = summary.get("by_severity") if isinstance(summary.get("by_severity"), dict) else {}
+    by_sev = _severity_counts(items)
     if by_sev:
         parts = [f"{s} {by_sev[s]}" for s in SEVERITY_ORDER if s in by_sev]
         parts += [f"{s} {n}" for s, n in sorted(by_sev.items()) if s not in SEVERITY_ORDER]
@@ -556,6 +647,8 @@ def _report_section(wb: dict) -> list[str]:
 
     if emptied:
         out.append(f"        !! {len(emptied)} visual(s) EMPTIED - every field binding was dropped")
+    if measure_line:
+        out.append(measure_line)
 
     out += ["", "        next step: --viz    (full worklist)   --viz --severity blocking", ""]
     return out
@@ -792,7 +885,11 @@ def _budgeted_worklist(grouped: dict[str, list[dict]], budget: int) -> tuple[lis
 
 
 def _viz_sections(
-    wb: dict, items: list[dict], grouped: dict[str, list[dict]], severity: str | None, budget: int
+    wb: dict,
+    items: list[dict],
+    grouped: dict[str, list[dict]],
+    filters: tuple[str | None, str | None],
+    budget: int,
 ) -> tuple[list[str], int]:
     """Emptied visuals + fidelity counts + the item-count heading, all charged to ``budget``.
 
@@ -800,10 +897,18 @@ def _viz_sections(
     worklist. Split out of `render_viz` only to keep that function under pylint's local-variable
     cap; the ordering inside is load-bearing and commented where it is.
     """
-    counts = _fidelity_counts(wb)
-    budget -= sum(_blen(x) + 1 for x in counts)
+    severity, category = filters
+    counts = _fidelity_counts(wb) if category is None else []
+    measure_line = _measure_filter_summary_line(wb) if category in (None, MEASURE_FILTER_CATEGORY) else None
+    measure_lines = [measure_line] if measure_line else []
+    budget -= sum(_blen(x) + 1 for x in counts + measure_lines)
 
-    scope = f" at severity {severity!r}" if severity else ""
+    scope_parts = []
+    if severity:
+        scope_parts.append(f"severity {severity!r}")
+    if category:
+        scope_parts.append(f"category {category!r}")
+    scope = " at " + ", ".join(scope_parts) if scope_parts else ""
     section = (
         f"--- {len(items)} ITEM(S) IN {len(grouped)} CATEGORY(IES) ---"
         if items
@@ -814,21 +919,23 @@ def _viz_sections(
     # how a section that IS budgeted still overshoots by exactly one heading.
     budget -= _blen(section) + 1
 
-    emptied = _emptied_block(_emptied_visuals(wb), budget)
+    emptied = _emptied_block(_emptied_visuals(wb), budget) if category is None else []
     budget -= sum(_blen(x) + 1 for x in emptied)
-    return emptied + counts + [section], budget
+    return emptied + counts + measure_lines + [section], budget
 
 
-def render_viz(wb_name: str, wb: dict, severity: str | None, max_bytes: int) -> str:
+def render_viz(wb_name: str, wb: dict, severity: str | None, category: str | None, max_bytes: int) -> str:
     """Report-side queue: emptied visuals first, then worklist items grouped by category.
 
     ``max_bytes`` governs EVERY section, the emptied-visuals block included. That block keeps its
     priority - it is the highest-severity content in the file, so it is claimed from the budget
     before any worklist detail - but priority is not exemption: see `_emptied_block`.
     """
-    items = [i for i in (worklist_of(wb).get("items") or []) if isinstance(i, dict)]
+    items = report_items_of(wb)
     if severity:
         items = [i for i in items if (i.get("severity") or "").lower() == severity.lower()]
+    if category:
+        items = [i for i in items if (i.get("category") or "uncategorised") == category]
 
     out = [f"=== {_clip(wb_name)} - REPORT REMEDIATION QUEUE ===", ""]
     banner_reserve = max(BANNER_RESERVE_FLOOR, max_bytes // 4)
@@ -838,7 +945,7 @@ def render_viz(wb_name: str, wb: dict, severity: str | None, max_bytes: int) -> 
     for item in items:
         grouped.setdefault(item.get("category") or "uncategorised", []).append(item)
 
-    head, budget = _viz_sections(wb, items, grouped, severity, budget)
+    head, budget = _viz_sections(wb, items, grouped, (severity, category), budget)
     out += head
 
     if not items:
@@ -851,7 +958,13 @@ def render_viz(wb_name: str, wb: dict, severity: str | None, max_bytes: int) -> 
     out += body
 
     if omitted:
-        out += _truncation_banner(max_bytes, shown, omitted, banner_reserve, recovery=RECOVERY_BY_SEVERITY)
+        out += _truncation_banner(
+            max_bytes,
+            shown,
+            omitted,
+            banner_reserve,
+            recovery=RECOVERY_BY_JSON if category else RECOVERY_BY_SEVERITY,
+        )
     return "\n".join(out)
 
 
@@ -881,19 +994,35 @@ def render_default(wb_name: str, wb: dict, target: Path, max_bytes: int) -> str:
     return "\n".join(out + report + [NEEDS_REVIEW_NOTE])
 
 
-def _list_row(name: str, wb: dict) -> tuple[str, int, int, int, int]:
-    """One workbook's urgency tuple: (name, calc requests, worklist items, blocking, emptied)."""
-    items = [i for i in (worklist_of(wb).get("items") or []) if isinstance(i, dict)]
+def _list_row(name: str, wb: dict) -> tuple[str, int, int, int, int, int, bool]:
+    """Urgency tuple: (name, calc requests, report items, blocking, emptied, measure filters, missing)."""
+    items = report_items_of(wb)
     blocking = sum(1 for i in items if (i.get("severity") or "").lower() == "blocking")
-    return name, len(requests_of(wb)), len(items), blocking, len(_emptied_visuals(wb))
+    status, payload = measure_filter_status(wb)
+    measure_filters = int(payload.get("count") or 0) if status == MEASURE_FILTER_PRESENT else 0
+    return (
+        name,
+        len(requests_of(wb)),
+        len(items),
+        blocking,
+        len(_emptied_visuals(wb)),
+        measure_filters,
+        status == MEASURE_FILTER_MISSING,
+    )
 
 
-def _list_line(row: tuple[str, int, int, int, int]) -> str:
+def _list_line(row: tuple[str, int, int, int, int, int, bool]) -> str:
     """Format one `--list` row. The name is clipped so a long one cannot push the line off-cap."""
-    name, n_reqs, n_items, blocking, emptied = row
+    name, n_reqs, n_items, blocking, emptied, measure_filters, measure_missing = row
     short = _clip(name, 52)
     line = f"    {short:<52} {n_reqs:>4} calc request(s)  {n_items:>4} report item(s)  {blocking:>3} blocking"
-    return line + (f"  !! {emptied} EMPTIED" if emptied else "")
+    if emptied:
+        line += f"  !! {emptied} EMPTIED"
+    if measure_filters:
+        line += f"  !! {measure_filters} MEASURE-FILTERS"
+    elif measure_missing:
+        line += "  ?? measure-filter key missing"
+    return line
 
 
 def render_list(found: list[tuple[str, dict, Path]], max_bytes: int) -> str:
@@ -907,10 +1036,11 @@ def render_list(found: list[tuple[str, dict, Path]], max_bytes: int) -> str:
     """
     rows = [_list_row(name, wb) for name, wb, _ in found]
     out = [
-        f"{len(found)} workbook(s), most urgent first (emptied visuals > blocking items > queue size):",
+        f"{len(found)} workbook(s), most urgent first "
+        "(invisible measure filters > emptied visuals > blocking items > queue size):",
         "",
     ]
-    ranked = sorted(rows, key=lambda r: (-r[4], -r[3], -(r[1] + r[2]), r[0].lower()))
+    ranked = sorted(rows, key=lambda r: (-r[5], -r[4], -r[3], -(r[1] + r[2]), r[0].lower()))
     budget = max_bytes - sum(_blen(x) + 1 for x in out)
     more = "    ... and {n} more workbook(s) not listed here; raise --max-bytes"
     return "\n".join(out + _fit_lines([_list_line(r) for r in ranked], budget, more))
@@ -927,8 +1057,12 @@ def build_json(wb_name: str, wb: dict, category: str | None) -> dict:
         "guidance": guidance_by_category(requests_of(wb)),
         "counts": category_counts(requests_of(wb)),
         "requests": slim,
-        "report_items": worklist_of(wb).get("items") or [],
+        "report_items": report_items_of(wb),
         "emptied_visuals": _emptied_visuals(wb),
+        "measure_filters_needs_review": wb.get("measure_filters_needs_review")
+        if "measure_filters_needs_review" in wb
+        else MEASURE_FILTER_MISSING,
+        "measure_filter_items": _measure_filter_work_items(wb),
         "viz_fidelity": [v for v in (wb.get("viz_fidelity") or []) if isinstance(v, dict)],
     }
 
@@ -946,7 +1080,9 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     p.add_argument("target", type=Path, help="bundle dir, handover/<workbook>.json, or report.json")
     p.add_argument("--workbook", help="select one workbook when the target holds several")
-    p.add_argument("--category", help="print full repair detail for one category")
+    p.add_argument(
+        "--category", help="print full repair detail for one model category; with --viz, filter report items"
+    )
     p.add_argument("--name", help="print one calculation in full, by name")
     p.add_argument("--viz", action="store_true", help="print the report-side remediation queue")
     p.add_argument(
@@ -987,10 +1123,10 @@ def _force_utf8_stdout() -> None:
 
 def _render(args: argparse.Namespace, wb_name: str, wb: dict, source: Path, budget: int) -> str:
     """Pick the view. Every one of these is capped; `--name` is handled by the caller."""
+    if args.viz:
+        return render_viz(wb_name, wb, args.severity, args.category, budget)
     if args.category:
         return render_category(wb_name, requests_of(wb), args.category, budget)
-    if args.viz:
-        return render_viz(wb_name, wb, args.severity, budget)
     if args.fidelity:
         return render_fidelity(wb_name, wb, budget)
     return render_default(wb_name, wb, source, budget)

--- a/tests/fixtures/handover-measure-filters.json
+++ b/tests/fixtures/handover-measure-filters.json
@@ -1,0 +1,39 @@
+{
+  "estate": {
+    "tool": "migrate_estate"
+  },
+  "workbook": {
+    "name": "Admin_Insights_Starter",
+    "model_translation_handoff": {
+      "needs_review": [],
+      "requests": [],
+      "summary": {
+        "total": 0,
+        "translated": 0,
+        "stub": 0
+      }
+    },
+    "remediation_worklist": {
+      "items": [],
+      "summary": {
+        "visuals_flagged": 0,
+        "visuals_clean": 0
+      },
+      "visuals": []
+    },
+    "measure_filters_needs_review": {
+      "count": 2,
+      "note": "worksheet filter on an aggregate/calculated measure was left to review (no faithful slicer mapping); it changes the values shown -- re-apply it as a visual-level filter in Power BI",
+      "worksheets": [
+        {
+          "reason": "manual attention required: aggregate/measure filter on 'Activity Threshold (T/F)' is not mapped to a slicer (filter scope requires manual attention)",
+          "worksheet": "Above Thresholds - BAN"
+        },
+        {
+          "reason": "manual attention required: aggregate/measure filter on 'Days Since Last Login' is not mapped to a slicer (filter scope requires manual attention)",
+          "worksheet": "Days since last login"
+        }
+      ]
+    }
+  }
+}

--- a/tests/test_read_handover.py
+++ b/tests/test_read_handover.py
@@ -32,7 +32,9 @@ from pathlib import Path
 
 import pytest
 
-SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+FIXTURES = ROOT / "tests" / "fixtures"
 sys.path.insert(0, str(SCRIPTS))
 
 import read_handover as rh  # noqa: E402  # pylint: disable=wrong-import-position
@@ -635,6 +637,98 @@ def test_default_view_surfaces_the_report_queue(tmp_path, capsys):
     assert "REPORT:" in out
     assert "EMPTIED" in out
     assert "--viz" in out
+
+
+def test_real_measure_filter_fixture_is_report_side_blocking_numeric_fidelity(capsys):
+    """Kills: ignoring the real `measure_filters_needs_review` field from Admin_Insights_Starter."""
+    path = FIXTURES / "handover-measure-filters.json"
+
+    _, default = run([str(path)], capsys)
+    _, viz = run([str(path), "--viz"], capsys)
+    _, blocking = run([str(path), "--viz", "--severity", "blocking"], capsys)
+
+    assert "REPORT: 2 remediation item(s)" in default
+    assert "severity: blocking 2" in default
+    assert "2 dropped aggregate/calculated measure filter(s)" in default
+    assert "INVISIBLE numeric-fidelity risk" in default
+    assert "## measure_filter_needs_review  (2 item(s))" in viz
+    assert "Above Thresholds - BAN" in viz
+    assert "Days since last login" in viz
+    assert "visual renders, values are wrong" in viz
+    assert "re-apply it as a visual-level filter" in viz
+    assert "Above Thresholds - BAN" in blocking
+
+
+def test_viz_category_drills_into_measure_filters_without_emptied_visual_noise(capsys):
+    """Kills: `--viz --category measure_filter_needs_review` falling through to model categories."""
+    path = FIXTURES / "handover-measure-filters.json"
+
+    _, out = run([str(path), "--viz", "--category", rh.MEASURE_FILTER_CATEGORY], capsys)
+
+    assert "## measure_filter_needs_review  (2 item(s))" in out
+    assert "Above Thresholds - BAN" in out
+    assert "No requests in category" not in out
+    assert "EMPTIED VISUALS" not in out
+
+
+def test_viz_category_truncation_recovery_does_not_suggest_severity(tmp_path, capsys):
+    """Kills: scoped report-category truncation pointing at `--severity`, which no longer narrows it."""
+    wb = make_workbook([])
+    wb["measure_filters_needs_review"] = {
+        "count": 40,
+        "note": "re-apply it as a visual-level filter in Power BI",
+        "worksheets": [{"worksheet": f"Sheet {i}", "reason": "R" * 200} for i in range(40)],
+    }
+    path = write_slice(tmp_path, wb)
+
+    _, out = run([str(path), "--viz", "--category", rh.MEASURE_FILTER_CATEGORY, "--max-bytes", "3000"], capsys)
+
+    assert "OUTPUT TRUNCATED" in out
+    assert "--json <file>" in out
+    assert "--severity" not in out
+
+
+def test_measure_filter_json_preserves_present_vs_missing(tmp_path, capsys):
+    """Kills: reducing missing `measure_filters_needs_review` to the same shape as zero dropped filters."""
+    present_json = tmp_path / "present.json"
+    missing_json = tmp_path / "missing.json"
+    present = FIXTURES / "handover-measure-filters.json"
+    missing = write_slice(tmp_path, make_workbook([]), "missing-key.json")
+
+    assert run([str(present), "--json", str(present_json)], capsys)[0] == 0
+    assert run([str(missing), "--json", str(missing_json)], capsys)[0] == 0
+
+    present_payload = json.loads(present_json.read_text(encoding="utf-8"))
+    missing_payload = json.loads(missing_json.read_text(encoding="utf-8"))
+    assert present_payload["measure_filters_needs_review"]["count"] == 2
+    assert len(present_payload["measure_filter_items"]) == 2
+    assert missing_payload["measure_filters_needs_review"] == rh.MEASURE_FILTER_MISSING
+    assert missing_payload["measure_filter_items"] == []
+
+
+def test_measure_filter_missing_is_not_a_false_zero(tmp_path, capsys):
+    """Kills: printing a clean zero when the engine never emitted the audit field at all."""
+    path = write_slice(tmp_path, make_workbook([]))
+
+    _, out = run([str(path)], capsys)
+
+    assert "measure filters: NOT RECORDED" in out
+    assert "0 dropped" not in out
+
+
+def test_measure_filter_present_zero_prints_no_empty_section(tmp_path, capsys):
+    """Kills: adding a noisy empty section for a workbook that explicitly recorded no dropped filters."""
+    wb = make_workbook([])
+    wb["measure_filters_needs_review"] = {"count": 0, "note": "none", "worksheets": []}
+    path = write_slice(tmp_path, wb)
+
+    _, default = run([str(path)], capsys)
+    _, viz = run([str(path), "--viz"], capsys)
+
+    assert "measure filters:" not in default
+    assert "measure_filter_needs_review" not in viz
+    assert "dropped aggregate/calculated measure filter" not in default
+    assert "No remediation worklist items" in viz
 
 
 # --------------------------------------------------------------------------------------------


### PR DESCRIPTION
References #298 item 1.

## Summary
- Surface `measure_filters_needs_review` as report-side work items in `scripts/read_handover.py`.
- Treat each dropped aggregate/calculated measure filter as `blocking` because the visual renders but the numbers are wrong: invisible numeric-fidelity risk is a sign-off blocker, not a cosmetic defect.
- `--viz --category measure_filter_needs_review` now drills into just these items; `--severity blocking` also includes them.
- Missing audit key is printed as `?? measure-filter key missing` / `NOT RECORDED`, not as zero. Explicit `count: 0` prints no empty section.

## Estate counts verified against `_bundle-208/handover/*.json`
- handover files: 38
- workbooks carrying `measure_filters_needs_review`: 7
- workbooks missing the key entirely: 31
- total dropped measure filters: 46

Per workbook:
- Admin_Insights_Starter: 35
- HR_Dashboard: 2
- RESTAPISample: 4
- Section_09_-_Filtering_Data: 2
- Section_12_-_Table_Calculations: 1
- Superstore: 1
- World_Indicators: 1

## Verbatim `_bundle-208 --list` output
```text38 workbook(s), most urgent first (invisible measure filters > emptied visuals > blocking items > queue size):

    Admin_Insights_Starter                                 60 calc request(s)   205 report item(s)   42 blocking  !! 15 EMPTIED  !! 35 MEASURE-FILTERS
    RESTAPISample                                           0 calc request(s)    30 report item(s)    6 blocking  !! 4 MEASURE-FILTERS
    HR_Dashboard                                            0 calc request(s)    66 report item(s)   14 blocking  !! 2 MEASURE-FILTERS
    Section_09_-_Filtering_Data                             0 calc request(s)     8 report item(s)    2 blocking  !! 2 MEASURE-FILTERS
    World_Indicators                                        1 calc request(s)    42 report item(s)    7 blocking  !! 1 MEASURE-FILTERS
    Section_12_-_Table_Calculations                        14 calc request(s)    36 report item(s)    4 blocking  !! 1 MEASURE-FILTERS
    Superstore                                              7 calc request(s)    41 report item(s)    4 blocking  !! 1 MEASURE-FILTERS
    Meridian_Calc_Gauntlet                                 10 calc request(s)    23 report item(s)    4 blocking  !! 3 EMPTIED  ?? measure-filter key missing
    Section_08_-_Organizing_Data                            0 calc request(s)    19 report item(s)    0 blocking  !! 2 EMPTIED  ?? measure-filter key missing
    Sales___Customer_Dashboards                            30 calc request(s)    53 report item(s)    8 blocking  !! 1 EMPTIED  ?? measure-filter key missing
    Section_15_-_Tableau_Sales___Customer_Dashboards       30 calc request(s)    53 report item(s)    8 blocking  !! 1 EMPTIED  ?? measure-filter key missing
    Meridian_Revenue_by_Region                              2 calc request(s)     4 report item(s)    0 blocking  !! 1 EMPTIED  ?? measure-filter key missing
    Meridian_Supply_Chain_KPIs                              0 calc request(s)     3 report item(s)    0 blocking  !! 1 EMPTIED  ?? measure-filter key missing
    ephemeral_field                                         0 calc request(s)     2 report item(s)    0 blocking  !! 1 EMPTIED  ?? measure-filter key missing
    Meridian_Hostile_Identifiers                            0 calc request(s)     0 report item(s)    0 blocking  !! 1 EMPTIED  ?? measure-filter key missing
    Section_13_-_Tableau_63_Charts                          3 calc request(s)   139 report item(s)   14 blocking  ?? measure-filter key missing
    global_superstores_db                                   0 calc request(s)    38 report item(s)    1 blocking  ?? measure-filter key missing
    Section_12_-_Row_Level_Calculations__Functions_        22 calc request(s)    15 report item(s)    1 blocking  ?? measure-filter key missing
    vishnu_dashboard                                        0 calc request(s)     5 report item(s)    1 blocking  ?? measure-filter key missing
    Meridian_Multi-Source__3_systems_                       0 calc request(s)     2 report item(s)    1 blocking  ?? measure-filter key missing
    shapes_test                                             0 calc request(s)     2 report item(s)    1 blocking  ?? measure-filter key missing
    Section_12_-_LOD_Expressions                            7 calc request(s)     5 report item(s)    0 blocking  ?? measure-filter key missing
    Meridian_Collision_Alpha                               10 calc request(s)     1 report item(s)    0 blocking  ?? measure-filter key missing
    Section_13_-_Multi-Measures                             0 calc request(s)     9 report item(s)    0 blocking  ?? measure-filter key missing
    Section_10_-_Parameters                                 0 calc request(s)     6 report item(s)    0 blocking  ?? measure-filter key missing
    Section_12_-_Aggregate_Calculations                     0 calc request(s)     4 report item(s)    0 blocking  ?? measure-filter key missing
    filtering                                               1 calc request(s)     2 report item(s)    0 blocking  ?? measure-filter key missing
    Meridian_Customer_Segments                              2 calc request(s)     1 report item(s)    0 blocking  ?? measure-filter key missing
    Meridian_RLS_Demo                                       1 calc request(s)     2 report item(s)    0 blocking  ?? measure-filter key missing
    Meridian_Trip_Economics                                 0 calc request(s)     3 report item(s)    0 blocking  ?? measure-filter key missing
    Section_14_-_Tableau_Dashboard                          0 calc request(s)     3 report item(s)    0 blocking  ?? measure-filter key missing
    Section_06_-_Metadata                                   0 calc request(s)     2 report item(s)    0 blocking  ?? measure-filter key missing
    Section_05_-_Data_Sources                               0 calc request(s)     1 report item(s)    0 blocking  ?? measure-filter key missing
    datasource_test                                         0 calc request(s)     0 report item(s)    0 blocking  ?? measure-filter key missing
    Meridian_Collision_Beta                                 0 calc request(s)     0 report item(s)    0 blocking  ?? measure-filter key missing
    sample-superstore                                       0 calc request(s)     0 report item(s)    0 blocking  ?? measure-filter key missing
    Section_07_-_Renaming                                   0 calc request(s)     0 report item(s)    0 blocking  ?? measure-filter key missing
    Section_11_-_Actions                                    0 calc request(s)     0 report item(s)    0 blocking  ?? measure-filter key missing
```

## Verbatim drill output
Command: `python scripts/read_handover.py C:\Users\gfranssens\vscode-projects\tableau-to-pbi-migration\_bundle-208 --workbook Admin_Insights_Starter --viz --category measure_filter_needs_review --max-bytes 12000`

```text=== Admin_Insights_Starter - REPORT REMEDIATION QUEUE ===

        !! 35 dropped aggregate/calculated measure filter(s) - INVISIBLE numeric-fidelity risk; values change while visuals still render
--- 35 ITEM(S) IN 1 CATEGORY(IES) ---

## measure_filter_needs_review  (35 item(s))
    FIX: worksheet filter on an aggregate/calculated measure was left to review (no faithful slicer mapping); it changes the values shown -- re-apply it as a visual-level filter in Power BI (INVISIBLE NUMERIC FIDELITY RISK: visual renders, values are wrong until filter is re-applied.)
    - blocking Above Thresholds - BAN
      why: INVISIBLE NUMERIC FIDELITY RISK: visual renders, values are wrong until filter is re-applied. manual attention required: aggregate/measure filter on 'Activity Threshold (T/F)' is not mapped to a slicer (filter scope requires manual attention)
    - blocking Days since last login
      why: INVISIBLE NUMERIC FIDELITY RISK: visual renders, values are wrong until filter is re-applied. manual attention required: aggregate/measure filter on 'Days Since Last Login' is not mapped to a slicer (filter scope requires manual attention)
    - blocking Hourly Concurrency
      why: INVISIBLE NUMERIC FIDELITY RISK: visual renders, values are wrong until filter is re-applied. manual attention required: aggregate/measure filter on 'Event Date (local)' is not mapped to a slicer (filter scope requires manual attention)
    - blocking How large are the stale items?
      why: INVISIBLE NUMERIC FIDELITY RISK: visual renders, values are wrong until filter is re-applied. manual attention required: aggregate/measure filter on 'Stale?' is not mapped to a slicer (filter scope requires manual attention)
    - blocking How large are the stale items?
      why: INVISIBLE NUMERIC FIDELITY RISK: visual renders, values are wrong until filter is re-applied. manual attention required: aggregate/measure filter on 'Size (MB)' is not mapped to a slicer (filter scope requires manual attention)
    - blocking How large are the stale items?
      why: INVISIBLE NUMERIC FIDELITY RISK: visual renders, values are wrong until filter is re-applied. manual attention required: aggregate/measure filter on 'Total Size (MB)' is not mapped to a slicer (filter scope requires manual attention)
    - blocking Item Breakdown - Bar
      why: INVISIBLE NUMERIC FIDELITY RISK: visual renders, values are wrong until filter is re-applied. manual attention required: aggregate/measure filter on 'Activity Threshold (T/F)' is not mapped to a slicer (filter scope requires manual attention)
    - blocking Items - BAN
      why: INVISIBLE NUMERIC FIDELITY RISK: visual renders, values are wrong until filter is re-applied. manual attention required: aggregate/measure filter on 'Activity Threshold (T/F)' is not mapped to a slicer (filter scope requires manual attention)
    - blocking Key Access Events
      why: INVISIBLE NUMERIC FIDELITY RISK: visual renders, values are wrong until filter is re-applied. manual attention required: aggregate/measure filter on 'Event Date (local)' is not mapped to a slicer (filter scope requires manual attention)
    - blocking Key Publish Events
      why: INVISIBLE NUMERIC FIDELITY RISK: visual renders, values are wrong until filter is re-applied. manual attention required: aggregate/measure filter on 'Event Date (local)' is not mapped to a slicer (filter scope requires manual attention)
    - blocking Load Time - BAN
      why: INVISIBLE NUMERIC FIDELITY RISK: visual renders, values are wrong until filter is re-applied. manual attention required: aggregate/measure filter on 'Activity Threshold (T/F)' is not mapped to a slicer (filter scope requires manual attention)
    - blocking Load Time - Line
      why: INVISIBLE NUMERIC FIDELITY RISK: visual renders, values are wrong until filter is re-applied. manual attention required: aggregate/measure filter on 'Activity Threshold (T/F)' is not mapped to a slicer (filter scope requires manual attention)
    - blocking Login user breakdown
      why: INVISIBLE NUMERIC FIDELITY RISK: visual renders, values are wrong until filter is re-applied. manual attention required: aggregate/measure filter on 'Days Since Last Login' is not mapped to a slicer (filter scope requires manual attention)
    - blocking Number of Owners - BAN
      why: INVISIBLE NUMERIC FIDELITY RISK: visual renders, values are wrong until filter is re-applied. manual attention required: aggregate/measure filter on 'Activity Threshold (T/F)' is not mapped to a slicer (filter scope requires manual attention)
    - blocking Performance Ratings
      why: INVISIBLE NUMERIC FIDELITY RISK: visual renders, values are wrong until filter is re-applied. manual attention required: aggregate/measure filter on 'Activity Threshold (T/F)' is not mapped to a slicer (filter scope requires manual attention)
    - blocking Project - BAN
      why: INVISIBLE NUMERIC FIDELITY RISK: visual renders, values are wrong until filter is re-applied. manual attention required: aggregate/measure filter on 'Activity Threshold (T/F)' is not mapped to a slicer (filter scope requires manual attention)
    - blocking Project Breakdown - Bar
      why: INVISIBLE NUMERIC FIDELITY RISK: visual renders, values are wrong until filter is re-applied. manual attention required: aggregate/measure filter on 'Activity Threshold (T/F)' is not mapped to a slicer (filter scope requires manual attention)
    - blocking Publish Data TL
      why: INVISIBLE NUMERIC FIDELITY RISK: visual renders, values are wrong until filter is re-applied. manual attention required: aggregate/measure filter on 'Event Date (local)' is not mapped to a slicer (filter scope requires manual attention)
    - blocking Publish workbooks TL
      why: INVISIBLE NUMERIC FIDELITY RISK: visual renders, values are wrong until filter is re-applied. manual attention required: aggregate/measure filter on 'Event Date (local)' is not mapped to a slicer (filter scope requires manual attention)
    - blocking Requests - Line
      why: INVISIBLE NUMERIC FIDELITY RISK: visual renders, values are wrong until filter is re-applied. manual attention required: aggregate/measure filter on 'Activity Threshold (T/F)' is not mapped to a slicer (filter scope requires manual attention)
    - blocking Tooltip: Top logins
      why: INVISIBLE NUMERIC FIDELITY RISK: visual renders, values are wrong until filter is re-applied. manual attention required: aggregate/measure filter on 'Event Date (local)' is not mapped to a slicer (filter scope requires manual attention)
    - blocking Tooltip: Top logins
      why: INVISIBLE NUMERIC FIDELITY RISK: visual renders, values are wrong until filter is re-applied. manual attention required: aggregate/measure filter on 'Distinct Events' is not mapped to a slicer (filter scope requires manual attention)
    - blocking Total Requests - BAN
      why: INVISIBLE NUMERIC FIDELITY RISK: visual renders, values are wrong until filter is re-applied. manual attention required: aggregate/measure filter on 'Activity Threshold (T/F)' is not mapped to a slicer (filter scope requires manual attention)
    - blocking Traffic to views
      why: INVISIBLE NUMERIC FIDELITY RISK: visual renders, values are wrong until filter is re-applied. manual attention required: aggregate/measure filter on 'Event Date (local)' is not mapped to a slicer (filter scope requires manual attention)
    - blocking Weekly Concurrency
      why: INVISIBLE NUMERIC FIDELITY RISK: visual renders, values are wrong until filter is re-applied. manual attention required: aggregate/measure filter on 'Event Date (local)' is not mapped to a slicer (filter scope requires manual attention)
    - blocking What is the space used by each item?
      why: INVISIBLE NUMERIC FIDELITY RISK: visual renders, values are wrong until filter is re-applied. manual attention required: aggregate/measure filter on 'Stale?' is not mapped to a slicer (filter scope requires manual attention)
    - blocking What is the space used by each item?
      why: INVISIBLE NUMERIC FIDELITY RISK: visual renders, values are wrong until filter is re-applied. manual attention required: aggregate/measure filter on 'Total Size (MB)' is not mapped to a slicer (filter scope requires manual attention)
    - blocking What is the total space used by stale and unused content?
      why: INVISIBLE NUMERIC FIDELITY RISK: visual renders, values are wrong until filter is re-applied. manual attention required: aggregate/measure filter on 'Stale?' is not mapped to a slicer (filter scope requires manual attention)
    - blocking What is the total space used by stale and unused content?
      why: INVISIBLE NUMERIC FIDELITY RISK: visual renders, values are wrong until filter is re-applied. manual attention required: aggregate/measure filter on 'Total Size (MB)' is not mapped to a slicer (filter scope requires manual attention)

!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
!! OUTPUT TRUNCATED at --max-bytes=11999. 29 of 35 item(s) shown; 6 NOT shown.
!! You have NOT seen the whole queue. Get the rest with either:
!!   --max-bytes 35997
!!   --json <file>   to write every row to a machine-readable file instead
!! NOT shown:
!!     measure_filter_needs_review: Which items use the most space?
!!     measure_filter_needs_review: Which top parent projects use the most space?
!!     measure_filter_needs_review: Which users use the most space?
!!     measure_filter_needs_review: Workbook Breakdown - Bar
!!     measure_filter_needs_review: Workbooks - BAN
!!     measure_filter_needs_review: data sources TL
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
```

## Actionability gaps in the engine field
The field gives `count`, a remediation `note`, and worksheet-level `{worksheet, reason}` rows. It does not name the exact Power BI visual/page/container, the original Tableau filter predicate/operator/threshold, or the target measure object to filter. The reader can make the risk visible and route it; the fixer still has to inspect the source worksheet/report artifact to recreate the exact visual-level filter.

## Validation
- `ruff format scripts/read_handover.py tests/test_read_handover.py`
- `ruff check scripts/read_handover.py tests/test_read_handover.py --fix`
- `python -m pytest tests/test_read_handover.py -q` → 71 passed
- `python -m pylint scripts` → 10.00/10, exit 0
- mutation check: replacing `return items + _measure_filter_work_items(wb)` with `return items` makes the new real-fixture test fail with pytest exit 1; `pytest tests\does_not_exist.py` exits 4, so test failure and command/collection failure are distinct.
- CI: checks pass, windows-bundle pass.
