### PR TITLE
Fix drifted agent duplicate guidance

### DIFF
--- a/.github/agents/pbi-migration-validator.agent.md
+++ b/.github/agents/pbi-migration-validator.agent.md
@@ -72,18 +72,11 @@ reasoning or self-report of success.
   | working copy | `<bundle>/pbip/` | agents edit **here**; every edit re-runnable from `_build/` and declared |
   | deliverable | `migrations/{workbooks,datasources}/<slug>/fabric/` | **COPIED at sign-off**, so the bundle survives as evidence |
 
-  A bundle is `<bundle>/{pbip,reports,semantic_models,handover,data}` — **no `out/` level** — and the
-  two sides differ in shape, so compare the matching **pair**, with **git** (✅ measured 2026-08-13;
-  bare `diff` on Windows is a PowerShell alias for `Compare-Object`, which given two directories
-  compares the two path *strings* and prints a confident non-answer):
+  A bundle is `<bundle>/{pbip,reports,semantic_models,handover,data}` — **no `out/` level**. Keep
+  `reports/` pristine so it remains the exact answer to *"what did our tier change versus what the
+  engine produced?"* — rewriting it cost a retracted upstream bug on 2026-08-10. Use git for that
+  comparison; the mechanics live in `powerbi-report-gotchas` §3.
 
-  `git diff --no-index --stat <bundle>/reports/<WB>.Report <bundle>/pbip/<WB>/<WB>.Report`
-  → *98 files changed, 2013 insertions(+), 553 deletions(-)*; **exit 1 = they differ** — but git also
-  exits 1 on `error: Could not access`, the likely slip here, so **check for a stat line**, not the code.
-
-  Keeping `reports/` pristine is what makes that an exact answer to *"what did our tier change versus
-  what the engine produced?"* — that cost a retracted upstream bug on 2026-08-10 (our fix pass had
-  rewritten `reports/`, and the diff was read as engine behaviour).
   ⚠️ **The copy must keep
   `definition.pbir`'s `byPath` resolving** — plain copy for a per-workbook model, path rewrite for a
   shared datasource; never ship `<bundle>/reports/` (reference-only: no model beside it). Mechanics:

--- a/.github/agents/pbi-report-builder.agent.md
+++ b/.github/agents/pbi-report-builder.agent.md
@@ -33,18 +33,11 @@ Power BI report. You are invoked by the `tableau-migrator` orchestrator.
   | working copy | `<bundle>/pbip/` | agents edit **here**; every edit re-runnable from `_build/` and declared |
   | deliverable | `migrations/{workbooks,datasources}/<slug>/fabric/` | **COPIED at sign-off**, so the bundle survives as evidence |
 
-  A bundle is `<bundle>/{pbip,reports,semantic_models,handover,data}` — **no `out/` level** — and the
-  two sides differ in shape, so compare the matching **pair**, with **git** (✅ measured 2026-08-13;
-  bare `diff` on Windows is a PowerShell alias for `Compare-Object`, which given two directories
-  compares the two path *strings* and prints a confident non-answer):
+  A bundle is `<bundle>/{pbip,reports,semantic_models,handover,data}` — **no `out/` level**. Keep
+  `reports/` pristine so it remains the exact answer to *"what did our tier change versus what the
+  engine produced?"* — rewriting it cost a retracted upstream bug on 2026-08-10. Use git for that
+  comparison; the mechanics live in `powerbi-report-gotchas` §3.
 
-  `git diff --no-index --stat <bundle>/reports/<WB>.Report <bundle>/pbip/<WB>/<WB>.Report`
-  → *98 files changed, 2013 insertions(+), 553 deletions(-)*; **exit 1 = they differ** — but git also
-  exits 1 on `error: Could not access`, the likely slip here, so **check for a stat line**, not the code.
-
-  Keeping `reports/` pristine is what makes that an exact answer to *"what did our tier change versus
-  what the engine produced?"* — that cost a retracted upstream bug on 2026-08-10 (our fix pass had
-  rewritten `reports/`, and the diff was read as engine behaviour).
   ⚠️ **The copy must keep
   `definition.pbir`'s `byPath` resolving** — plain copy for a per-workbook model, path rewrite for a
   shared datasource; never ship `<bundle>/reports/` (reference-only: no model beside it). Mechanics:
@@ -184,13 +177,10 @@ idioms → dated Microsoft Learn citation → cache into `visuals/<type>.md` →
      `visual.objects` and draws a blank rectangle while `validate` returns 0 errors. A green
      CLI/`validate` result is **never** evidence that a visual draws.
 2. **The cookbook is a *cache*, not the authority** (`.github/pbi.kb/visual-cookbook.md`). Don't open
-   it reflexively: 19 of the 29 entries are transcribed `catalog describe` output with zero drift, so
-   step 1 already gave you those. The ones worth opening are the **7 idioms** (`error-bars`,
-   `reference-lines`, `smallmultiples`, `zoom-slider`, `table-cond-format`, `table-databars`,
-   `forecast` — not visual types, so the CLI returns `VISUAL_TYPE_UNKNOWN`) and the **3 render-truth**
-   entries (`actionButton`, `shape`, `azureMap`). Trust by tier: 🟢 render-verified → copy and rebind, then
-   reconcile property names against the live CLI; 🟡 structural-template → a shape hint only, the
-   live CLI wins any conflict; 🔴 needs-capture → do not ship.
+   it reflexively; use its own "What's actually in here" table to decide when it carries guidance the
+   CLI cannot answer (idioms and render-truth entries). Trust by tier: 🟢 render-verified → copy and
+   rebind, then reconcile property names against the live CLI; 🟡 structural-template → a shape hint
+   only, the live CLI wins any conflict; 🔴 needs-capture → do not ship.
 3. **Research + human capture** for anything neither covers, then **write it back as a 🟢 entry** with
    the dated citation. Growing the cookbook is part of the job.
 
@@ -343,19 +333,22 @@ a visual validates clean but renders wrong. It is ~18 KB of PBIR/Desktop failure
 across every prior migration. Invoke it by name, or read
 [`.github/skills/powerbi-report-gotchas/SKILL.md`](../skills/powerbi-report-gotchas/SKILL.md).
 
-**What is in it, so you can tell when you need it.** If any row below matches what you are about to
-build or debug, you have not read enough yet:
+<!-- BEGIN:generated-skill-index:powerbi-report-gotchas -->
+**Generated skill section index.** Do not hand-edit this table; it is generated from the `powerbi-report-gotchas` skill headings by `scripts/sync_agent_conventions.py`. If a row matches what you are about to build or debug, invoke/read the skill section first.
 
-| § | Covers |
+| § | Skill section |
 |---|---|
-| 1 | Validation-invisible rendering bugs: `Else` ignored for table `fontColor`, azureMap `Location` + Lat/Long, the `Aggregation.Function` enum, `expansionStates`, measure-filters that silently zero a visual, "Column cannot be found" = a field-parameter model bug |
-| 2 | Data colours: `Conditional.Cases[]` vs `fillRule`, per-point colour needs a PROJECTED field, `scopeId` mode, string colour-helpers cannot drive rules |
-| 3 | PBIR mechanics: `filterConfig` is a SIBLING of `visual`, stacked bar = `barChart`, `displayName` renames headers, type-suffixed reference-line literals, theme rules, `formatString` scale |
-| 4 | Crosstabs: `tableEx` empty-rows, the `SUMMARIZECOLUMNS` Columns-pivot drop, prefer flat tables |
-| 5 | Maps: azureMap is the only non-deprecated one; choropleth `referenceLayer` encoding, fixed-view zoom, route maps need one row per endpoint |
-| 6 | Scatter: X and Y must BOTH be measures |
-| 7 | Desktop mechanics: no refresh verb, `cache.abf`, the XMLA fallback, MSIX `PBI_DESKTOP_PATH`, autosave races, the bridge as a serialization point |
-| 8 | Reading the spec: nested shelves, tooltips, manual sorts, stale internal names, Measure Names/Values, slicer defaults |
+| 1 | Validation-invisible rendering bugs |
+| 2 | Data colours and conditional formatting |
+| 3 | PBIR mechanics |
+| 4 | Crosstabs and tables — a recurring fragility class |
+| 5 | Maps — Azure Maps is the only non-deprecated option |
+| 6 | Scatter |
+| 7 | Desktop verification mechanics |
+| 8 | Reading the source spec |
+| 9 | Keeping the visual mapping current (research per idiom, not per instance) |
+| 10 | Reading the report-side handover queue |
+<!-- END:generated-skill-index:powerbi-report-gotchas -->
 
 **Semantic-model-owned bugs stay with `pbi-semantic-builder`.** Anything that turns out to be a TMDL or
 DAX defect (a field-parameter `sourceColumn` missing its brackets, a measure evaluated at the wrong

--- a/.github/agents/pbi-semantic-builder.agent.md
+++ b/.github/agents/pbi-semantic-builder.agent.md
@@ -38,18 +38,11 @@ examples, not hypothetical ones.
   | working copy | `<bundle>/pbip/` | agents edit **here**; every edit re-runnable from `_build/` and declared |
   | deliverable | `migrations/{workbooks,datasources}/<slug>/fabric/` | **COPIED at sign-off**, so the bundle survives as evidence |
 
-  A bundle is `<bundle>/{pbip,reports,semantic_models,handover,data}` — **no `out/` level** — and the
-  two sides differ in shape, so compare the matching **pair**, with **git** (✅ measured 2026-08-13;
-  bare `diff` on Windows is a PowerShell alias for `Compare-Object`, which given two directories
-  compares the two path *strings* and prints a confident non-answer):
+  A bundle is `<bundle>/{pbip,reports,semantic_models,handover,data}` — **no `out/` level**. Keep
+  `reports/` pristine so it remains the exact answer to *"what did our tier change versus what the
+  engine produced?"* — rewriting it cost a retracted upstream bug on 2026-08-10. Use git for that
+  comparison; the mechanics live in `powerbi-report-gotchas` §3.
 
-  `git diff --no-index --stat <bundle>/reports/<WB>.Report <bundle>/pbip/<WB>/<WB>.Report`
-  → *98 files changed, 2013 insertions(+), 553 deletions(-)*; **exit 1 = they differ** — but git also
-  exits 1 on `error: Could not access`, the likely slip here, so **check for a stat line**, not the code.
-
-  Keeping `reports/` pristine is what makes that an exact answer to *"what did our tier change versus
-  what the engine produced?"* — that cost a retracted upstream bug on 2026-08-10 (our fix pass had
-  rewritten `reports/`, and the diff was read as engine behaviour).
   ⚠️ **The copy must keep
   `definition.pbir`'s `byPath` resolving** — plain copy for a per-workbook model, path rewrite for a
   shared datasource; never ship `<bundle>/reports/` (reference-only: no model beside it). Mechanics:
@@ -210,16 +203,17 @@ Every file under a `*.SemanticModel` folder is hash-baselined by the engine run 
 `input_manifest.json`, and the orchestrator runs `python scripts/check_migration_progress.py --bundle
 <b> --tamper` before sign-off: it exits **1** on any generated file that changed without a matching
 declaration. `scripts/declare_generated_edit.py` is the **only** thing that writes one — it runs your
-script for you and records the before/after hashes into `_build/generated-edit-declarations.json`:
+script for you and records the before/after hashes as one append-only
+`_build/generated-edit-declarations/*.json` record:
 
 ```bash
 python scripts/declare_generated_edit.py --bundle <b> \
   --target pbip/<WB>/<Name>.SemanticModel/definition/cultures/en-US.tmdl \
   --script <b>/_build/fix_ai_instructions.py -- --only pbip/<WB>/<Name>.SemanticModel/definition/cultures/en-US.tmdl
-# DECLARE: RECORDED pbip/.../en-US.tmdl -> <b>/_build/generated-edit-declarations.json
+# DECLARE: RECORDED pbip/.../en-US.tmdl -> <b>/_build/generated-edit-declarations/<timestamp...>.json
 ```
 
-Only two things are already covered, and neither is the work you do here: `refresh_pbip_model.py`
+Only two things are already covered, and neither is the work you do here: the refresh skill
 self-declares **its own** `database.tmdl` compatibility-level bump, and `.pbi/` cache/autosave
 sidecars are outside the baseline entirely. Everything else you touch — `set_ai_instructions.py`
 writing the culture TMDL, an MCP description write, any `_build/fix_*.py` — is **yours to declare**.
@@ -282,16 +276,20 @@ failure knowledge, extracted from this persona so it does not sit in the region 
 first. Invoke by name, or read
 [`.github/skills/powerbi-semantic-model-gotchas/SKILL.md`](../skills/powerbi-semantic-model-gotchas/SKILL.md).
 
-**What is in it, so you can tell when you need it.** If any row matches what you are about to build or
-debug, you have not read enough yet:
+<!-- BEGIN:generated-skill-index:powerbi-semantic-model-gotchas -->
+**Generated skill section index.** Do not hand-edit this table; it is generated from the `powerbi-semantic-model-gotchas` skill headings by `scripts/sync_agent_conventions.py`. If a row matches what you are about to build or debug, invoke/read the skill section first.
 
-| § | Covers |
+| § | Skill section |
 |---|---|
-| 1 | Translating source fields: `ATTR()` at row grain, duplicate `CASE WHEN` branches, reference-line measure naming, stale `internal_name`s, the non-tabular `table`/`spatial` data types |
-| 2 | TMDL pitfalls that **crash Desktop on open**: `database.tmdl` shape, single-line DAX, measure/column name collisions, `.pbip` `$schema`, the **field-parameter `sourceColumn: [Value1]` bracket trap**, the **`'Table'[Col] = [Measure]` PLACEHOLDER error** |
-| 3 | MCP/Desktop rules: DAX uses a column's `name` not `sourceColumn`, explicit M culture and the `'4096' locale` failure, re-discovering the AS port, blank MCP response = success, pending-changes banner, junk artifacts |
-| 4 | Offline integrity checks the parser misses (**duplicate measure names break Desktop load**), table calcs at compat 1606, what `pbi-report-builder` needs decided at model-design time, modeling at scale |
-| 5 | **Live sources**: prove reachability first, why a static spec check is not a test, and never self-supplying a credential |
+| 1 | Translating source fields |
+| 2 | TMDL hand-authoring pitfalls |
+| 3 | MCP / Desktop operational gotchas |
+| 4 | Model integrity, table calcs, cross-agent hand-offs, and scale |
+| 5 | Live sources: prove reachability first, and never self-supply a credential |
+| 6 | File-based extracts: a legacy `.xls` + a custom OS locale silently corrupts DATA |
+| 7 | Legacy `.xls` navigation keys, and Desktop sessions that turn errors into hangs |
+| 8 | Reading the handover queue, and a retracted claim worth keeping |
+<!-- END:generated-skill-index:powerbi-semantic-model-gotchas -->
 
 **Report-layer bugs stay with `pbi-report-builder`** — own your layer. **New learnings go in the skill,
 not back in this file.**
@@ -351,6 +349,6 @@ throwing an error" is necessary but not sufficient:
    tables *did* load (`powerbi-semantic-model-gotchas` §5). For a live source confirm **per-table**:
    `EVALUATE ROW("n", COUNTROWS('<LiveTable>'))` must be non-zero for each.
 12. **Every TMDL edit you made is declared, and `--tamper` exits 0** — see "Declare every TMDL edit
-   you make" above. `refresh_pbip_model.py`'s own `database.tmdl` bump is the *only* self-declaring
+   you make" above. The refresh skill's own `database.tmdl` bump is the *only* self-declaring
    edit; an undeclared culture, description or fix-script edit blocks the orchestrator's sign-off,
    and `DECLARE: NO_CHANGE` means nothing was recorded.

--- a/.github/agents/tableau-migrator.agent.md
+++ b/.github/agents/tableau-migrator.agent.md
@@ -34,18 +34,11 @@ PBIR files yourself.
   | working copy | `<bundle>/pbip/` | agents edit **here**; every edit re-runnable from `_build/` and declared |
   | deliverable | `migrations/{workbooks,datasources}/<slug>/fabric/` | **COPIED at sign-off**, so the bundle survives as evidence |
 
-  A bundle is `<bundle>/{pbip,reports,semantic_models,handover,data}` — **no `out/` level** — and the
-  two sides differ in shape, so compare the matching **pair**, with **git** (✅ measured 2026-08-13;
-  bare `diff` on Windows is a PowerShell alias for `Compare-Object`, which given two directories
-  compares the two path *strings* and prints a confident non-answer):
+  A bundle is `<bundle>/{pbip,reports,semantic_models,handover,data}` — **no `out/` level**. Keep
+  `reports/` pristine so it remains the exact answer to *"what did our tier change versus what the
+  engine produced?"* — rewriting it cost a retracted upstream bug on 2026-08-10. Use git for that
+  comparison; the mechanics live in `powerbi-report-gotchas` §3.
 
-  `git diff --no-index --stat <bundle>/reports/<WB>.Report <bundle>/pbip/<WB>/<WB>.Report`
-  → *98 files changed, 2013 insertions(+), 553 deletions(-)*; **exit 1 = they differ** — but git also
-  exits 1 on `error: Could not access`, the likely slip here, so **check for a stat line**, not the code.
-
-  Keeping `reports/` pristine is what makes that an exact answer to *"what did our tier change versus
-  what the engine produced?"* — that cost a retracted upstream bug on 2026-08-10 (our fix pass had
-  rewritten `reports/`, and the diff was read as engine behaviour).
   ⚠️ **The copy must keep
   `definition.pbir`'s `byPath` resolving** — plain copy for a per-workbook model, path rewrite for a
   shared datasource; never ship `<bundle>/reports/` (reference-only: no model beside it). Mechanics:
@@ -107,10 +100,9 @@ PBIR files yourself.
    `-Update` belongs to *session start* only (`AGENTS.md` → "Session start"). Upgrading the bridge CLIs
    mid-migration would swap the validator underneath a half-built report. If preflight reports a CLI
    **below the correctness floor**, stop and tell the user to re-run session start with `-Update`.
-   It verifies the whole toolchain — Python + parser deps, **both skill plugins**, the MCP servers,
-   Power BI Desktop + Bridge CLI, `npx`, the .NET SDK, the CLI version matrix, and whether the
-   published skill bundles still match `.github/skills/`. If it exits non-zero, **stop and surface the
-   missing items with the printed install hints** — do not migrate against a half-configured machine.
+   Treat preflight's own output as the environment inventory; do not maintain a second checklist in
+   this persona. If it exits non-zero, **stop and surface the missing items with the printed install
+   hints** — do not migrate against a half-configured machine.
 1. **Read the brief, then confirm inputs.** The *dispatcher* — the top-level session, per `AGENTS.md`
    — decides **what** gets migrated and hands you one unit of work plus
    `migrations/workbooks/<name>/migration-brief.md`: scope, **autonomy** (`guided` / `standard` /

--- a/.github/skills/powerbi-report-gotchas/SKILL.md
+++ b/.github/skills/powerbi-report-gotchas/SKILL.md
@@ -210,6 +210,16 @@ idioms see `.github/pbi.kb/visuals/table-cond-format.md`.
     `byPath` next to it has no model to point at (2026-08-11 it read `"../../pbip/<wb>/<Name>.SemanticModel"`;
     on a 2026-08-13 bundle it reads `"../<Name>.SemanticModel"` — ⚠️ engine-version dependent, and
     unresolvable either way).
+  - **Compare engine truth to working copy with git, not PowerShell `diff`.** The two sides differ in
+    shape, so compare the matching pair with:
+
+    ```bash
+    git diff --no-index --stat <bundle>/reports/<WB>.Report <bundle>/pbip/<WB>/<WB>.Report
+    ```
+
+    On Windows, bare `diff` is a PowerShell alias for `Compare-Object` and can compare only the two
+    path strings. `git diff` exits 1 both when trees differ and when a path is wrong, so require a real
+    stat line, not just the exit code.
 
 - ⚠️ **A "shipped" deliverable can be structurally present and functionally EMPTY — check content, not
   existence.** Reported 2026-08-19 from a 46-asset estate, found by direct verification rather than by
@@ -304,15 +314,15 @@ idioms see `.github/pbi.kb/visuals/table-cond-format.md`.
 Every file under a `*.Report` folder is hash-baselined by the engine run, and the orchestrator's
 pre-sign-off `check_migration_progress.py --bundle <b> --tamper` exits **1** on any that changed
 without a matching declaration. `scripts/declare_generated_edit.py` is the **only** thing that writes
-one: it runs your `_build/` script for you and records the before/after hashes into
-`_build/generated-edit-declarations.json`.
+one: it runs your `_build/` script for you and records the before/after hashes as one append-only
+`_build/generated-edit-declarations/*.json` file.
 
 ```bash
 python scripts/declare_generated_edit.py --bundle <b> \
   --target pbip/<WB>/<WB>.Report/definition/pages/<p>/visuals/<id>/visual.json \
   --script <b>/_build/fix_axis_title.py \
   -- --only pbip/<WB>/<WB>.Report/definition/pages/<p>/visuals/<id>/visual.json
-# DECLARE: RECORDED pbip/.../visual.json -> <b>/_build/generated-edit-declarations.json
+# DECLARE: RECORDED pbip/.../visual.json -> <b>/_build/generated-edit-declarations/<timestamp...>.json
 ```
 
 Measured — each of these leaves the gate RED while looking like it worked:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -528,18 +528,11 @@ exists so each question is answered once per migration, not once per session.
   | working copy | `<bundle>/pbip/` | agents edit **here**; every edit re-runnable from `_build/` and declared |
   | deliverable | `migrations/{workbooks,datasources}/<slug>/fabric/` | **COPIED at sign-off**, so the bundle survives as evidence |
 
-  A bundle is `<bundle>/{pbip,reports,semantic_models,handover,data}` — **no `out/` level** — and the
-  two sides differ in shape, so compare the matching **pair**, with **git** (✅ measured 2026-08-13;
-  bare `diff` on Windows is a PowerShell alias for `Compare-Object`, which given two directories
-  compares the two path *strings* and prints a confident non-answer):
+  A bundle is `<bundle>/{pbip,reports,semantic_models,handover,data}` — **no `out/` level**. Keep
+  `reports/` pristine so it remains the exact answer to *"what did our tier change versus what the
+  engine produced?"* — rewriting it cost a retracted upstream bug on 2026-08-10. Use git for that
+  comparison; the mechanics live in `powerbi-report-gotchas` §3.
 
-  `git diff --no-index --stat <bundle>/reports/<WB>.Report <bundle>/pbip/<WB>/<WB>.Report`
-  → *98 files changed, 2013 insertions(+), 553 deletions(-)*; **exit 1 = they differ** — but git also
-  exits 1 on `error: Could not access`, the likely slip here, so **check for a stat line**, not the code.
-
-  Keeping `reports/` pristine is what makes that an exact answer to *"what did our tier change versus
-  what the engine produced?"* — that cost a retracted upstream bug on 2026-08-10 (our fix pass had
-  rewritten `reports/`, and the diff was read as engine behaviour).
   ⚠️ **The copy must keep
   `definition.pbir`'s `byPath` resolving** — plain copy for a per-workbook model, path rewrite for a
   shared datasource; never ship `<bundle>/reports/` (reference-only: no model beside it). Mechanics:

--- a/scripts/sync_agent_conventions.py
+++ b/scripts/sync_agent_conventions.py
@@ -53,6 +53,13 @@ AGENTS_DIR = REPO_ROOT / ".github" / "agents"
 
 BEGIN = "<!-- BEGIN:shared-conventions -->"
 END = "<!-- END:shared-conventions -->"
+SKILL_INDEX_BEGIN = "<!-- BEGIN:generated-skill-index:{skill} -->"
+SKILL_INDEX_END = "<!-- END:generated-skill-index:{skill} -->"
+SECTION_HEADING = re.compile(r"^##\s+(\d+)\.\s+(.+)$", re.MULTILINE)
+SKILL_INDEX_TARGETS = {
+    "pbi-report-builder.agent.md": "powerbi-report-gotchas",
+    "pbi-semantic-builder.agent.md": "powerbi-semantic-model-gotchas",
+}
 
 # GitHub documents a 30,000-character maximum for a custom agent prompt
 # (docs.github.com/en/copilot/reference/custom-agents-configuration).
@@ -141,6 +148,47 @@ def canonical_block() -> str:
 
 def _rendered() -> str:
     return f"{BEGIN}\n{PREAMBLE}\n{canonical_block()}\n{END}"
+
+
+def skill_section_index(skill_name: str) -> str:
+    """Generate the persona-visible section index from a skill's own headings."""
+    skill_path = REPO_ROOT / ".github" / "skills" / skill_name / "SKILL.md"
+    text = skill_path.read_text(encoding="utf-8")
+    rows = [(number, heading.strip()) for number, heading in SECTION_HEADING.findall(text)]
+    if not rows:
+        raise SystemExit(f"{skill_path.relative_to(REPO_ROOT)} has no numbered section headings")
+    table = [
+        f"<!-- BEGIN:generated-skill-index:{skill_name} -->",
+        "**Generated skill section index.** Do not hand-edit this table; it is generated from the "
+        f"`{skill_name}` skill headings by `scripts/sync_agent_conventions.py`. If a row matches "
+        "what you are about to build or debug, invoke/read the skill section first.",
+        "",
+        "| § | Skill section |",
+        "|---|---|",
+    ]
+    table.extend(f"| {number} | {heading} |" for number, heading in rows)
+    table.append(f"<!-- END:generated-skill-index:{skill_name} -->")
+    return "\n".join(table)
+
+
+def apply_skill_index(path: Path, write: bool) -> bool:
+    """Refresh a generated skill section index in one persona, when it has one."""
+    skill_name = SKILL_INDEX_TARGETS.get(path.name)
+    if skill_name is None:
+        return False
+    text = path.read_text(encoding="utf-8")
+    begin = SKILL_INDEX_BEGIN.format(skill=skill_name)
+    end = SKILL_INDEX_END.format(skill=skill_name)
+    if begin not in text or end not in text:
+        raise SystemExit(f"{path.relative_to(REPO_ROOT)} is missing generated index fences for {skill_name}")
+    head, rest = text.split(begin, 1)
+    _, tail = rest.split(end, 1)
+    updated = f"{head.rstrip()}\n\n{skill_section_index(skill_name)}\n\n{tail.lstrip()}"
+    if updated == text:
+        return False
+    if write:
+        path.write_text(updated, encoding="utf-8")
+    return True
 
 
 def _split_frontmatter(text: str) -> tuple[str, str]:
@@ -299,6 +347,17 @@ def check_bundle_paths(bundle: Path | None) -> list[str]:
     return problems
 
 
+def sync_agent_files(agents: list[Path], write: bool) -> list[Path]:
+    """Refresh generated convention blocks and generated skill indexes."""
+    drifted = []
+    for agent in agents:
+        conventions_changed = apply_to(agent, write=write)
+        index_changed = apply_skill_index(agent, write=write)
+        if conventions_changed or index_changed:
+            drifted.append(agent)
+    return drifted
+
+
 def report_sizes(agents: list[Path]) -> list[Path]:
     """Warn about personas over the documented prompt cap. Returns the over-cap files."""
     over = [p for p in agents if prompt_size(p) > PROMPT_CHAR_LIMIT]
@@ -343,7 +402,7 @@ def main(argv: list[str] | None = None) -> int:
     # Order matters: sync first, then check paths. In write mode the check must see the state this run
     # leaves on disk, not the one it replaced - otherwise a run that FIXES a bad path still reports it
     # (observed while testing this change), and the operator "fixes" an already-fixed file.
-    drifted = [p for p in agents if apply_to(p, write=not args.check)]
+    drifted = sync_agent_files(agents, write=not args.check)
     path_problems = check_bundle_paths(args.bundle)
 
     if args.check:


### PR DESCRIPTION
Fixes six drifted persona duplicates by deleting or generating stale copies, relocates the shared git-diff mechanics into the report gotchas skill, and keeps protected verdict/ownership rules intact.\n\nValidation:\n- python scripts/sync_agent_conventions.py --check\n- python scripts/check_navigation_index.py\n- python scripts/check_agent_capabilities.py\n- python -m pytest -q tests/test_sync_agent_conventions.py tests/test_agent_capabilities.py tests/test_repo_layout.py\n- python -m ruff format scripts\n- python -m ruff check scripts --fix\n- python -m pylint scripts