### PR TITLE
Make gate output actionable

### DIFF
--- a/scripts/check_field_bindings.py
+++ b/scripts/check_field_bindings.py
@@ -799,7 +799,7 @@ def _merge(pairs: list[dict[str, Any]], skipped: list[dict[str, Any]]) -> dict[s
 FAILING_STATUSES = frozenset({"UNRESOLVED", "INCOHERENT"})
 
 
-def render(report: dict[str, Any]) -> str:
+def render(report: dict[str, Any], *, verbose: bool = False) -> str:
     """Human-readable verdict, in the shape the sibling gates use."""
     if report["status"] == "SKIPPED":
         reasons = "; ".join(s["reason"] for s in report.get("skipped", [])) or "no report found"
@@ -807,30 +807,32 @@ def render(report: dict[str, Any]) -> str:
     scanned = report["reports_scanned"]
     # A skipped report is invisible in the pass count, so name it here too: "OK - 1 report(s)" on a
     # two-report bundle reads as full coverage when half of it was never checked.
-    tail = _skipped_tail(report)
+    tail = _skipped_tail(report, verbose=verbose)
     if report["status"] == "OK":
         return (
             f"FIELD BINDING CHECK: OK - every PBIR field reference in {scanned} report(s) resolves in its model.{tail}"
         )
     lines = [_headline(report, scanned, tail)]
+    inline_small_evidence = report["reports_unresolved"] + report["reports_incoherent"] <= 3
     for one in report["reports"]:
         if one["status"] not in FAILING_STATUSES:
             continue
-        lines.append(f"  {Path(one['report']).name}  (model: {Path(one['model']).name})")
-        lines += _render_findings(one["findings"], "near_miss")
-        lines += _render_findings(one["findings"], "missing")
-        lines += _render_coherence(one.get("coherence") or [])
-    if report["missing"] or report["near_misses"]:
+        lines += _render_report_summary(one, verbose=verbose, inline_small_evidence=inline_small_evidence)
+    if report["near_misses"]:
         lines.append(
-            "  A CASE-ONLY near-miss is a model-layer rename that never reached the report: rewrite the\n"
-            "  PBIR spelling to the model's, do NOT rename the model back - the fold was deliberate."
+            "  NEAR-MISS = model-layer rename that never reached the report; rewrite PBIR to the model spelling."
+        )
+    if report["missing"]:
+        lines.append(
+            "  MISSING   = field/table absent from the model; add it to TMDL or rebind/remove the PBIR reference."
         )
     if report.get("incoherent_visuals"):
         lines.append(
-            "  UNRELATED TABLES is what Desktop raises as InvalidUnconstrainedJoin - every field\n"
-            "  resolves, so this NEVER appears in a per-field check. Rebind the odd table out, or add\n"
-            "  the missing relationship; a listed AMBIGUOUS name is the likely mis-bind."
+            "  UNRELATED TABLES = visual fields resolve but Power BI cannot join their tables; rebind the odd table "
+            "out, or add/activate the relationship."
         )
+    if not verbose:
+        lines.append("  Run with --verbose to list every field, visual, and skipped report behind these counts.")
     return "\n".join(lines)
 
 
@@ -849,13 +851,37 @@ def _headline(report: dict[str, Any], scanned: int, tail: str) -> str:
     )
 
 
-def _skipped_tail(report: dict[str, Any]) -> str:
-    """Name the reports that were NOT graded, so a partial sweep cannot read as a full one."""
+def _skipped_tail(report: dict[str, Any], *, verbose: bool) -> str:
+    """Name or summarize reports that were NOT graded, so a partial sweep cannot read as a full one."""
     skipped = report.get("skipped") or []
     if not skipped:
         return ""
-    names = ", ".join(f"{Path(s['report']).name} ({s['reason']})" for s in skipped)
-    return f"\n  {len(skipped)} report(s) SKIPPED, not checked: {names}"
+    if verbose or len(skipped) <= 3:
+        names = ", ".join(f"{Path(s['report']).name} ({s['reason']})" for s in skipped)
+        return f"\n  {len(skipped)} report(s) SKIPPED, not checked: {names}"
+    counts: dict[str, int] = {}
+    for item in skipped:
+        counts[item["reason"]] = counts.get(item["reason"], 0) + 1
+    reasons = "; ".join(f"{count} {reason}" for reason, count in sorted(counts.items()))
+    return f"\n  {len(skipped)} report(s) SKIPPED, not checked ({reasons}; use --verbose for names)"
+
+
+def _render_report_summary(one: dict[str, Any], *, verbose: bool, inline_small_evidence: bool) -> list[str]:
+    """Render one report as category counts by default, with lossless evidence in verbose mode."""
+    lines = [f"  {Path(one['report']).name}  (model: {Path(one['model']).name})"]
+    inline_fields = verbose or (inline_small_evidence and one["near_misses"] + one["missing"] <= 3)
+    if one["near_misses"]:
+        lines.append(f"    - NEAR-MISS (case only): {one['near_misses']} reference(s)")
+    if one["missing"]:
+        lines.append(f"    - MISSING: {one['missing']} reference(s)")
+    if one.get("incoherent_visuals"):
+        lines.append(f"    - UNRELATED TABLES: {one['incoherent_visuals']} visual(s)")
+    if inline_fields:
+        lines += _render_findings(one["findings"], "near_miss")
+        lines += _render_findings(one["findings"], "missing")
+    if verbose or one.get("incoherent_visuals"):
+        lines += _render_coherence(one.get("coherence") or [])
+    return lines
 
 
 def _render_findings(findings: list[dict[str, Any]], status: str) -> list[str]:
@@ -901,6 +927,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--report", type=Path, help="explicit .Report folder (use with --model)")
     parser.add_argument("--json", type=Path, help="write the machine-readable verdict here")
     parser.add_argument("--quiet", action="store_true", help="suppress the rendered verdict")
+    parser.add_argument("--verbose", action="store_true", help="also list every field, visual, and skipped report")
     parser.add_argument("--warn-only", action="store_true", help="always exit 0")
     args = parser.parse_args(argv)
 
@@ -928,7 +955,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.json:
         args.json.write_text(json.dumps(merged, indent=2) + "\n", encoding="utf-8")
     if not args.quiet:
-        print(render(merged))
+        print(render(merged, verbose=args.verbose))
     if args.warn_only or merged["status"] not in FAILING_STATUSES:
         return 0
     return 1

--- a/scripts/check_relationship_health.py
+++ b/scripts/check_relationship_health.py
@@ -254,7 +254,7 @@ def merge(models: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
-def render(report: dict[str, Any]) -> str:
+def render(report: dict[str, Any], *, verbose: bool = False) -> str:
     """Human-readable verdict, matching sibling offline gates."""
     if report["status"] == STATUS_SKIPPED:
         return "RELATIONSHIP HEALTH CHECK: SKIPPED - nothing measured (no semantic model or TMDL files found)"
@@ -278,13 +278,29 @@ def render(report: dict[str, Any]) -> str:
             f"{model['relationship_components']} component(s), Date tables: {', '.join(model['date_tables'])}"
         )
         for finding in model["findings"]:
-            columns = ", ".join(finding["date_columns"])
-            lines.append(f"    - {finding['table']} has date column(s) [{columns}] but no path to Date/Calendar")
+            lines.append(_render_finding(finding, verbose=verbose))
     lines.append(
-        "  This is a model-owner decision: add the intended relationship, or document why the fact-like table "
-        "is disconnected."
+        "  MISSING_RELATIONSHIP = add the intended relationship to Date/Calendar, or document why this "
+        "fact-like table is intentionally disconnected."
     )
+    if not verbose:
+        lines.append("  Run with --verbose to list the date-like columns behind each table count.")
     return "\n".join(lines)
+
+
+def _render_finding(finding: dict[str, Any], *, verbose: bool) -> str:
+    """Render one stranded table, keeping column evidence optional."""
+    count = len(finding["date_columns"])
+    if not verbose:
+        return f"    - {finding['table']} has {count} date-like column(s) but no path to Date/Calendar"
+    columns = ", ".join(_column_with_line(finding, column) for column in finding["date_columns"])
+    return f"    - {finding['table']} has {count} date-like column(s) [{columns}] but no path to Date/Calendar"
+
+
+def _column_with_line(finding: dict[str, Any], column: str) -> str:
+    """Render a date-like column with its TMDL line when available."""
+    line = finding.get("date_column_lines", {}).get(column)
+    return f"{column}:{line}" if line else column
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -293,6 +309,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("paths", nargs="*", type=Path, help="bundle folder(s) or .SemanticModel folder(s)")
     parser.add_argument("--json", type=Path, help="write the machine-readable verdict here")
     parser.add_argument("--quiet", action="store_true", help="suppress the rendered verdict")
+    parser.add_argument("--verbose", action="store_true", help="also list the date-like columns behind each count")
     parser.add_argument("--warn-only", action="store_true", help="always exit 0 after a successful scan")
     args = parser.parse_args(argv)
 
@@ -306,7 +323,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.json:
         args.json.write_text(json.dumps(merged, indent=2) + "\n", encoding="utf-8")
     if not args.quiet:
-        print(render(merged))
+        print(render(merged, verbose=args.verbose))
     if args.warn_only:
         return EXIT_OK
     if merged["status"] == STATUS_SKIPPED:

--- a/scripts/check_sqlproxy_connections.py
+++ b/scripts/check_sqlproxy_connections.py
@@ -270,11 +270,11 @@ def _workbooks(value: Any) -> list[dict[str, Any]]:
     return []
 
 
-def render(report: dict[str, Any]) -> str:
+def render(report: dict[str, Any], *, verbose: bool = False) -> str:
     """Human-readable verdict, matching the sibling offline gates."""
     if report["status"] == STATUS_SKIPPED:
         return "SQLPROXY CONNECTION CHECK: SKIPPED - nothing measured (no semantic model or TMDL files found)"
-    warning_tail = _warning_tail(report)
+    warning_tail = _warning_tail(report, verbose=verbose)
     if report["status"] == STATUS_OK:
         return (
             f"SQLPROXY CONNECTION CHECK: OK - no sqlproxy-derived connection parameters in "
@@ -296,19 +296,30 @@ def render(report: dict[str, Any]) -> str:
                 f"({finding['tmdl']}:{finding['database_line'] or finding['server_line']})"
             )
     lines.append(
-        "  Database_sqlproxy* names the Tableau published datasource that must be migrated or rebound; "
-        "Power BI cannot query Tableau sqlproxy directly."
+        "  SQLPROXY = replace the Tableau sqlproxy parameters with the real upstream connection, or migrate "
+        "and rebind the published datasource first."
     )
+    if report.get("warnings"):
+        lines.append(
+            "  SECONDARY_DATASOURCES WARN = engine telemetry says these built workbooks depend on secondary "
+            "published datasources; verify they were migrated before trusting the report."
+        )
     return "\n".join(lines)
 
 
-def _warning_tail(report: dict[str, Any]) -> str:
+def _warning_tail(report: dict[str, Any], *, verbose: bool) -> str:
     """Render at-risk report.json telemetry without changing the blocking verdict."""
     risks = report.get("at_risk_workbooks") or []
     if not risks:
         return ""
-    names = ", ".join(f"{risk['workbook']} ({len(risk['secondary_datasources'])} secondary)" for risk in risks)
-    return f"\n  WARN: {len(risks)} built workbook(s) declare secondary_datasources in binding_signal: {names}"
+    if verbose or len(risks) <= 3:
+        names = ", ".join(f"{risk['workbook']} ({len(risk['secondary_datasources'])} secondary)" for risk in risks)
+        return f"\n  WARN: {len(risks)} built workbook(s) declare secondary_datasources in binding_signal: {names}"
+    total = sum(len(risk["secondary_datasources"]) for risk in risks)
+    return (
+        f"\n  WARN: {len(risks)} built workbook(s) declare {total} secondary_datasource reference(s) "
+        "in binding_signal (use --verbose for workbook names)"
+    )
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -318,6 +329,9 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--model", type=Path, help="explicit .SemanticModel folder")
     parser.add_argument("--json", type=Path, help="write the machine-readable verdict here")
     parser.add_argument("--quiet", action="store_true", help="suppress the rendered verdict")
+    parser.add_argument(
+        "--verbose", action="store_true", help="also list workbook names behind secondary-datasource warnings"
+    )
     parser.add_argument("--warn-only", action="store_true", help="always exit 0 after a successful scan")
     args = parser.parse_args(argv)
 
@@ -337,7 +351,7 @@ def main(argv: list[str] | None = None) -> int:
     if args.json:
         args.json.write_text(json.dumps(merged, indent=2) + "\n", encoding="utf-8")
     if not args.quiet:
-        print(render(merged))
+        print(render(merged, verbose=args.verbose))
     if args.warn_only:
         return EXIT_OK
     if merged["status"] == STATUS_SKIPPED:

--- a/tests/golden/check-gates-dirty/field-bindings.stdout
+++ b/tests/golden/check-gates-dirty/field-bindings.stdout
@@ -1,6 +1,9 @@
 FIELD BINDING CHECK: UNRESOLVED - 1 of 1 report(s) reference fields their model does not have (1 case-only near-miss(es), 1 missing)
   Admin_Insights_Starter.Report  (model: Admin_Insights_Starter.SemanticModel)
+    - NEAR-MISS (case only): 1 reference(s)
+    - MISSING: 1 reference(s)
     - NEAR-MISS (case only): report: _Measures[avg(0)]   model: _Measures[Avg(0)]  [Measure x1]
     - MISSING: report: sqlproxy[group_name]  [Column x1]
-  A CASE-ONLY near-miss is a model-layer rename that never reached the report: rewrite the
-  PBIR spelling to the model's, do NOT rename the model back - the fold was deliberate.
+  NEAR-MISS = model-layer rename that never reached the report; rewrite PBIR to the model spelling.
+  MISSING   = field/table absent from the model; add it to TMDL or rebind/remove the PBIR reference.
+  Run with --verbose to list every field, visual, and skipped report behind these counts.

--- a/tests/golden/check-gates-dirty/relationship-health.stdout
+++ b/tests/golden/check-gates-dirty/relationship-health.stdout
@@ -1,4 +1,5 @@
 RELATIONSHIP HEALTH CHECK: MISSING_RELATIONSHIP - 1 date-bearing table(s) stranded from Date/Calendar in 1 of 1 model(s); 1 active relationship(s).
   Admin_Insights_Starter.SemanticModel: 1 active relationship(s), 3 component(s), Date tables: Date
-    - sqlproxy has date column(s) [Calculation_920704701759684608] but no path to Date/Calendar
-  This is a model-owner decision: add the intended relationship, or document why the fact-like table is disconnected.
+    - sqlproxy has 1 date-like column(s) but no path to Date/Calendar
+  MISSING_RELATIONSHIP = add the intended relationship to Date/Calendar, or document why this fact-like table is intentionally disconnected.
+  Run with --verbose to list the date-like columns behind each table count.

--- a/tests/golden/check-gates-dirty/sqlproxy-connections.stdout
+++ b/tests/golden/check-gates-dirty/sqlproxy-connections.stdout
@@ -2,4 +2,5 @@ SQLPROXY CONNECTION CHECK: SQLPROXY - 1 sqlproxy-derived connection pair(s) in 1
   WARN: 1 built workbook(s) declare secondary_datasources in binding_signal: Admin_Insights_Starter (1 secondary)
   Admin_Insights_Starter.SemanticModel
     - Server_sqlproxy='10ax.online.tableau.com' / Database_sqlproxy='TSEvents' (Admin_Insights_Starter.SemanticModel/definition/expressions.tmdl:3)
-  Database_sqlproxy* names the Tableau published datasource that must be migrated or rebound; Power BI cannot query Tableau sqlproxy directly.
+  SQLPROXY = replace the Tableau sqlproxy parameters with the real upstream connection, or migrate and rebind the published datasource first.
+  SECONDARY_DATASOURCES WARN = engine telemetry says these built workbooks depend on secondary published datasources; verify they were migrated before trusting the report.


### PR DESCRIPTION
References #296.\n\n## Summary\n- collapse repeated gate evidence into counts by default\n- add --verbose detail mode for field bindings, relationship health, and sqlproxy warnings\n- update dirty-gate goldens for the deliberate prose changes\n\n## Validation\n- ruff format scripts/check_field_bindings.py scripts/check_relationship_health.py scripts/check_sqlproxy_connections.py\n- ruff check scripts/check_field_bindings.py scripts/check_relationship_health.py scripts/check_sqlproxy_connections.py --fix\n- python -m pytest tests/test_check_unit.py tests/test_dirty_gate_snapshots.py -q\n- python -m pylint scripts