### PR TITLE
docs: stop telling agents the deployer does not exist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -387,11 +387,19 @@ under the plugin, it is upstream — even when we also ship a mitigation on our 
 *our* tier (`scripts/`, the personas, the skills, the docs). When both apply, file upstream and keep a
 local issue only for the mitigation, cross-linked — never a second copy of the defect report.
 
-**Where does the output go?** Be honest about this rather than promising: **local PBIP is the only
-supported target today.** There is no publish step in this repo — `pbi-deployer` is phase 2 and does
-not exist yet. Getting a finished model/report into a Fabric workspace is a manual `fab import` or a
-Desktop publish. So the target question is not "local or Fabric?" but *"note the destination
-workspace in the brief so the manual publish is unambiguous."* Do not imply an automated deploy.
+**Where does the output go?** A migration produces a **local PBIP bundle**; publishing it is a
+separate, deliberate step — and that step has a tool. `scripts/deploy_estate.py` lands a bundle in an
+**existing** Fabric landing-zone workspace: models first, each report rebound from `byPath` to
+`byConnection` once its model exists, crash-safe by a run journal. Run `--dry-run` first — it reports
+the plan and the **item count**, which is the number a customer agrees before you deploy. Mechanics
+and the three tenant-measured facts it encodes: `scripts/README.md`; post-deploy check:
+`verify_bindings.py`.
+
+What it deliberately does **not** decide is **topology**. It takes ONE `--workspace` and never creates
+one, so cross-workspace shared-model binding, permission mapping and promotion out of the landing zone
+remain human decisions (#57). So the target question is not "local or Fabric?" but *"name the
+destination workspace in the brief, and say whether this run stops at the bundle or goes on to
+deploy."*
 
 ### Step 2 — five questions, asked ONCE, in one message
 

--- a/README.md
+++ b/README.md
@@ -413,8 +413,11 @@ workbooks; the patterns live in `docs/tableau-dax-translation-guide.md`.
 - **In progress:** re-rendering the origin-destination line map (`telecommunications-analytics`,
   `superstore-sales-performance`) and the Azure Maps choropleths, whose Desktop renders are being
   redone before they are featured as verified.
-- **Not built yet:** a `pbi-deployer` agent to publish to a Fabric workspace, refresh, and run a
-  screenshot-based fidelity check as an automated closing step.
+- **Not built yet:** a `pbi-deployer` *agent*. The deployment **script** already exists —
+  `scripts/deploy_estate.py` lands an estate in a Fabric landing-zone workspace (models first, each
+  report rebound to its deployed model), with `verify_bindings.py` as the post-deploy check. What is
+  missing is the agent that drives them, refreshes, and runs a screenshot-based fidelity check as an
+  automated closing step — plus the multi-workspace topology decisions tracked in #57.
 
 Contributions, especially additional worked examples against different Tableau workbooks, are welcome.
 


### PR DESCRIPTION
Fixes the doc-drift half of #314. Does not close #57 — that keeps its topology half.

## What was wrong

`AGENTS.md:391-394`, in the DISPATCHER section every migration starts from:

> **There is no publish step in this repo — `pbi-deployer` is phase 2 and does not exist yet.** … Do not imply an automated deploy.

`README.md:416-417`:

> **Not built yet:** a `pbi-deployer` agent to publish to a Fabric workspace, refresh, and run a screenshot-based fidelity check as an automated closing step.

master ships **`scripts/deploy_estate.py`, 1,707 lines**, with a **1,601-line** test suite. It landed via PR #105 and is documented at length in `scripts/README.md:41`.

## What this changes

Both now state what is true, and — more usefully — what is *genuinely* still missing:

- the **agent** that drives the script (the README wording was closer to defensible than AGENTS.md's; it just mislabelled a partially-delivered capability as absent)
- the refresh + screenshot-fidelity **closing step**
- **multi-workspace topology** — the script takes ONE `--workspace` and never creates one, so cross-workspace shared-model binding, permission mapping and promotion out of the landing zone stay human decisions

That last distinction is what #57 still tracks.

## What this deliberately does NOT do

**No `docs/INDEX.md` entry.** My own issue #314 asserted its absence was part of the defect. Checking that before acting showed it was wrong: `check_navigation_index.py:61` scopes the index to `scripts/check_*.py` gates only, and `INDEX.md:25` routes all scripts through `scripts/README.md`, which already carries a full `deploy_estate.py` entry naming `tableau-migrator` as its consumer. Adding an entry would re-introduce exactly the flattening PR #302 removed. I have corrected #314 accordingly.

## Verification

```
sync_agent_conventions.py --check   EXIT=0
check_navigation_index.py           EXIT=0
check_agent_capabilities.py         EXIT=0
pytest test_sync_agent_conventions test_repo_layout test_build_plugin   74 passed, EXIT=0
```

Confirmed the diff does not touch the generated `BEGIN/END:shared-conventions` block, so no persona is affected and no re-sync is needed. Docs only — no Python changed, so no ruff/pylint roots apply.
