### PR TITLE
feat(gates): warn before a persona hits the prompt cap, not at it

### DIFF
--- a/scripts/sync_agent_conventions.py
+++ b/scripts/sync_agent_conventions.py
@@ -69,6 +69,15 @@ SKILL_INDEX_TARGETS = {
 # and in these files the tail is the accumulated `## Gotchas` - precisely the hard-won learnings.
 PROMPT_CHAR_LIMIT = 30_000
 
+# Warn before it is urgent. Measured 2026-08-15 (issue #181): `pbi-report-builder` reached
+# 29,941/30,000 - **59 characters** of headroom - and nothing said so until a one-word edit would have
+# turned CI red. The trap is that the shared-conventions block is GENERATED, so an edit that targets
+# `AGENTS.md` propagates into all four personas and fails the build via a file the author never
+# opened. A band below the hard cap turns that ambush into notice.
+# 97% leaves ~900 characters, which is roughly one paragraph - enough to land the edit in hand and
+# then buy headroom back, rather than discovering it mid-change.
+PROMPT_NEAR_CAP_LIMIT = 29_100
+
 # The canonical bundle layout, so a documented path can be checked against reality rather than only
 # against the other copies of itself. `<bundle>/out/pbip/` survived in AGENTS.md and all four personas
 # for weeks (issue #123) precisely because every copy agreed: consistency was the ONLY thing checked,
@@ -358,12 +367,31 @@ def sync_agent_files(agents: list[Path], write: bool) -> list[Path]:
     return drifted
 
 
+def near_cap(agents: list[Path]) -> list[Path]:
+    """Personas inside the warning band: past the near-cap line but still UNDER the hard cap.
+
+    Deliberately excludes over-cap files. Those already fail loudly via `report_sizes`, and listing
+    a file under both headings would put a quiet advisory in competition with a hard verdict - the
+    reader then has to work out which one governs.
+    """
+    return [p for p in agents if PROMPT_NEAR_CAP_LIMIT < prompt_size(p) <= PROMPT_CHAR_LIMIT]
+
+
 def report_sizes(agents: list[Path]) -> list[Path]:
-    """Warn about personas over the documented prompt cap. Returns the over-cap files."""
+    """Warn about personas over the documented prompt cap. Returns the over-cap files.
+
+    The near-cap band is advisory ONLY: it is never added to the returned list, because that list
+    drives the exit code. A warning that fails the build is not a warning.
+    """
     over = [p for p in agents if prompt_size(p) > PROMPT_CHAR_LIMIT]
     for path in sorted(agents, key=prompt_size, reverse=True):
         size = prompt_size(path)
-        marker = "  OVER CAP" if size > PROMPT_CHAR_LIMIT else ""
+        if size > PROMPT_CHAR_LIMIT:
+            marker = "  OVER CAP"
+        elif size > PROMPT_NEAR_CAP_LIMIT:
+            marker = "  NEAR CAP"
+        else:
+            marker = ""
         log.info("  %6d chars (%3d%% of cap)  %s%s", size, 100 * size // PROMPT_CHAR_LIMIT, path.name, marker)
     if over:
         log.warning(
@@ -372,6 +400,22 @@ def report_sizes(agents: list[Path]) -> list[Path]:
             "files is the accumulated Gotchas. Trim before relying on the hosted path.",
             len(over),
             PROMPT_CHAR_LIMIT,
+        )
+    close = near_cap(agents)
+    if close:
+        log.warning(
+            "%d persona(s) are within %d chars of the %d-char cap and will fail on the next small "
+            "edit - including one aimed at AGENTS.md, which regenerates the shared block into ALL "
+            "four personas and so fails the build via a file you never opened. Buy headroom now: "
+            "move craft knowledge into a .github/skills/ bundle the persona already invokes by name "
+            "(that is how pbi-report-builder went from 153%% to under the cap). Not a failure: %s",
+            len(close),
+            PROMPT_CHAR_LIMIT - PROMPT_NEAR_CAP_LIMIT,
+            PROMPT_CHAR_LIMIT,
+            ", ".join(
+                f"{p.name} ({PROMPT_CHAR_LIMIT - prompt_size(p)} left)"
+                for p in sorted(close, key=prompt_size, reverse=True)
+            ),
         )
     return over
 

--- a/tests/test_sync_agent_conventions.py
+++ b/tests/test_sync_agent_conventions.py
@@ -249,3 +249,77 @@ def test_a_conditionally_written_root_file_warns_but_does_not_fail(repo, tmp_pat
 def test_this_repo_passes_its_own_gate() -> None:
     """No monkeypatching: the shipped AGENTS.md and personas must satisfy the rule they publish."""
     assert sac.check_bundle_paths(None) == []
+
+
+# ---------------------------------------------------------------------------
+# The near-cap warning band (issue #181).
+#
+# `pbi-report-builder` reached 29,941/30,000 - 59 characters - and nothing said so until an edit
+# would have turned CI red. Worse, the shared block is GENERATED, so an edit aimed at AGENTS.md
+# fails the build via a persona the author never opened. These tests pin the two properties that
+# make the band useful rather than merely present: it must exclude the over-cap files that already
+# fail loudly, and it must NEVER reach the exit code.
+# ---------------------------------------------------------------------------
+
+
+def _persona_of_size(path: Path, size: int) -> Path:
+    """Write a file whose `prompt_size` is exactly `size`, so boundaries can be asserted."""
+    path.write_text("x" * size, encoding="utf-8")
+    assert sac.prompt_size(path) == size, "fixture must hit the size exactly or the boundary tests lie"
+    return path
+
+
+def test_near_cap_band_catches_a_file_just_inside_it(tmp_path: Path) -> None:
+    """One character past the line is the whole point: the warning must fire BEFORE the cap."""
+    agent = _persona_of_size(tmp_path / "tight.agent.md", sac.PROMPT_NEAR_CAP_LIMIT + 1)
+    assert sac.near_cap([agent]) == [agent]
+
+
+def test_the_near_cap_line_itself_is_not_in_the_band(tmp_path: Path) -> None:
+    """Exclusive boundary. Pins `>` against a `>=` mutation that would warn a character early."""
+    agent = _persona_of_size(tmp_path / "exact.agent.md", sac.PROMPT_NEAR_CAP_LIMIT)
+    assert sac.near_cap([agent]) == []
+
+
+def test_a_comfortable_persona_is_not_in_the_band(tmp_path: Path) -> None:
+    """The negative case beside the positive one: a normal persona must stay silent."""
+    agent = _persona_of_size(tmp_path / "roomy.agent.md", sac.PROMPT_NEAR_CAP_LIMIT - 1)
+    assert sac.near_cap([agent]) == []
+
+
+def test_a_file_exactly_at_the_cap_is_near_cap_and_not_over(tmp_path: Path) -> None:
+    """`> PROMPT_CHAR_LIMIT` is what fails, so the cap itself is the last warnable size."""
+    agent = _persona_of_size(tmp_path / "brink.agent.md", sac.PROMPT_CHAR_LIMIT)
+    assert sac.near_cap([agent]) == [agent]
+    assert sac.report_sizes([agent]) == []
+
+
+def test_an_over_cap_persona_is_excluded_from_the_band(tmp_path: Path) -> None:
+    """It already fails loudly. Listing it twice puts an advisory in competition with a verdict.
+
+    This also pins the upper bound of the band: drop `<= PROMPT_CHAR_LIMIT` and this test fails.
+    """
+    agent = _persona_of_size(tmp_path / "over.agent.md", sac.PROMPT_CHAR_LIMIT + 1)
+    assert sac.near_cap([agent]) == []
+    assert sac.report_sizes([agent]) == [agent]
+
+
+def test_near_cap_never_reaches_the_exit_code(tmp_path: Path) -> None:
+    """The load-bearing property. `report_sizes`'s return drives `main`'s exit code, so a near-cap
+    persona must come back as zero over-cap files - a warning that fails the build is not a warning.
+    """
+    agent = _persona_of_size(tmp_path / "warnonly.agent.md", sac.PROMPT_NEAR_CAP_LIMIT + 500)
+    assert sac.near_cap([agent]) == [agent]
+    assert sac.report_sizes([agent]) == []
+
+
+def test_the_band_sits_below_the_cap() -> None:
+    """A near-cap limit at or above the cap would make the warning unreachable."""
+    assert 0 < sac.PROMPT_NEAR_CAP_LIMIT < sac.PROMPT_CHAR_LIMIT
+
+
+def test_this_repo_is_not_currently_in_the_band() -> None:
+    """No monkeypatching. If this fails, the warning is doing its job - buy headroom, do not delete
+    this test. Shipped sizes were 27,414-28,414 when the band was introduced.
+    """
+    assert sac.near_cap(sorted((REPO_ROOT / ".github" / "agents").glob("*.agent.md"))) == []

--- a/tests/test_sync_agent_conventions.py
+++ b/tests/test_sync_agent_conventions.py
@@ -19,6 +19,7 @@ outcome, so the negative case is asserted beside every positive one.
 
 from __future__ import annotations
 
+import logging
 import sys
 from pathlib import Path
 
@@ -318,8 +319,36 @@ def test_the_band_sits_below_the_cap() -> None:
     assert 0 < sac.PROMPT_NEAR_CAP_LIMIT < sac.PROMPT_CHAR_LIMIT
 
 
-def test_this_repo_is_not_currently_in_the_band() -> None:
-    """No monkeypatching. If this fails, the warning is doing its job - buy headroom, do not delete
-    this test. Shipped sizes were 27,414-28,414 when the band was introduced.
+def test_the_repo_personas_stay_under_the_HARD_cap() -> None:
+    """No monkeypatching, and deliberately the hard cap rather than the band.
+
+    An earlier version of this test asserted the shipped personas were not in the 97% BAND. Blind
+    review on PR #316 showed that defeats the whole design: `pytest -q` is a blocking step in
+    `.github/workflows/checks.yml`, so a persona at 98% - still inside its documented limit - would
+    turn CI red through pytest, exactly the build-break `report_sizes` is written to avoid. The band
+    is advisory; only the hard cap may fail a build, and it already does via `report_sizes`.
     """
-    assert sac.near_cap(sorted((REPO_ROOT / ".github" / "agents").glob("*.agent.md"))) == []
+    assert sac.report_sizes(sorted((REPO_ROOT / ".github" / "agents").glob("*.agent.md"))) == []
+
+
+def test_the_near_cap_warning_is_actually_EMITTED(tmp_path: Path, caplog) -> None:
+    """The band's whole value is the message a human reads, and list membership does not prove it.
+
+    Blind review deleted the `log.warning` call outright and all 30 tests still passed: every other
+    test here asserts a return value, and the warning is a side effect none of them observe. This
+    pins the visible behaviour - the file name and its exact remaining headroom.
+    """
+    agent = _persona_of_size(tmp_path / "loud.agent.md", sac.PROMPT_NEAR_CAP_LIMIT + 250)
+    with caplog.at_level(logging.WARNING, logger=sac.log.name):
+        sac.report_sizes([agent])
+    warnings = "\n".join(r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING)
+    assert "loud.agent.md" in warnings, "the warning must name the file, not just count personas"
+    assert "650 left" in warnings, "the warning must state the exact remaining headroom"
+
+
+def test_no_near_cap_warning_when_nothing_is_in_the_band(tmp_path: Path, caplog) -> None:
+    """The negative case beside the positive one: a comfortable persona must produce silence."""
+    agent = _persona_of_size(tmp_path / "quiet.agent.md", 20_000)
+    with caplog.at_level(logging.WARNING, logger=sac.log.name):
+        sac.report_sizes([agent])
+    assert [r for r in caplog.records if r.levelno >= logging.WARNING] == []

--- a/tests/test_sync_agent_conventions.py
+++ b/tests/test_sync_agent_conventions.py
@@ -342,8 +342,12 @@ def test_the_near_cap_warning_is_actually_EMITTED(tmp_path: Path, caplog) -> Non
     with caplog.at_level(logging.WARNING, logger=sac.log.name):
         sac.report_sizes([agent])
     warnings = "\n".join(r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING)
+    # Assert the INVARIANT (which file, how much headroom), never the phrasing around it. Blind
+    # review demonstrated that pinning "650 left" fails on a behaviour-preserving reword to
+    # "650 chars remaining" - a false alarm on a harmless edit. The looser form still catches both
+    # realistic regressions: a deleted warning and one downgraded to log.info both yield "".
     assert "loud.agent.md" in warnings, "the warning must name the file, not just count personas"
-    assert "650 left" in warnings, "the warning must state the exact remaining headroom"
+    assert "650" in warnings, "the warning must state the exact remaining headroom"
 
 
 def test_no_near_cap_warning_when_nothing_is_in_the_band(tmp_path: Path, caplog) -> None:


### PR DESCRIPTION
Implements the fourth acceptance criterion of #181. Deliberately does not use a closing keyword — the headroom half of that issue is separately done, and the owner should decide whether anything remains.

## Why

#181 was filed when `pbi-report-builder.agent.md` sat at **29,941 / 30,000 — 59 characters of headroom** — and nothing said so. Its fourth criterion:

> Consider whether `sync_agent_conventions.py` should **warn** above ~97% rather than only failing at 100%, so this is visible before it is urgent.

The headroom half is already fixed. Measured on master today:

```
28414 chars ( 94% of cap)  pbi-migration-validator.agent.md
28234 chars ( 94% of cap)  tableau-migrator.agent.md
27620 chars ( 92% of cap)  pbi-semantic-builder.agent.md
27414 chars ( 91% of cap)  pbi-report-builder.agent.md
```

What makes 59 characters dangerous rather than merely tight is the second-order effect the warning now names explicitly: **the shared-conventions block is generated**, so an edit aimed at `AGENTS.md` propagates into all four personas and fails the build via a file the author never opened.

## What it does

`PROMPT_NEAR_CAP_LIMIT = 29_100` (97%, ~900 chars ≈ one paragraph), plus `near_cap()`. Personas in the band get a `NEAR CAP` marker and a warning naming each file with its exact remaining characters.

```
INFO    30050 chars (100% of cap)  over.agent.md  OVER CAP
INFO    29500 chars ( 98% of cap)  near.agent.md  NEAR CAP
INFO    20000 chars ( 66% of cap)  comfortable.agent.md
WARNING 1 persona(s) exceed GitHub's documented 30000-char prompt cap. ...
WARNING 1 persona(s) are within 900 chars of the 30000-char cap and will fail on the next small
        edit - including one aimed at AGENTS.md, which regenerates the shared block into ALL four
        personas and so fails the build via a file you never opened. ... Not a failure:
        near.agent.md (500 left)
--- returned (drives exit code): ['over.agent.md']
```

**Two design constraints, both tested:**

1. **The band never reaches the exit code.** `report_sizes()`'s return drives `main()`'s exit code (`:442` → `:452`), so `near_cap` is never added to it. A warning that fails the build is not a warning.
2. **It excludes over-cap files.** They already fail loudly; listing a file under both headings puts a quiet advisory in competition with a hard verdict.

**No behaviour change today** — nothing is in the band, so CI output is unchanged until something genuinely approaches the cap.

## Verification

```
ruff format + ruff check --fix                        EXIT=0
pylint scripts                                        EXIT=0
pylint .github/skills/pbip-model-refresh/scripts      EXIT=0
pylint .github/skills/powerbi-ai-readiness/scripts    EXIT=0
pytest tests/test_sync_agent_conventions.py           30 passed
```

**Mutation-tested** — each mutation applied to the implementation, confirmed present in the file before running (a pattern that silently fails to match reads as "caught" and has produced false confidence here before):

| mutation | result |
|---|---|
| lower bound `>` → `>=` | **CAUGHT** |
| drop upper bound, over-cap leaks into the band | **CAUGHT** |
| `return over` → `return over + close` (band reaches exit code) | **CAUGHT** |

Baseline restored and re-run green afterwards.

`test_this_repo_is_not_currently_in_the_band` runs against the shipped personas with no monkeypatching — if it ever fails, the warning is working; buy headroom rather than deleting the test.
