### PR TITLE
docs: correct the estate_survey misattribution and the git add -A trap

### DIFF
--- a/.github/agents/pbi-migration-validator.agent.md
+++ b/.github/agents/pbi-migration-validator.agent.md
@@ -125,7 +125,12 @@ reasoning or self-report of success.
   variable), and never close a sibling's instance or one mid validator↔builder handoff. Run-owned
   leaks are enforced by `check_unit.py`'s `desktop-orphans` gate. Remove scratch/temp files you
   created; keep only committed deliverables plus re-runnable `_build/` scripts, and confirm nothing
-  scratch leaked into git before reporting done.
+  scratch leaked into git before reporting done. ⚠️ **Never `git add -A` after a gapped pull** —
+  measured: a merge staged **111** untracked scratch paths (a whole engine bundle, loose `_tmp_*.py`)
+  because `-A` cannot tell "files this merge introduces" from "files that happened to be lying
+  around". Stage from `git diff --name-status <old-HEAD> origin/master`. If you must undo one,
+  `reset --soft HEAD~1` **clears `MERGE_HEAD` even on a merge commit**, so recreate it or the next
+  commit is silently single-parent and the ancestry breaks.
 <!-- END:shared-conventions -->
 
 ## Inputs you require from the orchestrator

--- a/.github/agents/pbi-report-builder.agent.md
+++ b/.github/agents/pbi-report-builder.agent.md
@@ -86,7 +86,12 @@ Power BI report. You are invoked by the `tableau-migrator` orchestrator.
   variable), and never close a sibling's instance or one mid validator↔builder handoff. Run-owned
   leaks are enforced by `check_unit.py`'s `desktop-orphans` gate. Remove scratch/temp files you
   created; keep only committed deliverables plus re-runnable `_build/` scripts, and confirm nothing
-  scratch leaked into git before reporting done.
+  scratch leaked into git before reporting done. ⚠️ **Never `git add -A` after a gapped pull** —
+  measured: a merge staged **111** untracked scratch paths (a whole engine bundle, loose `_tmp_*.py`)
+  because `-A` cannot tell "files this merge introduces" from "files that happened to be lying
+  around". Stage from `git diff --name-status <old-HEAD> origin/master`. If you must undo one,
+  `reset --soft HEAD~1` **clears `MERGE_HEAD` even on a merge commit**, so recreate it or the next
+  commit is silently single-parent and the ancestry breaks.
 <!-- END:shared-conventions -->
 
 ## Skills you use, in this order

--- a/.github/agents/pbi-semantic-builder.agent.md
+++ b/.github/agents/pbi-semantic-builder.agent.md
@@ -91,7 +91,12 @@ examples, not hypothetical ones.
   variable), and never close a sibling's instance or one mid validator↔builder handoff. Run-owned
   leaks are enforced by `check_unit.py`'s `desktop-orphans` gate. Remove scratch/temp files you
   created; keep only committed deliverables plus re-runnable `_build/` scripts, and confirm nothing
-  scratch leaked into git before reporting done.
+  scratch leaked into git before reporting done. ⚠️ **Never `git add -A` after a gapped pull** —
+  measured: a merge staged **111** untracked scratch paths (a whole engine bundle, loose `_tmp_*.py`)
+  because `-A` cannot tell "files this merge introduces" from "files that happened to be lying
+  around". Stage from `git diff --name-status <old-HEAD> origin/master`. If you must undo one,
+  `reset --soft HEAD~1` **clears `MERGE_HEAD` even on a merge commit**, so recreate it or the next
+  commit is silently single-parent and the ancestry breaks.
 <!-- END:shared-conventions -->
 
 ## Skills you use

--- a/.github/agents/tableau-migrator.agent.md
+++ b/.github/agents/tableau-migrator.agent.md
@@ -87,7 +87,12 @@ PBIR files yourself.
   variable), and never close a sibling's instance or one mid validator↔builder handoff. Run-owned
   leaks are enforced by `check_unit.py`'s `desktop-orphans` gate. Remove scratch/temp files you
   created; keep only committed deliverables plus re-runnable `_build/` scripts, and confirm nothing
-  scratch leaked into git before reporting done.
+  scratch leaked into git before reporting done. ⚠️ **Never `git add -A` after a gapped pull** —
+  measured: a merge staged **111** untracked scratch paths (a whole engine bundle, loose `_tmp_*.py`)
+  because `-A` cannot tell "files this merge introduces" from "files that happened to be lying
+  around". Stage from `git diff --name-status <old-HEAD> origin/master`. If you must undo one,
+  `reset --soft HEAD~1` **clears `MERGE_HEAD` even on a merge commit**, so recreate it or the next
+  commit is silently single-parent and the ancestry breaks.
 <!-- END:shared-conventions -->
 
 ## Workflow

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -495,7 +495,7 @@ overstated (issue #194). Do not quietly drop this, and do not inflate it.
 > **Running the pipeline by hand, or standing behind someone who is?**
 > [`docs/operator-runbook.md`](docs/operator-runbook.md) is the command-by-command version of this
 > section: the day-before checklist, expected timings, the failure playbook (the `estate_survey.py`
-> credential hang, the `exit 3` DoD gate, the storage-decision/union skip), the verification
+> site-wide silent sweep, the `exit 3` DoD gate, the storage-decision/union skip), the verification
 > checklist and — importantly — what that checklist does **not** prove.
 
 ### Gate B — after parse + probe, before building
@@ -589,5 +589,10 @@ exists so each question is answered once per migration, not once per session.
   variable), and never close a sibling's instance or one mid validator↔builder handoff. Run-owned
   leaks are enforced by `check_unit.py`'s `desktop-orphans` gate. Remove scratch/temp files you
   created; keep only committed deliverables plus re-runnable `_build/` scripts, and confirm nothing
-  scratch leaked into git before reporting done.
+  scratch leaked into git before reporting done. ⚠️ **Never `git add -A` after a gapped pull** —
+  measured: a merge staged **111** untracked scratch paths (a whole engine bundle, loose `_tmp_*.py`)
+  because `-A` cannot tell "files this merge introduces" from "files that happened to be lying
+  around". Stage from `git diff --name-status <old-HEAD> origin/master`. If you must undo one,
+  `reset --soft HEAD~1` **clears `MERGE_HEAD` even on a merge commit**, so recreate it or the next
+  commit is silently single-parent and the ancestry breaks.
 <!-- END:shared-conventions -->

--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -401,6 +401,26 @@ alone. It is genuinely required only for a **direct** `estate_survey.py` call th
 wrapper — there the `--env-file` layer is consulted for *secrets* only, never the name, and omitting
 it raises an immediate `SystemExit` naming both options ✅ verified by direct call.
 
+⚠️ **It surveys the WHOLE site and prints NOTHING until it finishes. A working run is
+indistinguishable from a hung one.** Field-measured 2026-08-24 on a 273-workbook site: the survey
+issues **~275+ REST calls** — one site sweep plus a `/workbooks/{id}/connections` call for *every*
+workbook — and takes **6+ minutes** during which it emits **zero bytes**. ✅ Verified against the
+installed engine: the whole module holds exactly two `print` statements and both run *after* the
+survey completes.
+
+**Do not kill it, and do not go debugging your `.env`.** The rational reaction to several silent
+minutes is to assume a credential prompt or a bad URL, and an experienced engineer lost a session to
+exactly that — the cause was neither. Bare hostname and `https://…` normalise identically
+(`fetch_tds.py:103-112`), so the URL form is not it either. Time it against the site size (~1.3 s per
+workbook) and let it run.
+
+There is **no scoping flag** — no `--project`, no `--workbook` — so 12 workbooks on a 273-workbook
+site still costs the full sweep. Requested upstream as
+[`Yarbrdab000/tableau-fabric-skills#175`](https://github.com/Yarbrdab000/tableau-fabric-skills/issues/175),
+together with progress output. If you only need one project's data and the wait is not acceptable,
+a scoped REST script against `/projects` + `/workbooks?filter=projectName:eq:<name>` is a few dozen
+lines; that is a workaround, not the supported path.
+
 Expect on success: `[SURVEY] N workbook(s); M depend on a published datasource; K datasource(s) must
 be fetched first.` then one `[DEPENDS]` line per dependent workbook, then `[OK] survey written to …`.
 


### PR DESCRIPTION
Three corrections from a retrospective investigation by the SES engineer on a live 273-workbook migration. All three are things we had recorded *wrongly* or not at all.

## 1. It was never a credential hang

`AGENTS.md` described the `estate_survey.py` failure as a **"credential hang"**. The investigation found the cause is **scope**:

| | REST calls | wall time | output before completion |
|---|---|---|---|
| `estate_survey.py` (site-wide) | **~275+** | 6+ min | **none** |
| a hand-built scoped script, same goal | **13** | seconds | progress |

~275+ = one site sweep plus a `/workbooks/{id}/connections` call for **every** one of 273 workbooks.

**Verified against the installed engine before writing this:** the 484-line module contains exactly **two** `print` statements — `:469` and `:473` — and **both run after the survey completes**. Also verified: bare hostname and `https://…` normalise identically (`fetch_tds.py:103-112`), so the URL form was never it; and the full argparse surface has **no** `--project` or `--workbook`, so there is no supported way to narrow it.

**Why the wrong label was worse than no label.** It sent an experienced engineer to debug `.env` and URL formats for a problem that was neither. And "credential" invites the *"time-box it, then ask"* rule — whose 2-minute cap would **kill a working survey**. `AGENTS.md` already warns about exactly that failure ("an agent applied this 2-minute cap to a script that was already the bounded timer… and so recorded no verdict at all"); this is a second instance of it, and the runbook now says plainly: do not kill it, time it against site size (~1.3 s/workbook).

Scoping and progress requested upstream as [`Yarbrdab000/tableau-fabric-skills#175`](https://github.com/Yarbrdab000/tableau-fabric-skills/issues/175).

## 2. The `git add -A` corollary

A gapped pull with local commits produced conflicts, and a reflexive `git add -A` staged **111 untracked scratch paths** into the merge — a whole engine bundle, loose `_tmp_*.py`. Same root cause as the existing scratch-files bullet, worse outcome: **history rather than disk**.

The recovery trap is the part that would catch anyone: `reset --soft HEAD~1` **clears `MERGE_HEAD` even on a merge commit**, so the next plain commit is silently single-parent and the ancestry breaks.

## 3. Persona regeneration

Item 2 lives inside the generated `shared-conventions` block, so all four personas were regenerated with `sync_agent_conventions.py` rather than hand-edited.

They now sit at **27,918–28,918** (93–96% of cap). Note the largest is **182 characters** below the 29,100 near-cap band added in #316 — this PR is itself an instance of the AGENTS.md-propagates-into-all-four hazard that warning exists to catch, which is a reasonable sanity check that 97% is set about right: close, but no false alarm.

## Verification

```
sync_agent_conventions.py            EXIT=0   (4 of 4 regenerated)
sync_agent_conventions.py --check    EXIT=0
check_navigation_index.py            EXIT=0
check_agent_capabilities.py          EXIT=0
pytest test_sync_agent_conventions + test_repo_layout   73 passed, EXIT=0
```

Docs only — no Python changed, so the pylint roots do not apply.
