### PR TITLE
fix(credential-gate): read write targets from path keys, not payload text

### DIFF
--- a/scripts/hooks/credential_gate.py
+++ b/scripts/hooks/credential_gate.py
@@ -382,12 +382,39 @@ def _extract_args_text(payload: dict) -> str:
     return "\n".join(parts)
 
 
-# Any path-ish token ending in a guarded suffix, however it is quoted or escaped.
+# Any path-ish token ending in a guarded suffix, however it is quoted or escaped. Used ONLY for
+# shell commands now - see `_candidate_paths` - because a shell command line genuinely IS text with
+# no structured path argument to read instead.
 _PATH_RE = re.compile(
     r"[A-Za-z]:[\\/][^\"'\s,;)]+?(?:\.tmdl|\.pbism|\.pbir|\.pbip|\.platform)"
     r"|[^\"'\s,;)]*?(?:\.tmdl|\.pbism|\.pbir|\.pbip|\.platform)",
     re.IGNORECASE,
 )
+
+# apply_patch's payload is raw patch text, not a structured object (see `_extract_args_text`'s
+# docstring), so it has no "path" key for `_path_arguments` to read. Its target is the FILE HEADER
+# line only - "*** Add File: <path>", "*** Update File: <path>", "*** Delete File: <path>", and a
+# rename's "*** Move to: <path>" - never the `+`/`-` diff body, which is exactly where an added
+# line's CONTENT could mention a guarded suffix without the patch touching that file at all.
+_APPLY_PATCH_HEADER_RE = re.compile(
+    r"^\*\*\*\s*(?:Add File|Update File|Delete File|Move to):\s*(.+?)\s*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+def _apply_patch_paths(payload: dict) -> list[str]:
+    """Pull only the patch HEADER paths out of an apply_patch payload, never the diff body."""
+    text = ""
+    raw = payload.get("toolArgs") or payload.get("tool_args")
+    if isinstance(raw, str):
+        text = raw
+    else:
+        args = payload.get("toolInput") or payload.get("tool_input")
+        if isinstance(args, dict):
+            value = args.get("patch") or args.get("input") or args.get("text")
+            if isinstance(value, str):
+                text = value
+    return [match.strip() for match in _APPLY_PATCH_HEADER_RE.findall(text)]
 
 
 def _candidate_paths(tool: str, payload: dict) -> list[Path]:
@@ -395,17 +422,30 @@ def _candidate_paths(tool: str, payload: dict) -> list[Path]:
 
     Read tools are excluded deliberately: `view` legitimately carries a .tmdl path, and denying
     reads would break the agent's ability to inspect a model without protecting anything.
+
+    For a WRITE tool the target is read from structured path-shaped ARGUMENT KEYS only (via
+    `_path_arguments`, or the patch header for `apply_patch`) - never from the file body/content.
+    Measured: a write whose CONTENT merely mentions a guarded suffix (a doc, a code comment, a test
+    fixture, a commit message) was being denied for a path it never touches, because the old
+    flattened-text regex scanned the whole payload including the bytes being written. Reusing
+    `_path_arguments` is deliberate: it is the same structural extraction `_writes_a_control_file`
+    already relies on, proven against both measured payload shapes (preToolUse `toolArgs` string,
+    permissionRequest `toolInput` object).
+
+    For a SHELL tool there is no structured path argument to read - the command line genuinely IS
+    the artifact description (`Set-Content Model.tmdl -Value ...`) - so the flattened-text regex
+    scan is kept as-is.
     """
     tool_l = tool.lower()
-    is_write = tool_l in WRITE_TOOLS
-    is_shell = tool_l in SHELL_TOOLS
-    if not (is_write or is_shell):
+    if tool_l in WRITE_TOOLS:
+        raw_values = _apply_patch_paths(payload) if tool_l == "apply_patch" else _path_arguments(payload)
+        return [Path(value) for value in raw_values]
+
+    if tool_l not in SHELL_TOOLS:
         return []
 
     text = _extract_args_text(payload)
-    if not text:
-        return []
-    if is_shell and not any(h in text.lower() for h in SHELL_WRITE_HINTS):
+    if not text or not any(h in text.lower() for h in SHELL_WRITE_HINTS):
         return []
 
     seen: list[Path] = []

--- a/tests/test_credential_gate.py
+++ b/tests/test_credential_gate.py
@@ -827,6 +827,101 @@ def test_a_write_tool_is_judged_on_its_path_not_its_content(migration: Path) -> 
     assert deleted.get("permissionDecision") == "deny", "deleting the marker must still be denied"
 
 
+def test_a_write_tool_is_judged_on_its_path_not_a_mention_of_a_guarded_suffix(migration: Path) -> None:
+    """Issue #228, class 2: content that merely NAMES a guarded suffix must not be denied.
+
+    `_candidate_paths` used to run `_extract_args_text` (the WHOLE payload, including the file body
+    being written) through a regex that matches any token ending in `.tmdl`/`.pbism`/etc. So writing
+    `docs/notes.md` whose CONTENT documented "the Model.tmdl layout" was denied for a path
+    ("Model.tmdl") the write never touched - reproduced against the hook before this fix landed.
+
+    Every assertion here has its negative twin: a write that genuinely targets a guarded suffix, and
+    a shell command that genuinely writes one, must both still be denied.
+    """
+    run_gate("block", str(migration), "--sources", "shipment")
+
+    mentions_only = run_hook(
+        {
+            "toolName": "create",
+            "toolArgs": json.dumps(
+                {
+                    "path": str(migration / "docs" / "notes.md"),
+                    "file_text": "This note documents the Model.tmdl layout for future readers.",
+                }
+            ),
+            "cwd": str(migration),
+        }
+    )
+    assert mentions_only.get("permissionDecision") != "deny", (
+        "a write whose CONTENT merely mentions a guarded suffix must be allowed"
+    )
+
+    real_write = run_hook(
+        {
+            "toolName": "create",
+            "toolArgs": json.dumps({"path": str(migration / "fabric" / "Model.tmdl"), "file_text": "table Foo"}),
+            "cwd": str(migration),
+        }
+    )
+    assert real_write.get("permissionDecision") == "deny", "a genuine write to a guarded suffix must still be denied"
+
+    shell_write = run_hook(
+        {
+            "toolName": "powershell",
+            "toolArgs": json.dumps(
+                {"command": f"Set-Content -Path {migration / 'fabric' / 'Model.tmdl'} -Value 'table Foo'"}
+            ),
+            "cwd": str(migration),
+        }
+    )
+    assert shell_write.get("permissionDecision") == "deny", "a shell command that genuinely writes one must be denied"
+
+    read_only = run_hook(
+        {
+            "toolName": "view",
+            "toolArgs": json.dumps({"path": str(migration / "fabric" / "Model.tmdl")}),
+            "cwd": str(migration),
+        }
+    )
+    assert read_only.get("permissionDecision") != "deny", "a read-only tool must remain unaffected"
+
+
+def test_apply_patch_target_is_read_from_the_header_not_the_diff_body(migration: Path) -> None:
+    """apply_patch has no structured path key - its target lives in the patch HEADER line only.
+
+    Its `toolArgs` is raw patch text, not JSON (see `_extract_args_text`'s docstring), so
+    `_path_arguments` finds nothing for it; `_apply_patch_paths` reads the `*** Add/Update/Delete
+    File:` header instead. Scanning the diff BODY as before would deny a patch that only ADDS a
+    line mentioning a guarded suffix to an unrelated file - the same false positive, one tool over.
+    """
+    run_gate("block", str(migration), "--sources", "shipment")
+
+    unrelated_target = migration / "docs" / "notes.md"
+    mentions_only = run_hook(
+        {
+            "toolName": "apply_patch",
+            "toolArgs": (
+                f"*** Begin Patch\n*** Add File: {unrelated_target}\n"
+                "+This note documents the Model.tmdl layout for future readers.\n*** End Patch\n"
+            ),
+            "cwd": str(migration),
+        }
+    )
+    assert mentions_only.get("permissionDecision") != "deny", (
+        "a patch whose ADDED LINE merely mentions a guarded suffix must be allowed"
+    )
+
+    real_target = migration / "fabric" / "Model.tmdl"
+    real_write = run_hook(
+        {
+            "toolName": "apply_patch",
+            "toolArgs": f"*** Begin Patch\n*** Add File: {real_target}\n+table Foo\n*** End Patch\n",
+            "cwd": str(migration),
+        }
+    )
+    assert real_write.get("permissionDecision") == "deny", "a patch that genuinely adds a guarded suffix file must deny"
+
+
 def test_the_hook_lets_the_agent_inspect_the_gate_it_is_under(migration: Path) -> None:
     """Reading the audit log and the ACL is how an agent reports honestly - never deny it.
 


### PR DESCRIPTION
## Summary

scripts/hooks/credential_gate.py's _candidate_paths scanned the **entire flattened payload
text** — including the file body/content being written — for tokens ending in a guarded suffix
(.tmdl, .pbism, .pbir, .pbip, .platform). A write tool whose *content* merely mentioned
one of those suffixes (a doc, a code comment, a test fixture, a commit message) was denied for a
path it never touched.

## Fix

- Write tools now read the target from **structured path-shaped argument keys** (`path`,
  `file_path`, `filePath`, `notebook_path`, `target`, `destination`) via the existing
  `_path_arguments` helper — the same structural extraction `_writes_a_control_file` already
  relies on for the gate's own control files — never from the file body.
- `apply_patch` has no structured key at all (its payload is raw patch text), so its target is
  read from the patch **header line only** (`*** Add/Update/Delete File:`), never the diff body
  — otherwise a patch that only *adds a line mentioning* a guarded suffix to an unrelated file
  would still be denied.
- Shell tools are **unchanged**: a command line genuinely *is* text with no structured path
  argument to read, so the flattened-text regex scan is kept.

## Scope re: #228

This addresses **class 2** only — a write tool's argument text merely *mentioning* a guarded
suffix. **Class 1** (read-only greps/listings being denied) was already fixed on `master` before
this branch (_candidate_paths returns [] for non-write/non-shell tools) and is unaffected here.
Recommend narrowing #228 to class 2 rather than closing it wholesale, since this PR is scoped to
that half.

## Testing

- Reproduced the false positive against the unmodified hook (write to an innocuous `docs/notes.md`
  whose content mentions `Model.tmdl` was denied), then confirmed it is allowed after the fix.
- Added `test_a_write_tool_is_judged_on_its_path_not_a_mention_of_a_guarded_suffix` and
  `test_apply_patch_target_is_read_from_the_header_not_the_diff_body` to
  `tests/test_credential_gate.py`, each asserting the negative (false positive allowed) beside the
  positive (a genuine write / shell write / apply_patch add to a guarded suffix is still denied), plus
  a read-only-tool-unaffected check.
- Mutation-tested the fix three ways (reverting the write-tool branch to the old flattened-text scan;
  making `_apply_patch_paths` scan the whole patch body instead of just the header; dropping the
  `"path"` key from `_path_arguments`' key list) — all three were caught by the new tests (the
  third was also caught by the pre-existing `test_a_write_tool_is_judged_on_its_path_not_its_content`).
  No survivors.
- Gates: `ruff format`/`ruff check --fix` (0), `pylint scripts` / `pylint
  .github/skills/pbip-model-refresh/scripts` / `pylint .github/skills/powerbi-ai-readiness/scripts`
  (10.00/10 each), full `pytest tests/ -q` (1833 passed, 4 skipped).

Refs #228

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>