### PR TITLE
docs: distinguish unavailable model baselines

### DIFF
--- a/.github/agents/pbi-migration-validator.agent.md
+++ b/.github/agents/pbi-migration-validator.agent.md
@@ -68,16 +68,14 @@ reasoning or self-report of success.
   where you are.**
   | stage | location | rule |
   |---|---|---|
-  | engine truth | `<bundle>/reports/` (reliable); `<bundle>/semantic_models/` (if emitted) | **NEVER edit an existing baseline** |
+  | engine truth | `<bundle>/reports/`; `<bundle>/semantic_models/` (if emitted) | **NEVER edit an existing baseline** |
   | working copy | `<bundle>/pbip/` | agents edit **here**; every edit re-runnable from `_build/` and declared |
   | deliverable | `migrations/{workbooks,datasources}/<slug>/fabric/` | **COPIED at sign-off**, so the bundle survives as evidence |
 
-  A bundle may contain `<bundle>/{pbip,reports,semantic_models,handover,data}` — **no `out/` level**.
-  `reports/` is reliable; `semantic_models/` is conditional (4/12 pairs, 2026-08-24), so model
-  diffs must report a missing baseline—not no changes—and #274 totals must disclose coverage; keep
-  `reports/` pristine so it remains the exact answer to *"what did our tier change versus what the
-  engine produced?"* — rewriting it cost a retracted upstream bug on 2026-08-10. Use git for that
-  comparison; the mechanics live in `powerbi-report-gotchas` §3.
+  A bundle may contain `<bundle>/{pbip,reports,semantic_models,handover,data}` — **no `out/` level**;
+  `<bundle>/semantic_models/` is conditional (absent for 8/12 workbooks), and absent baseline ≠ no
+  changes — see `AGENTS.md`. Keep `<bundle>/reports/` pristine and compare it with git
+  (`powerbi-report-gotchas` §3).
 
   ⚠️ **The copy must keep
   `definition.pbir`'s `byPath` resolving** — plain copy for a per-workbook model, path rewrite for a

--- a/.github/agents/pbi-migration-validator.agent.md
+++ b/.github/agents/pbi-migration-validator.agent.md
@@ -68,11 +68,13 @@ reasoning or self-report of success.
   where you are.**
   | stage | location | rule |
   |---|---|---|
-  | engine truth | `<bundle>/reports/`, `<bundle>/semantic_models/` | **NEVER edited, by anyone** — a free pristine baseline the engine writes anyway |
+  | engine truth | `<bundle>/reports/` (reliable); `<bundle>/semantic_models/` (if emitted) | **NEVER edit an existing baseline** |
   | working copy | `<bundle>/pbip/` | agents edit **here**; every edit re-runnable from `_build/` and declared |
   | deliverable | `migrations/{workbooks,datasources}/<slug>/fabric/` | **COPIED at sign-off**, so the bundle survives as evidence |
 
-  A bundle is `<bundle>/{pbip,reports,semantic_models,handover,data}` — **no `out/` level**. Keep
+  A bundle may contain `<bundle>/{pbip,reports,semantic_models,handover,data}` — **no `out/` level**.
+  `reports/` is reliable; `semantic_models/` is conditional (4/12 pairs, 2026-08-24), so model
+  diffs must report a missing baseline—not no changes—and #274 totals must disclose coverage; keep
   `reports/` pristine so it remains the exact answer to *"what did our tier change versus what the
   engine produced?"* — rewriting it cost a retracted upstream bug on 2026-08-10. Use git for that
   comparison; the mechanics live in `powerbi-report-gotchas` §3.

--- a/.github/agents/pbi-report-builder.agent.md
+++ b/.github/agents/pbi-report-builder.agent.md
@@ -29,11 +29,13 @@ Power BI report. You are invoked by the `tableau-migrator` orchestrator.
   where you are.**
   | stage | location | rule |
   |---|---|---|
-  | engine truth | `<bundle>/reports/`, `<bundle>/semantic_models/` | **NEVER edited, by anyone** — a free pristine baseline the engine writes anyway |
+  | engine truth | `<bundle>/reports/` (reliable); `<bundle>/semantic_models/` (if emitted) | **NEVER edit an existing baseline** |
   | working copy | `<bundle>/pbip/` | agents edit **here**; every edit re-runnable from `_build/` and declared |
   | deliverable | `migrations/{workbooks,datasources}/<slug>/fabric/` | **COPIED at sign-off**, so the bundle survives as evidence |
 
-  A bundle is `<bundle>/{pbip,reports,semantic_models,handover,data}` — **no `out/` level**. Keep
+  A bundle may contain `<bundle>/{pbip,reports,semantic_models,handover,data}` — **no `out/` level**.
+  `reports/` is reliable; `semantic_models/` is conditional (4/12 pairs, 2026-08-24), so model
+  diffs must report a missing baseline—not no changes—and #274 totals must disclose coverage; keep
   `reports/` pristine so it remains the exact answer to *"what did our tier change versus what the
   engine produced?"* — rewriting it cost a retracted upstream bug on 2026-08-10. Use git for that
   comparison; the mechanics live in `powerbi-report-gotchas` §3.

--- a/.github/agents/pbi-report-builder.agent.md
+++ b/.github/agents/pbi-report-builder.agent.md
@@ -29,16 +29,14 @@ Power BI report. You are invoked by the `tableau-migrator` orchestrator.
   where you are.**
   | stage | location | rule |
   |---|---|---|
-  | engine truth | `<bundle>/reports/` (reliable); `<bundle>/semantic_models/` (if emitted) | **NEVER edit an existing baseline** |
+  | engine truth | `<bundle>/reports/`; `<bundle>/semantic_models/` (if emitted) | **NEVER edit an existing baseline** |
   | working copy | `<bundle>/pbip/` | agents edit **here**; every edit re-runnable from `_build/` and declared |
   | deliverable | `migrations/{workbooks,datasources}/<slug>/fabric/` | **COPIED at sign-off**, so the bundle survives as evidence |
 
-  A bundle may contain `<bundle>/{pbip,reports,semantic_models,handover,data}` — **no `out/` level**.
-  `reports/` is reliable; `semantic_models/` is conditional (4/12 pairs, 2026-08-24), so model
-  diffs must report a missing baseline—not no changes—and #274 totals must disclose coverage; keep
-  `reports/` pristine so it remains the exact answer to *"what did our tier change versus what the
-  engine produced?"* — rewriting it cost a retracted upstream bug on 2026-08-10. Use git for that
-  comparison; the mechanics live in `powerbi-report-gotchas` §3.
+  A bundle may contain `<bundle>/{pbip,reports,semantic_models,handover,data}` — **no `out/` level**;
+  `<bundle>/semantic_models/` is conditional (absent for 8/12 workbooks), and absent baseline ≠ no
+  changes — see `AGENTS.md`. Keep `<bundle>/reports/` pristine and compare it with git
+  (`powerbi-report-gotchas` §3).
 
   ⚠️ **The copy must keep
   `definition.pbir`'s `byPath` resolving** — plain copy for a per-workbook model, path rewrite for a

--- a/.github/agents/pbi-semantic-builder.agent.md
+++ b/.github/agents/pbi-semantic-builder.agent.md
@@ -34,11 +34,13 @@ examples, not hypothetical ones.
   where you are.**
   | stage | location | rule |
   |---|---|---|
-  | engine truth | `<bundle>/reports/`, `<bundle>/semantic_models/` | **NEVER edited, by anyone** — a free pristine baseline the engine writes anyway |
+  | engine truth | `<bundle>/reports/` (reliable); `<bundle>/semantic_models/` (if emitted) | **NEVER edit an existing baseline** |
   | working copy | `<bundle>/pbip/` | agents edit **here**; every edit re-runnable from `_build/` and declared |
   | deliverable | `migrations/{workbooks,datasources}/<slug>/fabric/` | **COPIED at sign-off**, so the bundle survives as evidence |
 
-  A bundle is `<bundle>/{pbip,reports,semantic_models,handover,data}` — **no `out/` level**. Keep
+  A bundle may contain `<bundle>/{pbip,reports,semantic_models,handover,data}` — **no `out/` level**.
+  `reports/` is reliable; `semantic_models/` is conditional (4/12 pairs, 2026-08-24), so model
+  diffs must report a missing baseline—not no changes—and #274 totals must disclose coverage; keep
   `reports/` pristine so it remains the exact answer to *"what did our tier change versus what the
   engine produced?"* — rewriting it cost a retracted upstream bug on 2026-08-10. Use git for that
   comparison; the mechanics live in `powerbi-report-gotchas` §3.

--- a/.github/agents/pbi-semantic-builder.agent.md
+++ b/.github/agents/pbi-semantic-builder.agent.md
@@ -34,16 +34,14 @@ examples, not hypothetical ones.
   where you are.**
   | stage | location | rule |
   |---|---|---|
-  | engine truth | `<bundle>/reports/` (reliable); `<bundle>/semantic_models/` (if emitted) | **NEVER edit an existing baseline** |
+  | engine truth | `<bundle>/reports/`; `<bundle>/semantic_models/` (if emitted) | **NEVER edit an existing baseline** |
   | working copy | `<bundle>/pbip/` | agents edit **here**; every edit re-runnable from `_build/` and declared |
   | deliverable | `migrations/{workbooks,datasources}/<slug>/fabric/` | **COPIED at sign-off**, so the bundle survives as evidence |
 
-  A bundle may contain `<bundle>/{pbip,reports,semantic_models,handover,data}` — **no `out/` level**.
-  `reports/` is reliable; `semantic_models/` is conditional (4/12 pairs, 2026-08-24), so model
-  diffs must report a missing baseline—not no changes—and #274 totals must disclose coverage; keep
-  `reports/` pristine so it remains the exact answer to *"what did our tier change versus what the
-  engine produced?"* — rewriting it cost a retracted upstream bug on 2026-08-10. Use git for that
-  comparison; the mechanics live in `powerbi-report-gotchas` §3.
+  A bundle may contain `<bundle>/{pbip,reports,semantic_models,handover,data}` — **no `out/` level**;
+  `<bundle>/semantic_models/` is conditional (absent for 8/12 workbooks), and absent baseline ≠ no
+  changes — see `AGENTS.md`. Keep `<bundle>/reports/` pristine and compare it with git
+  (`powerbi-report-gotchas` §3).
 
   ⚠️ **The copy must keep
   `definition.pbir`'s `byPath` resolving** — plain copy for a per-workbook model, path rewrite for a

--- a/.github/agents/tableau-migrator.agent.md
+++ b/.github/agents/tableau-migrator.agent.md
@@ -30,16 +30,14 @@ PBIR files yourself.
   where you are.**
   | stage | location | rule |
   |---|---|---|
-  | engine truth | `<bundle>/reports/` (reliable); `<bundle>/semantic_models/` (if emitted) | **NEVER edit an existing baseline** |
+  | engine truth | `<bundle>/reports/`; `<bundle>/semantic_models/` (if emitted) | **NEVER edit an existing baseline** |
   | working copy | `<bundle>/pbip/` | agents edit **here**; every edit re-runnable from `_build/` and declared |
   | deliverable | `migrations/{workbooks,datasources}/<slug>/fabric/` | **COPIED at sign-off**, so the bundle survives as evidence |
 
-  A bundle may contain `<bundle>/{pbip,reports,semantic_models,handover,data}` — **no `out/` level**.
-  `reports/` is reliable; `semantic_models/` is conditional (4/12 pairs, 2026-08-24), so model
-  diffs must report a missing baseline—not no changes—and #274 totals must disclose coverage; keep
-  `reports/` pristine so it remains the exact answer to *"what did our tier change versus what the
-  engine produced?"* — rewriting it cost a retracted upstream bug on 2026-08-10. Use git for that
-  comparison; the mechanics live in `powerbi-report-gotchas` §3.
+  A bundle may contain `<bundle>/{pbip,reports,semantic_models,handover,data}` — **no `out/` level**;
+  `<bundle>/semantic_models/` is conditional (absent for 8/12 workbooks), and absent baseline ≠ no
+  changes — see `AGENTS.md`. Keep `<bundle>/reports/` pristine and compare it with git
+  (`powerbi-report-gotchas` §3).
 
   ⚠️ **The copy must keep
   `definition.pbir`'s `byPath` resolving** — plain copy for a per-workbook model, path rewrite for a

--- a/.github/agents/tableau-migrator.agent.md
+++ b/.github/agents/tableau-migrator.agent.md
@@ -30,11 +30,13 @@ PBIR files yourself.
   where you are.**
   | stage | location | rule |
   |---|---|---|
-  | engine truth | `<bundle>/reports/`, `<bundle>/semantic_models/` | **NEVER edited, by anyone** — a free pristine baseline the engine writes anyway |
+  | engine truth | `<bundle>/reports/` (reliable); `<bundle>/semantic_models/` (if emitted) | **NEVER edit an existing baseline** |
   | working copy | `<bundle>/pbip/` | agents edit **here**; every edit re-runnable from `_build/` and declared |
   | deliverable | `migrations/{workbooks,datasources}/<slug>/fabric/` | **COPIED at sign-off**, so the bundle survives as evidence |
 
-  A bundle is `<bundle>/{pbip,reports,semantic_models,handover,data}` — **no `out/` level**. Keep
+  A bundle may contain `<bundle>/{pbip,reports,semantic_models,handover,data}` — **no `out/` level**.
+  `reports/` is reliable; `semantic_models/` is conditional (4/12 pairs, 2026-08-24), so model
+  diffs must report a missing baseline—not no changes—and #274 totals must disclose coverage; keep
   `reports/` pristine so it remains the exact answer to *"what did our tier change versus what the
   engine produced?"* — rewriting it cost a retracted upstream bug on 2026-08-10. Use git for that
   comparison; the mechanics live in `powerbi-report-gotchas` §3.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -515,6 +515,22 @@ exists so each question is answered once per migration, not once per session.
 
 ---
 
+### Engine model-baseline availability
+
+`reports/` is reliable engine truth; `semantic_models/` is not a per-workbook guarantee. In a
+12-workbook estate audited on 2026-08-24, all report baselines existed but only 4 models (33%) had
+an engine-truth counterpart; the other 8 working models were unpaired. This is a baseline-coverage
+fact, not evidence that those eight models needed no changes.
+
+Before calculating model churn, check that each working model has an engine-truth counterpart. A
+missing counterpart must be reported as **BASELINE UNAVAILABLE**, never as a clean/no-change diff;
+only an existing pair may yield “no changes.” Report model-pair coverage beside every engine-gap
+distribution and do not generalize model churn from the paired subset to the estate; see
+[issue #274](https://github.com/Guust-Franssens/tableau-to-powerbi-migration/issues/274) and the
+operational procedure in [`docs/operator-runbook.md`](docs/operator-runbook.md#engine-model-baseline-availability).
+
+---
+
 <!-- BEGIN:shared-conventions -->
 ## Shared agent conventions (all agents inherit these)
 
@@ -532,11 +548,13 @@ exists so each question is answered once per migration, not once per session.
   where you are.**
   | stage | location | rule |
   |---|---|---|
-  | engine truth | `<bundle>/reports/`, `<bundle>/semantic_models/` | **NEVER edited, by anyone** — a free pristine baseline the engine writes anyway |
+  | engine truth | `<bundle>/reports/` (reliable); `<bundle>/semantic_models/` (if emitted) | **NEVER edit an existing baseline** |
   | working copy | `<bundle>/pbip/` | agents edit **here**; every edit re-runnable from `_build/` and declared |
   | deliverable | `migrations/{workbooks,datasources}/<slug>/fabric/` | **COPIED at sign-off**, so the bundle survives as evidence |
 
-  A bundle is `<bundle>/{pbip,reports,semantic_models,handover,data}` — **no `out/` level**. Keep
+  A bundle may contain `<bundle>/{pbip,reports,semantic_models,handover,data}` — **no `out/` level**.
+  `reports/` is reliable; `semantic_models/` is conditional (4/12 pairs, 2026-08-24), so model
+  diffs must report a missing baseline—not no changes—and #274 totals must disclose coverage; keep
   `reports/` pristine so it remains the exact answer to *"what did our tier change versus what the
   engine produced?"* — rewriting it cost a retracted upstream bug on 2026-08-10. Use git for that
   comparison; the mechanics live in `powerbi-report-gotchas` §3.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -548,16 +548,14 @@ operational procedure in [`docs/operator-runbook.md`](docs/operator-runbook.md#e
   where you are.**
   | stage | location | rule |
   |---|---|---|
-  | engine truth | `<bundle>/reports/` (reliable); `<bundle>/semantic_models/` (if emitted) | **NEVER edit an existing baseline** |
+  | engine truth | `<bundle>/reports/`; `<bundle>/semantic_models/` (if emitted) | **NEVER edit an existing baseline** |
   | working copy | `<bundle>/pbip/` | agents edit **here**; every edit re-runnable from `_build/` and declared |
   | deliverable | `migrations/{workbooks,datasources}/<slug>/fabric/` | **COPIED at sign-off**, so the bundle survives as evidence |
 
-  A bundle may contain `<bundle>/{pbip,reports,semantic_models,handover,data}` — **no `out/` level**.
-  `reports/` is reliable; `semantic_models/` is conditional (4/12 pairs, 2026-08-24), so model
-  diffs must report a missing baseline—not no changes—and #274 totals must disclose coverage; keep
-  `reports/` pristine so it remains the exact answer to *"what did our tier change versus what the
-  engine produced?"* — rewriting it cost a retracted upstream bug on 2026-08-10. Use git for that
-  comparison; the mechanics live in `powerbi-report-gotchas` §3.
+  A bundle may contain `<bundle>/{pbip,reports,semantic_models,handover,data}` — **no `out/` level**;
+  `<bundle>/semantic_models/` is conditional (absent for 8/12 workbooks), and absent baseline ≠ no
+  changes — see `AGENTS.md`. Keep `<bundle>/reports/` pristine and compare it with git
+  (`powerbi-report-gotchas` §3).
 
   ⚠️ **The copy must keep
   `definition.pbir`'s `byPath` resolving** — plain copy for a per-workbook model, path rewrite for a

--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -72,7 +72,7 @@ Three locations, one direction (from `AGENTS.md`, and it is enforced):
 
 | stage | path | rule |
 |---|---|---|
-| engine truth | `<bundle>/reports/`, `<bundle>/semantic_models/` | **never edited, by anyone** |
+| engine truth | `<bundle>/reports/` (reliable); `<bundle>/semantic_models/` (only if emitted) | **never edit an existing baseline** |
 | working copy | `<bundle>/pbip/` | agents edit here; this is what `deploy_estate.py` reads |
 | deliverable | `migrations/{workbooks,datasources}/<slug>/fabric/` | copied at sign-off |
 
@@ -602,7 +602,8 @@ What a bundle contains ✅ verified against the reference bundle by listing it, 
 | `report.json` | the engine's full estate report (~1.8 MB for 38 workbooks) — the machine-readable form of the above | no |
 | `handover/` | one slice per workbook, so a per-workbook agent never loads the whole report | no |
 | `pbip/` | **the working copy** — one folder per deployable unit; what `deploy_estate.py` reads | **yes** |
-| `reports/`, `semantic_models/` | the engine's pristine output — the free baseline for `diff` | **never** |
+| `reports/` | the engine's pristine report output — reliable baseline for `diff` | **never** |
+| `semantic_models/` (when emitted) | pristine model output — baseline only for a working model with a counterpart | **never** |
 | `data/` | flat-file data landed next to the models that import it (4 folders on the reference bundle) | no |
 | `empty-model-check.json` | the exit-6 verdict: every model, its partitions, and why any of them would load zero rows. **Written on every run, pass or fail** | — |
 | `phase-timings.json` | per-phase elapsed seconds — see the note under §2's table for what it does *not* cover | — |
@@ -611,6 +612,24 @@ What a bundle contains ✅ verified against the reference bundle by listing it, 
 | `input_manifest.json`, `source-provenance.json` | what went in, and where upstream it came from | — |
 | `deploy-journal.jsonl` | written by step 6, not step 5: intent-then-outcome per item (§6.1) | — |
 | `deploy-estate-id.txt` | **minted at first deploy — keep it with the bundle** (§3.3) | — |
+
+#### Engine model-baseline availability
+
+`reports/` is a reliable engine-truth baseline. `semantic_models/` is conditional: a 12-workbook
+estate audited on 2026-08-24 had report baselines for all 12, but only 4 model pairs (33%); the
+remaining 8 working models had no engine-truth counterpart. An unpaired model does **not** mean
+“no changes were needed” — it means model churn is unmeasurable for that unit.
+
+Before diffing a model, verify its engine-truth counterpart exists. Record an absent counterpart as
+**BASELINE UNAVAILABLE**, distinctly from a clean/no-change diff; a tool using exit codes must give
+that state its own non-success/skip result, following `check_stub_measures.py`'s rule that “no stubs”
+and “no model” never print or exit the same way. Only an existing pair can produce “no changes.”
+
+For an engine-gap distribution, publish separate report and model denominators, state the paired-model
+coverage, and do not generalize model churn from the paired subset to the whole estate. The first
+field distribution in [issue #274](https://github.com/Guust-Franssens/tableau-to-powerbi-migration/issues/274)
+is report-complete but model-covered for 4 of 12 workbooks; treat any estate-level reading as
+report-biased unless that coverage is made explicit.
 
 **`pbip/` is not one folder per workbook.** On the reference bundle it held **39** folders = **23**
 converted workbooks + **16** datasource-only semantic models ✅ verified by reconciling `pbip/`


### PR DESCRIPTION
## Summary
- Make `semantic_models/` conditional while retaining `reports/` as reliable engine truth.
- Require `BASELINE UNAVAILABLE` rather than treating an unpaired model as a no-change diff.
- Document model-pair coverage and report bias for engine-gap distributions.

## Coverage inventory
The prior unconditional guarantee occurred in `AGENTS.md`, `docs/operator-runbook.md`, and both generated sites in each of the four personas: `pbi-migration-validator`, `pbi-report-builder`, `pbi-semantic-builder`, and `tableau-migrator`. `powerbi-report-gotchas/SKILL.md` only lists bundle-layout vocabulary; it does not promise a per-workbook model baseline.

## Validation
- `scripts/sync_agent_conventions.py --check`
- `scripts/check_navigation_index.py`
- `scripts/check_agent_capabilities.py`
- `pytest tests/test_sync_agent_conventions.py tests/test_repo_layout.py -q`

Refs #179