### PR TITLE
chore(gitignore): one root rule instead of five accreted patches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,27 @@ candidates.json
 /_bundle*/
 /_estate*/
 
+# THE GENERAL RULE, added after the five specific ones above proved the pattern does not scale.
+# Each of those was a separate near-miss patched separately - `/_harvest*/` and `/_sweep*/` both cite
+# issue #125, and `/_sweep*/`'s own comment says "one folder documented for two tools is how a name
+# collision starts". Nobody ever generalised, so the next tool to invent a prefix was unprotected by
+# construction. Measured 2026-08-24 on a customer machine: 14 `_*` roots plus loose `_probe_*.py` and
+# an 11 MB `_calibration-*.jsonl` at the repo root, and a reflexive `git add -A` after a gapped pull
+# staged 111 of them into a merge commit. `_probe_acmu` slipped past the existing `_probe-lab/`
+# purely because one uses an underscore and the other a hyphen.
+#
+# Root-anchored and deliberately covers FILES as well as directories, because the loose files were
+# the half nothing caught. ✅ Verified safe before adding: all 96 tracked underscore paths are NESTED
+# (`examples/*/_work/`, `.github/skills/*/scripts/_*.py`); there are ZERO top-level `_*` tracked
+# entries, so this cannot un-track anything that exists. If a root `_*` file ever needs committing,
+# negate it explicitly (`!/_thing`) rather than deleting this rule.
+#
+# ⚠️ This is a BACKSTOP, not the control. It cannot protect an output that does not start with `_` -
+# see the `ses-prep/` near-miss in issue #322, where a deliverable naming 17 real customer servers
+# landed unprefixed and unignored. Scripts that emit customer-identifying data must refuse to write
+# to an unignored path (`refuse_unignored_output`), not rely on someone choosing a lucky name.
+/_*
+
 # Power BI Desktop local cache/settings - machine-specific, regenerated automatically on open
 **/.pbi/cache.abf
 **/.pbi/localSettings.json
@@ -125,7 +146,6 @@ scripts/provision_snowflake_fixture.py
 scripts/setup_snowflake_keypair.py
 scripts/snowflake_fixture.sql
 tests/test_gate_matrix.py
-_probe-lab/
 _matrix/
 
 # Credential material. `.env` alone was not enough: a real secret arrived as a loose
@@ -160,7 +180,10 @@ Thumbs.db
 # (UV_INDEX_URL=https://pypi.org/simple uv lock).
 uv.lock
 
-# Throwaway agent-behaviour test fixtures (see scripts/probe_lab.py)
+# Throwaway agent-behaviour test fixtures (see scripts/probe_lab.py).
+# Kept although `/_*` above already covers it at the repo root: this pattern is UNANCHORED, so it
+# also matches a nested `_probe-lab/` inside a fixture tree, which the root-anchored rule does not.
+# (A second, duplicate copy of this line was removed in the same change.)
 _probe-lab/
 
 # Live multi-source test fixture: embeds real endpoint hostnames, so it is generated

--- a/tests/test_harvest_output_guard.py
+++ b/tests/test_harvest_output_guard.py
@@ -111,11 +111,22 @@ def test_the_two_harvesters_do_not_share_one_documented_folder() -> None:
 
 
 # --------------------------------------------------------------------------- the script's guard
+#
+# ⚠️ The unignored fixture is called `leaky`, with NO leading underscore, and must stay that way.
+# `.gitignore` now carries a root-anchored `/_*`, so EVERY `_*` path at the repo root is ignored by
+# construction - which means the old `_leaky` name was silently ignored and this negative case
+# asserted nothing. Renaming it back "for consistency with `_sweep`" would re-break it in a way that
+# still passes locally and fails only here.
+#
+# The rename also sharpens what these tests cover. Post-`/_*`, an underscore-prefixed output path is
+# safe whether or not the guard fires, so the guard's remaining value is for paths that do NOT start
+# with `_` - exactly the `ses-prep/` shape from issue #322, where a deliverable naming real customer
+# servers landed unprefixed and unignored.
 
 
 def test_guard_refuses_an_unignored_path_inside_a_work_tree(repo: Path) -> None:
-    assert h.unignored_output_paths(repo / "_leaky") == [repo / "_leaky" / artifact for artifact in h.OUTPUT_ARTIFACTS]
-    assert h.refuse_unignored_output(repo / "_leaky", allow_unignored=False) is True
+    assert h.unignored_output_paths(repo / "leaky") == [repo / "leaky" / artifact for artifact in h.OUTPUT_ARTIFACTS]
+    assert h.refuse_unignored_output(repo / "leaky", allow_unignored=False) is True
 
 
 def test_guard_proceeds_for_an_ignored_path(repo: Path) -> None:
@@ -134,15 +145,15 @@ def test_the_trailing_slash_trap_is_real_and_the_guard_avoids_it(repo: Path) -> 
     stamp = _git(["check-ignore", "-q", "--", f"{repo / 'definitely-not-ignored'}/"], repo)
     if stamp.returncode != 0:
         pytest.skip("this git no longer reports every trailing-slash path as ignored")
-    assert h.refuse_unignored_output(repo / "_leaky", allow_unignored=False) is True
+    assert h.refuse_unignored_output(repo / "leaky", allow_unignored=False) is True
 
 
 def test_guard_proceeds_when_the_directory_already_exists(repo: Path) -> None:
     """An existing `--out` (the `--skip-download` re-run) must be judged the same way."""
     (repo / "_sweep-again" / "assets").mkdir(parents=True)
-    (repo / "_leaky-again" / "assets").mkdir(parents=True)
+    (repo / "leaky-again" / "assets").mkdir(parents=True)
     assert h.refuse_unignored_output(repo / "_sweep-again", allow_unignored=False) is False
-    assert h.refuse_unignored_output(repo / "_leaky-again", allow_unignored=False) is True
+    assert h.refuse_unignored_output(repo / "leaky-again", allow_unignored=False) is True
 
 
 def test_guard_proceeds_outside_any_git_work_tree(tmp_path: Path) -> None:
@@ -170,7 +181,7 @@ def test_guard_checks_every_artifact_not_just_the_downloads(repo: Path) -> None:
 
 def test_override_flag_downgrades_the_refusal_to_a_warning(repo: Path, caplog) -> None:
     with caplog.at_level("WARNING"):
-        assert h.refuse_unignored_output(repo / "_leaky", allow_unignored=True) is False
+        assert h.refuse_unignored_output(repo / "leaky", allow_unignored=True) is False
     assert "--allow-unignored-out" in caplog.text
 
 
@@ -219,7 +230,7 @@ def test_cli_exits_nonzero_before_touching_anything(repo: Path) -> None:
     which carries every workbook name, so the guard cannot be conditional on downloading.
     """
     result = subprocess.run(
-        [sys.executable, str(REPO_ROOT / "scripts" / "harvest_estate_assets.py"), "--out", "_leaky", "--skip-download"],
+        [sys.executable, str(REPO_ROOT / "scripts" / "harvest_estate_assets.py"), "--out", "leaky", "--skip-download"],
         cwd=repo,
         capture_output=True,
         text=True,
@@ -227,4 +238,4 @@ def test_cli_exits_nonzero_before_touching_anything(repo: Path) -> None:
     )
     assert result.returncode != 0, f"the CLI accepted an unignored --out:\n{result.stdout}\n{result.stderr}"
     assert "REFUSING" in (result.stdout + result.stderr)
-    assert not (repo / "_leaky").exists(), "the refusal ran too late - it already created --out"
+    assert not (repo / "leaky").exists(), "the refusal ran too late - it already created --out"


### PR DESCRIPTION
One root-anchored rule replaces five accreted patterns, plus a duplicate removal.

## Why now

`.gitignore` grew by patching individual names, never a rule. `/_harvest*/` and `/_sweep*/` both cite issue #125, and `/_sweep*/`'s own comment says *"one folder documented for two tools is how a name collision starts"* — but nobody generalised, so the next tool to invent a prefix was unprotected **by construction**.

Field-measured 2026-08-24 on a customer machine: **14 `_*` roots** plus loose `_probe_*.py` and an **11 MB** `_calibration-*.jsonl` at the repo root, and a reflexive `git add -A` after a gapped pull staged **111 of them** into a merge commit. `_probe_acmu` slipped past the existing `_probe-lab/` purely because one uses an **underscore** and the other a **hyphen**.

This file already records the same class biting with an actual secret: *"a real secret arrived as a loose `PAT-snowflake-secret.txt` in the repo root and a `git add -A` staged it (caught before commit)"*.

## Verified safe before adding

| check | result |
|---|---|
| tracked paths that would become ignored | **0** |
| tracked underscore paths (all NESTED — `examples/*/_work/`, `.github/skills/*/scripts/_*.py`) | 96, all unaffected |
| top-level `_*` tracked entries | **0** |

Root-anchored, and deliberately covers **files** as well as directories — the loose files were the half nothing caught.

## Verified against the real offenders

⚠️ **Without trailing slashes.** My first attempt used them and reported `ses-prep/` as IGNORED, which is false — a trailing slash makes `git check-ignore` report *every* path as ignored. That trap is already documented in this repo at `harvest_estate_assets.py:120`; I walked straight into it and am recording that so the next person does not.

```
_probe_acmu                              IGNORED  [/_*]
_probe_awohc_oracle.py                   IGNORED  [/_*]
_calibration-daily-summary-stream.jsonl  IGNORED  [/_*]
_bundle-airborne-services                IGNORED  [/_*]
_tmp_iaai_twbx_extract                   IGNORED  [/_*]
ses-prep/connections.json                exposed
```

**That last line is the point, not a gap.** `ses-prep/` holds a deliverable naming **17 real customer servers** and has no underscore, so no pattern can save it. This rule is a **backstop**; the control is a script that refuses to write to an unignored path (`refuse_unignored_output`, already implemented for `harvest_estate_assets.py`) — tracked as #322 and deliberately not in this PR.

## Also

Removed a literal duplicate `_probe-lab/` (it appeared twice), keeping the unanchored copy and documenting *why*: it matches **nested** paths, which the root-anchored rule does not.
