### PR TITLE
feat(handover): surface the engine's custom-SQL deferral, third unread signal

### DIFF
--- a/scripts/read_handover.py
+++ b/scripts/read_handover.py
@@ -37,6 +37,14 @@ The problem is not that the data is unreachable. It is that reading it costs mor
   buried report-side signal, but worse for sign-off: the visual renders and the values are wrong.
   This reader turns each dropped aggregate/calculated measure filter into a blocking work item so
   a severity-scoped triage sees the invisible numeric-fidelity risk beside visible report defects.
+* **A model-side deferral is swallowed the same way.** ``partitions_needs_review`` is the engine's
+  own record of a table whose M partition is a deploy-valid but EMPTY scaffold - e.g. "custom SQL
+  native query for this connector isn't verified; complete it manually" - because the upstream
+  query couldn't be auto-emitted (issue #326). Nothing surfaced it before this tool: a real
+  migration resolved the gap by materializing ~2.3M rows from a packaged extract instead of
+  completing the live translation the engine had already named as the needed manual step. This
+  reader groups the reasons (a FAMILY, not one sentence) and ranks them ahead of the calc queue,
+  because an unresolved partition means the table has ZERO rows, not just an unevaluated cell.
 
 ⚠️ **What this tool is NOT.** An earlier version of this docstring claimed that reading the slice
 directly failed *silently* - that a truncated read returned ``needs_review[]`` (the same calcs with
@@ -138,6 +146,19 @@ MEASURE_FILTER_DEFAULT_NOTE = (
     "mapping); it changes the values shown -- re-apply it as a visual-level filter in Power BI"
 )
 MEASURE_FILTER_RISK = "INVISIBLE NUMERIC FIDELITY RISK: visual renders, values are wrong until filter is re-applied."
+
+# `partitions_needs_review[]` (workbook-level, confirmed against a real slice --
+# `_bundle-208/handover/Admin_Insights_Starter.json`: `[{"kind": "m_partition", "reason": "...",
+# "table": "..."}]`) is the engine's own record of a `_scaffold_review(...)` deferral: a table whose
+# M partition is a deploy-valid but EMPTY typed-table scaffold because the upstream query could not
+# be auto-emitted -- e.g. "custom SQL native query for this connector isn't verified; complete it
+# manually" (connection_to_m.py). It is a FAMILY of reasons, not one sentence -- a neighbouring
+# scaffold site uses a different reason for a catalog/database drill that isn't resolvable from the
+# .tds -- so this groups by the reason text rather than matching a fixed string.
+PARTITION_REVIEW_MISSING = "not_recorded"
+PARTITION_REVIEW_NONE = "none"
+PARTITION_REVIEW_PRESENT = "present"
+PARTITION_REVIEW_INVALID = "invalid"
 
 PBIP_WARNING_PREFIX = "manual attention required: "
 PBIP_WARNING_CATEGORY = "pbip_warning"
@@ -550,12 +571,94 @@ def _cascadable_lines(handoff: dict, budget: int) -> list[str]:
     return head + _fit_lines(rows, budget - sum(_blen(x) + 1 for x in head) - 1, more) + [""]
 
 
+def partitions_needs_review_status(wb: dict) -> tuple[str, list[dict]]:
+    """Return whether the engine recorded any M-partition scaffold deferral, without treating an
+    absent key as zero. Mirrors `measure_filter_status`/`pbip_warning_status` on purpose: this repo
+    has shipped a false "0 deferrals" three times (#276, #299, #309) from exactly this conflation."""
+    if "partitions_needs_review" not in wb:
+        return PARTITION_REVIEW_MISSING, []
+    rows = wb.get("partitions_needs_review")
+    if not isinstance(rows, list):
+        return PARTITION_REVIEW_INVALID, []
+    rows = [r for r in rows if isinstance(r, dict) and (r.get("reason") or "").strip()]
+    if not rows:
+        return PARTITION_REVIEW_NONE, []
+    return PARTITION_REVIEW_PRESENT, rows
+
+
+def _partition_review_groups(rows: list[dict]) -> dict[str, list[str]]:
+    """Group by the REASON text -- a family of deferrals, not one sentence -- tables listed under it.
+
+    The engine repeats the same reason once per affected table (e.g. one Snowflake datasource with
+    6 custom-SQL tables emits the identical sentence 6 times); printing it once per DISTINCT reason,
+    with every table it covers, is the same de-duplication `guidance_by_category` already does for
+    `category_guidance`.
+    """
+    grouped: dict[str, list[str]] = {}
+    for row in rows:
+        reason = (row.get("reason") or "").strip()
+        grouped.setdefault(reason, []).append(str(row.get("table") or "?"))
+    return grouped
+
+
+def _partition_review_summary_line(wb: dict) -> str | None:
+    """One-liner for the default view. `None` only for an explicit, present, empty list -- MISSING
+    and INVALID both print a loud line so absence never reads as a clean zero."""
+    status, rows = partitions_needs_review_status(wb)
+    if status == PARTITION_REVIEW_PRESENT:
+        groups = _partition_review_groups(rows)
+        return (
+            f"        !! {len(rows)} table partition(s) across {len(groups)} distinct reason(s) NEED MANUAL "
+            "COMPLETION -- the engine emitted a deploy-valid but EMPTY scaffold; see the reason(s) below"
+        )
+    if status == PARTITION_REVIEW_MISSING:
+        return "        partition scaffolds: NOT RECORDED (key missing; this is not a zero-deferral signal)"
+    if status == PARTITION_REVIEW_INVALID:
+        return "        partition scaffolds: INVALID SHAPE (key present but not a list; inspect raw handover)"
+    return None
+
+
+def _partition_review_group_block(reason: str, tables: list[str]) -> str:
+    """One reason, printed ONCE, with every affected table listed under it."""
+    return "\n".join([f"    REASON: {reason}", f"        tables: {', '.join(sorted(tables))}"])
+
+
+def _partition_review_block(wb: dict, budget: int) -> list[str]:
+    """The full, budgeted breakdown backing `_partition_review_summary_line` -- ranked ahead of the
+    calc-stub queue in `_model_section` because unlike a stub measure (which still evaluates, just
+    to BLANK), this scaffold's table has ZERO rows and carries a named manual completion step. A
+    real migration resolved this gap by materializing ~2.3M rows from a packaged extract instead of
+    completing the live translation the engine had already named (issue #326) -- exactly the outcome
+    surfacing this reason exists to prevent.
+    """
+    status, rows = partitions_needs_review_status(wb)
+    if status != PARTITION_REVIEW_PRESENT:
+        return []
+    groups = _partition_review_groups(rows)
+    head = f"    --- {len(rows)} TABLE PARTITION(S) NEED MANUAL COMPLETION ({len(groups)} reason(s)) ---"
+    blocks = [_partition_review_group_block(reason, groups[reason]) for reason in sorted(groups)]
+    more = "    ... and {n} more reason group(s) not named here; raise --max-bytes or use --json"
+    return [head] + _fit_lines(blocks, budget - _blen(head) - 1, more) + [""]
+
+
 def _model_section(wb_name: str, wb: dict, reqs: list[dict], target: Path, budget: int) -> list[str]:
-    """Model-side summary: coverage, the per-category queue, and any cascade ordering constraint."""
+    """Model-side summary: partition scaffolds first, then coverage, the per-category queue, and
+    any cascade ordering constraint."""
     handoff = handoff_of(wb)
     summary = handoff.get("summary") if isinstance(handoff.get("summary"), dict) else {}
 
     out = [f"=== HANDOVER QUEUE - {_clip(wb_name)} ===", f"source: {_clip(str(target))}", ""]
+
+    # Ranked FIRST, ahead of the calc-stub queue: an unresolved M partition means the table has NO
+    # rows at all, which is a more severe defect than a stub calc (which still evaluates to BLANK).
+    partition_line = _partition_review_summary_line(wb)
+    if partition_line:
+        out.append(partition_line)
+    partition_block = _partition_review_block(wb, budget - sum(_blen(x) + 1 for x in out))
+    out += partition_block
+    if partition_line and not partition_block:
+        out.append("")
+
     if not reqs:
         return out + ["MODEL: no residual calculations in the handover queue.", ""]
 
@@ -1136,12 +1239,13 @@ def render_default(wb_name: str, wb: dict, target: Path, max_bytes: int) -> str:
     return "\n".join(out + report + [NEEDS_REVIEW_NOTE])
 
 
-def _list_row(name: str, wb: dict) -> tuple[str, int, int, int, int, int, bool, int, bool]:
-    """Urgency tuple with calc, report, invisible-warning, and missing-audit counts."""
+def _list_row(name: str, wb: dict) -> tuple[str, int, int, int, int, int, bool, int, bool, int, bool]:
+    """Urgency tuple with calc, report, invisible-warning, partition-scaffold, and missing-audit counts."""
     items = report_items_of(wb)
     blocking = sum(1 for i in items if (i.get("severity") or "").lower() == "blocking")
     status, payload = measure_filter_status(wb)
     warning_status, warnings = pbip_warning_status(wb)
+    partition_status, partition_rows = partitions_needs_review_status(wb)
     measure_filters = int(payload.get("count") or 0) if status == MEASURE_FILTER_PRESENT else 0
     return (
         name,
@@ -1153,10 +1257,12 @@ def _list_row(name: str, wb: dict) -> tuple[str, int, int, int, int, int, bool, 
         status == MEASURE_FILTER_MISSING,
         len(warnings) if warning_status == PBIP_WARNING_PRESENT else 0,
         warning_status == PBIP_WARNING_MISSING,
+        len(partition_rows) if partition_status == PARTITION_REVIEW_PRESENT else 0,
+        partition_status == PARTITION_REVIEW_MISSING,
     )
 
 
-def _list_line(row: tuple[str, int, int, int, int, int, bool, int, bool]) -> str:
+def _list_line(row: tuple[str, int, int, int, int, int, bool, int, bool, int, bool]) -> str:
     """Format one `--list` row. The name is clipped so a long one cannot push the line off-cap."""
     line = f"    {_clip(row[0], 52):<52} {row[1]:>4} calc request(s)  {row[2]:>4} report item(s)  {row[3]:>3} blocking"
     if row[4]:
@@ -1169,6 +1275,10 @@ def _list_line(row: tuple[str, int, int, int, int, int, bool, int, bool]) -> str
         line += f"  !! {row[7]} PBIP-WARNINGS"
     elif row[8]:
         line += "  ?? pbip-warning key missing"
+    if row[9]:
+        line += f"  !! {row[9]} PARTITION-SCAFFOLDS"
+    elif row[10]:
+        line += "  ?? partition-review key missing"
     return line
 
 
@@ -1195,6 +1305,34 @@ def _pbip_warning_estate_lines(found: list[tuple[str, dict, Path]]) -> list[str]
     return out + [""]
 
 
+def _partition_review_estate_lines(found: list[tuple[str, dict, Path]]) -> list[str]:
+    """Estate totals for `--list`: unresolved M-partition scaffolds, missing vs present-empty."""
+    states = {
+        PARTITION_REVIEW_PRESENT: 0,
+        PARTITION_REVIEW_NONE: 0,
+        PARTITION_REVIEW_MISSING: 0,
+        PARTITION_REVIEW_INVALID: 0,
+    }
+    reasons: dict[str, int] = {}
+    workbooks_with_partitions = 0
+    for _, wb, _ in found:
+        status, rows = partitions_needs_review_status(wb)
+        states[status] = states.get(status, 0) + 1
+        if rows:
+            workbooks_with_partitions += 1
+        for reason, tables in _partition_review_groups(rows).items():
+            reasons[reason] = reasons.get(reason, 0) + len(tables)
+    total = sum(reasons.values())
+    out = [
+        f"Partition scaffolds: {total} table(s) need manual completion across "
+        f"{workbooks_with_partitions} workbook(s); present-empty {states[PARTITION_REVIEW_NONE]}, "
+        f"missing {states[PARTITION_REVIEW_MISSING]}, invalid {states[PARTITION_REVIEW_INVALID]}",
+    ]
+    if reasons:
+        out.append("Partition scaffold reasons: " + " | ".join(f"{r[:60]!r} {reasons[r]}" for r in sorted(reasons)))
+    return out + [""]
+
+
 def render_list(found: list[tuple[str, dict, Path]], max_bytes: int) -> str:
     """Every workbook in a bundle, ranked by urgency, with the size of both its queues.
 
@@ -1206,12 +1344,16 @@ def render_list(found: list[tuple[str, dict, Path]], max_bytes: int) -> str:
     """
     rows = [_list_row(name, wb) for name, wb, _ in found]
     out = [
-        f"{len(found)} workbook(s), most urgent first "
-        "(PBIP warnings > invisible measure filters > emptied visuals > blocking items > queue size):",
+        f"{len(found)} workbook(s), most urgent first (unresolved M-partition scaffolds > PBIP "
+        "warnings > invisible measure filters > emptied visuals > blocking items > queue size):",
         "",
     ]
     out += _pbip_warning_estate_lines(found)
-    ranked = sorted(rows, key=lambda r: (-r[7], -r[5], -r[4], -r[3], -(r[1] + r[2]), r[0].lower()))
+    out += _partition_review_estate_lines(found)
+    # Partition scaffolds rank FIRST: unlike a stub calc or a dropped visual binding, an unresolved
+    # M partition means the table has ZERO rows -- and it carries a named manual completion step
+    # the engine already wrote down (issue #326).
+    ranked = sorted(rows, key=lambda r: (-r[9], -r[7], -r[5], -r[4], -r[3], -(r[1] + r[2]), r[0].lower()))
     budget = max_bytes - sum(_blen(x) + 1 for x in out)
     more = "    ... and {n} more workbook(s) not listed here; raise --max-bytes"
     return "\n".join(out + _fit_lines([_list_line(r) for r in ranked], budget, more))
@@ -1236,6 +1378,10 @@ def build_json(wb_name: str, wb: dict, category: str | None) -> dict:
         "measure_filter_items": _measure_filter_work_items(wb),
         "pbip_warnings": wb.get("pbip_warnings") if "pbip_warnings" in wb else PBIP_WARNING_MISSING,
         "pbip_warning_items": _pbip_warning_work_items(wb),
+        "partitions_needs_review": wb.get("partitions_needs_review")
+        if "partitions_needs_review" in wb
+        else PARTITION_REVIEW_MISSING,
+        "partitions_needs_review_groups": _partition_review_groups(partitions_needs_review_status(wb)[1]),
         "viz_fidelity": [v for v in (wb.get("viz_fidelity") or []) if isinstance(v, dict)],
     }
 

--- a/tests/test_read_handover.py
+++ b/tests/test_read_handover.py
@@ -826,6 +826,137 @@ def test_pbip_warning_command_failure_is_not_scored_as_expected_output():
 
 
 # --------------------------------------------------------------------------------------------
+# Model-side partition scaffold deferrals (issue #326)
+#
+# `partitions_needs_review[]` shape confirmed against a real slice:
+# `_bundle-208/handover/Admin_Insights_Starter.json` -> `workbook.partitions_needs_review` ==
+# `[{"kind": "m_partition", "reason": "flat-file source; set the file path ...", "table": "sqlproxy"}, ...]`.
+# The specific "custom SQL native query for this connector isn't verified" reason used below comes
+# from the engine source (`connection_to_m.py`'s `_scaffold_review` call sites) rather than a slice
+# on this machine, since no local slice happened to carry a live-connector deferral -- it is the
+# same field and shape, just a different member of the reason FAMILY.
+# --------------------------------------------------------------------------------------------
+
+
+def test_partition_review_ranks_first_and_groups_tables_under_one_reason(tmp_path, capsys):
+    """Kills: printing the reason once per table (the engine's own repetition), and burying it
+    below the calc-stub queue instead of ranking it ahead of a mere stub (which still evaluates)."""
+    wb = make_workbook([make_request("A")])
+    wb["partitions_needs_review"] = [
+        {
+            "kind": "m_partition",
+            "reason": "custom SQL native query for this connector isn't verified; complete it manually",
+            "table": "sqlproxy (Sales)",
+        },
+        {
+            "kind": "m_partition",
+            "reason": "custom SQL native query for this connector isn't verified; complete it manually",
+            "table": "sqlproxy (Costs)",
+        },
+        {
+            "kind": "m_partition",
+            "reason": "generic ODBC source carried neither a DSN nor a driver name, so no connection "
+            "string could be reconstructed; set the ODBC connection manually",
+            "table": "OtherTable",
+        },
+    ]
+    path = write_slice(tmp_path, wb)
+
+    _, out = run([str(path)], capsys)
+
+    assert out.count("isn't verified; complete it manually") == 1, "reason must print once, not per table"
+    assert "sqlproxy (Sales)" in out and "sqlproxy (Costs)" in out
+    assert "OtherTable" in out
+    assert "3 table partition(s) across 2 distinct reason(s)" in out
+    partition_idx = out.index("NEED MANUAL COMPLETION")
+    model_idx = out.index("MODEL:")
+    assert partition_idx < model_idx, "an unresolved M partition (zero rows) must outrank a mere stub calc"
+
+
+def test_partition_review_missing_is_not_a_false_zero(tmp_path, capsys):
+    """Kills: printing a clean '0 table partitions' when the engine never emitted the key at all.
+
+    This repo has shipped exactly this false-green three times (#276, #299, #309); the rule per
+    `check_stub_measures.py:68-69` is that 'no stubs' and 'no model' must never print the same way.
+    """
+    path = write_slice(tmp_path, make_workbook([]))
+
+    _, out = run([str(path)], capsys)
+
+    assert "partition scaffolds: NOT RECORDED" in out
+    assert "0 table" not in out
+    assert "NEED MANUAL COMPLETION" not in out
+
+
+def test_partition_review_present_empty_prints_no_section(tmp_path, capsys):
+    """Kills: treating an engine-recorded empty list the same as a missing key (or vice versa)."""
+    wb = make_workbook([])
+    wb["partitions_needs_review"] = []
+    path = write_slice(tmp_path, wb)
+
+    _, out = run([str(path)], capsys)
+
+    assert "partition scaffolds: NOT RECORDED" not in out
+    assert "NEED MANUAL COMPLETION" not in out
+    assert "partition scaffolds:" not in out
+
+
+def test_partition_review_invalid_shape_is_reported_not_silently_dropped(tmp_path, capsys):
+    """Kills: a non-list `partitions_needs_review` (engine schema drift) rendering as clean-empty."""
+    wb = make_workbook([])
+    wb["partitions_needs_review"] = {"unexpected": "shape"}
+    path = write_slice(tmp_path, wb)
+
+    _, out = run([str(path)], capsys)
+
+    assert "partition scaffolds: INVALID SHAPE" in out
+
+
+def test_partition_review_json_preserves_present_vs_missing(tmp_path, capsys):
+    """Kills: reducing a missing `partitions_needs_review` key to the same JSON shape as zero rows."""
+    present_wb = make_workbook([])
+    present_wb["partitions_needs_review"] = [
+        {"kind": "m_partition", "reason": "R1", "table": "T1"},
+        {"kind": "m_partition", "reason": "R1", "table": "T2"},
+    ]
+    present = write_slice(tmp_path, present_wb, "present.json")
+    missing = write_slice(tmp_path, make_workbook([]), "missing.json")
+    present_json = tmp_path / "present-out.json"
+    missing_json = tmp_path / "missing-out.json"
+
+    assert run([str(present), "--json", str(present_json)], capsys)[0] == 0
+    assert run([str(missing), "--json", str(missing_json)], capsys)[0] == 0
+
+    present_payload = json.loads(present_json.read_text(encoding="utf-8"))
+    missing_payload = json.loads(missing_json.read_text(encoding="utf-8"))
+    assert len(present_payload["partitions_needs_review"]) == 2
+    assert present_payload["partitions_needs_review_groups"] == {"R1": ["T1", "T2"]}
+    assert missing_payload["partitions_needs_review"] == rh.PARTITION_REVIEW_MISSING
+    assert missing_payload["partitions_needs_review_groups"] == {}
+
+
+def test_partition_review_outranks_pbip_warnings_in_list(tmp_path, capsys):
+    """Kills: leaving partition scaffolds out of `--list` urgency, or ranking them below PBIP
+    warnings -- an unresolved partition means zero rows, which this repo's field incident (#326)
+    showed gets silently "fixed" by materializing the wrong data source unless it outranks noise."""
+    handover = tmp_path / "handover"
+    handover.mkdir()
+    warned_only = make_workbook([], name="WarnedOnly")
+    warned_only["pbip_warnings"] = ["manual attention required: table 'T' landed with NO relationship to any other"]
+    scaffolded = make_workbook([], name="Scaffolded")
+    scaffolded["partitions_needs_review"] = [{"kind": "m_partition", "reason": "R", "table": "T"}]
+    write_slice(handover, warned_only, "warned.json")
+    write_slice(handover, scaffolded, "scaffolded.json")
+
+    _, out = run([str(tmp_path), "--list"], capsys)
+
+    lines = [line for line in out.splitlines() if "calc request" in line]
+    assert "Scaffolded" in lines[0], "an unresolved M partition must outrank a PBIP-warning-only workbook"
+    assert "PARTITION-SCAFFOLDS" in lines[0]
+    assert "Partition scaffolds: 1 table(s)" in out
+
+
+# --------------------------------------------------------------------------------------------
 # --fidelity
 # --------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Surfaces the third engine signal our reader swallowed.

## What was invisible

The engine defers custom-SQL translation for connectors it cannot verify, and records it as `partitions_needs_review[]` — a table whose M partition is a **deploy-valid but EMPTY** typed-table scaffold:

> *"custom SQL native query for this connector isn't verified; complete it manually"* — `connection_to_m.py:3948-3951`

`read_handover.py` — the tool whose whole job is turning a 347 KB slice into a readable work queue — never showed it.

## The key is confirmed, not inferred

I asked the agent not to guess the JSON shape, because keying off a non-existent field would produce a reader that silently shows nothing — the exact bug being fixed. It confirmed against a real slice:

```
_bundle-208/handover/Admin_Insights_Starter.json
  partitions_needs_review: [{"kind": "m_partition", "reason": "...", "table": "..."}]
```

**Grouped by reason text, not a fixed string.** This is a *family* of deferrals — a neighbouring site in `connection_to_m.py` uses a different reason for a catalog/database drill unresolvable from the `.tds` — so matching one sentence would silently miss the others.

## Four states, so an absent key cannot read as zero

`present` / `none` / `not_recorded` / `invalid`. This repo has shipped that false green three times (#276, #299, #309) and `check_stub_measures.py:68-69` states the rule: *"'no stubs' and 'no model' must never print or exit the same way."*

## Why this one mattered

**6 tables across 4 workbooks** in a single SES bundle carried this deferral. Because nothing surfaced it, a fix-pass on `Airline_Scorecard_Dashboard` resolved the gap by materialising **~2.3M rows** from the packaged `.hyper` into CSV rather than completing the live Snowflake translation. It validated clean, refreshed clean, and was stale by construction — found by a human reading a migration brief.

The engine had already said what was needed. The toolkit never repeated it, so the shortcut looked like the only option.

⚠️ Note the discrimination this preserves: **3 other CSV tables in that same bundle were legitimately CSV in the Tableau source.** "It produced CSV" is not evidence of a deferral — which is precisely why the *reason* has to be surfaced rather than inferred from output shape.

## Verification

```
pytest tests/test_read_handover.py    83 passed, EXIT=0
ruff format --check                   EXIT=0
ruff check                            EXIT=0
pylint scripts                        EXIT=0
```

`read_handover.py` is 1,496 lines, over the 1,200 `C0302` cap — it carries a **pre-existing** waiver with the required one-line reason (*"One cohesive projection CLI; adding every engine handover signal here keeps drills consistent"*), which is exactly the case this change extends.

⚠️ **Recovered from a host crash mid-flight.** The agent had finished and tested but not committed; the work was on disk. I ran the full gate ritual myself rather than trusting its report.
