### PR TITLE
test: salvage the offline mock harness from an abandoned branch

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -44,6 +44,7 @@ Eligible files: tracked Markdown knowledge/navigation files, `.github/pbi.kb/**/
 | Find migration guidance | [`docs/migration-programme.md`](../docs/migration-programme.md) | Programme phases and operating model. |
 | Find migration guidance | [`docs/migration-spec.md`](../docs/migration-spec.md) | `migration-spec.json` contract. |
 | Find migration guidance | [`docs/operator-runbook.md`](../docs/operator-runbook.md) | Manual pipeline operation. |
+| Test the offline deployment rehearsal | [`docs/offline-mock-harness.md`](offline-mock-harness.md) | Offline Tableau-to-Fabric mock harness and fidelity boundary. |
 | Find migration guidance | [`docs/reference-capture.md`](../docs/reference-capture.md) | Tableau reference capture and evidence grading. |
 | Find migration guidance | [`docs/review-remediation-plan.md`](../docs/review-remediation-plan.md) | Route validation/review findings. |
 | Find migration guidance | [`docs/tableau-dax-translation-guide.md`](../docs/tableau-dax-translation-guide.md) | Translate Tableau calcs/LODs/table calcs. |

--- a/docs/offline-mock-harness.md
+++ b/docs/offline-mock-harness.md
@@ -1,0 +1,268 @@
+# Offline end-to-end mock harness
+
+Runs the whole Tableau → Power BI/Fabric pipeline **with no Tableau server, no Fabric tenant and no
+credentials**, in about eight seconds. Its job is to make a deploy regression-testable and to let the
+migration be rehearsed before it is run against a customer's tenant.
+
+```
+python -m pytest tests/test_mock_fabric.py tests/test_mock_tableau.py tests/test_e2e_offline.py -q
+```
+
+| file | what it is |
+|---|---|
+| [`tests/mocks/fabric.py`](../tests/mocks/fabric.py) | in-process Fabric REST fake, substituted at `deploy_estate._request` |
+| [`tests/mocks/tableau.py`](../tests/mocks/tableau.py) | Tableau REST + GraphQL Metadata fake, served over a loopback socket |
+| [`tests/mocks/estate.py`](../tests/mocks/estate.py) | a synthetic estate built from this repo's real fixture workbooks, plus a stand-in for the deterministic engine |
+| [`tests/test_mock_fabric.py`](../tests/test_mock_fabric.py) | 51 fidelity self-tests for the Fabric fake |
+| [`tests/test_mock_tableau.py`](../tests/test_mock_tableau.py) | 21 fidelity self-tests for the Tableau fake |
+| [`tests/test_e2e_offline.py`](../tests/test_e2e_offline.py) | 18 joined end-to-end tests (marked `slow`) |
+| [`tests/mutation_harness.py`](../tests/mutation_harness.py) | 22 deliberate mutations that prove those tests can fail |
+
+---
+
+## The rule this harness is built on
+
+**A mock that is kinder than the real service is worse than no mock at all**, because it manufactures
+confidence. So:
+
+* Behaviour that was **measured** against a real tenant or a real site is reproduced exactly, and the
+  test that pins it says so.
+* Behaviour that was **not** measured is implemented as the **strictest plausible** variant and listed
+  in [ASSUMED, NOT MEASURED](#assumed-not-measured) below. Over-rejecting costs a false alarm;
+  under-rejecting ships a bug to a customer.
+* Where being strict would **invent** a failure the real service does not have, the mock stays
+  permissive and says why (see item-display-name rules below). That is the one exception, and it is
+  as important as the others: a mock that rejects `Sales v1.2` wastes a day chasing a bug that does
+  not exist.
+* Every ASSUMED error **code name** is a plausible invention. **Never assert on an assumed code** -
+  assert on the status and the effect. The tests here do exactly that.
+
+## No network, by construction
+
+* The Fabric fake is **in-process**. Nothing is opened, not even a socket.
+* The Tableau fake binds `127.0.0.1:0` (an OS-assigned loopback port). A loopback socket is not a
+  network call - no packet leaves the machine - and it is necessary because
+  `harvest_estate_assets.py` and the engine's `estate_survey.py` run in **subprocesses** that no
+  monkeypatch can reach. `TableauSite.call(path)` exposes the same router with no socket at all, for
+  the engine's injected-caller seam.
+* `test_the_mock_never_points_at_a_real_host` asserts the generated environment contains a loopback
+  URL and no `online.tableau.com`.
+* `run_estate.py`'s provenance stamping is the one step that *could* contact a real site. It is safe
+  here for two reasons that are both worth knowing: `resolve_env` gives the **process environment
+  precedence over `.env`**, and the whole call is best-effort inside a broad `except`. In the E2E it
+  reports `0 confirmed against the site` and carries on.
+
+---
+
+## MEASURED — reproduced, with evidence
+
+### Fabric
+
+| # | Behaviour | Evidence | Pinned by |
+|---|---|---|---|
+| 1 | `POST /items` returns `201 {"id": ...}`, or `202` + `Location`/`x-ms-operation-id` for an LRO | measured against a real tenant | `test_a_long_running_create_must_be_polled_to_completion` |
+| 2 | **A repeated `Report`/`SemanticModel` displayName is ACCEPTED** - Fabric creates a duplicate | measured; this is why duplicates went undetected on a real estate | `test_a_duplicate_display_name_is_accepted_because_fabric_accepts_it` |
+| 3 | `GET /items` → `{"value": [...]}` with `id`, `displayName`, `type`, `description` | measured | `test_a_listing_row_carries_id_display_name_type_and_description` |
+| 4 | **`folderId` is OMITTED ENTIRELY at the workspace root** - not present-and-null | measured | `test_folder_id_is_omitted_at_the_root_not_returned_as_null` |
+| 5 | Paging via `continuationToken` + `continuationUri`; 68 items came back in **one** page with no token | measured | `test_paging_emits_a_continuation_token_and_uri`, `test_list_all_in_the_deployer_follows_the_continuation_token` |
+| 6 | `updateDefinition` replaces the definition and does **not** touch `description` or `folderId` | measured | `test_update_definition_leaves_description_and_folder_untouched` |
+| 7 | `PATCH {"description": ...}` updates the description | measured | `test_patch_updates_the_description_and_move_replaces_the_item` |
+| 8 | `POST /move {"targetFolderId": ...}`; an **empty body means the workspace root** | measured | `test_move_with_an_empty_body_means_the_workspace_root` |
+| 9 | Folder names are **REJECTED, not coerced**, with `InvalidFolderDisplayName`: `& / \ : ? * " \| < # %` and **`.` anywhere** (not just trailing), plus a leading/trailing space | measured | `test_a_folder_name_with_a_rejected_character_is_refused_not_coerced`, `test_a_folder_name_with_surrounding_space_is_refused` |
+| 10 | Folder names **accept** `- _ + ( )`, interior spaces and non-ASCII (`Ventes françaises` was accepted) | measured | `test_the_accepted_folder_characters_really_are_accepted` |
+| 11 | Nesting deeper than **10** levels → `FolderDepthOutOfRange` | measured | `test_folder_nesting_deeper_than_ten_is_refused` |
+| 12 | `GET /folders` rows carry `id`, `displayName`, `parentFolderId` | measured | `test_a_folder_listing_row_carries_id_display_name_and_parent` |
+| 13 | A workspace holds at most **1000** items | measured | `test_the_thousand_item_workspace_limit_is_enforced`, `test_the_default_workspace_limit_is_the_measured_one_thousand` |
+| 14 | `401` with `{"errorCode": "TokenExpired"}`, distinct from a plain invalid token | measured (a 66-item deploy outlived its token) | `test_token_expiry_answers_a_named_error_code_and_the_deployer_renews_once`, `test_an_invalid_token_is_not_reported_as_expired` |
+| 15 | `429` + `Retry-After` in **both** the seconds form and the RFC 9110 HTTP-date form | measured; the date form raised `ValueError` in `float()` and killed a deploy mid-estate | `test_retry_after_is_served_in_both_measured_forms`, `test_a_throttled_create_is_retried_after_the_http_date_delay` |
+| 16 | `ItemDisplayNameNotAvailableYet` / `ItemDisplayNameAlreadyInUse` are emitted as named codes | measured | `create_item` in `deploy_estate.py` branches on them; the mock emits them from `_create_item` |
+| 17 | The `202` body is **empty** - the id is only reachable through the operation | measured | `test_a_long_running_create_must_be_polled_to_completion` |
+| 18 | A **Failed** operation is indistinguishable from a successful one unless `/operations/{id}` is polled | measured: a probe reported both items deployed; one had failed and the workspace held one item | `test_a_failed_operation_is_indistinguishable_from_success_unless_polled` |
+| 19 | PBIR schema **2.0.0** `byConnection` sets `additionalProperties: false` and permits **only** `connectionString`; the five-field 1.0.0 shape is rejected | measured against the published schema, and against the service | `test_a_byconnection_block_with_extra_properties_is_refused` |
+| 20 | An empty report answers *"Content provider provided invalid package content stream"* | measured: 2 of 33 reports on a real estate | `test_a_report_with_no_pages_is_refused` |
+
+**Injectable failure modes** (each one broke a real run): a transient `500` or a `429` on a
+**listing**; a `Timeout` where our poll gives up but the operation succeeds server-side
+(`stall_operations`); a token that expires partway through a long run (`expire_tokens`); and a
+client-side network failure that surfaces as `HTTP 0` (`drop_network`), which the deployer treats as
+*"we never reached the host"* rather than as a service verdict.
+
+### Tableau
+
+| Behaviour | Evidence | Pinned by |
+|---|---|---|
+| A lost session answers `401` whose body contains the literal `401002` | `assess_estate.Site.get` re-authenticates **only** on that substring - read the source | `test_a_lost_session_answers_the_literal_code_the_client_looks_for`, `test_the_real_assess_client_recovers_from_a_dropped_session` |
+| Pagination numbers are **strings** (`"pageNumber"`, `"pageSize"`, `"totalAvailable"`) | Tableau REST API | `test_pagination_numbers_are_strings_because_tableau_emits_strings` |
+| The download header is the non-standard `Content-Disposition: name="X.twbx"` with **no** `filename=` | the engine's `fetch_tds.derive_filename` carries a fallback for exactly this | `test_the_download_header_uses_tableaus_non_standard_name_form` |
+| The `usage` block is absent unless `includeUsageStatistics=true` | Tableau REST API; it is the input to the tiering decision | `test_usage_statistics_are_absent_unless_requested` |
+| Content download returns real `.twbx`/`.tdsx` **bytes** | the fixtures are this repo's own `tests/fixtures/*.twb` | `test_content_download_returns_a_real_packaged_workbook`, `test_a_downloaded_workbook_parses_with_the_real_parser` |
+| **`estate_survey.py` blocks forever on a hidden `getpass` prompt when `TABLEAU_PAT_VALUE` is unset** | measured; it burned 13 minutes of a real session. Confirmed in `credential_resolver.resolve_secret`: the prompt fires when `allow_prompt` **and** `sys.stdin.isatty()` | `test_running_an_engine_script_without_the_pat_variable_fails_loudly` |
+
+The GraphQL structure answer is derived from the **served workbook bytes** with `xml.etree`, on
+purpose **independent of `parse_tableau`**: if the mock's expectations were produced by the parser
+under test, a parser bug would be invisible because both sides would move together.
+
+---
+
+## ASSUMED, NOT MEASURED
+
+Everything below is the **strictest plausible** behaviour, chosen because under-rejecting is the
+dangerous direction. If the real service turns out to be more forgiving, this mock over-rejects -
+which shows up as a false alarm in a test, not as a broken report in a customer tenant.
+
+| # | Assumption | Why this choice | Risk if wrong |
+|---|---|---|---|
+| A1 | **Every error-code name for an assumed rejection is invented**, e.g. `FolderDisplayNameAlreadyInUse`, `InvalidConnectionInformation`, `WorkspaceItemLimitExceeded` | The *status* and the *effect* were reasoned about; the string was not | None, provided nothing asserts on the string. The tests here assert status/effect only. |
+| A2 | `>` is also rejected in a folder name | `<` was measured as rejected; a matched pair is the plausible rule | Over-rejects a name Fabric might accept |
+| A3 | Two sibling folders cannot share a display name | The alternative - two identical siblings - is unusable | Over-rejects |
+| A4 | `parentFolderId` is omitted (not null) for a root folder | Mirrors the **measured** `folderId` omission on items | A client depending on the key would be under-tested |
+| A5 | A report bound **`byPath`** is refused outright | The service has no filesystem to resolve a relative path against. Strict because this is the single most common rebinding bug | Over-rejects; and the E2E depends on it to catch a lost rebind |
+| A6 | A `connectionString` with no `semanticModelId=<guid>` is refused | It names no model, so it cannot bind | Over-rejects |
+| A7 | A `semanticModelId` that does not resolve to a `SemanticModel` **in this workspace** is refused | This is what makes *"bound to the wrong/deleted model"* a test failure instead of a plausible success | Over-rejects a cross-workspace binding, which this pipeline never emits |
+| A8 | Unknown `type`, non-base64 `payload`, non-`InlineBase64` `payloadType`, missing `definition.pbism`/`definition.pbir` are all refused | A typo must not silently create something | Over-rejects |
+| A9 | A non-existent `folderId` on create is refused | The alternative is an item filed nowhere | Over-rejects |
+| A10 | An empty item display name is refused | An unnamed item is not addressable | Over-rejects |
+| A11 | `PATCH` with unknown keys is refused | Silent no-ops hide bugs | Over-rejects |
+| A12 | A **stalled** operation materialises its item **immediately** | The harsher, testable variant. A client that cannot see the item has no way to avoid the duplicate, so the invisible variant would only assert a known hazard | Understates how long a real duplicate window is |
+| A13 | Exactly **one** page size is used for both items and folders | Simplification | Paging is exercised deliberately anyway |
+| A14 | `single_row_as_object` (Tableau returning a lone row as an object, not a 1-element list) | **Off by default.** `assess_estate.paged` already handles it, but the behaviour was not observed here | If real, a client without that handling would be under-tested. Turn the switch on to test it. |
+| A15 | Sign-in requires the PAT **name and secret** to match | Strict: the half-right credential is the commonest mistake in this pipeline | Over-rejects |
+
+### Deliberately NOT made strict
+
+* **Item display names are not held to the folder character rules.** The rules in row 9 above were
+  measured on **folders**. Item names routinely contain dots (`Sales v1.2`). Importing the folder
+  rules would invent a failure - the one kind of infidelity that costs a day chasing a bug that does
+  not exist. Pinned by `test_an_item_display_name_is_not_held_to_the_folder_character_rules`.
+
+---
+
+## Not reproduced — left out on purpose
+
+| Left out | Why |
+|---|---|
+| **The real deterministic engine's PBIP output.** `tests/mocks/estate.py` ships a *stand-in* that emits the output **contract** (`report.json` with a `definition_of_done`, a semantic model for every workbook, and a schema-valid `.Report` with a `byPath` reference when the workbook has convertible pages), parsing each workbook with this repo's real parser. | The engine is a ~200-file plugin that is not installed in CI, and claiming to reproduce its conversion fidelity would be fiction. What is tested is that `run_estate.py` - the real one, unmodified - accepts the bundle and that `deploy_estate.py` can deploy it. |
+| **Azure AD / `az account get-access-token`.** `FabricService.token_for()` builds a real `deploy_estate.Token` whose `_mint` is bound to the fake. | Token *acquisition* is Azure's, not Fabric's. Token *expiry* mid-run is reproduced, because that is the part that broke a deploy. |
+| **Workspace/capacity administration, item deletion, Git integration, dataset refresh.** | `deploy_estate.py` never calls them. Serving an endpoint nothing exercises is fiction with extra steps. |
+| **Tableau flows, extract refresh schedules, custom-view content.** | Present as empty collections so a client that asks gets a well-formed answer; no behaviour is claimed. |
+| **Rate-limit *policy*** (when Fabric decides to throttle). | Only the *response shape* is reproduced, and it is injected explicitly. Guessing a policy would produce timing-dependent tests. |
+
+---
+
+## Where the seam is, and why it is `_request` and not `call`
+
+The task named `call(method, url, tok, body=None)`. The harness substitutes **`_request`** instead,
+one layer lower. The reason is that `call` is not a transport function - it carries policy:
+
+```python
+def call(method, url, tok, body=None):
+    status, headers, parsed = _request(method, url, str(tok), body)
+    if status == 401 and isinstance(tok, Token) and "TokenExpired" in json.dumps(parsed):
+        status, headers, parsed = _request(method, url, tok.refresh(), body)
+    return status, headers, parsed
+```
+
+Patching `call` would delete the one-shot token renewal from every test that uses the mock - the
+exact behaviour that a 66-item deploy needed. `FabricService.call` still exists and delegates to
+`.request`, for tests that want the convenience.
+
+Two consequences worth knowing:
+
+* `call`'s renewal is guarded by `isinstance(tok, Token)`, so a duck-typed token **silently skips
+  it**. Use `service.token_for(deploy_estate)`, which builds a genuine `Token` with `_mint` bound to
+  the fake.
+* `install()` also neutralises `time.sleep`, so a `Retry-After` wait and a 3-second operation poll
+  cost nothing while the deployer's own back-off arithmetic still runs.
+
+---
+
+## Mutation testing — proof the tests can fail
+
+A test that passes regardless of the code is worthless, so the suite was attacked with 22 deliberate
+mutations (`tests/mutation_harness.py` — run it with
+`python tests/mutation_harness.py`). Each patches the real deployer or the mock in a subprocess and
+re-runs the suite. **All 22 were caught; there were no survivors.**
+
+| mutation | caught by |
+|---|---|
+| `no-dedup-landing-claim` — `Landing.claim` always says "not here" | `test_re_running_the_same_deploy_creates_nothing_new` |
+| `bind-report-to-wrong-model` — `rebind` uses a null GUID | `test_the_whole_chain_lands_the_expected_workspace` |
+| `reports-before-models` — deploy order inverted | `test_the_whole_chain_lands_the_expected_workspace` |
+| `flatten-the-folder-tree` — `project_parents` returns `{}` | `test_the_whole_chain_lands_the_expected_workspace` |
+| `drop-the-provenance-stamp` — `stamp_for` returns `""` | `test_every_deployed_item_carries_a_provenance_stamp` |
+| `listing-failure-means-empty` — `Landing.read` falls back to empty | `test_a_listing_that_fails_AFTER_preflight_still_refuses_to_guess` |
+| `no-empty-report-skip` — `report_is_empty` always False | `test_the_whole_chain_lands_the_expected_workspace` |
+| `skip-the-folder-sanitiser` — `folder_display_name` is identity | `test_the_whole_chain_lands_the_expected_workspace` |
+| `mock-rejects-duplicate-names` — mock becomes kinder than Fabric | `test_a_duplicate_display_name_is_accepted_because_fabric_accepts_it` |
+| `mock-omits-nothing` — root `folderId` returned as `null` | `test_a_duplicate_display_name_is_accepted_because_fabric_accepts_it` |
+| `mock-accepts-bypath-reports` | `test_a_report_bound_by_path_is_refused` |
+| `mock-coerces-bad-folder-names` | `test_a_folder_name_with_a_rejected_character_is_refused_not_coerced[Q1.2026]` |
+| `mock-ignores-the-folder-depth-limit` | `test_folder_nesting_deeper_than_ten_is_refused` |
+| `mock-never-throttles` | `test_retry_after_is_served_in_both_measured_forms[3]` |
+| `mock-updatedefinition-also-moves-and-restamps` | `test_update_definition_leaves_description_and_folder_untouched` |
+| `mock-forgets-the-item-limit` | `test_the_default_workspace_limit_is_the_measured_one_thousand` |
+| `tableau-mock-accepts-any-pat-secret` | `test_sign_in_requires_both_halves_of_the_pat` |
+| `tableau-mock-returns-empty-graphql-instead-of-errors` | `test_an_unsupported_graphql_query_is_an_error_not_an_empty_result` |
+| `tableau-mock-always-sends-usage-statistics` | `test_usage_statistics_are_absent_unless_requested` |
+| `tableau-mock-uses-the-standard-content-disposition` | `test_the_download_header_uses_tableaus_non_standard_name_form` |
+| `tableau-mock-emits-integer-pagination` | `test_pagination_numbers_are_strings_because_tableau_emits_strings` |
+| `engine-stand-in-emits-no-pages` | `test_the_whole_chain_lands_the_expected_workspace` |
+
+Two mutations **survived the first pass**, and closing them is the most useful thing the exercise
+produced:
+
+1. **`listing-failure-means-empty` survived.** The workspace is listed **twice** - once by
+   `preflight`, once by `Landing.read` - and only the second decides whether an item already exists.
+   The original test failed the listing globally, so preflight refused first and the mutation was
+   never reached. Fixed by adding `test_a_listing_that_fails_AFTER_preflight_still_refuses_to_guess`,
+   which fails **precisely the second** listing.
+2. **`mock-forgets-the-item-limit` survived.** The limit test passed `item_limit=3` explicitly, so
+   nothing asserted the **default** was the measured 1000. Fixed by
+   `test_the_default_workspace_limit_is_the_measured_one_thousand`, which also asserts the mock and
+   the deployer agree on the number.
+
+A third finding was in the harness itself and is worth recording: the first mutation run reported
+**22/22 caught**, and every one of those was a **false positive** - the injected plugin was not on
+`sys.path`, so pytest exited non-zero on an `ImportError` before running a single test. The harness
+now fails loudly if the mutation did not apply. *A mutation run that catches everything on the first
+try deserves suspicion, not celebration.*
+
+---
+
+## What the E2E asserts
+
+`test_the_whole_chain_lands_the_expected_workspace` runs
+**survey/assess → harvest → parse/convert → deploy** and then reads the resulting workspace:
+
+1. **Exact item set** — 3 models, 2 reports. The third report is legitimately empty
+   (`federated_multi_connection.twb` has no worksheets) and is **skipped**, not deployed empty. That
+   is the MEASURED case `report_is_empty` exists for (2 of 33 reports on a real estate).
+2. **Zero duplicates** — and the mock would have *accepted* duplicates, because Fabric does. This is
+   a real check, not a tautology.
+3. **Models before reports**, asserted from creation order.
+4. **`byConnection` binding to the GUID the service returned for that report's own model** — not
+   `byPath`, not another model's id.
+5. **The Tableau project tree mirrored as folders**: `Finance/Q1-2026` and `R-D`, sanitised from
+   `Finance/Q1.2026` and `R&D` because Fabric rejects `.` and `&` in a folder name — with the
+   **nesting** preserved, which is what proves the tree survived rather than flattening.
+
+The rest of the file is the "it has to catch things" half: idempotent re-run, a transient listing
+failure at both layers, a throttled create with an HTTP-date `Retry-After`, an interrupted run that
+resumes, a resume with the journal **deleted**, a customer's same-named item that must **not** be
+overwritten, a token that expires mid-run, a dry run that creates nothing, and both item-limit gates.
+
+## Running it
+
+```powershell
+# everything
+python -m pytest tests/test_mock_fabric.py tests/test_mock_tableau.py tests/test_e2e_offline.py -q
+
+# just the fast fidelity suites (no socket, no subprocess)
+python -m pytest -q -m "not slow"
+
+# the joined end-to-end only
+python -m pytest tests/test_e2e_offline.py -q
+```
+
+The whole thing is ~8 seconds. `tests/test_e2e_offline.py` is marked `slow` (registered in
+`pyproject.toml`) because it binds a loopback socket and spawns a subprocess; nothing else does.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,9 @@ py-modules = []
 # folder a real gate rather than a claim. `ruff`/`pylint` need the same treatment in
 # `.github/workflows/checks.yml`; keep the two lists in step.
 testpaths = ["tests", ".github/skills"]
+markers = [
+    "slow: joined offline Tableau-to-Fabric mock integration tests",
+]
 
 [tool.ruff]
 exclude = [

--- a/tests/mocks/__init__.py
+++ b/tests/mocks/__init__.py
@@ -1,0 +1,10 @@
+"""Offline mock services for the Tableau -> Power BI/Fabric pipeline.
+
+``fabric``  - an in-process fake of the Fabric REST API (the ``deploy_estate`` seam).
+``tableau`` - a loopback HTTP fake of the Tableau REST + Metadata (GraphQL) APIs.
+``estate``  - a synthetic Tableau estate built from this repo's REAL workbook fixtures, plus a
+              stand-in for the deterministic engine so ``run_estate.py`` can be run offline.
+
+See ``docs/offline-mock-harness.md`` for what is faithfully reproduced, on what evidence, and the
+list of behaviours that are ASSUMED rather than measured.
+"""

--- a/tests/mocks/estate.py
+++ b/tests/mocks/estate.py
@@ -1,0 +1,418 @@
+"""A synthetic Tableau estate built from this repo's REAL fixtures, plus a stand-in for the engine.
+
+Two pieces, both of which exist so an end-to-end rehearsal does real work on real bytes:
+
+:func:`build_site`
+    A :class:`~tests.mocks.tableau.TableauSite` populated from ``tests/fixtures/*.twb`` - a nested
+    project tree, a published data source shared by two workbooks, usage counters, groups and grants.
+    Nothing here is invented Tableau XML; the workbooks are the ones the parser suite already uses.
+
+:func:`install_fake_engine`
+    A stand-in for the deterministic engine's ``migrate_estate.py``, laid out at the path
+    ``run_estate.py`` looks for (``<engine>/skills/tableau-migration/scripts/``), so ``run_estate``
+    itself runs unmodified: its definition-of-done gate, approval-collision check, handover slicing
+    and manifest all execute for real.
+
+    **This is a stand-in, not a mock of measured behaviour.** The real engine is a ~200-file plugin
+    that is not installed in CI, and reproducing its PBIP output is not something this harness can
+    claim to do faithfully. What it reproduces is the *contract* ``run_estate`` and ``deploy_estate``
+    consume: ``report.json`` with a ``definition_of_done``, and ``pbip/<workbook>/<name>.SemanticModel``
+    + a schema-valid ``<name>.Report`` with a ``byPath`` dataset reference where the workbook has
+    convertible pages. It parses each workbook with THIS repo's real parser, so the count of pages it
+    emits is derived from the workbook, not hard-coded.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import textwrap
+from pathlib import Path
+from typing import Any
+
+from .tableau import TableauSite
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FIXTURES = REPO_ROOT / "tests" / "fixtures"
+
+
+def build_site(**kwargs) -> TableauSite:
+    """A small estate with the shapes that have historically broken this pipeline.
+
+    * a NESTED project tree (``Finance/Q1.2026``), including a name Fabric will not accept as a
+      folder - the dot is rejected anywhere in a Fabric folder name;
+    * a project name (``R&D``) that sanitises into the same Fabric name as another (``R/D`` would),
+      which is where a silent content merge used to happen;
+    * a published data source that TWO workbooks depend on, so migration ORDER matters;
+    * a workbook with no deliberate-use signal at all, so tiering has something to tier.
+    """
+    site = TableauSite(**kwargs)
+    finance = site.project("Finance")
+    quarter = site.project("Q1.2026", parent=finance)
+    research = site.project("R&D")
+
+    shared = site.datasource(
+        "Corporate Cities",
+        finance,
+        FIXTURES / "standalone_datasource.tds",
+        is_certified=True,
+        has_extracts=True,
+        extract_last_refresh="2026-08-01T00:00:00Z",
+    )
+
+    sales = site.workbook("Sales Review", quarter, FIXTURES / "minimal.twb", views=2, usage=120)
+    ops = site.workbook("Ops Dashboard", research, FIXTURES / "federated_multi_connection.twb", views=1, usage=40)
+    site.workbook("Attic Copy", finance, FIXTURES / "published_datasource.twb", views=1, usage=0)
+
+    site.publish_dependency(sales, shared)
+    site.publish_dependency(ops, shared)
+
+    local = _group("All Users", "local", ["ana", "ben"])
+    entra = _group("Entra Finance", "example.com", ["cara"])
+    site.groups.extend([local, entra])
+    site.grant(finance, local, "Read")
+    site.grant(finance, entra, "Write")
+    site.grant(sales, local, "ViewUnderlyingData")
+
+    site.subscriptions.append({"id": "sub-1", "content": {"id": site.views[0].luid, "type": "View"}})
+    site.alerts.append({"id": "alert-1", "view": {"id": site.views[0].luid}})
+    return site
+
+
+def _group(name: str, domain: str, members: list[str]):
+    from .tableau import Group  # noqa: PLC0415  # local import keeps the public surface small
+
+    return Group(luid=f"group-{name.lower().replace(' ', '-')}", name=name, domain=domain, members=members)
+
+
+# --------------------------------------------------------------------------- the engine stand-in
+
+_FAKE_ENGINE = '''\
+"""A stand-in for the deterministic engine's migrate_estate.py: enough of its OUTPUT CONTRACT to run
+`run_estate.py` offline. Not a fidelity claim about the engine - see tests/mocks/estate.py."""
+
+import argparse
+import json
+import sys
+import uuid
+import zipfile
+from pathlib import Path
+
+sys.path.insert(0, {repo_scripts!r})
+
+from parse_tableau import parse_workbook
+
+
+def sanitise(name):
+    """The engine renames a workbook into a filesystem-safe project name; so do we."""
+    return "".join(c if (c.isalnum() or c in " -_") else "_" for c in name).strip()
+
+
+def emit(spec, out, name):
+    """Write one workbook's PBIP: a model and a report bound to it BY PATH (Git-integration shape)."""
+    project = out / "pbip" / name
+    model = project / (name + ".SemanticModel")
+    (model / "definition" / "tables").mkdir(parents=True, exist_ok=True)
+    (model / "definition.pbism").write_text(
+        json.dumps({{"version": "4.0", "settings": {{"qnaEnabled": True}}}}, indent=2), encoding="utf-8"
+    )
+    (model / "definition" / "model.tmdl").write_text("model Model\\n\\tculture: en-US\\n", encoding="utf-8")
+    for source in spec.get("data_sources") or []:
+        table = sanitise(source.get("name") or "Table")
+        (model / "definition" / "tables" / (table + ".tmdl")).write_text(
+            "table " + table + "\\n\\tcolumn Value\\n\\t\\tdataType: string\\n", encoding="utf-8"
+        )
+
+    pages = [f"page-{{index}}" for index, _worksheet in enumerate(spec.get("worksheets") or [], start=1)]
+    if not pages:
+        # A page-less report cannot pass the current PBIR structural gate or be deployed. The
+        # model remains a valid migration result, while the deployer's empty-report rule is tested
+        # directly in the joined suite.
+        return 0
+
+    report = project / (name + ".Report")
+    (report / "definition" / "pages").mkdir(parents=True, exist_ok=True)
+    (report / ".platform").write_text(
+        json.dumps(
+            {{
+                "$schema": "https://developer.microsoft.com/json-schemas/fabric/gitIntegration/platformProperties/2.0.0/schema.json",
+                "metadata": {{"type": "Report", "displayName": name}},
+                "config": {{"version": "2.0", "logicalId": str(uuid.uuid5(uuid.NAMESPACE_URL, "mock/" + name))}},
+            }},
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    (report / "definition.pbir").write_text(
+        json.dumps(
+            {{
+                "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definitionProperties/2.0.0/schema.json",
+                "version": "4.0",
+                "datasetReference": {{"byPath": {{"path": "../" + name + ".SemanticModel"}}}},
+            }},
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    (report / "definition" / "version.json").write_text(
+        json.dumps(
+            {{
+                "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/versionMetadata/1.0.0/schema.json",
+                "version": "2.0.0",
+            }},
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    (report / "definition" / "report.json").write_text(
+        json.dumps(
+            {{
+                "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/report/1.0.0/schema.json",
+                "themeCollection": {{}},
+                "layoutOptimization": "None",
+                "resourcePackages": [],
+            }},
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    (report / "definition" / "pages" / "pages.json").write_text(
+        json.dumps(
+            {{
+                "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/pagesMetadata/1.0.0/schema.json",
+                "pageOrder": pages or [],
+                "activePageName": pages[0] if pages else "",
+            }},
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    for page in pages:
+        (report / "definition" / "pages" / page).mkdir()
+        (report / "definition" / "pages" / page / "page.json").write_text(
+            json.dumps(
+                {{
+                    "$schema": "https://developer.microsoft.com/json-schemas/fabric/item/report/definition/page/1.0.0/schema.json",
+                    "name": page,
+                    "displayName": page,
+                    "displayOption": "FitToPage",
+                    "height": 720,
+                    "width": 1280,
+                }},
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+    (project / (name + ".pbip")).write_text(json.dumps({{"version": "1.0"}}), encoding="utf-8")
+    return len(pages)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("-i", "--input", required=True, type=Path)
+    ap.add_argument("-o", "--output", required=True, type=Path)
+    ap.add_argument("--approved-dax", type=Path)
+    args = ap.parse_args()
+
+    args.output.mkdir(parents=True, exist_ok=True)
+    workbooks, bound, failed = [], 0, 0
+    for source in sorted(list(args.input.glob("*.twb")) + list(args.input.glob("*.twbx"))):
+        name = sanitise(source.stem)
+        try:
+            spec = parse_workbook(source)
+        except Exception as exc:  # a parse failure is a workbook-level error, never a batch abort
+            workbooks.append({{"name": name, "error": str(exc)[:200]}})
+            failed += 1
+            continue
+        pages = emit(spec, args.output, name)
+        bound += 1 if pages else 0
+        workbooks.append(
+            {{
+                "name": name,
+                "bound_model": name,
+                "source_file": source.name,
+                "pages": pages,
+                "model_translation_handoff": {{"requests": []}},
+                "viz_fidelity": [],
+            }}
+        )
+
+    report = {{
+        "tool": "tableau-fabric-skills (mock stand-in)",
+        "generated_at": "2026-08-12T00:00:00Z",
+        "source": {{"kind": "folder", "root": str(args.input)}},
+        "pending_gates": [],
+        "definition_of_done": {{
+            "applicable": True,
+            "status": "failed" if failed else "pass",
+            "reports_bound": bound,
+            "reports_failed": failed,
+            "reports_warned": 0,
+            "workbooks_total": len(workbooks),
+        }},
+        "summary": {{"workbook_calcs_stubbed": 0, "visuals_warned": 0}},
+        "workbooks": workbooks,
+    }}
+    (args.output / "report.json").write_text(json.dumps(report, indent=2), encoding="utf-8")
+    (args.output / "input_manifest.json").write_text(
+        json.dumps({{"inputs": [{{"name": w.get("source_file")}} for w in workbooks]}}, indent=2), encoding="utf-8"
+    )
+    print("[OK] mock engine wrote", len(workbooks), "workbook(s)")
+    return 0  # the engine exits 0 even on a failed DoD - the whole reason run_estate.py exists
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+'''
+
+
+def install_fake_engine(root: Path) -> Path:
+    """Write the engine stand-in under ``root`` and return the path to pass as ``--engine``."""
+    scripts = root / "skills" / "tableau-migration" / "scripts"
+    scripts.mkdir(parents=True, exist_ok=True)
+    (scripts / "migrate_estate.py").write_text(
+        _FAKE_ENGINE.format(repo_scripts=str(REPO_ROOT / "scripts")), encoding="utf-8"
+    )
+    return root
+
+
+def engine_scripts_dir() -> Path | None:
+    """The REAL engine's scripts folder, or None when the plugin is not installed (e.g. in CI)."""
+    sys.path.insert(0, str(REPO_ROOT / "scripts"))
+    from harvest_estate_assets import engine_scripts_dir as resolve  # noqa: PLC0415
+
+    return resolve()
+
+
+def run_engine_script(script: str, argv: list[str], env: dict[str, str], *, timeout: int = 60) -> Any:
+    """Run one ENGINE script with the two guards that turn a silent hang into a loud failure.
+
+    MEASURED, and it cost 13 minutes of a real session: ``estate_survey.py`` resolves its PAT secret
+    through ``credential_resolver.resolve_secret``, whose LAST layer is a ``getpass`` prompt. With
+    ``TABLEAU_PAT_VALUE`` unset and a TTY attached it prints its prompt to the terminal and blocks
+    forever - no output, no error, no exit. Our ``.env`` does not prevent it either: the bridge in
+    ``tableau_env.engine_child_env`` only reaches an engine script *our Python* spawns.
+
+    So this refuses to launch without the variable the engine actually reads, always passes
+    ``--no-prompt``, and gives the child no stdin and a deadline. Any one of the three would have
+    turned that hang into an error in seconds.
+    """
+    import subprocess  # noqa: PLC0415
+
+    if not env.get("TABLEAU_PAT_VALUE"):
+        raise SystemExit(
+            f"refusing to run {script}: TABLEAU_PAT_VALUE is not set.\n"
+            "  The engine reads the PAT secret under ITS name, not ours (TABLEAU_PAT_SECRET), and\n"
+            "  without it the script falls through to a hidden getpass prompt and blocks forever."
+        )
+    scripts = engine_scripts_dir()
+    if scripts is None:
+        raise SystemExit("the deterministic engine is not installed on this machine")
+    command = [sys.executable, str(scripts / script), *argv]
+    if "--no-prompt" not in command:
+        command.append("--no-prompt")
+    return subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        check=False,
+        env={**env},
+        stdin=subprocess.DEVNULL,
+        timeout=timeout,
+    )
+
+
+def harvest(site: TableauSite, out: Path, *, base_url: str = "", token: str = "") -> list[Path]:
+    """Download every workbook and published data source to ``out/assets`` as REAL packaged bytes.
+
+    The engine's ``fetch_tds.py`` is the production path (see ``scripts/harvest_estate_assets.py``);
+    this is the same set of REST calls without the plugin dependency, so the offline chain still has
+    a genuine download step whose output is what the parser then reads.
+    """
+    import urllib.request  # noqa: PLC0415
+
+    assets = out / "assets"
+    assets.mkdir(parents=True, exist_ok=True)
+    written: list[Path] = []
+    jobs = [("workbooks", w.luid, w.name, w.extension) for w in site.workbooks]
+    jobs += [("datasources", d.luid, d.name, ".tdsx") for d in site.datasources]
+    for collection, luid, name, extension in jobs:
+        safe = "".join(c if c.isalnum() or c in "-_" else "_" for c in name)[:60]
+        target = assets / f"{safe}{extension}"
+        if base_url:
+            url = f"{base_url}/api/{site.rest_version}/sites/{site.site_id}/{collection}/{luid}/content"
+            request = urllib.request.Request(url, method="GET")
+            request.add_header("X-Tableau-Auth", token or next(iter(site.tokens), ""))
+            with urllib.request.urlopen(request, timeout=30) as response:
+                target.write_bytes(response.read())
+        else:
+            status, _headers, payload = site.handle(
+                "GET",
+                f"http://127.0.0.1/api/{site.rest_version}/sites/{site.site_id}/{collection}/{luid}/content",
+                {"x-tableau-auth": next(iter(site.tokens), "")},
+                b"",
+            )
+            if status != 200:
+                raise RuntimeError(f"download of {name} failed: HTTP {status}")
+            target.write_bytes(payload)
+        written.append(target)
+    return written
+
+
+def project_tree(site: TableauSite) -> dict[str, str]:
+    """``workbook name -> "Parent/Child"`` project path, for asserting the mirrored folder tree."""
+    by_luid = {p.luid: p for p in site.projects}
+    out = {}
+    for workbook in site.workbooks:
+        parts, node = [], workbook.project
+        while node is not None:
+            parts.append(node.name)
+            node = by_luid.get(node.parent_luid or "")
+        out[workbook.name] = "/".join(reversed(parts))
+    return out
+
+
+def write_estate_db(site: TableauSite, path: Path) -> Path:
+    """A minimal ``estate.db`` in ``assess_estate``'s schema, for tools that read it directly.
+
+    Prefer running the real ``assess_estate.py`` against the mock site (the E2E does); this exists
+    for tests that need the db without paying for the whole assessment.
+    """
+    import sqlite3  # noqa: PLC0415
+
+    sys.path.insert(0, str(REPO_ROOT / "scripts"))
+    from assess_estate import SCHEMA  # noqa: PLC0415
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.unlink(missing_ok=True)
+    connection = sqlite3.connect(path)
+    connection.executescript(SCHEMA)
+    connection.executemany(
+        "INSERT INTO project VALUES (?,?,?,?)",
+        [(p.luid, p.name, p.parent_luid, p.content_permissions) for p in site.projects],
+    )
+    connection.executemany(
+        "INSERT INTO workbook (luid, name, project) VALUES (?,?,?)",
+        [(w.luid, w.name, w.project.name) for w in site.workbooks],
+    )
+    connection.executemany(
+        "INSERT INTO datasource (luid, name, project) VALUES (?,?,?)",
+        [(d.luid, d.name, d.project.name) for d in site.datasources],
+    )
+    connection.commit()
+    connection.close()
+    return path
+
+
+def summarise(site: TableauSite) -> str:
+    """A one-line description of the estate, handy in an assertion message."""
+    return textwrap.dedent(
+        f"""\
+        {len(site.workbooks)} workbook(s), {len(site.datasources)} published datasource(s),
+        {len(site.projects)} project(s), {len(site.views)} view(s)"""
+    ).replace("\n", " ")
+
+
+def json_dump(value: Any) -> str:
+    """Compact JSON, for embedding a payload in a test failure message."""
+    return json.dumps(value, indent=2, sort_keys=True)[:2000]

--- a/tests/mocks/fabric.py
+++ b/tests/mocks/fabric.py
@@ -1,0 +1,731 @@
+"""An in-process fake of the Fabric REST API, faithful where we have measured it.
+
+Why
+---
+Verifying ``scripts/deploy_estate.py`` against a real tenant costs 10-25 minutes per run and mutates
+a real workspace. This reproduces the service well enough to rehearse and regression-test offline.
+
+The seam
+--------
+``deploy_estate`` reaches the network through exactly two module-level functions::
+
+    call(method, url, tok, body=None) -> (status, headers, body)   # adds the TokenExpired retry
+    _request(method, url, bearer, body=None) -> (status, headers, body)   # the bare HTTP call
+
+Substitute **``_request``**, not ``call`` (:func:`install`). Patching ``call`` would replace the
+token-renewal retry with the mock's own answer, so the one piece of client policy that a long deploy
+depends on would stop being exercised. ``FabricService.call`` exists anyway for callers that want the
+documented seam, and simply delegates to ``FabricService.request``.
+
+Fidelity discipline
+-------------------
+A mock kinder than the service manufactures false confidence. So:
+
+* Behaviour recorded here as MEASURED was observed against a real tenant (the evidence for each is
+  cited on the code that implements it, and collected in ``docs/offline-mock-harness.md``).
+* Everything else is implemented as the **strictest plausible** behaviour and listed in the
+  "ASSUMED, NOT MEASURED" section of that document. Error *codes* for assumed rejections are
+  plausible names, not observed ones - assert on status and behaviour, not on an assumed code.
+
+The single most important measured behaviour is that a repeated ``Report``/``SemanticModel``
+``displayName`` is **accepted**, creating a duplicate. Nothing downstream catches it, which is why
+the deployer's journal, run-lock and "ask the service first" rules are load-bearing.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+import re
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Callable
+from urllib.parse import parse_qs, urlparse
+
+API = "https://api.fabric.microsoft.com/v1"
+
+# MEASURED: a workspace holds at most 1000 items (folders do not count).
+WORKSPACE_ITEM_LIMIT = 1000
+
+# MEASURED: nesting deeper than 10 levels is refused with `FolderDepthOutOfRange`.
+MAX_FOLDER_DEPTH = 10
+
+# MEASURED against a live workspace: these are REJECTED in a folder display name (the API validates
+# rather than coercing), and `.` is rejected ANYWHERE in the name, not merely at the end.
+FOLDER_REJECTED_CHARS = frozenset('&/\\:?*"|<#%.')
+# ASSUMED (strictest plausible): `>` was never tried, and a name that rejects `<` almost certainly
+# rejects its partner. Rejecting it here can only make the harness harsher than the service.
+FOLDER_ASSUMED_REJECTED_CHARS = frozenset(">")
+
+# The item types this harness knows how to validate. Both are Power BI items, so a landing zone needs
+# no F capacity - only an appropriately licensed identity.
+MODEL_TYPE = "SemanticModel"
+REPORT_TYPE = "Report"
+KNOWN_ITEM_TYPES = frozenset({MODEL_TYPE, REPORT_TYPE, "Notebook", "Lakehouse", "DataPipeline", "Warehouse"})
+
+# PBIR schema 2.0.0 declares `additionalProperties: false` on `byConnection` and allows exactly this
+# one property. MEASURED: sending the widely-quoted five-field 1.0.0 shape is rejected with
+# `Workload_FailedToParseFile` naming each extra property.
+BYCONNECTION_ALLOWED = frozenset({"connectionString"})
+
+_SEMANTIC_MODEL_ID_RE = re.compile(r"semanticModelId=([0-9a-fA-F-]{6,})", re.IGNORECASE)
+
+
+class MockFabricError(AssertionError):
+    """Raised for harness misuse (a bad URL, an unroutable request) - never for a service verdict."""
+
+
+@dataclass
+class Item:
+    """One item in the fake workspace."""
+
+    id: str
+    display_name: str
+    item_type: str
+    workspace_id: str = ""
+    description: str = ""
+    folder_id: str | None = None
+    parts: list[dict[str, str]] = field(default_factory=list)
+
+    def row(self) -> dict[str, Any]:
+        """The shape a list/get returns.
+
+        MEASURED: ``folderId`` is **omitted entirely** for an item at the workspace root - it is not
+        present-and-null. Client code that reads ``row["folderId"]`` rather than ``row.get(...)``
+        breaks only against the real service, so the mock must omit it too.
+        """
+        row: dict[str, Any] = {
+            "id": self.id,
+            "displayName": self.display_name,
+            "type": self.item_type,
+            "workspaceId": self.workspace_id,
+            "description": self.description,
+        }
+        if self.folder_id:
+            row["folderId"] = self.folder_id
+        return row
+
+
+@dataclass
+class Folder:
+    """One folder in the fake workspace."""
+
+    id: str
+    display_name: str
+    parent_folder_id: str | None = None
+
+    def row(self) -> dict[str, Any]:
+        """MEASURED: rows carry ``id``, ``displayName``, ``parentFolderId``.
+
+        ASSUMED: ``parentFolderId`` is omitted at the root, mirroring the item behaviour above
+        (that half IS measured). Omitting is the stricter of the two shapes.
+        """
+        row: dict[str, Any] = {"id": self.id, "displayName": self.display_name}
+        if self.parent_folder_id:
+            row["parentFolderId"] = self.parent_folder_id
+        return row
+
+
+@dataclass
+class Operation:
+    """A long-running operation, as returned by a ``202 Accepted`` create/update."""
+
+    id: str
+    status: str = "Running"
+    item_id: str | None = None
+    error: dict[str, Any] | None = None
+    polls_before_terminal: int = 1
+    polls: int = 0
+
+    def poll(self) -> dict[str, Any]:
+        """Advance and report. A `Running` operation is indistinguishable from a failed one to a
+        client that never reads `status` - which is exactly the measured defect this models."""
+        self.polls += 1
+        if self.status == "Running" and self.polls_before_terminal >= 0 and self.polls >= self.polls_before_terminal:
+            self.status = "Succeeded" if self.error is None else "Failed"
+        body: dict[str, Any] = {"id": self.id, "status": self.status, "percentComplete": 100}
+        if self.status == "Failed" and self.error:
+            body["error"] = self.error
+        return body
+
+
+@dataclass
+class Rule:
+    """One injected failure. Consumed ``times`` times, then it stops matching."""
+
+    status: int
+    method: str | None = None
+    contains: str | None = None
+    body: dict[str, Any] | None = None
+    headers: dict[str, str] | None = None
+    times: int = 1
+    network: bool = False
+
+    def matches(self, method: str, url: str) -> bool:
+        """Whether this rule claims the request."""
+        if self.times <= 0:
+            return False
+        if self.method and self.method.upper() != method.upper():
+            return False
+        return not (self.contains and self.contains not in url)
+
+
+def _error(status: int, code: str, message: str) -> tuple[int, dict, dict]:
+    """A Fabric error response.
+
+    The shape matters: ``deploy_estate`` reads ``resp["errorCode"]`` first and
+    ``resp["error"]["errorCode"]`` second, and its token-renewal test is a substring match on the
+    whole serialized body.
+    """
+    body = {
+        "requestId": str(uuid.uuid4()),
+        "errorCode": code,
+        "message": message,
+        "error": {"errorCode": code, "message": message},
+    }
+    return status, {"x-ms-public-api-error-code": code}, body
+
+
+class FabricService:
+    """An in-memory Fabric tenant: workspaces, items, folders, operations - and injectable failures.
+
+    Usage::
+
+        service = FabricService()
+        service.install(monkeypatch, deploy_estate)
+        deploy_estate.deploy(bundle, service.workspace_id, service.issue_token(), options)
+        assert service.item_names(MODEL_TYPE) == ["Sales"]
+    """
+
+    def __init__(
+        self,
+        *,
+        workspace_id: str = "ws-0000",
+        workspace_name: str = "Landing Zone",
+        page_size: int = 100,
+        async_create: bool = False,
+        item_limit: int = WORKSPACE_ITEM_LIMIT,
+    ) -> None:
+        self.workspace_id = workspace_id
+        self.workspace_name = workspace_name
+        # MEASURED: 68 items came back in ONE page with no continuation token, so paging is only
+        # reachable deliberately. Small page sizes in a test are how it gets exercised at all.
+        self.page_size = page_size
+        self.async_create = async_create
+        self.item_limit = item_limit
+
+        self.items: dict[str, Item] = {}
+        self.folders: dict[str, Folder] = {}
+        self.operations: dict[str, Operation] = {}
+        self.forbidden_workspaces: set[str] = set()
+
+        self._tokens: set[str] = set()
+        self._expired: set[str] = set()
+        self._rules: list[Rule] = []
+        self._stalled_operations = 0
+        self._failed_operations: list[dict[str, Any]] = []
+        self._seq = 0
+        self.requests: list[tuple[str, str, dict | None]] = []
+
+    # ----------------------------------------------------------------- tokens
+
+    def issue_token(self) -> str:
+        """Mint a token this service will accept."""
+        self._seq += 1
+        value = f"token-{self._seq}"
+        self._tokens.add(value)
+        return value
+
+    def expire_tokens(self) -> None:
+        """Expire every token issued so far.
+
+        MEASURED: a real deploy of 66 items outlived its token and every remaining call answered
+        ``401 TokenExpired``, leaving a half-deployed workspace. ``deploy_estate.call`` renews once
+        and retries - which is only exercised if the mock is installed at ``_request``.
+        """
+        self._expired |= self._tokens
+        self._tokens = set()
+
+    # ------------------------------------------------------- failure injection
+
+    def fail_next(
+        self,
+        status: int,
+        *,
+        method: str | None = None,
+        contains: str | None = None,
+        body: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+        times: int = 1,
+    ) -> Rule:
+        """Make the next matching request fail. Returns the rule so a test can inspect it."""
+        rule = Rule(status=status, method=method, contains=contains, body=body, headers=headers, times=times)
+        self._rules.append(rule)
+        return rule
+
+    def throttle(self, *, retry_after: str | int = 1, contains: str | None = None, times: int = 1) -> Rule:
+        """Answer 429 with a ``Retry-After`` header.
+
+        MEASURED both forms: an integer number of seconds, and the RFC 9110 HTTP-date. The date form
+        raised ``ValueError`` in ``float()`` and killed a deploy mid-estate, so pass a date string
+        here to reproduce that exact input.
+        """
+        rule = self.fail_next(
+            429,
+            contains=contains,
+            times=times,
+            headers={"retry-after": str(retry_after)},
+            body={"errorCode": "TooManyRequests", "message": "Too many requests"},
+        )
+        return rule
+
+    def drop_network(self, *, contains: str | None = None, times: int = 1) -> Rule:
+        """Simulate a client-side network failure (DNS/route), not a service verdict.
+
+        ``_request`` turns ``URLError`` into ``(0, {}, {"error": {"message": ...}})`` and the
+        deployer treats a detail containing ``HTTP 0`` as "we could not reach the host", stopping
+        after three consecutive ones instead of marking the rest of the estate failed.
+        """
+        rule = Rule(status=0, contains=contains, times=times, network=True)
+        self._rules.append(rule)
+        return rule
+
+    def add_rule(self, rule: Rule) -> Rule:
+        """Register a pre-built rule (for a caller that needs more than ``fail_next`` expresses)."""
+        self._rules.append(rule)
+        return rule
+
+    def stall_operations(self, times: int = 1) -> None:
+        """Make the next ``times`` long-running operations never reach a terminal state.
+
+        MEASURED shape: our poll gives up and records ``Timeout`` while the operation completes
+        server-side, so the item IS there on the next listing. Reproducing it is what proves a
+        resume adopts the item instead of creating a second copy.
+
+        ASSUMED: **when** the item becomes visible. Here it is visible immediately, because that is
+        the case a client can actually get right; a client that cannot see it has no way to avoid
+        the duplicate, so testing against the invisible variant would only assert a known hazard.
+        """
+        self._stalled_operations += times
+
+    def fail_next_operation(self, code: str = "PowerBIItemCreateFailed", message: str = "operation failed") -> None:
+        """Make the next long-running operation reach ``Failed``, creating nothing.
+
+        MEASURED: a first probe reported the model deployed and the report fine; the report had in
+        fact FAILED and the workspace held one item. A client that never polls ``status`` cannot
+        tell the two apart, so this is the case that justifies polling at all.
+        """
+        self._failed_operations.append({"errorCode": code, "message": message})
+
+    # --------------------------------------------------------------- installation
+
+    def install(self, monkeypatch, module) -> None:
+        """Point a ``deploy_estate``-shaped module at this service.
+
+        Patches ``_request`` deliberately: everything ``call`` adds (today, the one-shot renewal on
+        ``401 TokenExpired``) stays under test. Also neutralises ``time.sleep`` so a 429 wait or an
+        operation poll costs nothing - the deployer's own back-off arithmetic still runs.
+        """
+        monkeypatch.setattr(module, "_request", self.request)
+        monkeypatch.setattr(module.time, "sleep", lambda _seconds: None)
+
+    def token_for(self, module) -> Any:
+        """A real ``deploy_estate.Token`` bound to this service instead of the Azure CLI.
+
+        ``call``'s renewal path is guarded by ``isinstance(tok, Token)``, so a duck-typed stand-in
+        would silently skip the very behaviour a token-expiry test is about.
+        """
+        token = module.Token.__new__(module.Token)
+        token.tenant = None
+        token._value = self.issue_token()  # noqa: SLF001  # pylint: disable=protected-access
+        token._mint = self.issue_token  # noqa: SLF001  # pylint: disable=protected-access
+        return token
+
+    # --------------------------------------------------------------- inspection
+
+    def item_names(self, item_type: str | None = None) -> list[str]:
+        """Display names currently in the workspace, sorted - duplicates included, deliberately."""
+        return sorted(i.display_name for i in self.items.values() if item_type in (None, i.item_type))
+
+    def duplicates(self) -> list[tuple[str, str]]:
+        """Every ``(displayName, type)`` present more than once. The mock does NOT prevent these."""
+        seen: dict[tuple[str, str], int] = {}
+        for item in self.items.values():
+            seen[(item.display_name, item.item_type)] = seen.get((item.display_name, item.item_type), 0) + 1
+        return sorted(key for key, count in seen.items() if count > 1)
+
+    def folder_paths(self) -> dict[str, str]:
+        """``folder id -> "A/B/C"`` for every folder, so a test can assert the mirrored tree."""
+        out = {}
+        for folder in self.folders.values():
+            parts, node = [], folder
+            while node is not None:
+                parts.append(node.display_name)
+                node = self.folders.get(node.parent_folder_id or "")
+            out[folder.id] = "/".join(reversed(parts))
+        return out
+
+    def item_folder_paths(self) -> dict[str, str]:
+        """``displayName (type) -> folder path`` (``""`` for the workspace root)."""
+        paths = self.folder_paths()
+        return {
+            f"{item.display_name} ({item.item_type})": paths.get(item.folder_id or "", "")
+            for item in self.items.values()
+        }
+
+    def part(self, item_id: str, path: str) -> bytes | None:
+        """The decoded bytes of one definition part of a stored item."""
+        for candidate in self.items[item_id].parts:
+            if candidate["path"] == path:
+                return base64.b64decode(candidate["payload"])
+        return None
+
+    def model_binding(self, report_name: str) -> str | None:
+        """The ``semanticModelId`` a stored report is bound to, read back out of its PBIR."""
+        for item in self.items.values():
+            if item.display_name == report_name and item.item_type == REPORT_TYPE:
+                raw = self.part(item.id, "definition.pbir")
+                if raw is None:
+                    return None
+                reference = json.loads(raw).get("datasetReference") or {}
+                connection = (reference.get("byConnection") or {}).get("connectionString", "")
+                found = _SEMANTIC_MODEL_ID_RE.search(connection)
+                return found.group(1) if found else None
+        return None
+
+    # ------------------------------------------------------------------ the seam
+
+    def call(self, method: str, url: str, tok: Any, body: dict | None = None) -> tuple[int, dict, dict]:
+        """The documented ``deploy_estate.call`` seam. Prefer :meth:`install`, which patches lower."""
+        return self.request(method, url, str(tok), body)
+
+    def request(self, method: str, url: str, bearer: str, body: dict | None = None) -> tuple[int, dict, dict]:
+        """The ``deploy_estate._request`` seam: one HTTP call, no retry policy of its own."""
+        self.requests.append((method.upper(), url, body))
+
+        for rule in self._rules:
+            if rule.matches(method, url):
+                rule.times -= 1
+                if rule.network:
+                    return 0, {}, {"error": {"message": "<urlopen error [Errno 11001] getaddrinfo failed>"}}
+                return rule.status, dict(rule.headers or {}), dict(rule.body or {"error": {"message": "injected"}})
+
+        if bearer in self._expired:
+            # MEASURED: the expiry answer names itself, which is what lets a client tell it apart
+            # from a genuine authorization failure and renew instead of aborting.
+            return _error(401, "TokenExpired", "Access token has expired, resubmit with a new access token")
+        if bearer not in self._tokens:
+            return _error(401, "Unauthorized", "The request lacks valid authentication credentials")
+
+        return self._route(method.upper(), url, body or {})
+
+    # --------------------------------------------------------------- routing
+
+    def _route(self, method: str, url: str, body: dict) -> tuple[int, dict, dict]:
+        parsed = urlparse(url)
+        path = parsed.path
+        if not path.startswith("/v1/"):
+            raise MockFabricError(f"not a Fabric v1 URL: {url}")
+        segments = path[len("/v1/") :].strip("/").split("/")
+
+        if segments[0] == "operations":
+            return self._operations(method, segments[1:])
+        if segments[0] != "workspaces" or len(segments) < 2:
+            raise MockFabricError(f"unroutable Fabric URL: {url}")
+
+        workspace = segments[1]
+        if workspace in self.forbidden_workspaces:
+            return _error(403, "InsufficientPrivileges", "The caller does not have the required permissions")
+        if workspace != self.workspace_id:
+            return _error(404, "WorkspaceNotFound", f"Workspace {workspace} not found")
+
+        rest = segments[2:]
+        if not rest:
+            if method != "GET":
+                return _error(405, "MethodNotAllowed", f"{method} is not allowed here")
+            return 200, {}, {"id": self.workspace_id, "displayName": self.workspace_name, "type": "Workspace"}
+        if rest[0] == "items":
+            return self._items(method, rest[1:], body, parse_qs(parsed.query))
+        if rest[0] == "folders":
+            return self._folders(method, rest[1:], body, parse_qs(parsed.query))
+        raise MockFabricError(f"unroutable Fabric URL: {url}")
+
+    # ----------------------------------------------------------------- items
+
+    def _items(self, method: str, rest: list[str], body: dict, query: dict) -> tuple[int, dict, dict]:
+        if not rest:
+            if method == "GET":
+                return self._page([i.row() for i in self.items.values()], query, "items")
+            if method == "POST":
+                return self._create_item(body)
+            return _error(405, "MethodNotAllowed", f"{method} is not allowed on items")
+
+        item_id = rest[0]
+        item = self.items.get(item_id)
+        if item is None:
+            return _error(404, "ItemNotFound", f"Item {item_id} not found")
+        action = rest[1] if len(rest) > 1 else ""
+        if action == "updateDefinition" and method == "POST":
+            return self._update_definition(item, body)
+        if action == "move" and method == "POST":
+            return self._move_item(item, body)
+        if not action and method == "PATCH":
+            return self._patch_item(item, body)
+        if not action and method == "GET":
+            return 200, {}, item.row()
+        raise MockFabricError(f"unroutable item action: {method} {'/'.join(rest)}")
+
+    def _create_item(self, body: dict) -> tuple[int, dict, dict]:
+        name = str(body.get("displayName") or "")
+        item_type = str(body.get("type") or "")
+        parts = ((body.get("definition") or {}).get("parts")) or []
+
+        problem = self._reject_item(name, item_type, parts, body.get("folderId"))
+        if problem:
+            return problem
+        # MEASURED: a repeated Report/SemanticModel displayName is NOT rejected - Fabric happily
+        # creates a duplicate, and nothing downstream notices. This is the single behaviour most
+        # worth reproducing: it is why duplicates went undetected in a real run.
+        if len(self.items) >= self.item_limit:
+            return _error(400, "WorkspaceItemLimitExceeded", f"A workspace holds at most {self.item_limit} items")
+
+        item = Item(
+            id=str(uuid.uuid4()),
+            display_name=name,
+            item_type=item_type,
+            workspace_id=self.workspace_id,
+            description=str(body.get("description") or ""),
+            folder_id=body.get("folderId") or None,
+            parts=[dict(p) for p in parts],
+        )
+        self.items[item.id] = item
+        if not self.async_create:
+            return 201, {}, item.row()
+
+        # MEASURED: `202 Accepted` carries an EMPTY body, so a failed operation is indistinguishable
+        # from a successful one until `/operations/{id}` is polled for `status`.
+        return 202, *self._start_operation(item.id)
+
+    def _reject_item(
+        self, name: str, item_type: str, parts: list[dict], folder_id: str | None
+    ) -> tuple[int, dict, dict] | None:
+        """Every reason a create is refused, or None. Order matters only for the message."""
+        if not name:
+            return _error(400, "InvalidItemDisplayName", "displayName is required")
+        # ASSUMED (strictest plausible): length cap and no surrounding whitespace. Deliberately NOT
+        # the folder character rules - item names with dots are routine, so importing that rule here
+        # would invent a failure the service does not have.
+        if len(name) > 256 or name != name.strip():
+            return _error(400, "InvalidItemDisplayName", f"{name!r} is not a valid item display name")
+        if item_type not in KNOWN_ITEM_TYPES:  # ASSUMED
+            return _error(400, "UnsupportedItemType", f"{item_type!r} is not a supported item type")
+        if folder_id and folder_id not in self.folders:  # ASSUMED
+            return _error(400, "InvalidFolderId", f"folder {folder_id} does not exist in this workspace")
+        return self._reject_definition(item_type, parts)
+
+    def _reject_definition(self, item_type: str, parts: list[dict]) -> tuple[int, dict, dict] | None:
+        """Validate the definition payload the way the service does where we have measured it."""
+        by_path = {}
+        for part in parts:
+            if part.get("payloadType") != "InlineBase64":  # ASSUMED
+                return _error(400, "InvalidItemDefinition", "only InlineBase64 payloads are supported")
+            try:
+                by_path[part["path"]] = base64.b64decode(part["payload"], validate=True)
+            except (KeyError, ValueError, binascii.Error):  # ASSUMED
+                return _error(400, "InvalidItemDefinition", f"part {part.get('path')!r} is not valid base64")
+
+        if item_type == MODEL_TYPE:
+            if "definition.pbism" not in by_path:  # ASSUMED
+                return _error(400, "InvalidItemDefinition", "a SemanticModel definition needs definition.pbism")
+            return None
+        if item_type != REPORT_TYPE:
+            return None
+        return self._reject_report(by_path)
+
+    def _reject_report(self, by_path: dict[str, bytes]) -> tuple[int, dict, dict] | None:
+        """The report rules, three of which are measured and each of which cost a real run."""
+        if "definition.pbir" not in by_path:  # ASSUMED
+            return _error(400, "InvalidItemDefinition", "a Report definition needs definition.pbir")
+        try:
+            pbir = json.loads(by_path["definition.pbir"])
+        except json.JSONDecodeError:
+            return _error(400, "Workload_FailedToParseFile", "definition.pbir is not valid JSON")
+
+        # MEASURED: a report with no pages is refused, and the message is this opaque - which is why
+        # `deploy_estate.report_is_empty` detects it locally instead.
+        try:
+            pages = json.loads(by_path.get("definition/pages/pages.json", b"{}"))
+        except json.JSONDecodeError:
+            pages = {}
+        if not pages.get("pageOrder"):
+            return _error(400, "PowerBIItemCreateFailed", "Content provider provided invalid package content stream")
+
+        reference = pbir.get("datasetReference") or {}
+        if "byPath" in reference:
+            # MEASURED: byPath is a Git-integration mechanism; the service cannot resolve a path, so
+            # deploying a migrated PBIP unchanged fails. (Rejection measured; error CODE assumed.)
+            return _error(400, "InvalidItemDefinition", "datasetReference.byPath cannot be resolved by the service")
+        connection = reference.get("byConnection")
+        if not isinstance(connection, dict):
+            return _error(400, "InvalidConnectionInformation", "datasetReference.byConnection is required")
+        # MEASURED: PBIR schema 2.0.0 sets `additionalProperties: false` here, and the five-field
+        # 1.0.0 shape is rejected with each extra property named.
+        extra = sorted(set(connection) - BYCONNECTION_ALLOWED)
+        if extra:
+            return _error(
+                400,
+                "Workload_FailedToParseFile",
+                "definition.pbir: property "
+                + ", ".join(repr(name) for name in extra)
+                + " is not allowed by the 2.0.0 schema",
+            )
+        found = _SEMANTIC_MODEL_ID_RE.search(str(connection.get("connectionString") or ""))
+        if not found:
+            # MEASURED: the model's identity has nowhere to go except inside the connection string;
+            # omitting `semanticModelId=<guid>` is answered with InvalidConnectionInformation.
+            return _error(400, "InvalidConnectionInformation", "connectionString carries no semanticModelId")
+        target = self.items.get(found.group(1))
+        if target is None or target.item_type != MODEL_TYPE:
+            # ASSUMED (strictest plausible): a binding to a guid that is not a semantic model in this
+            # workspace is refused rather than stored. This is what makes "bound to the duplicate" or
+            # "bound to a deleted model" a test failure instead of a silent success.
+            return _error(400, "InvalidConnectionInformation", f"semanticModelId {found.group(1)} does not resolve")
+        return None
+
+    def _update_definition(self, item: Item, body: dict) -> tuple[int, dict, dict]:
+        parts = ((body.get("definition") or {}).get("parts")) or []
+        problem = self._reject_definition(item.item_type, parts)
+        if problem:
+            return problem
+        # MEASURED: updateDefinition replaces the definition and does NOT change description or
+        # folderId. The deployer therefore has to re-stamp and re-move separately; a mock that
+        # helpfully carried those across would hide both bugs.
+        item.parts = [dict(p) for p in parts]
+        if not self.async_create:
+            return 200, {}, {}
+        return 202, *self._start_operation(item.id)
+
+    def _patch_item(self, item: Item, body: dict) -> tuple[int, dict, dict]:
+        # MEASURED: PATCH with {"description": ...} updates the description.
+        unknown = sorted(set(body) - {"description", "displayName"})  # ASSUMED: unknown keys refused
+        if unknown:
+            return _error(400, "InvalidParameter", f"unsupported propert(y/ies): {', '.join(unknown)}")
+        if "displayName" in body:
+            item.display_name = str(body["displayName"])
+        if "description" in body:
+            item.description = str(body["description"])
+        return 200, {}, item.row()
+
+    def _move_item(self, item: Item, body: dict) -> tuple[int, dict, dict]:
+        # MEASURED: an empty body means the workspace root.
+        target = body.get("targetFolderId")
+        if target and target not in self.folders:
+            return _error(400, "InvalidFolderId", f"folder {target} does not exist in this workspace")
+        item.folder_id = target or None
+        return 200, {}, item.row()
+
+    # --------------------------------------------------------------- folders
+
+    def _folders(self, method: str, rest: list[str], body: dict, query: dict) -> tuple[int, dict, dict]:
+        if rest:
+            raise MockFabricError(f"unroutable folder action: {method} folders/{'/'.join(rest)}")
+        if method == "GET":
+            return self._page([f.row() for f in self.folders.values()], query, "folders")
+        if method != "POST":
+            return _error(405, "MethodNotAllowed", f"{method} is not allowed on folders")
+
+        name = str(body.get("displayName") or "")
+        parent = body.get("parentFolderId") or None
+        problem = self._reject_folder(name, parent)
+        if problem:
+            return problem
+        folder = Folder(id=str(uuid.uuid4()), display_name=name, parent_folder_id=parent)
+        self.folders[folder.id] = folder
+        return 201, {}, folder.row()
+
+    def _reject_folder(self, name: str, parent: str | None) -> tuple[int, dict, dict] | None:
+        if parent and parent not in self.folders:
+            return _error(400, "InvalidFolderId", f"parent folder {parent} does not exist")
+        # MEASURED: the API REJECTS an invalid folder display name rather than coercing it, and a
+        # leading or trailing space is invalid. Accepted: - _ + ( ), interior spaces, non-ASCII.
+        bad = sorted(set(name) & (FOLDER_REJECTED_CHARS | FOLDER_ASSUMED_REJECTED_CHARS))
+        if not name or name != name.strip() or bad:
+            return _error(
+                400,
+                "InvalidFolderDisplayName",
+                f"{name!r} is not a valid folder name" + (f" (rejected: {''.join(bad)})" if bad else ""),
+            )
+        depth = 1
+        node = self.folders.get(parent or "")
+        while node is not None:
+            depth += 1
+            node = self.folders.get(node.parent_folder_id or "")
+        # MEASURED: deeper than 10 levels answers FolderDepthOutOfRange.
+        if depth > MAX_FOLDER_DEPTH:
+            return _error(400, "FolderDepthOutOfRange", f"folders nest at most {MAX_FOLDER_DEPTH} levels")
+        # ASSUMED (strictest plausible): two siblings cannot share a display name.
+        siblings = [f for f in self.folders.values() if (f.parent_folder_id or None) == parent]
+        if any(f.display_name.casefold() == name.casefold() for f in siblings):
+            return _error(400, "FolderDisplayNameAlreadyInUse", f"a sibling folder is already called {name!r}")
+        return None
+
+    # ------------------------------------------------------------ operations
+
+    def _start_operation(self, item_id: str) -> tuple[dict, dict]:
+        """Register a long-running operation for an item and return (headers, empty body)."""
+        operation = Operation(id=str(uuid.uuid4()), item_id=item_id)
+        if self._stalled_operations > 0:
+            self._stalled_operations -= 1
+            operation.polls_before_terminal = -1
+        if self._failed_operations:
+            operation.error = self._failed_operations.pop(0)
+            # A create whose operation FAILS leaves nothing behind. Keeping the item would be the
+            # kind of leniency that lets a client "succeed" on an item the service never made.
+            self.items.pop(item_id, None)
+            operation.item_id = None
+        self.operations[operation.id] = operation
+        return {"location": f"{API}/operations/{operation.id}", "x-ms-operation-id": operation.id}, {}
+
+    def _operations(self, method: str, rest: list[str]) -> tuple[int, dict, dict]:
+        if method != "GET" or not rest:
+            raise MockFabricError(f"unroutable operation call: {method} operations/{'/'.join(rest)}")
+        operation = self.operations.get(rest[0])
+        if operation is None:
+            return _error(404, "OperationNotFound", f"operation {rest[0]} not found")
+        if len(rest) > 1 and rest[1] == "result":
+            if operation.status != "Succeeded":
+                return _error(400, "OperationNotCompleted", "the operation has not succeeded")
+            return 200, {}, self.items[operation.item_id].row()
+        return 200, {}, operation.poll()
+
+    # ------------------------------------------------------------------ paging
+
+    def _page(self, rows: list[dict], query: dict, collection: str) -> tuple[int, dict, dict]:
+        """One page of a collection, with a continuation token when there is more.
+
+        MEASURED: a real listing of 68 items came back in ONE page with no token - which is exactly
+        why reading only page one survived a live run and still duplicated items on a bigger estate.
+        """
+        start = 0
+        token = (query.get("continuationToken") or [None])[0]
+        if token is not None:
+            if not token.startswith("offset-"):
+                return _error(400, "InvalidContinuationToken", "the continuation token is not recognised")
+            start = int(token.split("-", 1)[1])
+        page = rows[start : start + self.page_size]
+        body: dict[str, Any] = {"value": page}
+        if start + self.page_size < len(rows):
+            next_token = f"offset-{start + self.page_size}"
+            body["continuationToken"] = next_token
+            body["continuationUri"] = (
+                f"{API}/workspaces/{self.workspace_id}/{collection}?continuationToken={next_token}"
+            )
+        return 200, {}, body
+
+
+def install_predicate(service: FabricService, predicate: Callable[[str, str], bool], response: tuple) -> None:
+    """Escape hatch: fail whatever ``predicate(method, url)`` selects, with a canned response."""
+    rule = Rule(status=response[0], times=10**6, headers=response[1], body=response[2])
+    rule.matches = lambda method, url: predicate(method, url)  # type: ignore[method-assign]
+    service.add_rule(rule)

--- a/tests/mocks/tableau.py
+++ b/tests/mocks/tableau.py
@@ -1,0 +1,656 @@
+"""A loopback fake of the Tableau Server/Cloud REST + Metadata (GraphQL) APIs.
+
+Why a real socket
+-----------------
+The front half of the pipeline reaches Tableau three different ways, and only one of them can be
+patched in-process:
+
+* ``scripts/assess_estate.py`` and ``scripts/tableau_lineage.py`` build ``urllib`` requests directly;
+* the deterministic engine's ``estate_survey.py`` / ``fetch_tds.py`` run in a **subprocess**, which no
+  monkeypatch can reach.
+
+So this serves the API over ``127.0.0.1`` on an ephemeral port. That is loopback, not network: no
+packet leaves the machine and no real Tableau site is contacted. Point ``TABLEAU_SERVER_URL`` at the
+URL :func:`serve` yields and every one of those callers exercises its real HTTP code path.
+
+What it serves
+--------------
+``POST /api/<ver>/auth/signin`` and ``/auth/signout``; the paged site collections
+(``workbooks``, ``views``, ``datasources``, ``projects``, ``groups``, ``flows``, ``subscriptions``,
+``dataAlerts``, ``customviews``), ``groups/<id>/users``, ``<object>/<id>/permissions``,
+``workbooks/<luid>/connections``, ``workbooks|datasources/<luid>/content`` (real ``.twbx``/``.tdsx``
+bytes), and ``POST /api/metadata/graphql``.
+
+Fidelity notes (see ``docs/offline-mock-harness.md`` for the full ASSUMED list)
+------------------------------------------------------------------------------
+* Pagination values are emitted as **strings** (``"totalAvailable": "3"``), which is what Tableau's
+  JSON actually does - a client that does arithmetic on them without ``int()`` breaks here too.
+* A lost session answers **401 with error code ``401002``**, the string ``assess_estate`` looks for
+  before re-authenticating. :meth:`TableauSite.expire_session` is how a test provokes it.
+* Downloads carry Tableau's non-standard ``Content-Disposition: name="X.twbx"`` (no ``filename=``),
+  so a client that only understands ``filename=`` must fall back - as ``fetch_tds`` does.
+* The GraphQL structure answer is DERIVED FROM THE SERVED BYTES (sheets, dashboards and calculated
+  fields are read out of the workbook XML), so the Metadata API cannot disagree with the file the
+  same site hands out. On a real site those two can drift; here a drift would be a harness bug.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import re
+import threading
+import uuid
+import zipfile
+from dataclasses import dataclass, field
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+from xml.etree import ElementTree
+
+DEFAULT_REST_VERSION = "3.21"
+
+# The error code Tableau returns for a lost/expired session. `assess_estate.Site.get` re-signs-in on
+# seeing this string anywhere in the body, so the code has to appear literally.
+SESSION_LOST = "401002"
+
+
+def twbx_bytes(twb: Path, *, inner_name: str | None = None) -> bytes:
+    """Package a real ``.twb`` into ``.twbx`` bytes, the way Tableau hands one back.
+
+    Real bytes are the point: the parser under test must do real work, and a hand-written stub would
+    only ever exercise the shapes we already thought of.
+    """
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr(inner_name or twb.name, twb.read_bytes())
+    return buffer.getvalue()
+
+
+def tdsx_bytes(tds: Path, *, inner_name: str | None = None) -> bytes:
+    """The same, for a standalone data source."""
+    return twbx_bytes(tds, inner_name=inner_name)
+
+
+@dataclass
+class Project:
+    """A Tableau project. ``parent_luid`` is what makes the tree a tree."""
+
+    luid: str
+    name: str
+    parent_luid: str | None = None
+    content_permissions: str = "ManagedByOwner"
+
+    def row(self) -> dict[str, Any]:
+        """REST shape. ``parentProjectId`` is absent at the top level, as on a real site."""
+        row = {
+            "id": self.luid,
+            "name": self.name,
+            "contentPermissions": self.content_permissions,
+            "description": "",
+        }
+        if self.parent_luid:
+            row["parentProjectId"] = self.parent_luid
+        return row
+
+
+@dataclass
+class Workbook:
+    """A published workbook, including the bytes the site will hand back on download."""
+
+    luid: str
+    name: str
+    project: Project
+    content: bytes
+    extension: str = ".twbx"
+    owner_luid: str = "owner-1"
+    size_mb: int = 1
+    created_at: str = "2026-01-02T03:04:05Z"
+    updated_at: str = "2026-02-03T04:05:06Z"
+    connections: list[dict[str, Any]] = field(default_factory=list)
+
+    def row(self) -> dict[str, Any]:
+        """REST shape, matching what ``assess_estate`` reads."""
+        return {
+            "id": self.luid,
+            "name": self.name,
+            "contentUrl": self.name.replace(" ", ""),
+            "size": str(self.size_mb),
+            "createdAt": self.created_at,
+            "updatedAt": self.updated_at,
+            "project": {"id": self.project.luid, "name": self.project.name},
+            "owner": {"id": self.owner_luid},
+        }
+
+
+@dataclass
+class Datasource:
+    """A published data source."""
+
+    luid: str
+    name: str
+    project: Project
+    content: bytes
+    is_certified: bool = False
+    has_extracts: bool = False
+    extract_last_refresh: str | None = None
+    downstream: list[str] = field(default_factory=list)
+
+    def row(self) -> dict[str, Any]:
+        """REST shape."""
+        return {
+            "id": self.luid,
+            "name": self.name,
+            "type": "sqlproxy" if self.has_extracts else "excel-direct",
+            "isCertified": self.is_certified,
+            "project": {"id": self.project.luid, "name": self.project.name},
+            "owner": {"id": "owner-1"},
+        }
+
+
+@dataclass
+class View:
+    """A view (sheet or dashboard) inside a workbook, with its usage counter."""
+
+    luid: str
+    name: str
+    workbook_luid: str
+    total_view_count: int = 0
+    updated_at: str = "2026-02-03T04:05:06Z"
+
+    def row(self) -> dict[str, Any]:
+        """REST shape. ``usage`` is only present when ``includeUsageStatistics=true`` was asked for."""
+        return {
+            "id": self.luid,
+            "name": self.name,
+            "contentUrl": f"{self.workbook_luid}/sheets/{self.name}",
+            "workbook": {"id": self.workbook_luid},
+            "updatedAt": self.updated_at,
+            "usage": {"totalViewCount": str(self.total_view_count)},
+        }
+
+
+@dataclass
+class Group:
+    """A Tableau group. ``domain`` "local" is the one with no Entra counterpart."""
+
+    luid: str
+    name: str
+    domain: str = "local"
+    members: list[str] = field(default_factory=list)
+
+    def row(self) -> dict[str, Any]:
+        """REST shape."""
+        return {"id": self.luid, "name": self.name, "domain": {"name": self.domain}}
+
+
+@dataclass
+class Grant:
+    """One permission row, as ``granteeCapabilities`` returns it."""
+
+    object_type: str
+    object_luid: str
+    grantee_type: str
+    grantee_luid: str
+    capability: str
+    mode: str = "Allow"
+
+
+class TableauSite:
+    """The estate this fake serves, plus the switches a test needs to make it misbehave."""
+
+    def __init__(
+        self,
+        *,
+        site_id: str = "site-0000",
+        content_url: str = "mock",
+        rest_version: str = DEFAULT_REST_VERSION,
+        page_size: int | None = None,
+        single_row_as_object: bool = False,
+    ) -> None:
+        self.site_id = site_id
+        self.content_url = content_url
+        self.rest_version = rest_version
+        # A page size the SERVER enforces, independent of the client's `pageSize=` request. Tableau
+        # caps the request; a small cap here is how a test proves the client follows pagination.
+        self.page_size = page_size
+        # ASSUMED: Tableau's JSON returns a single row as an object rather than a one-element list.
+        # Both clients defend against it, so the switch exists; it is off by default because we have
+        # not measured it.
+        self.single_row_as_object = single_row_as_object
+
+        self.projects: list[Project] = []
+        self.workbooks: list[Workbook] = []
+        self.datasources: list[Datasource] = []
+        self.views: list[View] = []
+        self.groups: list[Group] = []
+        self.flows: list[dict[str, Any]] = []
+        self.subscriptions: list[dict[str, Any]] = []
+        self.alerts: list[dict[str, Any]] = []
+        self.custom_views: list[dict[str, Any]] = []
+        self.grants: list[Grant] = []
+
+        self.tokens: set[str] = set()
+        self.pat_credentials: dict[str, str] = {"mock-pat": "mock-secret"}
+        self.requests: list[tuple[str, str]] = []
+        self._expired: set[str] = set()
+        self._forbidden_paths: set[str] = set()
+
+    # ------------------------------------------------------------- authoring
+
+    def project(self, name: str, parent: Project | None = None, **kwargs) -> Project:
+        """Add a project and return it."""
+        made = Project(luid=str(uuid.uuid4()), name=name, parent_luid=parent.luid if parent else None, **kwargs)
+        self.projects.append(made)
+        return made
+
+    def workbook(
+        self, name: str, project: Project, twb: Path, *, views: int = 1, usage: int = 10, **kwargs
+    ) -> Workbook:
+        """Add a workbook backed by a REAL ``.twb`` fixture, packaged as ``.twbx``."""
+        made = Workbook(luid=str(uuid.uuid4()), name=name, project=project, content=twbx_bytes(twb), **kwargs)
+        self.workbooks.append(made)
+        for index in range(views):
+            self.views.append(
+                View(
+                    luid=str(uuid.uuid4()),
+                    name=f"{name} sheet {index + 1}",
+                    workbook_luid=made.luid,
+                    total_view_count=usage,
+                )
+            )
+        return made
+
+    def datasource(self, name: str, project: Project, tds: Path, **kwargs) -> Datasource:
+        """Add a published data source backed by a REAL ``.tds`` fixture, packaged as ``.tdsx``."""
+        made = Datasource(luid=str(uuid.uuid4()), name=name, project=project, content=tdsx_bytes(tds), **kwargs)
+        self.datasources.append(made)
+        return made
+
+    def publish_dependency(self, workbook: Workbook, datasource: Datasource) -> None:
+        """Make ``workbook`` depend on a PUBLISHED ``datasource``.
+
+        This is the shape that makes a workbook's own calc count understate its real complexity: the
+        calculated fields live in the data source, so the workbook alone reports fewer than it has.
+        """
+        workbook.connections.append(
+            {
+                "id": str(uuid.uuid4()),
+                "type": "sqlproxy",
+                "datasource": {"id": datasource.luid, "name": datasource.name},
+                "datasourceName": datasource.name,
+                "serverAddress": "",
+            }
+        )
+        datasource.downstream.append(workbook.name)
+
+    def grant(self, obj: Any, group: Group, capability: str, mode: str = "Allow") -> None:
+        """Record one permission row on a project or workbook."""
+        kind = "project" if isinstance(obj, Project) else "workbook"
+        self.grants.append(Grant(kind, obj.luid, "group", group.luid, capability, mode))
+
+    # ------------------------------------------------------------- misbehave
+
+    def expire_session(self) -> None:
+        """Invalidate every issued token, so the next call answers ``401002``.
+
+        MEASURED on Tableau Cloud (and the reason ``harvest_estate_assets`` signs in per asset): a
+        session drops mid-loop, and a client that treats that as a hard failure truncates the run.
+        """
+        self._expired |= self.tokens
+        self.tokens = set()
+
+    def forbid(self, path_fragment: str) -> None:
+        """Answer 403 for any path containing this fragment (one workbook's permissions, say)."""
+        self._forbidden_paths.add(path_fragment)
+
+    def mint_token(self) -> str:
+        """Issue a valid session token without the sign-in round trip (test convenience only)."""
+        token = str(uuid.uuid4())
+        self.tokens.add(token)
+        return token
+
+    # ------------------------------------------------------------- transport
+
+    def handle(self, method: str, url: str, headers: dict[str, str], body: bytes) -> tuple[int, dict, bytes]:
+        """Route one request. Transport-agnostic, so it can be driven with or without a socket."""
+        parsed = urlparse(url)
+        path, query = parsed.path, parse_qs(parsed.query)
+        self.requests.append((method, path + (f"?{parsed.query}" if parsed.query else "")))
+
+        if path.endswith("/auth/signin") and method == "POST":
+            return self._signin(body)
+        if any(fragment in path for fragment in self._forbidden_paths):
+            return self._fail(403, "403004", "Permission denied")
+
+        token = headers.get("x-tableau-auth", "")
+        if token in self._expired:
+            return self._fail(401, SESSION_LOST, "Invalid authentication credentials were provided")
+        if token not in self.tokens:
+            return self._fail(401, "401001", "Signin Error")
+
+        if path.endswith("/auth/signout"):
+            self.tokens.discard(token)
+            return 204, {}, b""
+        if path.endswith("/api/metadata/graphql"):
+            return self._graphql(body)
+        marker = f"/api/{self.rest_version}/sites/{self.site_id}"
+        if marker not in path:
+            return self._fail(404, "404000", f"no route for {path}")
+        return self._rest(path.split(marker, 1)[1], query)
+
+    def call(self, path: str) -> dict[str, Any]:
+        """The in-process seam the engine's ``survey_site(call, site_id)`` takes.
+
+        Same router, no socket - so an engine function that accepts an injected caller can be driven
+        directly, while its CLI still goes over loopback.
+        """
+        token = next(iter(self.tokens), "")
+        url = f"http://127.0.0.1/api/{self.rest_version}{path}"
+        status, _headers, payload = self.handle("GET", url, {"x-tableau-auth": token}, b"")
+        if status != 200:
+            raise RuntimeError(f"GET {path} failed ({status}): {payload[:200]!r}")
+        return json.loads(payload)
+
+    # --------------------------------------------------------------- helpers
+
+    @staticmethod
+    def _json(status: int, payload: dict) -> tuple[int, dict, bytes]:
+        return status, {"Content-Type": "application/json;charset=utf-8"}, json.dumps(payload).encode("utf-8")
+
+    def _fail(self, status: int, code: str, summary: str) -> tuple[int, dict, bytes]:
+        return self._json(status, {"error": {"code": code, "summary": summary, "detail": summary}})
+
+    def _signin(self, body: bytes) -> tuple[int, dict, bytes]:
+        try:
+            credentials = json.loads(body or b"{}").get("credentials") or {}
+        except json.JSONDecodeError:
+            return self._fail(400, "400006", "bad request body")
+        name = credentials.get("personalAccessTokenName")
+        secret = credentials.get("personalAccessTokenSecret")
+        # Strict on purpose: a PAT is two values, and the failure when only one is right is the
+        # single most common credential mistake this pipeline hits.
+        if not name or self.pat_credentials.get(name) != secret:
+            return self._fail(401, "401001", "Signin Error: invalid personal access token")
+        site = (credentials.get("site") or {}).get("contentUrl", "")
+        if site != self.content_url:
+            return self._fail(404, "404000", f"site {site!r} not found")
+        token = str(uuid.uuid4())
+        self.tokens.add(token)
+        return self._json(
+            200,
+            {
+                "credentials": {
+                    "token": token,
+                    "site": {"id": self.site_id, "contentUrl": self.content_url},
+                    "user": {"id": "user-1"},
+                }
+            },
+        )
+
+    def _page(self, rows: list[dict], collection: str, item: str, query: dict) -> tuple[int, dict, bytes]:
+        """One page, with Tableau's string-valued pagination block."""
+        size = int((query.get("pageSize") or ["100"])[0])
+        if self.page_size:
+            size = min(size, self.page_size)
+        number = int((query.get("pageNumber") or ["1"])[0])
+        window = rows[(number - 1) * size : number * size]
+        payload = window[0] if (self.single_row_as_object and len(window) == 1) else window
+        return self._json(
+            200,
+            {
+                "pagination": {"pageNumber": str(number), "pageSize": str(size), "totalAvailable": str(len(rows))},
+                collection: {item: payload},
+            },
+        )
+
+    # ------------------------------------------------------------------ REST
+
+    def _rest(self, path: str, query: dict) -> tuple[int, dict, bytes]:
+        segments = [s for s in path.split("?")[0].strip("/").split("/") if s]
+        if not segments:
+            return self._fail(404, "404000", "no collection named")
+        collection = segments[0]
+
+        if len(segments) == 1:
+            return self._collection(collection, query)
+        luid, action = segments[1], (segments[2] if len(segments) > 2 else "")
+        if action == "permissions":
+            return self._permissions(collection.rstrip("s"), luid)
+        if collection == "groups" and action == "users":
+            group = next((g for g in self.groups if g.luid == luid), None)
+            rows = [{"id": f"user-{n}", "name": n} for n in (group.members if group else [])]
+            return self._page(rows, "users", "user", query)
+        if collection == "workbooks" and action == "connections":
+            workbook = next((w for w in self.workbooks if w.luid == luid), None)
+            if workbook is None:
+                return self._fail(404, "404011", "workbook not found")
+            return self._json(200, {"connections": {"connection": workbook.connections}})
+        if action == "content":
+            return self._content(collection, luid)
+        return self._fail(404, "404000", f"no route for {path}")
+
+    def _collection(self, collection: str, query: dict) -> tuple[int, dict, bytes]:
+        table: dict[str, tuple[list[dict], str, str]] = {
+            "workbooks": ([w.row() for w in self.workbooks], "workbooks", "workbook"),
+            "datasources": ([d.row() for d in self.datasources], "datasources", "datasource"),
+            "projects": ([p.row() for p in self.projects], "projects", "project"),
+            "groups": ([g.row() for g in self.groups], "groups", "group"),
+            "flows": (self.flows, "flows", "flow"),
+            "subscriptions": (self.subscriptions, "subscriptions", "subscription"),
+            "dataAlerts": (self.alerts, "dataAlerts", "dataAlert"),
+            "customviews": (self.custom_views, "customViews", "customView"),
+        }
+        if collection == "views":
+            usage = (query.get("includeUsageStatistics") or ["false"])[0] == "true"
+            rows = []
+            for view in self.views:
+                row = view.row()
+                if not usage:
+                    # Tableau omits the usage block unless it was asked for; a mock that always
+                    # returned it would hide a client that forgot the flag.
+                    row.pop("usage", None)
+                rows.append(row)
+            return self._page(rows, "views", "view", query)
+        if collection not in table:
+            return self._fail(404, "404000", f"unknown collection {collection!r}")
+        rows, key, item = table[collection]
+        return self._page(rows, key, item, query)
+
+    def _permissions(self, object_type: str, luid: str) -> tuple[int, dict, bytes]:
+        by_grantee: dict[str, list[dict]] = {}
+        for grant in self.grants:
+            if grant.object_type == object_type and grant.object_luid == luid:
+                by_grantee.setdefault(grant.grantee_luid, []).append({"name": grant.capability, "mode": grant.mode})
+        grantees = [
+            {"group": {"id": grantee}, "capabilities": {"capability": capabilities}}
+            for grantee, capabilities in by_grantee.items()
+        ]
+        return self._json(200, {"permissions": {"granteeCapabilities": grantees}})
+
+    def _content(self, collection: str, luid: str) -> tuple[int, dict, bytes]:
+        if collection == "workbooks":
+            found = next((w for w in self.workbooks if w.luid == luid), None)
+            name, payload = (found.name + found.extension, found.content) if found else ("", b"")
+        else:
+            found = next((d for d in self.datasources if d.luid == luid), None)
+            name, payload = (found.name + ".tdsx", found.content) if found else ("", b"")
+        if found is None:
+            return self._fail(404, "404011", f"{collection[:-1]} {luid} not found")
+        # Tableau's real header is the non-standard `name=`, with no `filename=`. Serving the
+        # standard form instead would let a client that only understands `filename=` pass here and
+        # fail against the site.
+        headers = {"Content-Type": "application/octet-stream", "Content-Disposition": f'name="{name}"'}
+        return 200, headers, payload
+
+    # --------------------------------------------------------------- GraphQL
+
+    def _graphql(self, body: bytes) -> tuple[int, dict, bytes]:
+        try:
+            query = json.loads(body or b"{}").get("query") or ""
+        except json.JSONDecodeError:
+            return self._json(200, {"errors": [{"message": "could not parse the request body"}]})
+        if "downstreamWorkbooks" in query:
+            return self._json(200, {"data": {"publishedDatasources": self._lineage()}})
+        if "workbooks" in query:
+            return self._json(
+                200,
+                {
+                    "data": {
+                        "workbooks": [self._structure(w) for w in self.workbooks],
+                        "publishedDatasources": [
+                            {
+                                "name": d.name,
+                                "isCertified": d.is_certified,
+                                "hasExtracts": d.has_extracts,
+                                "extractLastRefreshTime": d.extract_last_refresh,
+                                "upstreamTables": [{"fullName": f"[dbo].[{d.name}]"}],
+                            }
+                            for d in self.datasources
+                        ],
+                    }
+                },
+            )
+        # A query we do not serve is an ERROR, not an empty answer: silently returning `{}` is how a
+        # caller concludes "this estate has no dependencies" and sequences the migration wrong.
+        return self._json(200, {"errors": [{"message": "unsupported query for the mock Metadata API"}]})
+
+    def _lineage(self) -> list[dict[str, Any]]:
+        by_name = {w.name: w for w in self.workbooks}
+        return [
+            {
+                "id": f"gid-{d.luid}",
+                "luid": d.luid,
+                "name": d.name,
+                "projectName": d.project.name,
+                "hasExtracts": d.has_extracts,
+                "downstreamWorkbooks": [
+                    {"luid": by_name[n].luid, "name": n, "projectName": by_name[n].project.name}
+                    for n in d.downstream
+                    if n in by_name
+                ],
+            }
+            for d in self.datasources
+        ]
+
+    def _structure(self, workbook: Workbook) -> dict[str, Any]:
+        """The Metadata API's view of a workbook, READ OUT OF the bytes this site serves."""
+        node = structure_from_workbook(workbook.content)
+        node["name"] = workbook.name
+        node["projectName"] = workbook.project.name
+        return node
+
+
+def structure_from_workbook(content: bytes) -> dict[str, Any]:
+    """Derive ``{sheets, dashboards, embeddedDatasources}`` from real workbook XML.
+
+    Deliberately independent of ``parse_tableau``: if the mock's answers were produced by the parser
+    under test, a parser bug would be invisible because both sides would share it.
+    """
+    xml = content
+    if content[:2] == b"PK":
+        with zipfile.ZipFile(io.BytesIO(content)) as archive:
+            inner = next(n for n in archive.namelist() if n.endswith((".twb", ".tds")))
+            xml = archive.read(inner)
+    root = ElementTree.fromstring(xml)
+
+    sources = []
+    for datasource in root.findall("./datasources/datasource"):
+        name = datasource.get("caption") or datasource.get("name") or ""
+        if name == "Parameters":
+            continue
+        fields = []
+        for column in datasource.findall("./column"):
+            calculation = column.find("./calculation")
+            formula = calculation.get("formula") if calculation is not None else None
+            fields.append(
+                {
+                    "name": (column.get("caption") or column.get("name") or "").strip("[]"),
+                    "__typename": "CalculatedField" if formula else "ColumnField",
+                    "role": (column.get("role") or "dimension").upper(),
+                    "dataType": (column.get("datatype") or "string").upper(),
+                    **({"formula": formula} if formula else {}),
+                }
+            )
+        sources.append(
+            {
+                "name": name,
+                "hasUserReference": any("USER" in (f.get("formula") or "").upper() for f in fields),
+                "fields": fields,
+            }
+        )
+    return {
+        "sheets": [{"name": w.get("name")} for w in root.findall("./worksheets/worksheet")],
+        "dashboards": [{"name": d.get("name")} for d in root.findall("./dashboards/dashboard")],
+        "embeddedDatasources": sources,
+    }
+
+
+class _Handler(BaseHTTPRequestHandler):
+    """Adapts :meth:`TableauSite.handle` onto ``http.server``."""
+
+    site: TableauSite
+
+    def _serve(self) -> None:
+        length = int(self.headers.get("Content-Length") or 0)
+        body = self.rfile.read(length) if length else b""
+        headers = {k.lower(): v for k, v in self.headers.items()}
+        status, out_headers, payload = self.site.handle(self.command, self.path, headers, body)
+        self.send_response(status)
+        for key, value in out_headers.items():
+            self.send_header(key, value)
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        if payload:
+            self.wfile.write(payload)
+
+    do_GET = _serve
+    do_POST = _serve
+    do_PUT = _serve
+    do_DELETE = _serve
+
+    def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
+        """Silence the default stderr access log; ``site.requests`` is the record that matters."""
+
+
+@contextlib.contextmanager
+def serve(site: TableauSite):
+    """Run ``site`` on an ephemeral loopback port. Yields the base URL (no trailing slash)."""
+    handler = type("_BoundHandler", (_Handler,), {"site": site})
+    server = ThreadingHTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_address[1]}"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def env_for(site: TableauSite, base_url: str, *, pat_name: str = "mock-pat") -> dict[str, str]:
+    """The environment variables every Tableau-auth script in this repo expects, pointed at the mock.
+
+    Includes the ENGINE's ``TABLEAU_PAT_VALUE`` as well as our ``TABLEAU_PAT_SECRET``: the two tiers
+    spell the secret differently, and an engine script that only knows its own name is exactly the
+    caller that hangs on a hidden prompt when it is missing.
+    """
+    secret = site.pat_credentials[pat_name]
+    return {
+        "TABLEAU_SERVER_URL": base_url,
+        "TABLEAU_SITE": site.content_url,
+        "TABLEAU_PAT_NAME": pat_name,
+        "TABLEAU_PAT_SECRET": secret,
+        "TABLEAU_PAT_VALUE": secret,
+        "TABLEAU_REST_API_VERSION": site.rest_version,
+    }
+
+
+_LUID_RE = re.compile(r"[0-9a-f]{8}-[0-9a-f]{4}-", re.I)
+
+
+def looks_like_luid(value: str) -> bool:
+    """Whether a string is shaped like a Tableau LUID (used by tests asserting identity-by-luid)."""
+    return bool(_LUID_RE.match(value or ""))

--- a/tests/mutation_harness.py
+++ b/tests/mutation_harness.py
@@ -1,0 +1,246 @@
+"""Mutation harness: prove the offline suite's assertions can actually fail.
+
+    python tests/mutation_harness.py
+
+Not named ``test_*``, so pytest does not collect it -- it *drives* pytest. Each mutation is a snippet
+that monkeypatches the REAL deployer (or the mock) at interpreter start, injected as a pytest plugin
+into a subprocess; then the relevant suite is re-run. A mutation that produces a GREEN run is a HOLE
+in the tests, not a success.
+
+Read ``docs/offline-mock-harness.md`` for the result table and for the two holes this found.
+
+One trap is guarded explicitly: if the injected plugin fails to import, pytest exits non-zero before
+running a single test and a naive harness scores that as CAUGHT. The first run of this file reported
+22/22 caught for exactly that reason. ``run()`` raises rather than reporting a false green.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PY = sys.executable
+
+# name -> a conftest-style patch injected via a sitecustomize-like plugin file
+MUTATIONS = {
+    "no-dedup-landing-claim": """
+import deploy_estate as de
+# Pretend the workspace is always empty: every run creates fresh items.
+de.Landing.claim = lambda self, item, journal: (None, None)
+""",
+    "bind-report-to-wrong-model": """
+import deploy_estate as de
+_orig = de.rebind
+def rebind(parts, workspace_name, model_name, model_id):
+    return _orig(parts, workspace_name, model_name, "00000000-0000-0000-0000-000000000000")
+de.rebind = rebind
+""",
+    "reports-before-models": """
+import deploy_estate as de
+_orig = de.discover
+def discover(bundle):
+    # Swap model/report so reports are deployed first.
+    return [(n, r or m, m) for n, m, r in _orig(bundle)]
+de.discover = discover
+""",
+    "flatten-the-folder-tree": """
+import deploy_estate as de
+de.project_parents = lambda estate_db: {}
+""",
+    "drop-the-provenance-stamp": """
+import deploy_estate as de
+de.stamp_for = lambda item: ""
+""",
+    "listing-failure-means-empty": """
+import deploy_estate as de
+_orig = de.Landing.read
+def read(cls, workspace, tok, adopt=False):
+    landing, why = _orig(workspace, tok, adopt)
+    return (landing or cls([], adopt)), ""
+de.Landing.read = classmethod(read)
+""",
+    "no-empty-report-skip": """
+import deploy_estate as de
+de.report_is_empty = lambda folder: False
+""",
+    "skip-the-folder-sanitiser": """
+import deploy_estate as de
+de.folder_display_name = lambda name: name
+""",
+    "mock-omits-nothing-folderid-null-at-root": """
+import mocks.fabric as mf
+_orig = mf.Item.row
+@property
+def row(self):
+    out = dict(_orig.fget(self))
+    out.setdefault("folderId", None)
+    return out
+mf.Item.row = row
+""",
+    "mock-rejects-duplicate-names": """
+import mocks.fabric as mf
+_orig = mf.FabricService._create_item
+def create(self, body):
+    name, kind = body.get("displayName"), body.get("type")
+    if any(i.display_name == name and i.item_type == kind for i in self.items.values()):
+        return mf._error(400, "ItemDisplayNameAlreadyInUse", "already in use")
+    return _orig(self, body)
+mf.FabricService._create_item = create
+""",
+    "mock-accepts-bypath-reports": """
+import mocks.fabric as mf
+mf.FabricService._reject_report = lambda self, by_path: None
+""",
+    "mock-coerces-bad-folder-names": """
+import mocks.fabric as mf
+mf.FabricService._reject_folder = lambda self, name, parent: None
+""",
+    "mock-ignores-the-folder-depth-limit": """
+import mocks.fabric as mf
+mf.MAX_FOLDER_DEPTH = 100
+""",
+    "mock-never-throttles": """
+import mocks.fabric as mf
+mf.FabricService.throttle = lambda self, **kw: None
+""",
+    "mock-updatedefinition-also-moves-and-restamps": """
+import mocks.fabric as mf
+_orig = mf.FabricService._update_definition
+def upd(self, item, body):
+    out = _orig(self, item, body)
+    item.description = None
+    item.folder_id = None
+    return out
+mf.FabricService._update_definition = upd
+""",
+    "mock-forgets-the-item-limit": """
+import mocks.fabric as mf
+mf.WORKSPACE_ITEM_LIMIT = 10 ** 9
+_orig = mf.FabricService.__init__
+def init(self, **kw):
+    kw.setdefault("item_limit", 10 ** 9)
+    _orig(self, **kw)
+mf.FabricService.__init__ = init
+""",
+    "tableau-mock-accepts-any-pat-secret": """
+import mocks.tableau as mt
+_orig = mt.TableauSite._signin
+def signin(self, body):
+    import json, uuid
+    creds = (json.loads(body or b"{}").get("credentials") or {})
+    if (creds.get("site") or {}).get("contentUrl") != self.content_url:
+        return _orig(self, body)
+    token = str(uuid.uuid4())
+    self.tokens.add(token)
+    return self._json(200, {"credentials": {"token": token,
+        "site": {"id": self.site_id, "contentUrl": self.content_url}, "user": {"id": "user-1"}}})
+mt.TableauSite._signin = signin
+""",
+    "tableau-mock-returns-empty-graphql-instead-of-errors": """
+import mocks.tableau as mt
+_orig = mt.TableauSite._graphql
+def gql(self, body):
+    out = _orig(self, body)
+    import json
+    payload = json.loads(out[2])
+    if payload.get("errors"):
+        return self._json(200, {"data": {}})
+    return out
+mt.TableauSite._graphql = gql
+""",
+    "tableau-mock-always-sends-usage-statistics": """
+import mocks.tableau as mt
+_orig = mt.TableauSite._collection
+def coll(self, collection, query):
+    if collection == "views":
+        query = dict(query, includeUsageStatistics=["true"])
+    return _orig(self, collection, query)
+mt.TableauSite._collection = coll
+""",
+    "tableau-mock-uses-the-standard-content-disposition": """
+import mocks.tableau as mt
+_orig = mt.TableauSite._content
+def content(self, collection, luid):
+    status, headers, payload = _orig(self, collection, luid)
+    if "Content-Disposition" in headers:
+        headers["Content-Disposition"] = headers["Content-Disposition"].replace("name=", "filename=")
+    return status, headers, payload
+mt.TableauSite._content = content
+""",
+    "tableau-mock-emits-integer-pagination": """
+import mocks.tableau as mt
+import json
+_orig = mt.TableauSite._page
+def page(self, rows, collection, item, query):
+    status, headers, payload = _orig(self, rows, collection, item, query)
+    body = json.loads(payload)
+    body["pagination"] = {k: int(v) for k, v in body["pagination"].items()}
+    return status, headers, json.dumps(body).encode()
+mt.TableauSite._page = page
+""",
+    "engine-stand-in-emits-no-pages": """
+import mocks.estate as me
+me._FAKE_ENGINE = me._FAKE_ENGINE.replace('"pageOrder": pages or []', '"pageOrder": []')
+""",
+}
+
+
+def run(name: str, code: str, target: str) -> tuple[str, int, str]:
+    plugin = ROOT / "tests" / "_mutation_plugin.py"
+    plugin.write_text(
+        "import sys\nfrom pathlib import Path\n"
+        f"sys.path.insert(0, r'{ROOT / 'scripts'}')\nsys.path.insert(0, r'{ROOT / 'tests'}')\n" + code,
+        encoding="utf-8",
+    )
+    proc = subprocess.run(
+        [PY, "-m", "pytest", target, "-q", "-p", "_mutation_plugin", "--no-header", "-x", "--tb=no"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        env={
+            **os.environ,
+            "PYTHONPATH": os.pathsep.join([str(ROOT / "tests"), str(ROOT / "scripts")]),
+        },
+    )
+    plugin.unlink(missing_ok=True)
+    if "Error importing plugin" in proc.stdout + proc.stderr:
+        raise SystemExit(f"{name}: the mutation never applied - the harness would report a FALSE 'CAUGHT'")
+    caught = [line.split("::")[-1].split(" ")[0] for line in proc.stdout.splitlines() if line.startswith("FAILED")]
+    if caught:
+        return name, proc.returncode, caught[0]
+    lines = (proc.stdout.strip() or proc.stderr.strip() or "(no output)").splitlines()
+    return name, proc.returncode, lines[-1][:120]
+
+
+def main() -> int:
+    targets = ["tests/test_e2e_offline.py", "tests/test_mock_fabric.py", "tests/test_mock_tableau.py"]
+    for target in targets:
+        baseline = subprocess.run(
+            [PY, "-m", "pytest", target, "-q", "--no-header"], cwd=ROOT, capture_output=True, text=True, check=False
+        )
+        print(f"BASELINE {target:32s} exit={baseline.returncode}  {baseline.stdout.strip().splitlines()[-1]}")
+    print()
+    survivors = []
+    for name, code in MUTATIONS.items():
+        if name.startswith("mock-"):
+            target = "tests/test_mock_fabric.py"
+        elif name.startswith("tableau-mock-"):
+            target = "tests/test_mock_tableau.py"
+        else:
+            target = "tests/test_e2e_offline.py"
+        label, rc, detail = run(name, code, target)
+        verdict = "CAUGHT " if rc != 0 else "SURVIVED"
+        if rc == 0:
+            survivors.append(label)
+        print(f"{verdict}  {label:52s} -> {detail}")
+    print()
+    print("survivors (holes in the suite):", survivors or "none")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_e2e_offline.py
+++ b/tests/test_e2e_offline.py
@@ -1,0 +1,508 @@
+"""The joined offline end-to-end test: Tableau site -> assess -> harvest -> convert -> Fabric.
+
+Nothing here touches a network. The Tableau half is a loopback HTTP server serving this repo's own
+fixture workbooks; the Fabric half is an in-process fake substituted at ``deploy_estate._request``.
+Every script in between - ``assess_estate``, ``run_estate``, ``parse_tableau``, ``deploy_estate`` -
+is the REAL one, unmodified.
+
+The suite is written to FAIL when the pipeline regresses, which is a different goal from "runs
+green". The mutations each assertion was proven against are listed in
+``docs/offline-mock-harness.md``; in short, the E2E catches a lost duplicate check, a report bound
+to the wrong model, models deployed after reports, a flattened folder tree and a re-run that
+re-creates instead of updating.
+
+Run just this file::
+
+    python -m pytest tests/test_e2e_offline.py -q
+
+Skip the slow half (the subprocess engine + the loopback server)::
+
+    python -m pytest -q -m "not slow"
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+sys.path.insert(0, str(ROOT / "tests"))
+
+import assess_estate as ae  # noqa: E402
+import deploy_estate as de  # noqa: E402
+import run_estate  # noqa: E402
+from mocks import estate, tableau  # noqa: E402
+from mocks.fabric import MODEL_TYPE, REPORT_TYPE, FabricService  # noqa: E402
+
+pytestmark = pytest.mark.slow
+
+# Two of the three fixture workbooks have convertible worksheets; `federated_multi_connection.twb`
+# has none, so its report is legitimately empty. That is not a defect to work around - it is the
+# MEASURED case (2 of 33 reports on a real estate) that `report_is_empty` exists for, and the E2E
+# asserts the resulting item count rather than pretending every workbook yields two items.
+EXPECTED_MODELS = ["Attic_Copy", "Ops_Dashboard", "Sales_Review"]
+EXPECTED_REPORTS = ["Attic_Copy", "Sales_Review"]
+
+
+def options(**overrides) -> argparse.Namespace:
+    """The deployer's CLI namespace, with the defaults ``main()`` would have supplied."""
+    base = {
+        "dry_run": False,
+        "force_unlock": False,
+        "journal": None,
+        "estate_db": None,
+        "no_folders": False,
+        "adopt_existing": False,
+    }
+    return argparse.Namespace(**(base | overrides))
+
+
+@pytest.fixture(name="pipeline", scope="module")
+def _pipeline(tmp_path_factory):
+    """Everything up to (but not including) the deploy, run ONCE for the whole module.
+
+    The front half is deterministic and read-only, so re-running it per test would only buy slower
+    feedback. Each deploy test still gets its own workspace and its own copy of the bundle path.
+    """
+    work = tmp_path_factory.mktemp("estate")
+    site = estate.build_site()
+
+    with tableau.serve(site) as base:
+        client = ae.Site(tableau.env_for(site, base))
+        client.sign_in()
+        raw = ae.collect(client, None)
+        assembled = ae.assemble(raw, 0.99)
+        assess_dir = work / "_assessment"
+        assess_dir.mkdir()
+        estate_db = ae.write_store(assess_dir, raw, assembled)
+        harvested = estate.harvest(site, work, base_url=base, token=client.token)
+        client.sign_out()
+
+    engine = estate.install_fake_engine(work / "engine")
+    code = run_estate.main(
+        [
+            "--input",
+            str(work / "assets"),
+            "--output",
+            str(work / "bundle"),
+            "--engine",
+            str(engine),
+            "--allow-noncanonical-engine",
+        ]
+    )
+    assert code == 0, "the coordinator must accept the bundle before anything is deployed"
+
+    return {
+        "site": site,
+        "work": work,
+        "bundle": work / "bundle",
+        "estate_db": estate_db,
+        "harvested": harvested,
+        "assembled": assembled,
+    }
+
+
+@pytest.fixture(name="bundle")
+def _bundle(pipeline, tmp_path):
+    """A private copy of the bundle, so a deploy's journal/lock cannot leak between tests."""
+    import shutil  # noqa: PLC0415
+
+    target = tmp_path / "bundle"
+    shutil.copytree(pipeline["bundle"], target)
+    return target
+
+
+# ------------------------------------------------------------------ front half
+
+
+def test_the_front_half_produced_real_artifacts_from_real_bytes(pipeline):
+    """Harvest downloaded packaged workbooks and the engine turned them into a PBIP bundle."""
+    assert {p.suffix for p in pipeline["harvested"]} == {".twbx", ".tdsx"}
+    assert all(p.read_bytes()[:2] == b"PK" for p in pipeline["harvested"])
+
+    report = json.loads((pipeline["bundle"] / "report.json").read_text(encoding="utf-8"))
+    assert report["definition_of_done"]["status"] == "pass"
+    assert {w["name"] for w in report["workbooks"]} == set(EXPECTED_MODELS)
+
+
+def test_the_assessment_recorded_the_nested_project_tree(pipeline):
+    """The deploy mirrors folders FROM this table, so the nesting has to survive the assessment."""
+    with sqlite3.connect(pipeline["estate_db"]) as connection:
+        luids = dict(connection.execute("select name, luid from project"))
+        parents = dict(connection.execute("select name, parent_luid from project"))
+    assert parents["Q1.2026"] == luids["Finance"]
+
+
+# ------------------------------------------------------------- the joined E2E
+
+
+def test_the_whole_chain_lands_the_expected_workspace(monkeypatch, bundle, pipeline):
+    """The outcome assertion the whole harness exists for.
+
+    Item count, ordering, binding, folder tree, zero duplicates - all read back out of the mock
+    workspace rather than inferred from an exit code.
+    """
+    service = FabricService()
+    service.install(monkeypatch, de)
+    tok = service.token_for(de)
+
+    code = de.deploy(bundle, service.workspace_id, tok, options(estate_db=pipeline["estate_db"]))
+    assert code == de.EXIT_OK
+
+    # 1. exactly what was expected, no more: the empty report is SKIPPED, not deployed empty.
+    assert service.item_names(MODEL_TYPE) == EXPECTED_MODELS
+    assert service.item_names(REPORT_TYPE) == EXPECTED_REPORTS
+
+    # 2. zero duplicates. The mock would have ACCEPTED them (Fabric does), so this is a real check.
+    assert service.duplicates() == []
+
+    # 3. every model was created before the report that binds to it.
+    creates = [url for method, url, _body in service.requests if method == "POST" and url.endswith("/items")]
+    del creates  # ordering is asserted precisely below, from the item ids themselves
+    order = [item.display_name for item in service.items.values()]
+    for name in EXPECTED_REPORTS:
+        model_at = order.index(name)
+        report_at = len(order) - 1 - order[::-1].index(name)
+        assert model_at < report_at, f"{name}: the model must exist before its report is bound"
+
+    # 4. each report is bound BY CONNECTION to the guid the service returned for ITS model.
+    models = {i.display_name: i.id for i in service.items.values() if i.item_type == MODEL_TYPE}
+    for name in EXPECTED_REPORTS:
+        assert service.model_binding(name) == models[name], f"{name} is bound to the wrong model"
+
+    # 5. the Tableau project tree is mirrored, sanitised where Fabric rejects a character.
+    #    `Q1.2026` cannot be a Fabric folder name (a dot is rejected ANYWHERE, not just trailing),
+    #    and `R&D` cannot either - the deployer coerces both, and the NESTING under Finance is what
+    #    proves the tree itself survived rather than collapsing to a flat list of root folders.
+    placed = service.item_folder_paths()
+    assert placed[f"Sales_Review ({MODEL_TYPE})"] == "Finance/Q1-2026"
+    assert placed[f"Sales_Review ({REPORT_TYPE})"] == "Finance/Q1-2026"
+    assert placed[f"Attic_Copy ({MODEL_TYPE})"] == "Finance"
+    assert placed[f"Ops_Dashboard ({MODEL_TYPE})"] == "R-D"
+    assert set(service.folder_paths().values()) == {"Finance", "Finance/Q1-2026", "R-D"}
+
+
+def test_every_deployed_item_carries_a_provenance_stamp(monkeypatch, bundle, pipeline):
+    """Ownership evidence lives in the SERVICE, not only in a local journal.
+
+    A journal can be lost; the stamp is what lets the next run tell our item from a customer's
+    same-named one, and it is the difference between a safe resume and overwriting their content.
+    """
+    service = FabricService()
+    service.install(monkeypatch, de)
+    de.deploy(bundle, service.workspace_id, service.token_for(de), options(estate_db=pipeline["estate_db"]))
+
+    assert service.items
+    for item in service.items.values():
+        assert str(item.description or "").startswith(de.PROVENANCE), item.display_name
+
+
+def test_a_report_is_never_left_bound_by_path(monkeypatch, bundle):
+    """``byPath`` is what the engine emits and what the service cannot resolve.
+
+    The mock refuses it outright (ASSUMED-strict), so a deploy that forgot to rebind fails loudly
+    here instead of producing a report that opens to an error in the customer's tenant.
+    """
+    service = FabricService()
+    service.install(monkeypatch, de)
+    de.deploy(bundle, service.workspace_id, service.token_for(de), options())
+
+    for item in service.items.values():
+        if item.item_type != REPORT_TYPE:
+            continue
+        pbir = json.loads(service.part(item.id, "definition.pbir"))
+        assert "byConnection" in pbir["datasetReference"]
+        assert "byPath" not in pbir["datasetReference"]
+
+
+def test_a_page_less_report_is_not_sent_to_fabric(tmp_path):
+    """The deployer must refuse the service-invalid report shape before issuing a create call."""
+    report = tmp_path / "empty.Report"
+    pages = report / "definition" / "pages"
+    pages.mkdir(parents=True)
+    (pages / "pages.json").write_text('{"pageOrder": []}', encoding="utf-8")
+
+    assert de.report_is_empty(report)
+
+
+# --------------------------------------------------------- it has to CATCH things
+
+
+def test_re_running_the_same_deploy_creates_nothing_new(monkeypatch, bundle, pipeline):
+    """Idempotency, asserted on the WORKSPACE rather than on the exit code.
+
+    Both runs share a journal (the same bundle), which is the normal resume shape.
+    """
+    service = FabricService()
+    service.install(monkeypatch, de)
+    tok = service.token_for(de)
+    opts = options(estate_db=pipeline["estate_db"])
+
+    assert de.deploy(bundle, service.workspace_id, tok, opts) == de.EXIT_OK
+    first = {i.id: (i.display_name, i.item_type) for i in service.items.values()}
+    folders_first = set(service.folders)
+
+    assert de.deploy(bundle, service.workspace_id, tok, opts) == de.EXIT_OK
+    second = {i.id: (i.display_name, i.item_type) for i in service.items.values()}
+
+    assert second == first, "a re-run must UPDATE the same ids, never create new ones"
+    assert service.duplicates() == []
+    assert set(service.folders) == folders_first, "a re-run must reuse the folders it made"
+
+
+def test_a_transient_failure_on_the_listing_stops_the_run_instead_of_duplicating(monkeypatch, bundle):
+    """MEASURED root cause of real duplicates: a failed listing read as "the workspace is empty".
+
+    Preflight refuses first, so nothing is created.
+    """
+    service = FabricService()
+    service.install(monkeypatch, de)
+    tok = service.token_for(de)
+
+    assert de.deploy(bundle, service.workspace_id, tok, options()) == de.EXIT_OK
+    before = {i.id for i in service.items.values()}
+
+    service.fail_next(500, method="GET", contains="/items", times=6)
+    code = de.deploy(bundle, service.workspace_id, tok, options())
+
+    assert code == de.EXIT_PREFLIGHT, "an unreadable workspace must not be treated as an empty one"
+    assert {i.id for i in service.items.values()} == before
+    assert service.duplicates() == []
+
+
+def test_a_listing_that_fails_AFTER_preflight_still_refuses_to_guess(monkeypatch, bundle):
+    """The same defect one layer deeper, and it needs its own test.
+
+    Preflight reads the workspace, then ``Landing.read`` reads it AGAIN - and it is the second read
+    that decides whether an item already exists. A mutation that makes only ``Landing`` fall back to
+    "empty" survives the test above, because preflight's read succeeded and short-circuited the run.
+    Failing precisely the second listing is what exercises the layer that actually duplicates.
+    """
+    service = FabricService()
+    service.install(monkeypatch, de)
+    tok = service.token_for(de)
+
+    assert de.deploy(bundle, service.workspace_id, tok, options()) == de.EXIT_OK
+    before = {i.id for i in service.items.values()}
+
+    original = service.request
+    listings = {"n": 0}
+
+    def fail_the_second_listing(method, url, bearer, body=None):
+        if method == "GET" and "/items" in url:
+            listings["n"] += 1
+            if listings["n"] == 2:
+                return 500, {}, {"errorCode": "InternalError", "message": "transient"}
+        return original(method, url, bearer, body)
+
+    monkeypatch.setattr(de, "_request", fail_the_second_listing)
+    code = de.deploy(bundle, service.workspace_id, tok, options())
+
+    assert code == de.EXIT_PREFLIGHT, "Landing.read must refuse, not fall back to an empty workspace"
+    assert {i.id for i in service.items.values()} == before, "and above all, it must not duplicate"
+    assert service.duplicates() == []
+
+
+def test_a_throttled_listing_is_refused_rather_than_read_as_empty(monkeypatch, bundle):
+    """A 429 on the landing-zone read is NOT retried, and that is the correct choice.
+
+    Retrying would be nicer; guessing would be catastrophic. What matters is that the run stops with
+    nothing created rather than deciding the workspace is empty and duplicating the estate. The
+    ``Retry-After`` here is the RFC 9110 HTTP-date form - the variant that once raised ``ValueError``
+    inside ``float()`` and killed a deploy mid-estate.
+    """
+    service = FabricService()
+    service.install(monkeypatch, de)
+    tok = service.token_for(de)
+    service.throttle(retry_after="Wed, 21 Oct 2026 07:28:00 GMT", contains="/items", times=1)
+
+    assert de.deploy(bundle, service.workspace_id, tok, options()) == de.EXIT_PREFLIGHT
+    assert not service.items, "nothing may be created off the back of a listing we could not read"
+
+
+def test_a_throttled_create_is_retried_after_the_http_date_delay(monkeypatch, bundle):
+    """Where a 429 IS retried - on the create - the HTTP-date form must not crash the run.
+
+    ``_post_item`` honours ``Retry-After`` exactly once. Feeding it the date form here is the
+    regression test for the ``float()`` ``ValueError`` that killed a real deploy mid-estate.
+    """
+    service = FabricService()
+    service.install(monkeypatch, de)
+    tok = service.token_for(de)
+    service.fail_next(
+        429,
+        method="POST",
+        contains="/items",
+        times=1,
+        headers={"retry-after": "Wed, 21 Oct 2026 07:28:00 GMT"},
+        body={"errorCode": "TooManyRequests", "message": "Too many requests"},
+    )
+
+    assert de.deploy(bundle, service.workspace_id, tok, options()) == de.EXIT_OK
+    assert service.item_names(MODEL_TYPE) == EXPECTED_MODELS
+    assert service.duplicates() == []
+
+
+def test_an_interrupted_run_resumes_without_duplicating(monkeypatch, bundle):
+    """The resume path, driven by a real interruption rather than a hand-written journal.
+
+    The first run is cut off after two items have genuinely landed; the second must adopt them -
+    identified by the SERVICE-side provenance stamp - and finish the rest.
+    """
+    service = FabricService()
+    service.install(monkeypatch, de)
+    tok = service.token_for(de)
+
+    original = service.request
+    creates = {"n": 0}
+
+    def die_after_two_creates(method, url, bearer, body=None):
+        if method == "POST" and url.endswith("/items"):
+            creates["n"] += 1
+            if creates["n"] > 2:
+                return 0, {}, {"error": {"message": "[Errno 11001] getaddrinfo failed"}}
+        return original(method, url, bearer, body)
+
+    monkeypatch.setattr(de, "_request", die_after_two_creates)
+    assert de.deploy(bundle, service.workspace_id, tok, options()) == de.EXIT_FAILED
+    landed = {i.id for i in service.items.values()}
+    assert len(landed) == 2, "exactly the two creates that got through"
+
+    monkeypatch.setattr(de, "_request", original)
+    assert de.deploy(bundle, service.workspace_id, tok, options()) == de.EXIT_OK
+
+    assert landed <= {i.id for i in service.items.values()}, "the survivors must be adopted, not orphaned"
+    assert service.item_names(MODEL_TYPE) == EXPECTED_MODELS
+    assert service.duplicates() == []
+
+
+def test_a_partial_run_that_lost_its_journal_still_does_not_duplicate(monkeypatch, bundle):
+    """The nastiest resume: the journal is GONE, so only the service-side stamp can identify our own
+    items. Without the stamp this run would either duplicate everything or refuse to proceed."""
+    service = FabricService()
+    service.install(monkeypatch, de)
+    tok = service.token_for(de)
+
+    assert de.deploy(bundle, service.workspace_id, tok, options()) == de.EXIT_OK
+    before = {i.id for i in service.items.values()}
+    (bundle / "deploy-journal.jsonl").unlink()
+
+    assert de.deploy(bundle, service.workspace_id, tok, options()) == de.EXIT_OK
+    assert {i.id for i in service.items.values()} == before
+    assert service.duplicates() == []
+
+
+def test_a_customers_same_named_item_is_not_overwritten(monkeypatch, bundle):
+    """A landing zone is not necessarily empty. An unstamped item of the same name is THEIRS.
+
+    Overwriting it destroyed a customer's content on a real run; the refusal is what replaced that.
+    """
+    service = FabricService()
+    service.install(monkeypatch, de)
+    tok = service.token_for(de)
+
+    theirs = service.call(
+        "POST",
+        f"https://api.fabric.microsoft.com/v1/workspaces/{service.workspace_id}/items",
+        tok,
+        {
+            "displayName": "Sales_Review",
+            "type": MODEL_TYPE,
+            "definition": {
+                "parts": [
+                    {
+                        "path": "definition.pbism",
+                        "payload": base64.b64encode(b'{"version":"4.0"}').decode(),
+                        "payloadType": "InlineBase64",
+                    }
+                ]
+            },
+        },
+    )[2]["id"]
+    original = service.part(theirs, "definition.pbism")
+
+    code = de.deploy(bundle, service.workspace_id, tok, options())
+
+    assert code != de.EXIT_OK, "refusing to overwrite unowned content must be a failure, not a warning"
+    assert service.part(theirs, "definition.pbism") == original, "their content must be untouched"
+    assert not service.items[theirs].description, "and it must not be stamped as ours"
+
+
+def test_the_token_expiring_mid_run_does_not_lose_the_estate(monkeypatch, bundle):
+    """MEASURED: a 66-item deploy outlived its token and every remaining call answered 401.
+
+    ``call`` renews once and retries. Installing at ``_request`` is what keeps that under test.
+    """
+    service = FabricService()
+    service.install(monkeypatch, de)
+    tok = service.token_for(de)
+
+    original_request = service.request
+    state = {"calls": 0}
+
+    def expire_after_three(method, url, bearer, body=None):
+        state["calls"] += 1
+        if state["calls"] == 3:
+            service.expire_tokens()
+        return original_request(method, url, bearer, body)
+
+    monkeypatch.setattr(de, "_request", expire_after_three)
+
+    assert de.deploy(bundle, service.workspace_id, tok, options()) == de.EXIT_OK
+    assert service.item_names(MODEL_TYPE) == EXPECTED_MODELS
+    assert service.duplicates() == []
+
+
+def test_a_dry_run_creates_absolutely_nothing(monkeypatch, bundle, pipeline):
+    """The rehearsal mode the workshop will actually use first."""
+    service = FabricService()
+    service.install(monkeypatch, de)
+
+    code = de.deploy(
+        bundle, service.workspace_id, service.token_for(de), options(dry_run=True, estate_db=pipeline["estate_db"])
+    )
+
+    assert code == de.EXIT_OK
+    assert not service.items
+    assert not service.folders
+    assert not [m for m, _u, _b in service.requests if m == "POST"]
+
+
+def test_the_workspace_item_limit_is_enforced_before_anything_is_created(monkeypatch, bundle):
+    """A landing zone that cannot hold the estate must be refused up front, not discovered at 90%.
+
+    Two independent limits are in play and they are worth telling apart: the SERVICE enforces 1000
+    items (the mock reproduces that, see ``test_mock_fabric``), while the DEPLOYER refuses earlier,
+    at 90% of its own constant, so it never gets close. This asserts the deployer's gate, which is
+    the one that saves a half-deployed workspace.
+    """
+    service = FabricService()
+    service.install(monkeypatch, de)
+    monkeypatch.setattr(de, "WORKSPACE_ITEM_LIMIT", 2)
+
+    code = de.deploy(bundle, service.workspace_id, service.token_for(de), options())
+
+    assert code == de.EXIT_PREFLIGHT
+    assert not service.items, "preflight must refuse before the first create"
+
+
+def test_the_service_side_limit_is_a_hard_stop_not_a_silent_truncation(monkeypatch, bundle):
+    """And if the deployer's own gate were removed, the SERVICE still refuses - loudly.
+
+    Reproducing the real 400 rather than quietly dropping the item is what makes the failure legible
+    in the run log instead of showing up as a missing report weeks later.
+    """
+    service = FabricService(item_limit=2)
+    service.install(monkeypatch, de)
+
+    code = de.deploy(bundle, service.workspace_id, service.token_for(de), options())
+
+    assert code == de.EXIT_FAILED
+    assert len(service.items) == 2, "the service caps it; nothing beyond the cap is invented"

--- a/tests/test_mock_fabric.py
+++ b/tests/test_mock_fabric.py
@@ -1,0 +1,562 @@
+"""Fidelity self-tests for the offline Fabric mock.
+
+Every test here asserts a behaviour of the MOCK, not of the deployer, and each names the evidence
+that put it there. That matters more than it sounds: a mock is only useful if it is at least as
+strict as the service, and the only way to keep it that way is to pin each strictness in a test that
+fails when someone relaxes it. Where a behaviour is ASSUMED rather than measured, the test says so in
+its docstring and asserts the *shape* (status / effect) rather than an invented error code.
+
+See ``docs/offline-mock-harness.md`` for the full evidence table.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+sys.path.insert(0, str(ROOT / "tests"))
+
+import deploy_estate as de  # noqa: E402
+from mocks.fabric import API, MODEL_TYPE, REPORT_TYPE, WORKSPACE_ITEM_LIMIT, FabricService  # noqa: E402
+
+
+def part(path: str, payload: str) -> dict:
+    """One inline base64 definition part, the shape the Fabric items API takes."""
+    return {"path": path, "payload": base64.b64encode(payload.encode()).decode(), "payloadType": "InlineBase64"}
+
+
+def model_body(name: str, **extra) -> dict:
+    return {
+        "displayName": name,
+        "type": MODEL_TYPE,
+        "definition": {"parts": [part("definition.pbism", '{"version":"4.0"}')]},
+        **extra,
+    }
+
+
+def report_body(name: str, model_id: str, **extra) -> dict:
+    pbir = json.dumps(
+        {
+            "version": "4.0",
+            "datasetReference": {
+                "byConnection": {
+                    "connectionString": f"Data Source=powerbi://api.powerbi.com/v1.0/myorg/ws;"
+                    f"Initial Catalog={name};Integrated Security=ClaimsToken;"
+                    f"semanticModelId={model_id}"
+                }
+            },
+        }
+    )
+    return {
+        "displayName": name,
+        "type": REPORT_TYPE,
+        "definition": {
+            "parts": [
+                part("definition.pbir", pbir),
+                part("definition/pages/pages.json", json.dumps({"pageOrder": ["p1"]})),
+            ]
+        },
+        **extra,
+    }
+
+
+@pytest.fixture(name="service")
+def _service() -> FabricService:
+    return FabricService()
+
+
+@pytest.fixture(name="tok")
+def _tok(service: FabricService) -> str:
+    return service.issue_token()
+
+
+def create(service: FabricService, tok: str, body: dict):
+    return service.call("POST", f"{API}/workspaces/{service.workspace_id}/items", tok, body)
+
+
+# --------------------------------------------------------------------- MEASURED
+
+
+def test_a_duplicate_display_name_is_accepted_because_fabric_accepts_it(service, tok):
+    """MEASURED, and the single most important behaviour in this mock.
+
+    Fabric does NOT reject a repeated Report/SemanticModel displayName; it creates a second item
+    with the same name. That is exactly why duplicates went undetected on a real estate, and a mock
+    that rejected the second create would have made the whole class of bug untestable.
+    """
+    first = create(service, tok, model_body("Sales"))
+    second = create(service, tok, model_body("Sales"))
+
+    assert first[0] == 201
+    assert second[0] == 201, "Fabric accepts a duplicate display name; the mock must too"
+    assert first[2]["id"] != second[2]["id"]
+    assert service.item_names(MODEL_TYPE) == ["Sales", "Sales"]
+    assert service.duplicates() == [("Sales", MODEL_TYPE)]
+
+
+def test_folder_id_is_omitted_at_the_root_not_returned_as_null(service, tok):
+    """MEASURED: a root-level item's listing row has NO ``folderId`` key at all.
+
+    ``.get("folderId")`` cannot tell the two apart, but ``"folderId" in row`` can - and a mock that
+    returned ``None`` would let a client that depends on the key existing pass here and fail live.
+    """
+    create(service, tok, model_body("Root Item"))
+    folder = service.call("POST", f"{API}/workspaces/{service.workspace_id}/folders", tok, {"displayName": "Sales"})
+    create(service, tok, model_body("Filed Item", folderId=folder[2]["id"]))
+
+    _status, _headers, listing = service.call("GET", f"{API}/workspaces/{service.workspace_id}/items", tok)
+    rows = {row["displayName"]: row for row in listing["value"]}
+
+    assert "folderId" not in rows["Root Item"], "root items omit folderId entirely"
+    assert rows["Filed Item"]["folderId"] == folder[2]["id"]
+
+
+def test_a_listing_row_carries_id_display_name_type_and_description(service, tok):
+    """MEASURED shape of ``GET /items``: ``{"value": [...]}`` with those fields."""
+    create(service, tok, model_body("Sales", description="deployed by tests"))
+    _status, _headers, listing = service.call("GET", f"{API}/workspaces/{service.workspace_id}/items", tok)
+    row = listing["value"][0]
+
+    assert set(row) >= {"id", "displayName", "type", "description"}
+    assert row["type"] == MODEL_TYPE
+    assert row["description"] == "deployed by tests"
+
+
+def test_paging_emits_a_continuation_token_and_uri(service, tok):
+    """MEASURED: 68 items came back in ONE page with no token.
+
+    So paging is real but not reachable by accident - the page size is configurable precisely so a
+    test can force it. A client that ignores ``continuationToken`` sees a short list and believes it.
+    """
+    service.page_size = 2
+    for index in range(5):
+        create(service, tok, model_body(f"Item {index}"))
+
+    status, _headers, page = service.call("GET", f"{API}/workspaces/{service.workspace_id}/items", tok)
+    assert status == 200
+    assert len(page["value"]) == 2
+    assert page["continuationToken"]
+    assert page["continuationUri"].startswith("http")
+
+    seen = list(page["value"])
+    token = page["continuationToken"]
+    while token:
+        _s, _h, page = service.call(
+            "GET", f"{API}/workspaces/{service.workspace_id}/items?continuationToken={token}", tok
+        )
+        seen += page["value"]
+        token = page.get("continuationToken")
+    assert len(seen) == 5
+
+
+def test_list_all_in_the_deployer_follows_the_continuation_token(monkeypatch, service):
+    """The deployer's own pager against the mock's pager - the pairing that matters."""
+    service.page_size = 2
+    tok = service.issue_token()
+    for index in range(5):
+        create(service, tok, model_body(f"Item {index}"))
+    service.install(monkeypatch, de)
+
+    status, rows = de.list_all(service.workspace_id, tok, "items")
+    assert status == 200
+    assert len(rows) == 5
+
+
+def test_update_definition_leaves_description_and_folder_untouched(service, tok):
+    """MEASURED: ``updateDefinition`` replaces only the definition.
+
+    This is why the deployer stamps a description and moves an item as SEPARATE calls; a mock that
+    let ``updateDefinition`` carry them would hide an omission that only shows up live.
+    """
+    folder = service.call("POST", f"{API}/workspaces/{service.workspace_id}/folders", tok, {"displayName": "Sales"})
+    _s, _h, created = create(service, tok, model_body("Sales", description="v1", folderId=folder[2]["id"]))
+    item_id = created["id"]
+
+    status, _headers, _body = service.call(
+        "POST",
+        f"{API}/workspaces/{service.workspace_id}/items/{item_id}/updateDefinition",
+        tok,
+        {"definition": {"parts": [part("definition.pbism", '{"version":"9.9"}')]}},
+    )
+
+    assert status in (200, 202)
+    item = service.items[item_id]
+    assert item.description == "v1", "updateDefinition must not clear the description"
+    assert item.folder_id == folder[2]["id"], "updateDefinition must not move the item"
+    assert b"9.9" in service.part(item_id, "definition.pbism")
+
+
+def test_patch_updates_the_description_and_move_replaces_the_item(service, tok):
+    """MEASURED: ``PATCH {"description": ...}`` and ``POST /move {"targetFolderId": ...}``."""
+    _s, _h, created = create(service, tok, model_body("Sales"))
+    item_id = created["id"]
+    folder = service.call("POST", f"{API}/workspaces/{service.workspace_id}/folders", tok, {"displayName": "Sales"})
+
+    service.call("PATCH", f"{API}/workspaces/{service.workspace_id}/items/{item_id}", tok, {"description": "hello"})
+    service.call(
+        "POST",
+        f"{API}/workspaces/{service.workspace_id}/items/{item_id}/move",
+        tok,
+        {"targetFolderId": folder[2]["id"]},
+    )
+
+    assert service.items[item_id].description == "hello"
+    assert service.items[item_id].folder_id == folder[2]["id"]
+
+
+def test_move_with_an_empty_body_means_the_workspace_root(service, tok):
+    """MEASURED: an empty ``/move`` body re-places the item at the root."""
+    folder = service.call("POST", f"{API}/workspaces/{service.workspace_id}/folders", tok, {"displayName": "Sales"})
+    _s, _h, created = create(service, tok, model_body("Sales", folderId=folder[2]["id"]))
+
+    service.call("POST", f"{API}/workspaces/{service.workspace_id}/items/{created['id']}/move", tok, {})
+
+    assert service.items[created["id"]].folder_id is None
+
+
+@pytest.mark.parametrize(
+    "bad", ["Q1.2026", "R&D", "a/b", "a\\b", "a:b", "a?b", "a*b", 'a"b', "a|b", "a<b", "a#b", "a%b"]
+)
+def test_a_folder_name_with_a_rejected_character_is_refused_not_coerced(service, tok, bad):
+    """MEASURED: the API REJECTS with ``InvalidFolderDisplayName``; it does not clean the name up.
+
+    The dot is the one that surprises: it is rejected ANYWHERE, not just trailing, which is why a
+    Tableau project called ``Q1.2026`` cannot be mirrored verbatim.
+    """
+    status, _headers, body = service.call(
+        "POST", f"{API}/workspaces/{service.workspace_id}/folders", tok, {"displayName": bad}
+    )
+
+    assert status == 400
+    assert body["errorCode"] == "InvalidFolderDisplayName"
+    assert not service.folders
+
+
+@pytest.mark.parametrize("bad", [" leading", "trailing "])
+def test_a_folder_name_with_surrounding_space_is_refused(service, tok, bad):
+    """MEASURED: a leading or trailing space is rejected (interior spaces are fine)."""
+    status, _headers, _body = service.call(
+        "POST", f"{API}/workspaces/{service.workspace_id}/folders", tok, {"displayName": bad}
+    )
+    assert status == 400
+
+
+@pytest.mark.parametrize("good", ["Ventes fran\u00e7aises", "90 - Torture Chamber", "a_b", "a+b", "a (2)"])
+def test_the_accepted_folder_characters_really_are_accepted(service, tok, good):
+    """MEASURED acceptances - and just as important as the rejections.
+
+    A mock that over-rejects is not "safely strict": it makes the deployer's sanitiser look wrong and
+    invites someone to mangle names Fabric was perfectly happy with. ``Ventes fran\u00e7aises`` was
+    accepted by the real API.
+    """
+    status, _headers, body = service.call(
+        "POST", f"{API}/workspaces/{service.workspace_id}/folders", tok, {"displayName": good}
+    )
+    assert status == 201, body
+
+
+def test_folder_nesting_deeper_than_ten_is_refused(service, tok):
+    """MEASURED: level 11 answers ``FolderDepthOutOfRange``."""
+    parent = None
+    for level in range(10):
+        status, _headers, body = service.call(
+            "POST",
+            f"{API}/workspaces/{service.workspace_id}/folders",
+            tok,
+            {"displayName": f"L{level}", "parentFolderId": parent},
+        )
+        assert status == 201, f"level {level + 1} should be allowed"
+        parent = body["id"]
+
+    status, _headers, body = service.call(
+        "POST",
+        f"{API}/workspaces/{service.workspace_id}/folders",
+        tok,
+        {"displayName": "L10", "parentFolderId": parent},
+    )
+    assert status == 400
+    assert body["errorCode"] == "FolderDepthOutOfRange"
+
+
+def test_a_folder_listing_row_carries_id_display_name_and_parent(service, tok):
+    """MEASURED shape of ``GET /folders``."""
+    _s, _h, root = service.call("POST", f"{API}/workspaces/{service.workspace_id}/folders", tok, {"displayName": "A"})
+    service.call(
+        "POST",
+        f"{API}/workspaces/{service.workspace_id}/folders",
+        tok,
+        {"displayName": "B", "parentFolderId": root["id"]},
+    )
+
+    _status, _headers, listing = service.call("GET", f"{API}/workspaces/{service.workspace_id}/folders", tok)
+    rows = {row["displayName"]: row for row in listing["value"]}
+
+    assert set(rows["A"]) >= {"id", "displayName"}
+    assert "parentFolderId" not in rows["A"], "a root folder omits parentFolderId"
+    assert rows["B"]["parentFolderId"] == root["id"]
+
+
+def test_the_thousand_item_workspace_limit_is_enforced(tok):
+    """MEASURED capacity limit. Exercised at a small limit so the test stays instant."""
+    service = FabricService(item_limit=3)
+    tok = service.issue_token()
+    for index in range(3):
+        assert create(service, tok, model_body(f"Item {index}"))[0] == 201
+
+    status, _headers, body = create(service, tok, model_body("One Too Many"))
+    assert status == 400
+    assert "limit" in json.dumps(body).lower()
+    assert len(service.items) == 3
+
+
+def test_the_default_workspace_limit_is_the_measured_one_thousand():
+    """The number itself, not just that SOME limit exists.
+
+    Without this, a mock configured with a limit of a billion still passes the test above (it only
+    ever exercises an explicitly-supplied small limit), and the harness would quietly stop modelling
+    the capacity ceiling the deployer's own preflight is sized against.
+    """
+    assert WORKSPACE_ITEM_LIMIT == 1000
+    assert FabricService().item_limit == 1000
+    assert de.WORKSPACE_ITEM_LIMIT == WORKSPACE_ITEM_LIMIT, "the mock and the deployer must agree"
+
+
+def test_token_expiry_answers_a_named_error_code_and_the_deployer_renews_once(monkeypatch, service):
+    """MEASURED: ``401`` with ``{"errorCode": "TokenExpired"}``, distinct from a plain bad token.
+
+    Installing at ``_request`` (not ``call``) is what keeps the renewal under test - patching ``call``
+    would delete the very policy this asserts.
+    """
+    service.install(monkeypatch, de)
+    tok = service.token_for(de)
+    assert create(service, tok, model_body("Before"))[0] == 201
+
+    service.expire_tokens()
+    status, _headers, body = de.call("POST", f"{API}/workspaces/{service.workspace_id}/items", tok, model_body("After"))
+
+    assert status == 201, body
+    assert service.item_names() == ["After", "Before"]
+
+
+def test_an_invalid_token_is_not_reported_as_expired(service):
+    """MEASURED distinction: a token that was never valid must NOT carry ``TokenExpired``.
+
+    Conflating them would make the deployer renew (and retry) on a credential that will never work.
+    """
+    status, _headers, body = service.call("GET", f"{API}/workspaces/{service.workspace_id}/items", "not-a-token")
+    assert status == 401
+    assert body.get("errorCode") != "TokenExpired"
+
+
+@pytest.mark.parametrize("retry_after", [3, "Wed, 21 Oct 2026 07:28:00 GMT"])
+def test_retry_after_is_served_in_both_measured_forms(monkeypatch, service, retry_after):
+    """MEASURED both forms. The HTTP-date form once raised ``ValueError`` inside ``float()``.
+
+    A mock that only ever emitted an integer would never have caught it.
+    """
+    service.install(monkeypatch, de)
+    tok = service.issue_token()
+    service.throttle(retry_after=retry_after, contains="/items")
+
+    status, headers, _body = de.call("GET", f"{API}/workspaces/{service.workspace_id}/items", tok)
+    assert status == 429
+    assert headers["retry-after"] == str(retry_after)
+
+    delay = de._retry_after(headers)  # noqa: SLF001  # pylint: disable=protected-access
+    assert isinstance(delay, float), "the HTTP-date form must not escape as a ValueError"
+    assert delay >= 0
+
+
+def test_a_network_level_failure_surfaces_as_http_zero(monkeypatch, service):
+    """The deployer distinguishes "the service said no" from "we never reached the service".
+
+    ``_request`` maps ``URLError`` to status ``0``, and a detail containing ``HTTP 0`` is what stops
+    a run rather than marking every remaining workbook failed.
+    """
+    service.install(monkeypatch, de)
+    tok = service.issue_token()
+    service.drop_network(contains="/items")
+
+    status, _headers, body = de.call("GET", f"{API}/workspaces/{service.workspace_id}/items", tok)
+    assert status == 0
+    assert "error" in body
+
+
+def test_a_long_running_create_must_be_polled_to_completion(monkeypatch):
+    """MEASURED: ``202`` + ``Location``/``x-ms-operation-id``, with an EMPTY body.
+
+    A client that reads an id out of the 202 gets nothing; it has to poll, then fetch ``/result``.
+    """
+    service = FabricService(async_create=True)
+    service.install(monkeypatch, de)
+    tok = service.issue_token()
+
+    status, headers, body = service.call("POST", f"{API}/workspaces/{service.workspace_id}/items", tok, model_body("S"))
+    assert status == 202
+    assert body == {}, "the 202 body is empty - the id is only available via the operation"
+    assert headers.get("location") or headers.get("x-ms-operation-id")
+
+    state, _payload = de.await_operation(headers["location"], tok)
+    assert state == "Succeeded"
+    _s, _h, result = service.call("GET", f"{headers['location']}/result", tok)
+    assert service.items[result["id"]].display_name == "S"
+
+
+def test_a_failed_operation_is_indistinguishable_from_success_unless_polled(monkeypatch):
+    """MEASURED incident: a probe reported both items deployed; one had FAILED and was never created.
+
+    The 202 looks identical either way. Only ``GET /operations/{id}`` shows ``status: Failed``.
+    """
+    service = FabricService(async_create=True)
+    service.install(monkeypatch, de)
+    tok = service.issue_token()
+    service.fail_next_operation()
+
+    status, headers, body = service.call(
+        "POST", f"{API}/workspaces/{service.workspace_id}/items", tok, model_body("Doomed")
+    )
+    assert (status, body) == (202, {}), "the failure is not visible in the immediate response"
+
+    state, payload = de.await_operation(headers["location"], tok)
+    assert state == "Failed"
+    assert payload.get("error"), "a Failed operation carries the reason"
+    assert not service.items, "a Failed operation creates nothing"
+
+
+def test_a_stalled_operation_still_created_the_item_server_side(monkeypatch):
+    """MEASURED shape: our poll gives up (``Timeout``) while the service completes anyway.
+
+    That is the exact input that produces a duplicate on resume if the client does not re-list, so
+    the mock has to be able to produce it.
+    """
+    service = FabricService(async_create=True)
+    service.install(monkeypatch, de)
+    tok = service.issue_token()
+    service.stall_operations()
+
+    _status, headers, _body = service.call(
+        "POST", f"{API}/workspaces/{service.workspace_id}/items", tok, model_body("Slow")
+    )
+    state, _payload = de.await_operation(headers["location"], tok, timeout=1.0)
+    assert state == "Timeout"
+    assert service.item_names() == ["Slow"], "the item exists even though our poll timed out"
+
+
+# --------------------------------------------------------------------- ASSUMED
+# These encode the STRICTEST plausible behaviour where the real service was not measured. Each
+# asserts the effect, never an invented error-code string. See the ASSUMED table in the doc.
+
+
+def test_a_report_bound_by_path_is_refused(service, tok):
+    """ASSUMED (strict). The service cannot resolve a relative filesystem path, so a ``byPath``
+    reference must not deploy. Treated as a hard rejection because accepting it would let the
+    single most common rebinding bug through the harness silently."""
+    body = report_body("Sales", "irrelevant")
+    body["definition"]["parts"][0] = part(
+        "definition.pbir", json.dumps({"datasetReference": {"byPath": {"path": "../Sales.SemanticModel"}}})
+    )
+    status, _headers, _payload = create(service, tok, body)
+    assert status == 400
+    assert not service.items
+
+
+def test_a_byconnection_block_with_extra_properties_is_refused(service, tok):
+    """MEASURED against the PBIR 2.0.0 schema: ``byConnection`` sets ``additionalProperties: false``
+    and permits only ``connectionString``. The five-field 1.0.0 shape is rejected."""
+    _s, _h, model = create(service, tok, model_body("Sales"))
+    body = report_body("Sales", model["id"])
+    payload = json.loads(base64.b64decode(body["definition"]["parts"][0]["payload"]))
+    payload["datasetReference"]["byConnection"].update(
+        {"pbiModelDatabaseName": "x", "connectionType": "pbiServiceXmlaStyleLive"}
+    )
+    body["definition"]["parts"][0] = part("definition.pbir", json.dumps(payload))
+
+    status, _headers, error = create(service, tok, body)
+    assert status == 400
+    assert "pbiModelDatabaseName" in json.dumps(error)
+
+
+def test_a_connection_string_without_a_semantic_model_id_is_refused(service, tok):
+    """ASSUMED (strict): a connection string that names no model id cannot bind to anything."""
+    body = report_body("Sales", "")
+    payload = json.loads(base64.b64decode(body["definition"]["parts"][0]["payload"]))
+    payload["datasetReference"]["byConnection"]["connectionString"] = "Data Source=powerbi://x;Initial Catalog=Sales"
+    body["definition"]["parts"][0] = part("definition.pbir", json.dumps(payload))
+
+    status, _headers, _error = create(service, tok, body)
+    assert status == 400
+
+
+def test_a_report_bound_to_a_model_that_is_not_here_is_refused(service, tok):
+    """ASSUMED (strict), and the assumption that gives the E2E its teeth.
+
+    Binding to a GUID that does not resolve to a SemanticModel IN THIS WORKSPACE is refused, so
+    "the report was bound to the duplicate/deleted model" becomes a test failure rather than a
+    plausible-looking success. If the real service is more forgiving, this mock over-rejects - which
+    is the safe direction."""
+    status, _headers, _error = create(service, tok, report_body("Sales", "00000000-0000-0000-0000-000000000000"))
+    assert status == 400
+
+
+def test_a_report_with_no_pages_is_refused(service, tok):
+    """MEASURED message, ASSUMED trigger boundary: Fabric answered "Content provider provided
+    invalid package content stream" for reports whose ``pageOrder`` was empty."""
+    _s, _h, model = create(service, tok, model_body("Sales"))
+    body = report_body("Sales", model["id"])
+    body["definition"]["parts"][1] = part("definition/pages/pages.json", json.dumps({"pageOrder": []}))
+
+    status, _headers, error = create(service, tok, body)
+    assert status == 400
+    assert "package content stream" in json.dumps(error)
+
+
+def test_a_non_base64_part_payload_is_refused(service, tok):
+    """ASSUMED (strict): ``InlineBase64`` that is not base64 cannot be decoded by anything."""
+    body = model_body("Sales")
+    body["definition"]["parts"][0]["payload"] = "not base64!!"
+    assert create(service, tok, body)[0] == 400
+
+
+def test_an_unknown_item_type_is_refused(service, tok):
+    """ASSUMED (strict): a typo in ``type`` must not silently create something."""
+    assert create(service, tok, model_body("Sales") | {"type": "SemanticModle"})[0] == 400
+
+
+def test_a_folder_id_that_does_not_exist_is_refused(service, tok):
+    """ASSUMED (strict): the alternative is an item filed nowhere, which is worse than an error."""
+    assert create(service, tok, model_body("Sales", folderId="folder-does-not-exist"))[0] == 400
+
+
+def test_an_item_display_name_is_not_held_to_the_folder_character_rules(service, tok):
+    """Deliberately NOT strict, because inventing a limit invents a failure.
+
+    Item display names routinely contain dots (``Sales v1.2``). The folder rules were measured on
+    FOLDERS; importing them here would make the mock reject something Fabric accepts, which is the
+    one kind of infidelity that wastes a day chasing a bug that does not exist."""
+    assert create(service, tok, model_body("Sales v1.2 (EMEA) & Ops"))[0] == 201
+
+
+def test_an_empty_item_display_name_is_refused(service, tok):
+    """ASSUMED (strict): an unnamed item is not addressable."""
+    assert create(service, tok, model_body(""))[0] == 400
+
+
+def test_a_forbidden_workspace_answers_403_not_404(service, tok):
+    """The deployer must distinguish "no permission" from "no such workspace"; both are fatal but
+    they need different remediation text."""
+    service.forbidden_workspaces.add(service.workspace_id)
+    status, _headers, _body = service.call("GET", f"{API}/workspaces/{service.workspace_id}", tok)
+    assert status == 403
+
+
+def test_the_request_log_records_what_was_actually_sent(service, tok):
+    """Inspection surface, not fidelity - but the tests below lean on it, so it is pinned here."""
+    create(service, tok, model_body("Sales"))
+    methods = [method for method, _url, _body in service.requests]
+    assert "POST" in methods

--- a/tests/test_mock_tableau.py
+++ b/tests/test_mock_tableau.py
@@ -1,0 +1,361 @@
+"""Fidelity self-tests for the offline Tableau mock.
+
+Same rule as the Fabric mock's suite: each test names the evidence behind the behaviour it pins, and
+the ASSUMED ones say so. The bulk of the value here is that the REAL clients in ``scripts/`` -
+``assess_estate.Site`` and ``tableau_lineage`` - are driven against it unmodified, so a
+mock-vs-client mismatch is a test failure rather than a surprise on the day.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import sys
+import zipfile
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+sys.path.insert(0, str(ROOT / "tests"))
+
+import assess_estate as ae  # noqa: E402
+import tableau_lineage as tl  # noqa: E402
+from mocks import estate, tableau  # noqa: E402
+
+
+@pytest.fixture(name="site")
+def _site() -> tableau.TableauSite:
+    return estate.build_site()
+
+
+@pytest.fixture(name="served")
+def _served(site):
+    with tableau.serve(site) as base:
+        yield site, base
+
+
+def signed_in(site) -> str:
+    status, _headers, payload = site.handle(
+        "POST",
+        f"http://x/api/{site.rest_version}/auth/signin",
+        {},
+        json.dumps(
+            {
+                "credentials": {
+                    "personalAccessTokenName": "mock-pat",
+                    "personalAccessTokenSecret": site.pat_credentials["mock-pat"],
+                    "site": {"contentUrl": site.content_url},
+                }
+            }
+        ).encode(),
+    )
+    assert status == 200
+    return json.loads(payload)["credentials"]["token"]
+
+
+# ------------------------------------------------------------------ transport
+
+
+def test_sign_in_requires_both_halves_of_the_pat(site):
+    """The right PAT NAME with the wrong secret must fail, and vice versa.
+
+    This is the single most common credential mistake this pipeline hits, and a mock that accepted
+    any non-empty pair would make the error message untestable.
+    """
+    body = json.dumps(
+        {
+            "credentials": {
+                "personalAccessTokenName": "mock-pat",
+                "personalAccessTokenSecret": "wrong",
+                "site": {"contentUrl": site.content_url},
+            }
+        }
+    ).encode()
+    status, _headers, _payload = site.handle("POST", f"http://x/api/{site.rest_version}/auth/signin", {}, body)
+    assert status == 401
+
+
+def test_an_unknown_site_content_url_is_a_404(site):
+    body = json.dumps(
+        {
+            "credentials": {
+                "personalAccessTokenName": "mock-pat",
+                "personalAccessTokenSecret": site.pat_credentials["mock-pat"],
+                "site": {"contentUrl": "some-other-site"},
+            }
+        }
+    ).encode()
+    status, _headers, _payload = site.handle("POST", f"http://x/api/{site.rest_version}/auth/signin", {}, body)
+    assert status == 404
+
+
+def test_a_lost_session_answers_the_literal_code_the_client_looks_for(site):
+    """MEASURED, and load-bearing: ``assess_estate.Site.get`` re-authenticates only when the response
+    body contains the string ``401002``. A mock that answered a bare 401 would make the re-auth path
+    dead code that nobody notices until a long survey drops its session."""
+    token = signed_in(site)
+    site.expire_session()
+
+    status, _headers, payload = site.handle(
+        "GET",
+        f"http://x/api/{site.rest_version}/sites/{site.site_id}/projects",
+        {"x-tableau-auth": token},
+        b"",
+    )
+    assert status == 401
+    assert "401002" in payload.decode()
+
+
+def test_the_real_assess_client_recovers_from_a_dropped_session(served):
+    """The recovery path, driven through the REAL client rather than asserted about."""
+    site, base = served
+    client = ae.Site(tableau.env_for(site, base))
+    client.sign_in()
+    path = f"/sites/{client.site_id}/projects"
+    assert client.paged(path, "projects", "project")
+
+    site.expire_session()
+    projects, _continuation = client.paged(path, "projects", "project")
+    assert len(projects) == len(site.projects), "the client must re-auth and finish the page"
+    assert client.reauths == 1, "the recovery must be recorded, not silent"
+
+
+def test_pagination_numbers_are_strings_because_tableau_emits_strings(site):
+    """MEASURED quirk of the REST API: ``pageNumber``/``pageSize``/``totalAvailable`` are strings.
+
+    Emitting ints would let a client that never coerces them pass here and then compare ``"1" < 2``
+    against the site.
+    """
+    token = signed_in(site)
+    _status, _headers, payload = site.handle(
+        "GET", f"http://x/api/{site.rest_version}/sites/{site.site_id}/projects", {"x-tableau-auth": token}, b""
+    )
+    pagination = json.loads(payload)["pagination"]
+    assert all(isinstance(value, str) for value in pagination.values()), pagination
+
+
+def test_paging_actually_pages(site):
+    """A page size smaller than the collection must require a second request."""
+    site.page_size = 2
+    token = signed_in(site)
+    seen = []
+    for number in (1, 2):
+        _status, _headers, payload = site.handle(
+            "GET",
+            f"http://x/api/{site.rest_version}/sites/{site.site_id}/projects?pageNumber={number}&pageSize=100",
+            {"x-tableau-auth": token},
+            b"",
+        )
+        seen += json.loads(payload)["projects"]["project"]
+    assert len(seen) == len(site.projects)
+
+
+def test_the_real_client_follows_pagination_to_the_end(served):
+    site, base = served
+    site.page_size = 1
+    client = ae.Site(tableau.env_for(site, base))
+    client.sign_in()
+    rows, _continuation = client.paged(f"/sites/{client.site_id}/workbooks", "workbooks", "workbook")
+    assert len(rows) == len(site.workbooks)
+    assert len([r for _m, r in site.requests if "/workbooks?" in r]) == len(site.workbooks), "one request per page"
+
+
+def test_usage_statistics_are_absent_unless_requested(site):
+    """MEASURED: the ``usage`` block appears only with ``includeUsageStatistics=true``.
+
+    Always returning it would hide a client that forgot the flag and would then read zero traffic on
+    a live site - the input to the tiering decision.
+    """
+    token = signed_in(site)
+    base = f"http://x/api/{site.rest_version}/sites/{site.site_id}/views"
+    _s, _h, without = site.handle("GET", base, {"x-tableau-auth": token}, b"")
+    _s, _h, with_usage = site.handle("GET", base + "?includeUsageStatistics=true", {"x-tableau-auth": token}, b"")
+
+    assert all("usage" not in row for row in json.loads(without)["views"]["view"])
+    assert any("usage" in row for row in json.loads(with_usage)["views"]["view"])
+
+
+# ------------------------------------------------------------------- download
+
+
+def test_content_download_returns_a_real_packaged_workbook(site):
+    """Real bytes are the whole point: the parser has to do genuine work downstream."""
+    token = signed_in(site)
+    workbook = site.workbooks[0]
+    status, headers, payload = site.handle(
+        "GET",
+        f"http://x/api/{site.rest_version}/sites/{site.site_id}/workbooks/{workbook.luid}/content",
+        {"x-tableau-auth": token},
+        b"",
+    )
+
+    assert status == 200
+    assert payload[:2] == b"PK", "a .twbx is a zip"
+    with zipfile.ZipFile(io.BytesIO(payload)) as archive:
+        assert any(name.endswith(".twb") for name in archive.namelist())
+    assert "Content-Disposition" in headers
+
+
+def test_the_download_header_uses_tableaus_non_standard_name_form(site):
+    """MEASURED: Tableau sends ``Content-Disposition: name="X.twbx"`` with NO ``filename=``.
+
+    The engine's ``fetch_tds.derive_filename`` has a fallback precisely because of this. Serving the
+    standard ``filename=`` form would make that fallback untested and let a regression through.
+    """
+    token = signed_in(site)
+    _status, headers, _payload = site.handle(
+        "GET",
+        f"http://x/api/{site.rest_version}/sites/{site.site_id}/workbooks/{site.workbooks[0].luid}/content",
+        {"x-tableau-auth": token},
+        b"",
+    )
+    disposition = headers["Content-Disposition"]
+    assert "name=" in disposition
+    assert "filename=" not in disposition
+
+
+def test_a_downloaded_workbook_parses_with_the_real_parser(site, tmp_path):
+    """End of the honesty chain: served bytes -> file -> this repo's own parser."""
+    sys.path.insert(0, str(ROOT / "scripts"))
+    from parse_tableau import parse_workbook  # noqa: PLC0415
+
+    target = tmp_path / "wb.twbx"
+    target.write_bytes(site.workbooks[0].content)
+    spec = parse_workbook(target)
+    assert spec.get("worksheets")
+
+
+def test_a_missing_luid_is_a_404_not_an_empty_download(site):
+    token = signed_in(site)
+    status, _headers, _payload = site.handle(
+        "GET",
+        f"http://x/api/{site.rest_version}/sites/{site.site_id}/workbooks/nope/content",
+        {"x-tableau-auth": token},
+        b"",
+    )
+    assert status == 404
+
+
+# -------------------------------------------------------------------- GraphQL
+
+
+def test_an_unsupported_graphql_query_is_an_error_not_an_empty_result(site):
+    """The strictest choice available, and it is the right one.
+
+    An empty ``{"data": {...}}`` is how a caller concludes "this estate has no dependencies" and
+    sequences the migration wrong. An ``errors`` array cannot be mistaken for an answer.
+    """
+    token = signed_in(site)
+    status, _headers, payload = site.handle(
+        "POST",
+        "http://x/api/metadata/graphql",
+        {"x-tableau-auth": token},
+        json.dumps({"query": "{ somethingWeDoNotServe { id } }"}).encode(),
+    )
+    assert status == 200, "GraphQL reports errors with HTTP 200, as the real API does"
+    assert json.loads(payload)["errors"]
+
+
+def test_the_structure_query_is_derived_from_the_served_bytes(site):
+    """The mock reads the workbook XML itself rather than repeating a hard-coded answer.
+
+    Independent of ``parse_tableau`` on purpose: if both sides shared the parser, a parser bug would
+    be invisible because the expectation would move with it.
+    """
+    token = signed_in(site)
+    _status, _headers, payload = site.handle(
+        "POST",
+        "http://x/api/metadata/graphql",
+        {"x-tableau-auth": token},
+        json.dumps({"query": ae.STRUCTURE_QUERY}).encode(),
+    )
+    workbooks = {w["name"]: w for w in json.loads(payload)["data"]["workbooks"]}
+
+    assert workbooks["Sales Review"]["sheets"], "minimal.twb has worksheets"
+    assert not workbooks["Ops Dashboard"]["sheets"], "federated_multi_connection.twb has none"
+
+
+def test_the_lineage_query_reports_two_downstream_workbooks(served):
+    """Driven through the REAL ``tableau_lineage`` client, not asserted about the payload."""
+    site, base = served
+    session = tl.sign_in(base, site.content_url, "mock-pat", site.pat_credentials["mock-pat"], site.rest_version)
+    plan = tl.build_plan(tl.fetch_lineage(session), site.content_url)
+
+    assert [row["name"] for row in plan] == ["Corporate Cities"]
+    assert plan[0]["downstream_count"] == 2, "migration ORDER depends on this number"
+
+
+# ------------------------------------------------------- the real assess run
+
+
+def test_the_real_assessment_runs_end_to_end_against_the_mock(served, tmp_path):
+    """``assess_estate``'s three passes, its scoring, and its SQLite store - all offline."""
+    site, base = served
+    client = ae.Site(tableau.env_for(site, base))
+    client.sign_in()
+    raw = ae.collect(client, None)
+    assembled = ae.assemble(raw, 0.99)
+    db = ae.write_store(tmp_path, raw, assembled)
+
+    assert db.is_file()
+    names = {row["name"] for row in assembled["workbooks"]}
+    assert names == {"Sales Review", "Ops Dashboard", "Attic Copy"}
+    assert assembled["iam_hard_cases"], "a Read/ViewUnderlyingData split is an IAM hard case"
+
+
+def test_the_estate_db_carries_the_nested_project_tree(served, tmp_path):
+    """The deploy step mirrors folders FROM this table, so the nesting has to survive the write."""
+    import sqlite3  # noqa: PLC0415
+
+    site, base = served
+    client = ae.Site(tableau.env_for(site, base))
+    client.sign_in()
+    raw = ae.collect(client, None)
+    db = ae.write_store(tmp_path, raw, ae.assemble(raw, 0.99))
+
+    with sqlite3.connect(db) as connection:
+        rows = dict(connection.execute("select name, parent_luid from project"))
+        luids = dict(connection.execute("select name, luid from project"))
+    assert rows["Q1.2026"] == luids["Finance"], "Q1.2026 is nested under Finance"
+    assert rows["Finance"] is None
+
+
+# --------------------------------------------------------------- the loud gate
+
+
+def test_running_an_engine_script_without_the_pat_variable_fails_loudly(monkeypatch):
+    """MEASURED, and it cost 13 minutes of a real session.
+
+    ``estate_survey.py`` resolves its secret through ``credential_resolver``, whose last layer is a
+    ``getpass`` prompt. With ``TABLEAU_PAT_VALUE`` unset it does not fail - it blocks forever with no
+    output. The harness refuses to launch instead, which turns a silent hang into an error.
+    """
+    with pytest.raises(SystemExit) as raised:
+        estate.run_engine_script("estate_survey.py", [], env={"TABLEAU_PAT_SECRET": "ours"})
+    assert "TABLEAU_PAT_VALUE" in str(raised.value)
+
+
+def test_env_for_exports_both_the_ours_and_engine_names(site):
+    """Our scripts read ``TABLEAU_PAT_SECRET``; the engine reads ``TABLEAU_PAT_VALUE``.
+
+    The bridge in ``tableau_env.engine_child_env`` only reaches an engine script OUR python spawns,
+    so anything else needs both names set explicitly.
+    """
+    env = tableau.env_for(site, "http://127.0.0.1:1")
+    assert env["TABLEAU_PAT_SECRET"] == env["TABLEAU_PAT_VALUE"]
+    assert env["TABLEAU_SERVER_URL"].startswith("http://127.0.0.1")
+
+
+def test_the_mock_never_points_at_a_real_host(site):
+    """A guard against the worst possible harness bug: talking to production by accident."""
+    env = tableau.env_for(site, "http://127.0.0.1:9")
+    assert "127.0.0.1" in env["TABLEAU_SERVER_URL"]
+    assert "online.tableau.com" not in json.dumps(env)
+
+
+def test_the_server_really_is_loopback_only(served):
+    site, base = served
+    del site
+    assert base.startswith("http://127.0.0.1:")


### PR DESCRIPTION
Salvages the offline mock harness from `feat/e2e-mock-harness` — written, self-reviewed across two adversarial rounds, and **never opened as a PR**.

## Why the files, not the branch

```
8 commits ahead of master, 130 BEHIND, tip 2026-08-12
merging as-is -> 47 conflict markers
```

The conflicts come from its commits also touching `scripts/deploy_estate.py`, which master has since rewritten — **1,707 lines vs the branch's 1,315**, so merging would *regress* it. Only the 9 purely-additive files were taken; each confirmed absent from master first.

## What it buys

The whole Tableau → Power BI/Fabric pipeline runs with **no Tableau server, no Fabric tenant, no credentials**, in about eight seconds. Every defect found this week was found by a **customer hitting it first**; this makes a deploy regression-testable and lets a migration be rehearsed before it touches a customer tenant.

Fabric fake is in-process (no socket opened); Tableau fake serves REST + GraphQL Metadata over loopback. 51 + 21 fidelity self-tests cover the fakes themselves, on the harness's own governing rule: *"a mock that is kinder than the real service is worse than no mock at all, because it manufactures confidence."*

## Adapted to today's `scripts/`

`mocks/estate.py` grew 346 → 418 lines to track drift in the substitution points. Nothing in `scripts/` was modified.

## Verification

```
pytest tests/test_e2e_offline.py                        18 passed, EXIT=0
pytest tests/test_mock_fabric.py test_mock_tableau.py   72 passed, EXIT=0
check_navigation_index.py                               EXIT=0
mutation_harness.py                                     EXIT=0, survivors: none
```

`slow` marker registered in `pyproject.toml`; `docs/offline-mock-harness.md` indexed at `docs/INDEX.md:47`.

## ⚠️ One finding from independently verifying the mutation harness

This repo has a recorded incident with **this exact harness**: it once reported 22/22 caught where **every one was a false positive** — an import error exited non-zero and scored as "caught". The harness now guards that at `:210`, and its own docstring documents it.

I hand-verified rather than trusting the headline, and the guard is **narrower than the failure class**. One mutation, `engine-stand-in-emits-no-pages`, reported `-> 1 error in 3.33s` where every other names a failing test. Reproduced directly:

```
MUTATION APPLIED: True
ERROR at setup of test_the_front_half_produced_real_artifacts_from_real_bytes
AssertionError: the coordinator must accept the bundle before anything is deployed
```

**The verdict is correct** — the mutation applied and a real assertion caught it. But it surfaced as a pytest **setup ERROR**, not a `FAILED` line, so `run()`'s `FAILED`-line parser found nothing and it was scored by **return code alone**. The `:210` guard only matches the literal string `"Error importing plugin"`, so any *other* non-assertion error (a collection failure, a syntax error in a mutation) would score identically as CAUGHT.

Not blocking — the substance holds and no mutation survives — but the harness should distinguish pytest `ERROR` from `FAILED`, or at minimum report which it saw. Filing as follow-up.

⚠️ **Recovered from a host crash mid-flight.** The salvage was complete on disk but uncommitted. I ran the gates and the hand-verification myself rather than trusting an agent report.
