### PR TITLE
Bank two render-verified findings from a live migration into the skill bundles

### DIFF
--- a/.github/skills/powerbi-report-gotchas/SKILL.md
+++ b/.github/skills/powerbi-report-gotchas/SKILL.md
@@ -203,7 +203,13 @@ boolean artifact showed the defect. Reproduce on the artifact that actually carr
 
 Grep your own output before believing it is absent — and classify by **container**, since the two rows
 above are the same regex but different severities:
-`"Value":\s*"'(true|false)'"` (measured: 4 hits across 2,074 `visual.json`, all in the colour slot).
+`"Value":\s*"'(true|false)'"`.
+
+⚠️ **Classify the hits; do not expect a fixed count.** An earlier draft cited "4 hits across 2,074
+`visual.json`" as if it were a stable control. It is not reproducible: the hits live in *untracked*
+engine bundles, so the denominator moves with whatever scratch is on the machine — a re-run measured
+**8 across 3,122**, with **0 in tracked files**. What holds, and what is worth acting on, is the
+**container classification**: every hit found so far sits in the data-colour slot, none in a filter.
 
 ## 2. Data colours and conditional formatting
 

--- a/.github/skills/powerbi-report-gotchas/SKILL.md
+++ b/.github/skills/powerbi-report-gotchas/SKILL.md
@@ -170,6 +170,41 @@ These pass `validate` but render wrong. Only a live Desktop screenshot catches t
   undetectable by screenshot** — a wrong measure reference and an environmental blank look identical.
   Fall back to executing the encoded path against the live model.
 
+### A literal must carry the COLUMN's type — and the same mistake fails two opposite ways
+
+🟢 render-verified (Desktop 2.157.828.0). PBIR encodes a literal's type in the string itself:
+`'x'` = string · `10L` = Int64 · `100D` = Double · bare `true` = boolean. Comparing a **boolean**
+column against the **string** `"'true'"` is a type mismatch that `validate` cannot see —
+`result: succeeded, errorCount: 0, warningCount: 0` — and whose symptom depends entirely on **which
+slot** the literal sits in:
+
+| slot | outcome | how you find it |
+|---|---|---|
+| `objects.dataPoint[].selector.data[].scopeId.Comparison.Right` (**data colour**) | the **entire colour encoding is silently dropped**; every series takes the default colour | ❌ only by eye, against the source |
+| `filterConfig` → `Where[].Condition.Comparison.Right` (**filter**) | the visual is **replaced by an error card** — *"Something's wrong with one or more filters"* + a **Fix this** button | ✅ immediately obvious |
+
+**The silent one is the dangerous one.** A `stackedAreaChart` split by a boolean rendered entirely in
+one colour: correct data, correct axes, correct shape — and a chart that no longer says what the
+source said. Changing only the literal to bare `true` made the second series appear.
+
+**Blast radius of the loud one is ONE visual, not the page.** In the same frame as the error card, the
+azureMap, both area charts and both slicers rendered normally. So N bad filters cost you N visuals —
+useful for triage, and it means "the page is blank" is *not* this bug.
+
+**How to test a suspected literal bug — and the trap that wasted a cycle.** Use a **3-state** run on
+the **real artifact**: `baseline` (no encoding) · `broken` · `correct`, changing *only* the literal.
+The `correct` state is not optional — it is what proves your hand-written JSON is otherwise valid and
+that the reload took effect; without it "broken looks wrong" is unfalsifiable. Measured control, a
+`multiRowCard` filtered to profitable orders: Sales $2,326,534 → $1,841,231, Profit $292,297 →
+$432,805, Ratio 12.6% → 23.5% — Sales down, Profit *up*, exactly as the semantics demand.
+⚠️ **Do not invent your own analogue.** A fabricated *numeric* case (`"1.0D"` → `"'1.0'"`) rendered
+**pixel-identical to baseline** and would have been written up as "benign"; only the engine's real
+boolean artifact showed the defect. Reproduce on the artifact that actually carries the bug.
+
+Grep your own output before believing it is absent — and classify by **container**, since the two rows
+above are the same regex but different severities:
+`"Value":\s*"'(true|false)'"` (measured: 4 hits across 2,074 `visual.json`, all in the colour slot).
+
 ## 2. Data colours and conditional formatting
 
 See the `powerbi-report-authoring` skill → `references/conditional-formatting.md`; for table-specific

--- a/.github/skills/powerbi-semantic-model-gotchas/SKILL.md
+++ b/.github/skills/powerbi-semantic-model-gotchas/SKILL.md
@@ -605,6 +605,63 @@ exists to prevent.
 **Trust `powerbi-desktop status` + `currentFilePath`, never the pid `open` hands back.** Match the
 instance to your own `.pbip` path before you touch it.
 
+### A PEM/key parse error on ONE table is a data-source IDENTITY mismatch, not a bad key
+
+Field report 2026-08-25 (estate built on engine 2.146.0). One table refused to refresh with
+`ADBC: [snowflake] Failed to parse PEM block containing the private key`, while its siblings in the
+**same model**, on the same server with the same key-pair, refreshed fine. A bad key cannot do that —
+it would fail every connection identically. **That asymmetry is the whole diagnosis**; treat it as the
+first thing to check, because the error names a subsystem that is not the cause.
+
+Power BI keys credential identity on the **argument tuple** of the connection call, not on the server.
+✅ The engine models the same thing: `storage_mode.py:99` registers snowflake as
+`("Snowflake.Databases", "server_warehouse", "database_schema_table")`.
+
+| | connection call |
+|---|---|
+| siblings (worked) | `Snowflake.Databases(#"Server_snowflake", #"Warehouse_snowflake", [Role="UDP_TABLEAU_APP"])` |
+| the one that failed | `Snowflake.Databases("<host>", "UDP_DB", [Implementation="2.0"])` |
+
+Same host, different tuple → a **distinct data source** with no stored credential. The connector
+surfaces that as a PEM parse failure instead of a sign-in prompt, which sends you to the wrong
+subsystem entirely. Two compounding authoring errors, both worth recognising:
+
+- **`UDP_DB` is a database, not a warehouse.** ✅ `storage_mode.py:113` documents the verified shape —
+  `Snowflake.Databases(#"Server", #"Warehouse"){[Name="UDP_DB", Kind="Database"]}[Data]` — where the
+  database belongs in the **navigation step**. It had been hoisted into the warehouse positional arg.
+- **Hardcoded literals replaced the M parameters**, which guarantees a different tuple even when the
+  values look right.
+
+⚠️ **This was ours, not the engine's — do not file it upstream.** `Implementation="2.0"` appears
+**nowhere** in the engine (checked at 2.260.0; the estate was 2.146.0, which we could not inspect), and
+the reporter's own account attributes it to an earlier hand fix-pass. Filing it would have been a
+retraction.
+
+**The rule:** when hand-rewiring a connection, copy a working sibling's signature **byte-for-byte**.
+Never re-enter a credential to "fix" a PEM error before diffing the tuple against a table that works.
+
+### Class-suffixed M parameters mean FEDERATED — and `_sqlproxy` + `localhost` is a phantom
+
+Same investigation, worth separating because it is a reusable read of the artifact. The model carried
+orphaned `Server_sqlproxy = "localhost"` and `Database_sqlproxy = "DS_Aircraft_Health"` expressions.
+Those are **engine-emitted, not hand-written leftovers**: `connection_to_m.py:2869` suffixes M
+parameters **by connector class** (`Server_snowflake`, `Warehouse_snowflake`) and does so **only for a
+federated datasource** — `if len(conns) <= 1: return {}` keeps the bare `Server`/`Database` names.
+
+So the naming itself is diagnostic:
+
+- **bare `Server` / `Database`** → single-connection datasource.
+- **class-suffixed `Server_<class>`** → federated; each table binds its own upstream.
+- **`Server_sqlproxy = "localhost"` + `Database_sqlproxy = "<name>"`** → a **phantom published
+  datasource**: a secondary published dependency whose proxy never rebound. The table opens empty.
+  ⚠️ `localhost` alone is an ordinary local SQL Server/Postgres, and a `_sqlproxy` parameter pointing
+  at a **real** host is a successful rebind — only the **combination** is a phantom.
+
+This is upstream `Yarbrdab000/tableau-fabric-skills#174` (fixed at engine 2.274.0, which adds a
+`phantom_published_proxy_tables` finding). Before that build the phantom ships silently, and the
+orphans are exactly what mislead a later fix-pass into hand-wiring a bad connection — the PEM entry
+above is what that looks like when it goes wrong.
+
 ## 6. File-based extracts: a legacy `.xls` + a custom OS locale silently corrupts DATA
 
 Measured 2026-08-08 (`book_8-1-Dashboards`, Tableau Superstore extract landed as a legacy BIFF8
@@ -951,6 +1008,32 @@ Unknown. Three workbooks (ACMU `_Measures.tmdl:87` `'Selected Measure'`, Airline
 Phase `'Measure - All Phases'`) each shipped a bare `BLANK()` dispatcher while every branch measure
 it referenced was translated correctly. That pattern is real and reported from the field. The cause
 is not established. Do not fill the gap with a plausible story.
+
+**2026-08-25 — two causes RULED OUT, and a contradiction of the paragraph above.** A field report
+(SES estate, engine 2.146.0) compared two workbooks in one estate whose `'Selected Measure'` calcs
+have **byte-identical `TableauFormula` annotation text**, both 15 branches, all branches returning
+numeric measures:
+
+| workbook | outcome |
+|---|---|
+| ACMU | ✅ translated to a working `SWITCH(...)` |
+| `IA_Airborne_Services_Dashboard` | ❌ stubbed to `BLANK()` |
+
+Same formula, same engine, same run, opposite results. That **rules out formula content and branch
+type** as the cause, and points at something order- or run-state-dependent instead. It also
+independently rules out branch *count*: the engine author probed 15 identical branches directly at
+2.260.0 and they translate (`Yarbrdab000/tableau-fabric-skills#168`).
+
+⚠️ **But it contradicts this section's own record**, which lists ACMU's `'Selected Measure'` among the
+three that *shipped a stub*. Both cannot be true of the same artifact. Unresolved as of writing —
+plausibly a version difference (the field bundle is 2.146.0; the entry above predates it and names
+`_Measures.tmdl:87`), plausibly one observation is of a re-run rather than the original. **Do not
+cite either outcome for ACMU as settled** until a single build is measured end to end.
+
+⚠️ Also note the reporter's supporting evidence included a matching `lineageTag` GUID across the two
+measures. That corroborates nothing: `stabilize_lineage_tags` re-derives every GUID from the object's
+**identity path**, so any two models with a same-named measure in a same-named table collide by
+construction. The byte-identical annotation text is the real evidence and stands without it.
 
 ### The idiom itself: a parameter-driven measure dispatcher
 


### PR DESCRIPTION
Two hard-won findings from a live customer migration, banked where the owning agents read them.

## `powerbi-report-gotchas` — a PBIR literal must carry the COLUMN's type

The same one-character mistake fails two **opposite** ways, and `validate` returns `errorCount: 0` for both:

| slot | outcome |
|---|---|
| `objects.dataPoint[].selector…` (data colour) | the **entire colour encoding is silently dropped** — chart renders, data correct, and it lies |
| `filterConfig` | the visual is **replaced by an error card** ("Something's wrong with one or more filters") |

Blast radius of the loud one is **one visual, not the page** — useful for triage, and it means "the page is blank" is *not* this bug.

Includes the 3-state test recipe (`baseline` / `broken` / `correct`, where the `correct` state is the mandatory validity control) and the trap that nearly produced a wrong verdict: **a fabricated numeric analogue rendered pixel-identical to baseline**, so only the engine's real artifact showed the defect. Reproduce on the artifact that actually carries the bug.

Filed upstream as `Yarbrdab000/tableau-fabric-skills#178`, where it turned out the engine author had already fixed this class once in the slicer path — it survives in the data-colour path at 2.260.0.

## `powerbi-semantic-model-gotchas` — a PEM error on ONE table is an identity mismatch

A private-key parse error on one table of a model whose siblings refresh fine cannot be a bad key — that would fail every connection identically. **The asymmetry is the diagnosis.** Power BI keys credentials on the connection call's *argument tuple*, so a database name hoisted into the warehouse positional arg, or a hardcoded literal replacing an M parameter, creates a distinct data source with no stored credential — surfaced as a PEM failure, which sends you to the wrong subsystem entirely.

Explicitly attributed to **our** tier, not the engine, with the evidence for that attribution — filing it upstream would have been a retraction.

Docs only; no code paths touched.
