### PR TITLE
Key the version-upgrade timing rule on downstream investment, not the calendar

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -24,8 +24,11 @@ readiness matrix. Session start is the **only safe moment** to change them.
 - Being **above** the recorded known-good matrix is not an error — it raises a WARN, because that is
   exactly when the version-specific Gotchas in `.github/agents/` need re-verification. Don't "fix" it
   by downgrading; re-verify the prose.
-- **Never upgrade mid-migration.** Swapping the validator underneath a half-built report is worse than
-  a slightly old CLI. Between migrations is fine.
+- **Mid-migration, don't upgrade the installed tooling.** The risk is not the calendar but *work
+  already validated by the current CLI* — swap the validator underneath it and earlier results are no
+  longer covered by the same check. Between migrations is fine. A version-*comparison* run into a
+  fresh output dir is not an upgrade and is always safe — see the engine timing rule in
+  [`/AGENTS.md`](../AGENTS.md).
 - It cannot update the **skill bundles** — `copilot plugin update` hits a file lock while any Copilot
   session is running. That lock only blocks renaming the plugin directory, not writing inside it, so a
   *content* refresh needs no restart: `python scripts/sync_installed_skills.py`.
@@ -41,7 +44,7 @@ readiness matrix. Session start is the **only safe moment** to change them.
 |---|---|---|
 | Session start (nothing in flight) | `preflight.ps1 -Update -CheckUpstream` | Safe; the CLI floor is a correctness floor, and this is the one moment upgrading is allowed |
 | Migration start (orchestrator step 0) | `preflight.ps1` (plain) | Confirm READY without changing tooling mid-flow |
-| Mid-migration | never | Swapping the validator under a half-built report is worse than a slightly old one |
+| Mid-migration | don't re-arm `-Update` | Swapping the validator mid-build leaves earlier-validated work uncovered by the same check; a comparison run into a fresh dir is a separate, always-safe operation (see [`/AGENTS.md`](../AGENTS.md)) |
 
 ## Everything else
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,7 @@ in a hand-written scaffold five days later; name the location every time.
 |---|---|---|
 | Session start (nothing in flight) | `preflight.ps1 -Update -CheckUpstream` | Safe; the CLI floor is a correctness floor, and this is the one moment upgrading is allowed |
 | Migration start (orchestrator step 0) | `preflight.ps1` (plain) | Confirm READY without swapping tooling mid-flow — and without a network round trip on every migration |
-| Mid-migration | **never** | Swapping the validator under a half-built report is worse than a slightly old one |
+| Mid-migration | **don't upgrade the installed tooling** | The variable is not the calendar but *work already validated by the current CLI*: swap the validator mid-build and earlier results are no longer covered by the same check. A version-*comparison* run into a fresh output dir is not an upgrade (engine section) and is not forbidden here. |
 
 **`-CheckUpstream` answers a question the version matrix cannot.** Every other check compares an
 installed version against a **hard-coded** number — that says "is what I have good enough", never
@@ -120,9 +120,12 @@ before it can migrate with a broken environment.
 
 Keep only the judgement the gate cannot carry:
 
-- **Timing rule:** `-Update` is for session start only, before any migration is in flight. At migration
-  start run plain preflight; mid-migration, do not upgrade. Swapping the validator under a half-built
-  report is worse than a slightly old CLI.
+- **Timing rule (installed tooling):** `-Update` is for session start only, before any migration is in
+  flight; at migration start run plain preflight; mid-migration, do not re-arm it. What is at risk is
+  not the calendar position but *un-checkpointed work already validated by the current CLI* — swap the
+  validator underneath it and earlier results are no longer covered by the same check. This governs
+  *upgrading the installed CLIs*; running a second engine version into a fresh output dir to
+  **compare** is a different, always-safe operation (see the engine timing rule below).
 - **`powerbi-report-author >= 0.1.4` is a correctness floor, not hygiene.** Older builds returned
   `errorCount: 0` for PBIR that Power BI Desktop cannot open, so being below the floor silently
   green-lights broken reports. `-Update` repairs only below-floor npm bridge CLIs; it is not a blind
@@ -366,7 +369,22 @@ Keeping it current: `copilot plugin update tableau-fabric-skills@tableau-collect
 sessions** (a running Copilot session file-locks the plugin directory). Mid-session, only a *content*
 refresh is possible — `python scripts/sync_engine_plugin.py --source <checkout>` — and it refuses a
 downgrade, because walking the canonical engine backwards is how you would turn a cleanup into the
-regression above. Never upgrade the engine mid-migration.
+regression above.
+
+**Whether a version change is safe keys on downstream investment, not the calendar** — specifically,
+whether it would mix two engine versions inside one deliverable, or discard hand-authoring layered on
+the engine's output. Each verdict is checkable at the moment you decide, which is what lets this
+replace the blunt "never mid-migration" it used to read:
+
+| Doing this | Verdict | Check, right now |
+|---|---|---|
+| **Comparing** two versions — run the second via `--allow-noncanonical-engine` into a fresh `--output` dir, keep the old bundle, diff | ✅ always safe — not an upgrade; the installed canonical engine is untouched | is the installed plugin left as-is and `--output` a new dir? |
+| Re-running a unit on a newer engine with **~no hand-authoring since it ran** | ✅ re-run into a fresh dir; nothing hand-made is lost | the `<bundle>/reports/` vs `<bundle>/pbip/` diff (shared conventions) is ~empty |
+| Re-running a unit with **substantial hand-authored TMDL/PBIR** on top | ⛔ finish or checkpoint that unit first | that same diff is large |
+| **Partial** re-run into an **existing** bundle (some workbooks, not all) | ⛔ **never** | `write_engine_receipt` stamps one `engine.version` over the whole bundle, so it would claim a single version for artifacts two builds produced — the #107 shape, and `check_engine_receipts.py` cannot see an intra-bundle mix |
+
+So the escape hatch above is usable between migrations, and mid-migration when the diff shows little at
+risk; the one move that is *always* wrong is the last row — a partial re-run into a live bundle.
 
 Historic cost of not having this: **three** retracted or nearly-retracted defect reports. The engine
 went 2.60.0 → 2.72.0 unnoticed; then 2.113.0 → 2.126.0 (13 releases) *mid-dry-run*; then 2.113.0 →


### PR DESCRIPTION
Fixes #345.

`AGENTS.md` stated a blanket **"never upgrade mid-migration"**. The rule keyed on *elapsed position in a migration* when the thing actually at risk is **downstream investment** — whether a change would mix two engine versions inside one deliverable, or discard hand-authoring layered on engine output.

As written it forbade a **version-comparison run**, which is one of the toolkit's highest-value diagnostics and is explicitly supported (`--allow-noncanonical-engine` into a fresh `--output`, leaving the installed canonical engine untouched). It also made `scripts/sync_engine_plugin.py` unusable by convention — a shipped tool whose own docstring calls it *"the mid-session escape hatch"*.

## What changed

**The split the issue missed:** sites ~83 and ~124 govern the **npm CLIs**; only ~369 governs the **engine**. The CLI sites keep their verdict (don't swap the validator mid-build) but with the reason corrected — *work already validated by the current CLI*, not the calendar — and no longer over-generalise onto the engine.

The engine site becomes a decision-time-checkable table:

| Doing this | Verdict | Check, right now |
|---|---|---|
| **Comparing** two versions into a fresh `--output` | ✅ always safe — not an upgrade | is the installed plugin untouched and `--output` new? |
| Re-run with ~no hand-authoring since | ✅ | `<bundle>/reports/` vs `<bundle>/pbip/` diff is ~empty |
| Re-run with substantial hand-authored TMDL/PBIR | ⛔ finish or checkpoint first | that diff is large |
| **Partial** re-run into an **existing** bundle | ⛔ **never** | `write_engine_receipt` stamps one `engine.version` per bundle |

Every verdict has a check an agent can evaluate *at the moment it decides* — a condition that cannot be checked would be worse than the blunt prohibition it replaces.

## A hazard the issue did not contain

The last row is new. `write_engine_receipt` stamps a **single** `engine` block over a whole bundle, and `check_engine_receipts.py` compares only that value — so a partial re-run into an existing bundle makes the receipt claim one version for artifacts two builds produced, and nothing can detect the intra-bundle mix. That is the #107 shape, and it is now named as the one always-wrong move.

## Verification and limits

Claims were checked against source, not prose. I independently confirmed the `sync_engine_plugin.py` docstring and the single-`engine`-block receipt before merging this description.

⚠️ **No live two-version A/B was executed.** "Always safe" for the comparison row rests on verified code semantics (installed engine untouched, output to a fresh dir), not an executed run — deliberately not overstated in the text.

Five further files still carry the older phrasing (`preflight.ps1`, `scripts/README.md`, `docs/operator-runbook.md`, `docs/review-remediation-plan.md`, `tableau-migrator.agent.md`). Each was checked: all are CLI-framed or conservative, none dangerously contradicts the new rule. Follow-up routing for their owners.

Docs only. Gates: conventions-sync ✅ (shared block untouched, personas unaffected) · navigation ✅ · capability-wiring ✅ · 66 tests.
