### PR TITLE
Close the three blind-review findings reprobe_blocked.py shipped with

### DIFF
--- a/scripts/reprobe_blocked.py
+++ b/scripts/reprobe_blocked.py
@@ -366,17 +366,6 @@ def _read_stdin() -> str:
     return sys.stdin.read()
 
 
-def _maybe_read_stdin() -> str | None:
-    """Read piped stdin when no other source was given; None on a TTY or when stdin is unavailable."""
-    stream = sys.stdin
-    try:
-        if stream is None or stream.isatty():
-            return None
-        return stream.read()
-    except (OSError, ValueError):  # pytest replaces stdin with a stream that raises on read
-        return None
-
-
 def gather_units(args: argparse.Namespace) -> tuple[list[UnitInput], bool]:
     """Collect units and report whether ANY input source was provided.
 
@@ -384,6 +373,13 @@ def gather_units(args: argparse.Namespace) -> tuple[list[UnitInput], bool]:
     given but was legitimately empty" (a clean estate - `list --json` of nothing gated is `{"units":
     []}`), which must NOT both collapse to the same exit code (finding #3). Raises `InputError` /
     `OSError` upward for structurally broken input (truncated JSON, an unreadable `--units-from`).
+
+    ⚠️ stdin is read ONLY when explicitly requested (`--stdin` or `--units-from -`). Blind review
+    2026-08-27: an implicit "read stdin when nothing else was given" fallback blocked forever on a
+    non-TTY pipe that stayed open - `isatty()` is False and `read()` never returns - instead of
+    printing the usage error. Agent and CI harnesses routinely hold stdin open, and this tool's
+    stated consumer is `tableau-migrator`, so the convenience cost an unkillable hang. The documented
+    invocation already passes `--stdin`.
     """
     units = [UnitInput(path=Path(raw)) for raw in (args.unit or [])]
     provided = bool(args.unit)
@@ -394,9 +390,6 @@ def gather_units(args: argparse.Namespace) -> tuple[list[UnitInput], bool]:
     elif args.units_from:
         text = Path(args.units_from).read_text(encoding="utf-8")
         provided = True
-    elif not units:
-        text = _maybe_read_stdin()
-        provided = provided or text is not None
     if text is not None:
         units.extend(read_units_source(text))
     return units, provided
@@ -412,6 +405,11 @@ def _errored(unit: Path, reason: str) -> UnitResult:
     return UnitResult(unit=unit, category=CAT_ERRORED, verdict=None, reason=reason, elapsed_sec=0.0)
 
 
+def _anomaly(unit: Path, reason: str) -> UnitResult:
+    """Caller-supplied state disagrees with the marker on disk (drives a non-zero exit)."""
+    return UnitResult(unit=unit, category=CAT_ANOMALY, verdict=None, reason=reason, elapsed_sec=0.0)
+
+
 def _classify_selection(unit: UnitInput, resolved: Path) -> tuple[bool, UnitResult | None, bool]:
     """Decide selection for one resolved unit: (probe_it, pre_result, forged).
 
@@ -423,8 +421,15 @@ def _classify_selection(unit: UnitInput, resolved: Path) -> tuple[bool, UnitResu
     An explicitly requested path that does not exist or is not a directory is `errored`, not
     `skipped` (finding #3): a typo'd/moved/truncated input must not masquerade as a clean estate by
     exiting 0.
+
+    ⚠️ The state string is compared CASE-INSENSITIVELY, and a non-BLOCKED state never silently wins
+    over the marker on disk. Blind review 2026-08-27: a caller-supplied `"blocked"` (lowercase) fell
+    through to the non-BLOCKED branch and returned `skipped` for a unit whose marker was present
+    RIGHT THEN, so the sweep reported exit 0 - "clean, nothing left blocked" - over a still-armed
+    gate. An untrusted input string must not outrank ground truth, which is this module's own stated
+    principle; a genuine disagreement is reported as an ANOMALY (non-zero) rather than skipped.
     """
-    state = (unit.state or "").strip()
+    state = (unit.state or "").strip().upper()
     if state == FORGED_STATE:
         return (
             False,
@@ -432,6 +437,16 @@ def _classify_selection(unit: UnitInput, resolved: Path) -> tuple[bool, UnitResu
             True,
         )
     if state and state != BLOCKED_STATE:
+        if resolved.is_dir() and unit_is_blocked(resolved):
+            return (
+                False,
+                _anomaly(
+                    resolved,
+                    f"state={state} (from list) but the gate marker is present NOW - refusing to skip a "
+                    "blocked unit on a caller-supplied state; re-list, or pass the path directly",
+                ),
+                False,
+            )
         return False, _skip(resolved, f"state={state} (from list); not re-probing"), False
     if not resolved.is_dir():
         return False, _errored(resolved, f"does not exist or is not a directory: {resolved}"), False

--- a/tests/test_reprobe_blocked.py
+++ b/tests/test_reprobe_blocked.py
@@ -168,10 +168,18 @@ def test_select_honours_a_blocked_state_but_reverifies_the_marker(tmp_path: Path
 
 
 def test_select_does_not_probe_non_blocked_states(tmp_path: Path) -> None:
+    """A non-BLOCKED state stops the probe - but when the marker is present it is LOUD, not silent.
+
+    This test previously asserted a silent `skipped` for exactly the disagreement it builds (marker
+    on disk, `list` claiming `cleared-earned`). Blind review 2026-08-27: that is the shape that
+    reports exit 0 - "clean, nothing left blocked" - over a still-armed gate, so the verdict is now
+    `anomaly`. The no-probe half of the original intent is unchanged and still asserted; the sibling
+    test below covers the benign case where the marker really is gone.
+    """
     unit = _blocked_unit(tmp_path)  # marker present, but list says already cleared
     to_probe, skipped, forged = rb.select([rb.UnitInput(path=unit, state="cleared-earned")])
     assert not to_probe
-    assert skipped[0].category == rb.CAT_SKIPPED
+    assert skipped[0].category == rb.CAT_ANOMALY
     assert forged is False
 
 
@@ -383,8 +391,15 @@ def test_probe_unit_isolates_a_runner_that_raises_and_the_sweep_continues(tmp_pa
 def test_default_probe_runner_builds_a_probe_command_and_never_a_clear_or_authorize(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Pin 'never clears itself' at the command-construction level: only the probe is ever spawned."""
-    captured: dict[str, list[str]] = {}
+    """Pin 'never clears itself' at the command-construction level: only the probe is ever spawned.
+
+    ⚠️ Records EVERY spawned command, not just the last one. Blind review 2026-08-27 proved the
+    single-value form (`captured["cmd"] = cmd`) could not fail: injecting a `credential_gate.py
+    clear --earned` BEFORE the probe left this test green, because the probe's own command
+    overwrote the evidence. A guard on the ACL boundary that cannot fail is worse than no guard,
+    because it is credited as coverage.
+    """
+    captured: dict[str, list[list[str]]] = {"cmds": []}
 
     class _Proc:
         returncode = 1
@@ -392,17 +407,22 @@ def test_default_probe_runner_builds_a_probe_command_and_never_a_clear_or_author
         stderr = ""
 
     def fake_run(cmd, **_kwargs):
-        captured["cmd"] = cmd
+        captured["cmds"].append(list(cmd))
         return _Proc()
 
     monkeypatch.setattr(rb.subprocess, "run", fake_run)
     outcome = rb._default_probe_runner(
         Path("/x/unit"), rb.SweepOptions(apply=True, refresh_timeout_sec=None, per_unit_timeout_sec=0)
     )
-    cmd = " ".join(captured["cmd"])
+    assert len(captured["cmds"]) == 1, f"expected exactly one spawned command, got {captured['cmds']}"
+    cmd = " ".join(captured["cmds"][0])
     assert "probe_live_source.py" in cmd
     assert "--bundle" in cmd
-    assert "credential_gate.py" not in cmd
+    for spawned in captured["cmds"]:
+        joined = " ".join(spawned)
+        assert "credential_gate.py" not in joined, f"the sweep must never spawn the gate: {joined}"
+        assert "clear" not in spawned, f"the sweep must never clear: {joined}"
+        assert "authorize" not in spawned, f"the sweep must never authorize: {joined}"
     assert " clear" not in cmd and "authorize" not in cmd
     assert outcome.verdict == "NO_CREDENTIAL"
 
@@ -527,3 +547,58 @@ def test_negative_per_unit_timeout_is_rejected(tmp_path: Path) -> None:
 def test_zero_per_unit_timeout_is_accepted(tmp_path: Path) -> None:
     args = rb._parse_args(["--unit", str(tmp_path), "--per-unit-timeout-sec", "0"])
     assert args.per_unit_timeout_sec == 0
+
+
+def test_lowercase_blocked_state_is_normalised_and_still_probed(tmp_path: Path) -> None:
+    """A `list` state differing only in CASE must not fall through to the not-blocked branch."""
+    unit = _blocked_unit(tmp_path)
+    probe_it, pre, forged = rb._classify_selection(rb.UnitInput(path=unit, state="blocked"), unit)
+    assert probe_it is True, "a lowercase 'blocked' must normalise to BLOCKED and be probed"
+    assert pre is None
+    assert forged is False
+
+
+def test_non_blocked_state_never_silently_skips_a_unit_whose_marker_is_present(tmp_path: Path) -> None:
+    """Ground truth outranks a caller-supplied state; the disagreement is loud, not a skip."""
+    unit = _blocked_unit(tmp_path)
+    probe_it, pre, _ = rb._classify_selection(rb.UnitInput(path=unit, state="clean"), unit)
+    assert probe_it is False
+    assert pre is not None
+    assert pre.category == rb.CAT_ANOMALY, f"expected anomaly, got {pre.category}"
+    assert "marker is present NOW" in pre.reason
+
+
+def test_a_stale_non_blocked_state_still_skips_when_the_marker_is_gone(tmp_path: Path) -> None:
+    """The anomaly fires on DISAGREEMENT only - an ordinary cleared unit stays a cheap skip."""
+    unit = tmp_path / "cleared"
+    unit.mkdir()
+    probe_it, pre, _ = rb._classify_selection(rb.UnitInput(path=unit, state="clean"), unit)
+    assert probe_it is False
+    assert pre is not None and pre.category == rb.CAT_SKIPPED
+
+
+def test_forged_state_is_matched_case_insensitively(tmp_path: Path) -> None:
+    """The security signal must not be lost to casing either."""
+    unit = _blocked_unit(tmp_path)
+    _, pre, forged = rb._classify_selection(rb.UnitInput(path=unit, state="forged-override"), unit)
+    assert forged is True
+    assert pre is not None and pre.category == rb.CAT_SKIPPED
+
+
+def test_stdin_is_never_read_implicitly(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No source + no --stdin is a usage error, NOT a blocking read on an open pipe."""
+
+    class _NeverRead:
+        @staticmethod
+        def isatty() -> bool:
+            return False
+
+        @staticmethod
+        def read() -> str:  # pragma: no cover - reaching this IS the failure
+            raise AssertionError("gather_units must not read stdin unless --stdin was passed")
+
+    monkeypatch.setattr(rb.sys, "stdin", _NeverRead())
+    args = rb._parse_args([])
+    units, provided = rb.gather_units(args)
+    assert units == []
+    assert provided is False


### PR DESCRIPTION
Fixes #355.

#350 merged with three of its blind review's findings unaddressed. Two of the four exit-code routes
**were** fixed before merge (typo'd path and malformed JSON both exit 5); these are the rest. Each was
reproduced on `master` before the fix and re-tested after.

Urgency: this tool is about to be recommended to a customer for sweeping a **~44-unit estate**, where a
false `clean` verdict is expensive.

| # | Before (on master) | After |
|---|---|---|
| **1. ACL guard** | Injecting `credential_gate.py clear --earned` before the probe left the test **green** — it recorded only the last command | Records every command; asserts exactly one spawned and that `credential_gate.py`/`clear`/`authorize` appear in none. The same injection now **fails** |
| **2. State outranks the marker** | Lowercase `"blocked"` fell through to the not-blocked branch → `skipped`, **exit 0 "clean"** over a still-armed gate | Case-insensitive compare (incl. `FORGED-OVERRIDE`); a non-BLOCKED state while the marker exists is an **anomaly** (non-zero), not a silent skip. Now exits 1 |
| **3. stdin hang** | Bare invocation with an open stdin pipe **hung forever** | Exits 2 with the usage message; stdin read only when explicitly requested |

Runtime ACL behaviour was always correct — the review verified with an OS-level audit hook that only
`probe_live_source.py --bundle` is ever spawned. Finding 1 is that the **guard** was vacuous, not the
behaviour.

### One test changed rather than added

`test_select_does_not_probe_non_blocked_states` asserted a silent `skipped` for the exact disagreement
its own comment describes (*"marker present, but list says already cleared"*). That is the shape that
produces the false clean verdict, so it now asserts the anomaly and keeps its no-probe half. A sibling
test covers the benign case where the marker really is gone.

### Verification

- `ruff format` / `ruff check` clean; `pylint scripts` **10.00/10, exit 0**
- `test_reprobe_blocked.py` + `test_credential_gate.py` + `test_probe_earned_clear.py` → **155 passed**
- Every fix mutation-tested. Reverting `.upper()` → 2 fail; removing the anomaly branch → 2 fail;
  re-injecting the gate call → the ACL test fails.

⚠️ One mutation first read as **survived** and was a regex that never applied. Re-run with the mutation
verified as applied, it is caught. Recording it because that is the same false-positive shape the
review warned about, in the opposite direction.

### Not in scope

The fail-open federated-leg issue (#353) is a different defect in the same subsystem and is untouched
here.
