### PR TITLE
fix(gate): point the final verify at the bundle, not the ship copy (#354)

### DIFF
--- a/.github/agents/tableau-migrator.agent.md
+++ b/.github/agents/tableau-migrator.agent.md
@@ -288,9 +288,13 @@ PBIR files yourself.
       deleted to make room, and what you deliberately did NOT record because it was a one-off.
       "Nothing worth recording" is a legitimate outcome — say it plainly rather than inventing one.
 15. **Final gate — prove nothing was built behind the credential stop.** For any migration with a live
-    source, run `python scripts/credential_gate.py verify migrations/workbooks/<name>` and paste the
-    verdict. Exit 1 = artifacts exist while the gate was applied, or the override was forged: that run
-    is **unvalidated and must not ship**.
+    source, run `python scripts/credential_gate.py verify <bundle>` — the **`<bundle>`** you passed to
+    `--bundle` in steps 6/6b, where the audit history lives (parser path: migration/spec dir) — and
+    paste the verdict. Exit 1 = artifacts exist while the gate was applied, or the override was forged:
+    **unvalidated, must not ship**. ⚠️ **Never run `verify` at the ship destination
+    `migrations/{workbooks,datasources}/<slug>/fabric/`**: that copy has no `.credential-gate-audit.log`,
+    so `verify` finds no `block` entry and falsely reports "no gate was ever applied" (exit 0) on the
+    artifacts flagged unshippable (#354; `docs/credential-gate.md`).
 16. **(Phase 2 / on request)** Delegate to `pbi-deployer` to publish to Fabric and run validation.
     Not in the default flow until that agent exists.
 

--- a/docs/credential-gate.md
+++ b/docs/credential-gate.md
@@ -112,8 +112,39 @@ python scripts/credential_gate.py list      <estate-root>     # which units are 
 python scripts/credential_gate.py block     <migration-dir> --sources "a" "b"
 python scripts/credential_gate.py clear     <migration-dir> --reason probe-data-ok
 python scripts/credential_gate.py authorize <migration-dir> --who "<name>"   # humans only
-python scripts/credential_gate.py verify    <migration-dir>   # exit 1 = violation
+python scripts/credential_gate.py verify    <migration-dir>   # exit 1 = violation — point at the bundle, NOT the ship copy (see below)
 ```
+
+### Where to run `verify` — the bundle, never the ship copy
+
+`verify` reads the audit log **at exactly the path you give it** —
+`<migration-dir>/.credential-gate-audit.log` — and nowhere else. It never searches upward or sideways
+for a related gate. So *which directory you point it at* is the whole decision, and there is exactly
+one correct target: **the directory where the gate was armed and probed** — the engine `<bundle>` you
+passed to `--bundle` during the reachability steps, or the migration/spec dir on the parser path. That
+directory holds the `block` entry (and the `probe-cleared` / `authorize` that earned the lift), so
+`verify` there sees the real history and fails closed (exit 1) on a violation.
+
+⚠️ **Do NOT run `verify` at the ship destination `migrations/{workbooks,datasources}/<slug>/fabric/`.**
+At sign-off the built artifacts are **copied** there, but the audit log is **not** — it lives at the
+bundle root, outside the copied tree. `verify` at the destination therefore finds no `block` entry,
+concludes *"no gate was ever applied to this migration"*, and exits **0** — the same false green
+whether the gate was honestly cleared or the model was built behind a live-source stop that was never
+resolved. Identical bytes, opposite verdict (reproduced 2026-08-27 on the same copied `.tmdl`):
+
+| you run | `.credential-gate-audit.log` present? | verdict |
+|---|---|---|
+| `verify <bundle>` | yes | `VIOLATION — artifact(s) exist while the gate is applied … Do not ship them.` **exit 1** |
+| `verify migrations/…/<slug>/fabric/` (or its parent) | no | `OK — no gate was ever applied to this migration` **exit 0** |
+
+**A `verify` whose path has no `.credential-gate-audit.log` proves nothing.** Treat an `OK` there as
+*unverified*, not *clean* — from the outside it is indistinguishable from the genuine "extract-only,
+never gated" pass this same message is designed to report.
+
+> **This is a stopgap, not the final design.** `verify` cannot yet recover the originating bundle from
+> a ship copy. The hook exists — both locations carry the same `engine-output-receipt.json` sha256,
+> which a future `verify` could follow back to the bundle, or a `--also-check <bundle>` flag could
+> name — but until that lands the rule is simply *point `verify` at the bundle*. Tracked in issue #354.
 
 ### Across MANY units: enumerate, then re-probe. Do not mass-authorize.
 

--- a/tests/test_credential_gate_verify_target.py
+++ b/tests/test_credential_gate_verify_target.py
@@ -1,0 +1,66 @@
+"""Regression guard for issue #354: the final-gate `verify` command must target the audit-bearing
+bundle, never the ship-destination copy.
+
+`credential_gate.py verify` reads the audit log at **exactly** the path given, and nowhere else. The
+engine flow copies the built artifacts to `migrations/{workbooks,datasources}/<slug>/fabric/` at
+sign-off, but the audit log stays in the bundle. So a `verify` pointed at the ship destination finds
+no `block` entry, reports a false *"no gate was ever applied"*, and exits 0 on the very artifacts the
+bundle flagged unshippable.
+
+`tableau-migrator.agent.md` step 15 shipped exactly that: `verify migrations/workbooks/<name>`. This
+test fails if any persona's `credential_gate.py verify` COMMAND targets a ship-destination path again.
+It deliberately matches only the literal command form, so the prose warning that *tells* a reader not
+to point `verify` at `migrations/.../fabric/` (a `verify` span and a path span, no command prefix
+between them) does not trip it.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+AGENTS_DIR = REPO_ROOT / ".github" / "agents"
+
+# `... credential_gate.py verify <ARG>` — capture the target, stopping at whitespace or a closing
+# backtick. Requires the `credential_gate.py verify ` command prefix, so a bare `verify` mentioned in
+# prose does not match.
+VERIFY_CMD = re.compile(r"credential_gate\.py\s+verify\s+([^\s`]+)")
+
+# A ship-destination / gated-copy target: the copied deliverable trees, or any `fabric/` path segment.
+# The audit log lives in the bundle root, never in these, so a `verify` here proves nothing.
+SHIP_TARGET = re.compile(r"migrations/(workbooks|datasources)/|(^|/)fabric(/|$)", re.IGNORECASE)
+
+
+def _agent_files() -> list[Path]:
+    return sorted(AGENTS_DIR.glob("*.agent.md"))
+
+
+def test_agents_dir_is_populated() -> None:
+    """The personas we scan must actually exist, or the guard would pass vacuously."""
+    assert _agent_files(), f"no persona files found under {AGENTS_DIR}"
+
+
+@pytest.mark.parametrize("persona", _agent_files(), ids=lambda p: p.name)
+def test_verify_command_never_targets_ship_destination(persona: Path) -> None:
+    """No persona may document a `credential_gate.py verify` command aimed at a ship copy (#354)."""
+    text = persona.read_text(encoding="utf-8")
+    offenders = [arg for arg in VERIFY_CMD.findall(text) if SHIP_TARGET.search(arg)]
+    assert not offenders, (
+        f"{persona.name}: a `credential_gate.py verify` command points at a ship-destination copy "
+        f"{offenders}. The audit log lives in the bundle, so `verify` there returns a false OK "
+        f"(#354). Target the `<bundle>` (or the migration/spec dir), not migrations/.../fabric/."
+    )
+
+
+def test_final_gate_documents_the_bundle_target() -> None:
+    """tableau-migrator's final gate must document `verify <bundle>`, the audit-bearing target."""
+    text = (AGENTS_DIR / "tableau-migrator.agent.md").read_text(encoding="utf-8")
+    targets = VERIFY_CMD.findall(text)
+    assert targets, "tableau-migrator no longer documents any `credential_gate.py verify` command"
+    assert all(not SHIP_TARGET.search(t) for t in targets), (
+        f"a documented verify command targets a ship path: {targets}"
+    )
+    assert "<bundle>" in targets, (
+        f"the final gate should verify `<bundle>` (where the engine-path audit history lives); found targets {targets}"
+    )


### PR DESCRIPTION
## Problem (#354)

`tableau-migrator.agent.md` **step 15** — the mandated final gate — ran:

```
python scripts/credential_gate.py verify migrations/workbooks/<name>
```

That path is the **sign-off ship destination**. In the engine-bundle flow (the dominant path) the gate is armed/probed against the `<bundle>`, and artifacts are **copied** to `migrations/{workbooks,datasources}/<slug>/fabric/` at sign-off — but the audit log (`.credential-gate-audit.log`) stays in the bundle. `verify` reads the audit log **at exactly the path given**, so at the ship destination it finds no `block` entry, reports *"no gate was ever applied"*, and **exits 0** — for the very artifacts the bundle says must never ship.

**Reproduced 2026-08-27** on identical copied artifacts:

| you run | verdict |
|---|---|
| `verify <bundle>` | `VIOLATION … Do not ship them.` **exit 1** |
| `verify <ship destination>` | `OK — no gate was ever applied` **exit 0** |

## Fix — the STOPGAP only

This does **not** redesign `verify`. The proper fix (teaching `verify` to resolve the originating bundle from a ship copy, e.g. via the shared `engine-output-receipt.json` sha256 or a `--also-check` flag) needs design and touches `scripts/credential_gate.py` — that stays open on **#354**.

- **Persona step 15** now targets `<bundle>` (where the audit history lives), notes the parser-path dir, and carries an explicit ⚠️ "never run `verify` at the ship destination" warning. Stays under the 30,000-char cap (**29,094**, 96%).
- **`docs/credential-gate.md`** gains a new *"Where to run `verify` — the bundle, never the ship copy"* section: the full mechanism, a same-bytes/opposite-verdict table, and the #354 stopgap note. The persona carries the rule; the doc carries the essay.
- **`tests/test_credential_gate_verify_target.py`** (new) guards that no persona's `credential_gate.py verify` **command** targets a ship-destination path. Mutation-tested: reintroducing `verify migrations/workbooks/<name>` makes it fail (exit 1), confirmed present on disk first.

## Other `verify`-at-destination references

Grepped `.github/agents/`, `docs/`, `scripts/README.md`, `AGENTS.md`. The persona step 15 was the **only** real verify-at-destination defect. Not fixed (not owned / not this defect):

- **`scripts/README.md:36`** references *"tableau-migrator **step 13**"* as the gate caller — the verify final gate is **step 15** (step 13 is "Summarize the migration"). Stale step number, **not** a verify-at-destination bug. **Reported, not fixed** (not an owned file).
- `AGENTS.md:158`, `docs/credential-gate-testing.md:216`, `docs/operator-runbook.md:611` mention `verify` conceptually with **no** destination path — not defects.

## Verification (exit-code judged)

- `sync_agent_conventions.py --check` → 0
- `check_navigation_index.py` → 0
- `check_agent_capabilities.py` → 0
- `pytest tests/test_repo_layout.py tests/test_skills.py` (+ new guard) → **72 passed**

Refs #354 (stopgap — issue stays open).