### PR TITLE
docs: subagentStart transcriptPath went empty after 2026-07-31

### DIFF
--- a/docs/agent-architecture.md
+++ b/docs/agent-architecture.md
@@ -435,6 +435,17 @@ back in a persona.
     "agentDescription":"Read-only reviewer that critiques…"}
    ```
 
+   ⚠️ **`transcriptPath` stopped being populated after 2026-07-31 — do not build on it.** The same
+   probe hook, same persona, same machine, logged 16 payloads: **5/5 carried a real
+   `…\events.jsonl` path on 07-31; 11/11 from 08-01 through 08-03 carried an empty string.** A clean
+   cutover, not intermittent. The cause was never established (no CLI version was recorded on either
+   side), so this is a measurement, not a diagnosis — but the shape above is the *07-31* shape, and
+   a hook that reads `transcriptPath` to locate a subagent's transcript would have silently degraded
+   to reading nothing. Treat every field here as **advisory and version-fragile**: re-measure before
+   depending on one, and fail loudly on an empty value rather than proceeding. Evidence retained
+   outside the repo (session `files/hook-probe-subagentstart-evidence.log`); the probe hook itself is
+   long gone, so re-measuring means re-installing it.
+
    **This does not change the §5 rule.** A hook can carry supplementary context, but it can still be
    disabled wholesale via `disableAllHooks`, so nothing whose absence is silent and harmful may move
    into it. Useful for *advisory* context; never for load-bearing rules.


### PR DESCRIPTION
## What

The `subagentStart` experiment in `docs/agent-architecture.md` records a measured payload shape in
which `transcriptPath` is a real `...\events.jsonl` path. That is the **2026-07-31** shape, and it
stopped holding the next day.

## Evidence

Re-read the retained probe log — 16 payloads, same persona (`pbi-migration-validator`), same hook,
same machine. A clean cutover, not intermittent flakiness:

| date | payloads | `transcriptPath` |
|---|---|---|
| 07-31 | 5 | **SET** (`events.jsonl`) |
| 08-01 → 08-03 | 11 | **EMPTY** |

## Why it is worth recording

The cause is **not** established — no CLI version was captured on either side — so this lands as a
measurement, not a diagnosis, and says so.

It matters because of the failure *shape*: a hook reading `transcriptPath` to locate a subagent's
transcript would not raise. It would silently degrade to reading nothing. That is the category this
repo treats as unacceptable, so the note tells future readers to treat every field in that payload as
advisory and version-fragile, and to fail loudly on an empty value.

## Scope

Docs only, additive, 11 lines. Does not alter the experiment's verdict — `subagentStart` still fires
and still injects; only the field-shape caveat is new.

Related to #359 only by adjacency; this is deliberately a separate branch after the commit initially
landed on that PR's branch by mistake.
