### PR TITLE
Scope ruff's Markdown exclusion to the measured trees, and re-bound the visual-fidelity claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,9 +369,12 @@ repository, on identical code:
 The global install cannot see the project's optional dependencies, so it invents import errors CI
 never reports. Chasing those is pure waste, and the real signal is buried among them.
 
-The paths are CI's paths, deliberately. Running `ruff format .` instead reformats fenced Python
-inside two committed markdown files under `docs/` and `.github/pbi.kb/` — measured — which CI neither
-checks nor fixes, so you would carry unrelated modifications in your diff forever.
+The paths are CI's paths, deliberately. Repo-wide `ruff format .` is safe because
+`pyproject.toml` excludes the two documentation trees where the drift was measured (`docs/`,
+`.github/pbi.kb/`) and uses `force-exclude = true` so explicitly named files in those trees are
+excluded too. Other Markdown outside CI's roots is still formatted by `ruff format .` and still
+ungated. Keep the commands scoped anyway: the `pylint` roots below are intentionally separate, and
+local lint should mirror CI rather than relying on broader repo defaults.
 
 ```powershell
 uv sync --all-extras   # NOT --extra dev: several tests import tableauhyperapi, which lives in `extract`

--- a/docs/capabilities-and-limitations.md
+++ b/docs/capabilities-and-limitations.md
@@ -3,11 +3,13 @@
 **Answers the question**: "Are there AI tools that can help migrate dashboards from Tableau to
 Power BI, and what are their limitations?"
 
-This is a grounded, evidence-based answer, not a generic claim. Everything below comes from actual
+This is a grounded, evidence-based answer, not a generic claim. Most examples below come from actual
 end-to-end runs of this toolkit against **16 real, publicly available Tableau Public workbooks** (every
 folder under `examples/`), ranging from a 7-worksheet KPI dashboard to a 91-worksheet enterprise
-navigation app, plus IronViz infographics and custom-geometry charts. Where a specific behavior was
-observed on a specific workbook, that workbook's slug is cited so the claim is checkable.
+navigation app, plus IronViz infographics and custom-geometry charts. The known-limits section also
+cites later field evidence from a 44-unit customer estate where the hardest report-layer migrations
+exposed gaps the public examples did not. Where a specific behavior was observed on a specific
+workbook or unit, that source is cited so the claim is checkable.
 
 ## What the pipeline does automatically
 
@@ -130,9 +132,21 @@ a single pass does.
 - **Extract-based data sources with no live upstream** migrate structurally, but real row data requires
   the separate `.hyper` extraction step (or repointing to a true upstream if one exists behind the
   extract).
-- **Visual polish is a separate pass.** Chart-type and layout mapping is automated and directionally
-  correct, but exact spacing, colors, and fonts still deserve a design pass before a customer-facing
-  rollout.
+- **Report-layer fidelity is the biggest variable, not just "visual polish."** On the hardest field
+  units, the customer did not elect to rebuild the semantic models, but that does not mean the model
+  tier is risk-free: the same field record includes unresolved model defects such as stubbed
+  `BLANK()` measures and missing reference columns. The report layer is where manual rework was chosen
+  before customer rollout. In a later 44-unit SES estate, the two hardest units exposed this tail risk:
+  [**IA CAPS Dashboard**](https://github.com/Guust-Franssens/tableau-to-powerbi-migration/issues/342)
+  shipped provisional after retry validation found **3 FAIL / 8 PARTIAL of 11 pages**, including two
+  hard-crash pages, and the customer chose to have their team manually repair the visual layer;
+  [**IA IPTV Dashboard**](https://github.com/Guust-Franssens/tableau-to-powerbi-migration/issues/342)
+  was baseline **FAIL / NOT READY with 22 findings**. Other measured failure modes include wrong chart
+  types for Tableau idioms, field-parameter swaps that validate but do not engage, bindings that
+  validate but render against the wrong field, and pages that fail outright in high-page-count
+  workbooks. This is the tail of an estate rather than the median outcome, and the available evidence
+  does not yet prove which part of "not great" on CAPS was chart choice, data binding, layout, or
+  formatting, so treat the report layer as a first draft that needs explicit fidelity validation.
 
 ## Bottom line
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,12 @@ exclude = [
     # both nested trees (the user's own workbook and data-source migrations).
     "examples",
     "migrations",
+    # Ruff formats fenced Python in Markdown. Exclude only the documentation trees CI does not lint;
+    # keep Markdown under scripts/tests/.github/skills covered by the CI ruff roots.
+    "docs/**/*.md",
+    ".github/pbi.kb/**/*.md",
 ]
+force-exclude = true
 line-length = 120
 indent-width = 4
 target-version = "py311"


### PR DESCRIPTION
Closes **#339** and **#342**.

## #339 — `ruff format` rewrote committed markdown that CI never checked

A contributor following the documented ritual produced a diff nobody asked for, and CI had no opinion on it.

Fixed by excluding **only the two trees where the drift was measured** (`docs/**/*.md`, `.github/pbi.kb/**/*.md`) plus `force-exclude = true`.

⚠️ **Both refinements came out of blind review.** The first attempt excluded `*.md` globally, which silently removed **8 files from CI's own gate** (the five `.github/skills/*/SKILL.md`, `scripts/README.md`, two `tests/fixtures/*/README.md`). And without `force-exclude`, `ruff format <file>` — the exact invocation `CONTRIBUTING.md:34` documents — still rewrote the docs. Neither was visible from the acceptance test alone.

## #342 — the limitations doc understated the visual gap

It called the gap *"spacing, colors, and fonts"*; the field measured materially worse. Now re-bounded and **linked to #342** so each claim is checkable.

The review also caught a claim drifting optimistic: the first attempt said the semantic-model tier *"has held up on hard workbooks"*, dropping the qualifier that made #342's original defensible. It now reads *"the customer did not elect to rebuild the semantic models, but that does not mean the model tier is risk-free"*, and discloses the `BLANK()`-dispatcher and missing-column record behind open #337.

## Blind review: approve (2 rounds)

Round 1 returned **request changes** with 5 findings. Round 2 verified the fixes by **injecting a misformatted `python` fence into all 8 previously-lost files simultaneously** and comparing CI's literal command under both configs — proving each file is individually back in scope, rather than trusting a matching count:

```
BRANCH config : 8 files would be reformatted, 175 already formatted   EXIT 1
MASTER-eq cfg : 8 files would be reformatted, 175 already formatted   EXIT 1
clean run     : 183 files already formatted                           EXIT 0   (= master)
```

It also enumerated the file set `ruff check` visits under both configs and found **no difference in either direction**, so `force-exclude` did not move the boundary on the lint side.

Every number transcribed from #342 was verified faithful, with the 44-unit figure corroborated in three other repo locations.

## Known residual

**16** markdown files outside CI's roots are still in `ruff format .` scope and ungated — all four personas, `AGENTS.md`, `CONTRIBUTING.md`, `SECURITY.md`, five `fixtures/**/README.md`. Safe today only because none contains a Python fence. `README.md` now states this explicitly rather than implying full coverage. Master had the same hole across 70 files; this shrinks it to 16.

## Gates
`ruff format .` → 199 unchanged, tree clean · CI-scoped → **183**, exit 0 · `pylint scripts` **10.00/10 exit 0** · `pytest -k "not upstream_repro_pins"` exit 0.
