### PR TITLE
Give every caption-less datasource a stable, unique id

### DIFF
--- a/scripts/parse_tableau.py
+++ b/scripts/parse_tableau.py
@@ -17,6 +17,7 @@ usage:   python scripts/parse_tableau.py <workbook.twb|.twbx|datasource.tds|.tds
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import logging
 import re
@@ -43,6 +44,7 @@ _KEYWORDLESS_LOD_RE = re.compile(r"\{[^{}]*\b[A-Z][A-Z0-9_]*\s*\(", re.IGNORECAS
 _TABLE_CALC_RE = re.compile(r"\b(WINDOW_\w+|RUNNING_\w+|INDEX|RANK\w*|LOOKUP|TOTAL|PREVIOUS_VALUE)\s*\(", re.IGNORECASE)
 _PARAM_EQUALITY_RE = re.compile(r"if\s*\[Parameters\]\.\[[^\]]+\]\s*=\s*\[[^\]]+\]\s*then", re.IGNORECASE)
 _BRACKET_TOKEN_RE = re.compile(r"\[([^\[\]]+)\]")
+_ASCII_ALNUM_RE = re.compile(r"[a-zA-Z0-9]")
 # Tableau's feature-flagged attribute spelling: `_.fcp.<Feature>.<true|false>...<realAttrName>`
 _FCP_ATTR = re.compile(r"^_\.fcp\.(?P<feature>[^.]+)\.(?P<state>true|false)\.\.\.(?P<attr>.+)$")
 _SHELF_FIELD_RE = re.compile(r"\[([^\[\]]+)\]\.\[([^\[\]]+)\]")
@@ -76,9 +78,18 @@ class IdRegistry:
     def make(self, prefix: str, *parts: str) -> str:
         """Build a stable, unique id like 'fld.ds_name__field_name', disambiguating collisions."""
         base = f"{prefix}.{'__'.join(slugify(p) for p in parts if p)}"
-        count = self.seen.get(base, 0)
+        if base not in self.seen:
+            self.seen[base] = 1
+            return base
+
+        count = self.seen[base]
+        candidate = f"{base}_{count}"
+        while candidate in self.seen:
+            count += 1
+            candidate = f"{base}_{count}"
         self.seen[base] = count + 1
-        return base if count == 0 else f"{base}_{count}"
+        self.seen[candidate] = 1
+        return candidate
 
 
 def _wrap_datasource_as_workbook(ds_el: etree._Element) -> etree._Element:
@@ -381,6 +392,25 @@ def _parse_published_datasource(ds_el: etree._Element, connection: dict[str, Any
     }
 
 
+def _datasource_display_name(
+    ds_el: etree._Element, connection: dict[str, Any], published: dict[str, Any] | None
+) -> str:
+    """Return the stable label used for both datasource caption fallback and synthetic id seed."""
+    for candidate in (
+        ds_el.get("caption"),
+        published.get("id") if published else None,
+        ds_el.get("formatted-name"),
+        ds_el.get("name"),
+    ):
+        if candidate and candidate.strip() and _ASCII_ALNUM_RE.search(candidate):
+            return candidate.strip()
+
+    raw = etree.tostring(ds_el, method="c14n", exclusive=True)
+    digest = hashlib.sha256(raw).hexdigest()[:12]
+    conn_class = connection.get("class") or "unknown"
+    return f"{conn_class}_{digest}"
+
+
 def _collect_leaf_relations(rel: etree._Element) -> list[etree._Element]:
     """Descend container relations (collection/join/union wrappers) to their leaf table/text relations,
     so a multi-file collection or a join surfaces each underlying physical table instead of one opaque
@@ -578,7 +608,9 @@ def _parse_single_data_source(
     column-instances (declared only inside a worksheet's <datasource-dependencies>, not centrally on
     the datasource) can still be resolved later."""
     internal_name = ds_el.get("name", "")
-    caption = ds_el.get("caption") or internal_name
+    connection = _parse_connection(ds_el, hyper_files)
+    published = _parse_published_datasource(ds_el, connection)
+    caption = _datasource_display_name(ds_el, connection, published)
     ds_id = ids.make("ds", caption)
 
     tables = _parse_tables(ds_el, ids)
@@ -591,7 +623,6 @@ def _parse_single_data_source(
         if ci.get("column", "") in name_to_id
     }
 
-    connection = _parse_connection(ds_el, hyper_files)
     data_source = {
         "id": ds_id,
         "caption": caption,
@@ -601,7 +632,6 @@ def _parse_single_data_source(
         "joins": _parse_joins(ds_el),
         "fields": fields,
     }
-    published = _parse_published_datasource(ds_el, connection)
     if published is not None:
         data_source["published_datasource"] = published
     return data_source, internal_name, instance_map, name_to_id
@@ -624,6 +654,13 @@ def parse_data_sources(
         data_sources.append(data_source)
         instance_maps[internal_name] = instance_map
         name_to_id_maps[internal_name] = name_to_id
+
+    seen_ids: set[str] = set()
+    for data_source in data_sources:
+        ds_id = data_source["id"]
+        if ds_id in seen_ids:
+            raise ValueError(f"Duplicate datasource id {ds_id!r}; migration-spec ids must be unique")
+        seen_ids.add(ds_id)
 
     logger.info("Parsed %d data source(s)", len(data_sources))
     return data_sources, instance_maps, name_to_id_maps

--- a/tests/test_parse_tableau.py
+++ b/tests/test_parse_tableau.py
@@ -8,14 +8,22 @@ usage:   pytest -q
 import sys
 from pathlib import Path
 
+import pytest
+
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
-from parse_tableau import _conn_attr, _published_ds_name, _parse_published_datasource, parse_workbook  # noqa: E402  (path insert must precede this import)
+import parse_tableau  # noqa: E402  (path insert must precede this import)
+from parse_tableau import _conn_attr, _published_ds_name, _parse_published_datasource, parse_workbook  # noqa: E402
 
 FIXTURE = Path(__file__).resolve().parent / "fixtures" / "minimal.twb"
 PUBLISHED_FIXTURE = Path(__file__).resolve().parent / "fixtures" / "published_datasource.twb"
 TDS_FIXTURE = Path(__file__).resolve().parent / "fixtures" / "standalone_datasource.tds"
 FEDERATED_FIXTURE = Path(__file__).resolve().parent / "fixtures" / "federated_multi_connection.twb"
+CAPTIONLESS_TDS_FIXTURES = {
+    "CustomSQL_Parameter_And_Doubled_Operators.tds": "ds.customsqlparametertest",
+    "Meridian_Custom_SQL_Databricks.tds": "ds.meridiantripslivedatabricks",
+    "Meridian_Custom_SQL_Snowflake.tds": "ds.meridiancalcgauntletlivesnowflake",
+}
 
 
 def test_parses_top_level_shape():
@@ -443,6 +451,96 @@ def test_empty_repository_location_in_tds_is_not_a_published_datasource():
     spec = parse_workbook(TDS_FIXTURE)
     assert "published_datasource" not in spec["data_sources"][0]
     assert not [limit for limit in spec["limitations_encountered"] if "PUBLISHED Tableau data source" in limit["issue"]]
+
+
+def test_captionless_datasources_use_stable_published_names_for_ids():
+    """Regression for #333, grounded in three real caption-less .tds exports.
+
+    They used to all emit id='ds.' because standalone .tds roots often carry neither caption nor
+    internal name. Published datasource identity is already parsed from repository-location, so it is
+    the stable readable fallback before opaque formatted-name/hash fallbacks.
+    """
+    seen_ids = set()
+    for fixture_name, expected_id in CAPTIONLESS_TDS_FIXTURES.items():
+        spec = parse_workbook(Path(__file__).resolve().parent / "fixtures" / fixture_name)
+        ds = spec["data_sources"][0]
+
+        assert ds["id"] == expected_id
+        assert ds["id"] != "ds."
+        assert ds["caption"] == ds["published_datasource"]["id"]
+        assert all(field["id"].startswith(f"fld.{expected_id.replace('.', '_')}__") for field in ds["fields"])
+        assert not any(field["id"].startswith("fld.ds__") for field in ds["fields"])
+        seen_ids.add(ds["id"])
+
+    assert len(seen_ids) == len(CAPTIONLESS_TDS_FIXTURES)
+
+
+def test_unsluggable_datasource_name_falls_through_to_stable_ascii_name():
+    """Non-ASCII-only names must not short-circuit to slugify's constant 'field' fallback."""
+    from lxml import etree  # noqa: PLC0415
+
+    def ids_by_internal_name(datasource_names: list[str]) -> dict[str, str]:
+        datasources = "".join(
+            f"<datasource name='{name}'><repository-location id='{published_name}' site='s' /></datasource>"
+            for name, published_name in zip(datasource_names, ["売上マスタ", "顧客分析"], strict=True)
+        )
+        root = etree.fromstring(f"<workbook><datasources>{datasources}</datasources></workbook>")
+        parsed, _, _ = parse_tableau.parse_data_sources(root, {}, parse_tableau.IdRegistry())
+        return {ds["internal_name"]: ds["id"] for ds in parsed}
+
+    forward = ids_by_internal_name(["federated.aaa111", "federated.bbb222"])
+    reversed_order = ids_by_internal_name(["federated.bbb222", "federated.aaa111"])
+
+    assert forward == {
+        "federated.aaa111": "ds.federated_aaa111",
+        "federated.bbb222": "ds.federated_bbb222",
+    }
+    assert forward == reversed_order
+    assert "ds.field" not in forward.values()
+
+
+def test_duplicate_datasource_id_guard_fails_loudly(monkeypatch):
+    """If id generation regresses, duplicate datasource ids must fail instead of corrupting the spec."""
+    from lxml import etree  # noqa: PLC0415
+
+    original_make = parse_tableau.IdRegistry.make
+
+    def duplicate_datasource_id(self, prefix: str, *parts: str) -> str:
+        if prefix == "ds":
+            return "ds.duplicate"
+        return original_make(self, prefix, *parts)
+
+    root = etree.fromstring(
+        "<workbook><datasources>"
+        "<datasource caption='Orders'><connection class='federated' /></datasource>"
+        "<datasource caption='Customers'><connection class='federated' /></datasource>"
+        "</datasources></workbook>"
+    )
+    monkeypatch.setattr(parse_tableau.IdRegistry, "make", duplicate_datasource_id)
+
+    with pytest.raises(ValueError, match="Duplicate datasource id 'ds\\.duplicate'"):
+        parse_tableau.parse_data_sources(root, {}, parse_tableau.IdRegistry())
+
+
+def test_field_id_suffixes_cannot_collide_with_legitimate_slugged_names():
+    """A generated _1 suffix must not collide with a real field whose caption slug already ends _1."""
+    from lxml import etree  # noqa: PLC0415
+
+    root = etree.fromstring(
+        "<workbook><datasources>"
+        "<datasource caption='Orders'>"
+        "<column caption='Sales' name='[sales_a]' datatype='real' role='measure' type='quantitative' />"
+        "<column caption='Sales' name='[sales_b]' datatype='real' role='measure' type='quantitative' />"
+        "<column caption='Sales 1' name='[sales_1]' datatype='real' role='measure' type='quantitative' />"
+        "</datasource>"
+        "</datasources></workbook>"
+    )
+
+    parsed, _, _ = parse_tableau.parse_data_sources(root, {}, parse_tableau.IdRegistry())
+    field_ids = [field["id"] for field in parsed[0]["fields"]]
+
+    assert field_ids == ["fld.ds_orders__sales", "fld.ds_orders__sales_1", "fld.ds_orders__sales_1_1"]
+    assert len(field_ids) == len(set(field_ids))
 
 
 def test_published_datasource_raises_high_severity_limitation():


### PR DESCRIPTION
Closes **#333** — `parse_tableau` emitted the id `ds.` for any caption-less datasource.

## Why this was a data-integrity defect, not a naming nit

`migration-spec.json` is the contract between the deterministic parser and every downstream agent, and its design premise is *"stable synthetic IDs everywhere — avoids ambiguous name-matching"*. An id emitted identically for every caption-less datasource destroys exactly that.

Measured on the 7 real published datasources harvested from a live Tableau site:

```
master : 7 of 7 emit bare 'ds.'  ->  all collapsing onto ONE key
branch : 0 degenerate ids, 0 within-file duplicates
```

The issue reported "3 of 3"; on our own trial-site assets it is **7 of 7**. Anything indexing by datasource id was reading one arbitrary source and silently losing the rest.

## The fix

A tier cascade — `caption` → published-datasource `id` → `formatted-name` → internal Tableau `name` → canonical-XML SHA256 — with two additional properties added during review:

- **Unsluggable candidates are skipped.** A first attempt made `ds.field` the new `ds.` for any name with no ASCII alphanumerics (`売上マスタ`), which was a *strict regression against master* for non-Latin published datasources and reintroduced ordinal instability. Now such candidates fall through to the ASCII tiers.
- **`IdRegistry` records emitted ids**, not just slug bases, so its own `_N` suffix can no longer collide with a legitimately-slugged name. This closed the same defect at **field** level, which was silent on master.

## Blind review: 2 rounds, approve

The reviewer verified stability harder than the issue asked, since that is the load-bearing property — an id that changes between runs breaks every downstream reference:

| probe | result |
|---|---|
| in-process re-parse, all ids in all 52 real assets | identical |
| cross-process, `PYTHONHASHSEED` 0 / 12345 / 999 / 7 | byte-identical, all four |
| file renamed · XML re-serialised + rezipped | stable |
| unrelated datasource **injected first** | 64/64 pre-existing ids preserved (not ordinal) |
| two datasources reordered | identical id set |

**200,000 randomised sequences** over adversarial name pools: **0 duplicates emitted**.

**No renumbering of already-committed specs**, proved two ways: a full-spec diff over all 52 assets shows round-1 → round-2 delta of **zero** across 68 datasources / 1475 fields; and old/new `IdRegistry` diverge *only* on inputs where the old one emitted a duplicate — with **0 duplicates** among the 2,576 registry-shaped ids (235 `_N`-suffixed) in the 23 committed `migration-spec.json` files.

Five mutations now caught, including deleting the duplicate guard and reverting `IdRegistry` — both of which passed silently before.

## Documented residuals, non-blocking

- The **content-hash tier is now reachable** (it was 0/76 on real data) and re-keys on any edit to a nameless datasource. Unique-but-fragile beats constant-and-colliding, so the trade is deliberate.
- The `while candidate in self.seen` probe is behaviourally load-bearing but not pinned by a test; one reversed-ordering case would close it.
- **NFC/NFD** normalise to different slugs (`Café` NFC → `ds.caf`, NFD → `ds.cafe`). Byte-identical on master — pre-existing in `slugify`, out of scope here.

## Gates
`pylint scripts` **10.00/10 exit 0** · `pytest -k "not upstream_repro_pins"` exit 0, **2340 passed** · ruff clean.
