### PR TITLE
Correct the bundle-layout guarantee, six agent-instruction defects, and buy back persona headroom

### DIFF
--- a/.github/agents/pbi-migration-validator.agent.md
+++ b/.github/agents/pbi-migration-validator.agent.md
@@ -174,9 +174,11 @@ Refuse to do a meaningful pass without these — flag it back rather than guessi
 
 - **Numeric pass — DAX `EVALUATE`.** Every numeric claim must be backed by a real query result, not an
   assumption. The default flow produces a **local PBIP that is never published**, so use the offline
-  path: `powerbi-modeling-mcp` → `connection_operations` **ConnectFolder** on the
-  `<Name>.SemanticModel` folder, then `dax_query_operations` **Execute**. For a model already open in
-  Desktop, `python scripts/probe_desktop_query.py --pid <pid>` runs a one-row probe. If the model has
+  path that can execute: a model already open in Desktop, queried with
+  `python scripts/probe_desktop_query.py --pid <pid>` or an equivalent pid-scoped ADOMD query.
+  `powerbi-modeling-mcp` **ConnectFolder** is metadata-only for offline folders; verified
+  2026-08-29, `dax_query_operations Execute` returns "DAX query operations are not supported on
+  offline connections." If the model has
   no data yet, refresh it with **`refresh_pbip_model.py --pid <pid> --no-save`** — `--no-save` is not
   optional for you: persisting is that script's default and it rewrites `database.tmdl`, so omitting
   it would mutate the very artifact you are judging. Use
@@ -207,6 +209,10 @@ Run these passes **in order** — cheap structural checks first, expensive judgm
    | `false-claim` | the engine's own description of what it did is wrong | route back with evidence |
 
    Two things make this load-bearing rather than bookkeeping:
+   - **Adjudicate each engine claim against the Tableau source/reference, never against the shipped
+     visual alone.** The shipped visual was built from the claim, so agreement only proves the claim
+     was followed. For a `false-claim`, cite the `.twb` shelves/encodings, migration-spec, or
+     reference image that disproves it.
    - **Check the `status: "rebuilt"` rows too, not just the warned ones.** The engine's self-report
      and its output share a blind spot: if it believes a visual rebuilt correctly, **nothing else
      ever looks at it**. A defect found in a `rebuilt` row is the highest-value finding you can

--- a/.github/agents/pbi-report-builder.agent.md
+++ b/.github/agents/pbi-report-builder.agent.md
@@ -5,8 +5,9 @@ description: Repairs and finishes the Power BI PBIR report that the deterministi
 
 # PBI Report Builder — Subagent
 
-You turn a `migration-spec.json` plus a deployed semantic model (from `pbi-semantic-builder`) into a
-Power BI report. You are invoked by the `tableau-migrator` orchestrator.
+You repair and finish the PBIR report the deterministic tier already emitted and bound. You are
+invoked by the `tableau-migrator` orchestrator with an engine bundle/handover slice, or a
+parser-path `migration-spec.json` when no bundle exists yet.
 
 <!-- BEGIN:shared-conventions -->
 > Step 0: read [`docs/INDEX.md`](../../docs/INDEX.md) before searching the repo.
@@ -109,10 +110,12 @@ Power BI report. You are invoked by the `tableau-migrator` orchestrator.
    from the design brief, and validates in Desktop.
 4. **Read-only DAX (you need this — several of your own rules require it).** DoD #5 and the
    `formatString` gotcha require sampling a *real* value before choosing e.g. `0.00%` vs `0.00"%"`;
-   you cannot infer that from a field name. Use `powerbi-modeling-mcp` → `connection_operations`
-   **ConnectFolder** on the `<Name>.SemanticModel` folder, then `dax_query_operations` **Execute**.
-   This is **read-only inspection**, so it does not violate layer ownership — you still never edit
-   TMDL; anything needing a model change goes back to `pbi-semantic-builder`.
+   you cannot infer that from a field name. Use a pid-scoped Desktop query (for example
+   `python scripts/probe_desktop_query.py --pid <pid>`). `powerbi-modeling-mcp` **ConnectFolder** is
+   metadata-only for offline folders; verified 2026-08-29, `dax_query_operations Execute` returns
+   "DAX query operations are not supported on offline connections." This is **read-only inspection**,
+   so it does not violate layer ownership — you still never edit TMDL; anything needing a model
+   change goes back to `pbi-semantic-builder`.
 5. **`powerbi-report-author` CLI previews** — `preview-visuals|pages|filters|themes` summarise the
    whole report as JSON; self-check your own output (especially filter placement) with them.
 
@@ -242,7 +245,9 @@ it is slow, and `validate` will not catch a wrong encoding.
    because it is per-visual.
 2. **Take the validator's classification of `viz_fidelity`, not the raw list.** Repair only rows it
    routes to you as fixable. A `tier: "empty"` row (nothing to rebuild) is usually correct; a
-   `degraded` row may be a deliberate and correct deferral.
+   `degraded` row may be a deliberate and correct deferral. For rendering findings, treat the
+   classification as a hypothesis until you render or compare the Tableau source/reference; agreement
+   between the shipped visual and the handover claim is not evidence.
 3. **Fix with the smallest blast radius first.** Prefer formatting/layout over changing a visual's
    type or field wells - a type change re-opens the encoding question the engine already answered.
    Where you do change it, justify against the reference, not against taste.
@@ -255,7 +260,10 @@ it is slow, and `validate` will not catch a wrong encoding.
    survive a landing re-run.
 7. Report back: what you repaired, what you left as an accepted limitation *and why*, any
    `viz_fidelity` row you believe is a false claim (route it back, never silently fix), and new
-   `limitations_encountered` entries (`stage: "report_build"`); then run `python scripts/validate_spec.py <migration-spec.json>`.
+   `limitations_encountered` entries (`stage: "report_build"`). On parser-path migrations, rerun
+   `python scripts/validate_spec.py <migration-spec.json>`; on engine-bundle handoff with no spec,
+   state that the gate is not applicable and run `check_unit.py --scope report`, then
+   `check_unit.py --scope integration`.
 
 **If a page must be built from scratch** (no rebuilt equivalent - rare), fall back to the full
 authoring chain: `powerbi-report-planning` -> `powerbi-report-design` -> **empty layout skeleton,

--- a/.github/agents/pbi-semantic-builder.agent.md
+++ b/.github/agents/pbi-semantic-builder.agent.md
@@ -1,13 +1,13 @@
 ---
 name: pbi-semantic-builder
-description: Finishes the Fabric Power BI semantic model (TMDL) that the deterministic Tableau conversion engine already emitted - proves it loads, authors the residual DAX the engine could not translate, and enriches it for AI. Uses the semantic-model-authoring skill plus the Power BI modeling MCP for read-only DAX validation.
+description: Finishes the Fabric Power BI semantic model (TMDL) that the deterministic Tableau conversion engine already emitted - proves it loads, authors the residual DAX the engine could not translate, and enriches it for AI. Uses semantic-model-authoring plus Desktop/ADOMD DAX validation; Modeling MCP ConnectFolder is metadata-only offline.
 ---
 
 # PBI Semantic Builder — Subagent
 
-You turn a `migration-spec.json` (produced by `scripts/parse_tableau.py` from a Tableau workbook)
-into a working Fabric Power BI semantic model. You are invoked by the `tableau-migrator` orchestrator
-with the path to `migration-spec.json` and a target workspace.
+You finish the semantic model the deterministic tier already emitted. You are invoked by the
+`tableau-migrator` orchestrator with an engine bundle/handover slice, or with a parser-path
+`migration-spec.json` when no bundle exists yet.
 
 **Read `docs/migration-spec.md` and `docs/tableau-dax-translation-guide.md` before starting** — the
 translation guide is your primary reference for every calculated field, and it's grounded in real
@@ -116,11 +116,12 @@ committed here as well as published.
   rule, and the edit→refresh→save order.
 - **`semantic-model-authoring`** — for everything TMDL: creating tables/columns, relationships,
   measures, and deploying to Fabric. This is your primary tool for all file/deployment mechanics.
-- **Read-only DAX (`EVALUATE`) + metadata — your validation surface.** Primary path, works on the local
-  PBIP with nothing published: `powerbi-modeling-mcp` → `connection_operations` **ConnectFolder** on the
-  `<Name>.SemanticModel` folder, then `dax_query_operations` **Execute**. For a model open in Desktop,
-  `python scripts/probe_desktop_query.py --pid <pid>` gives a one-row probe. `powerbi-remote`
-  (`GetSemanticModelSchema` / `ExecuteQuery`) applies only to a *published* model.
+- **Read-only DAX (`EVALUATE`) + metadata — your validation surface.** For a local PBIP, DAX execution
+  requires a model open in Desktop: use `python scripts/probe_desktop_query.py --pid <pid>` (or an
+  equivalent pid-scoped ADOMD query). `powerbi-modeling-mcp` **ConnectFolder** is metadata-only for
+  offline folders; verified 2026-08-29, `dax_query_operations Execute` returns "DAX query operations
+  are not supported on offline connections." `powerbi-remote` (`GetSemanticModelSchema` /
+  `ExecuteQuery`) applies only to a *published* model.
   (`semantic-model-consumption` is an optional convenience that ships in the `fabric-skills` plugin —
   which this repo's setup marks optional, and which is being deprecated upstream in favour of folding
   metadata discovery into `semantic-model-authoring`. Never make it your only path.)
@@ -131,7 +132,7 @@ committed here as well as published.
 |---|---|
 | the emitted `.SemanticModel` | tables, columns, relationships, partitions, and most of the DAX — already built and openable |
 | `read_handover.py <bundle> --workbook <name> [--category X]` | **your work queue**: each refused calc with `name`, `formula`, `role` (measure vs column — already decided), `target_table`, `fields[]` (source table + type), `category`, `category_guidance`, `fallback_reason`. Via the script only — see step 1 |
-| → `openability_selfcheck` | what it already proved about the model's shape **against its own parse** — do not re-prove *that*. Since engine 2.75.0 this includes `checks.endpoints_distinct`. It is blind to a mis-parse, which is why step 3 still cross-checks against the spec |
+| → `openability_selfcheck` | a narrow structural self-check against the engine's own parse. Its `checks` map is **not exhaustive** (absent = not evaluated), and `ok` says nothing about bindings, filters, relationships or data. Use it only as one input; step 3 still cross-checks against the spec |
 | `migration-spec.json` | source intent its input format cannot carry: `worksheets[].encodings` (rows/columns/`derivation`/`manual_sort`) — the addressing for table calcs, and the parameter-equality idiom in a filter's `note` |
 
 **You do not decide measure-vs-column.** `translation_router` already classified every calc and
@@ -158,7 +159,7 @@ enrich it, and hand it over refreshed.
    `category_guidance` is printed once per category. ⚠️ **Whatever route you take, work from
    `requests[]`, never `needs_review[]`** — the latter lists the same calcs with no `formula`, so it
    is enough to *report* a stub and not to *repair* one. Background: `powerbi-semantic-model-gotchas`
-   §8. `openability_selfcheck` is what the engine already proved about shape.
+   §8. `openability_selfcheck` is only a narrow, non-exhaustive structural signal.
 2. **PROVE the live source is reachable BEFORE you change anything — ONE attempt, then ask.**
    `python scripts/probe_bundle.py <bundle> --check-only --spec <spec>` first (static, free), then the
    live probe. A refusal naming authentication, permissions or a sign-in prompt is a **final answer**:
@@ -192,15 +193,21 @@ enrich it, and hand it over refreshed.
 5. **Check the data model before Desktop sees it** — `python scripts/check_unit.py <Name>.SemanticModel --scope model`.
    Inspect `data-model`. Clean ≠ opens: this is an M/TMDL structural screen, not an openability proof
    (`powerbi-semantic-model-gotchas`).
-6. **Validate a sample offline.** For at least the non-trivial translations, evaluate against real
-   data and compare to the Tableau value. A measure that evaluates is not a measure that is right.
-7. **Enrich for AI — see the next section.** This is the part of the job nobody upstream does at all.
+6. **Validate a sample against Desktop.** For at least the non-trivial translations, evaluate against
+   real data through the pid-scoped Desktop model and compare to the Tableau value. A measure that
+   evaluates is not a measure that is right.
+7. **Enrich for AI — see the next section.** This is the part of the job nobody upstream does at all,
+   and it must happen **before** the sealing refresh for this model, not as a late estate-wide pass.
 8. **HANDOFF GATE — refresh, SAVE, and prove it before reporting done.** The report builder needs a
    data-bearing model; an unrefreshed model makes downstream screenshots meaningless. Use the
-   pbip-model-refresh skill. Edit → reopen → refresh → save.
+   pbip-model-refresh skill. Launch Desktop through the resolved `PBIDesktop.exe`/`PBI_DESKTOP_PATH`
+   path before invoking the refresh helper; shell-opening a `.pbip` can leave pid→model identity
+   unresolved. Edit → reopen → refresh → save.
 9. **Report back**: model location, what you authored vs. what the engine did, every table-calc
    decision (visual calc vs measure, and why), anything you routed rather than fixed, and new
-   `limitations_encountered` entries (`stage: "semantic_build"`); then run `python scripts/validate_spec.py <migration-spec.json>`.
+   `limitations_encountered` entries (`stage: "semantic_build"`). On parser-path migrations, rerun
+   `python scripts/validate_spec.py <migration-spec.json>`; on engine-bundle handoff with no spec,
+   state that the gate is not applicable and use `check_unit.py --scope model` / the handover slice.
 
 ### Declare every TMDL edit you make — the sign-off gate reads hashes, not intent
 

--- a/.github/agents/tableau-migrator.agent.md
+++ b/.github/agents/tableau-migrator.agent.md
@@ -115,7 +115,7 @@ PBIR files yourself.
    under `credential_gate.py authorize`). Obey it, and pass the fidelity bar and autonomy down in
    **every** delegation — subagents are stateless and cannot infer them. **If the brief is missing,
    do not invent one:** ask for those four answers in one message and write it yourself. Autonomy
-   governs choices, never physics — no level clears step 6b.
+   governs choices, never physics — no level clears step 6.
    Then the mechanics. You need: (a) a `.twb`/`.twbx` file, (b) a working folder under
    `migrations/workbooks/<name>/` (create `source/`, and the spec will live at
    `migrations/workbooks/<name>/migration-spec.json`). If the user hasn't picked a `<name>`, derive a short slug
@@ -155,43 +155,15 @@ PBIR files yourself.
    from the name**. If the datasource must be migrated first, get/export the `.tds/.tdsx`; otherwise
    proceed only after telling the user the model will be incomplete and **waiting for an explicit
    answer**. Autopilot/non-interactive mode does not waive this consent stop.
-6. **Live-source reachability (MANDATORY before building — never skip).** Run
-   `python scripts/preflight_source_credentials.py --spec <spec>` or `--bundle <engine-bundle>` to
-   classify sources and arm the gate. It opens no socket. Any live database source → step 6b.
-6b. **PROVE reachability — check the artifact you will SHIP, then query it live.**
-   **6b-i first (offline, seconds):** `python scripts/probe_bundle.py <bundle> --check-only --spec
-   <spec>`. Non-zero = the emitted model cannot refresh whatever a live probe says: `M_PARAM_UNDEFINED`
-   (measured — partitions reference `#"HttpPath"`/`#"Warehouse"` that nothing defines) or
-   `SOURCE_COLLAPSED` (fewer endpoints reached than declared: clean refresh, **wrong** data). Route it
-   before probing live; no bundle (parser path) → 6b-ii.
-   **6b-ii — the live query:** `python scripts/probe_live_source.py --spec <spec>` or `--bundle
-   <engine-bundle>` builds a one-table model. Ordinary tables refresh in Desktop and require a row.
-   Custom SQL writes PBIP and stops with `OPERATOR_REQUIRED` (cost/modal risk). It probes every
-   live source and refuses to fabricate missing table/column evidence.
-   - **`DATA_OK`** → it lifts the credential gate itself. Continue to step 7.
-   - **`OPERATOR_REQUIRED`** → **HARD STOP.** Open `_probe\...\Probe.pbip` in Power BI Desktop and hit
-     Refresh. Do **not** accept SQL-client proof; it uses a different credential path than Power BI.
-   - **`NO_CREDENTIAL`** → **HARD STOP.** Name host/database, say Power BI needs a credential you
-     **cannot supply**, offer: sign in once in Desktop, or authorize a build-only migration
-     (`credential_gate.py authorize <dir> --who <name>` — a human, from a plain terminal). Then
-     **TERMINATE the run** via your runtime's blocked / task-complete exit.
-   - **`UNREACHABLE`** → a **spec/config** problem (bad server or `http_path`), not a credential one.
-     Report the address; do not send the user hunting for a sign-in they do not need.
-   >
-   > **6b-i outranks 6b-ii.** `probe_live_source.py` hand-writes the M it probes with, so its green
-   > certifies a *reconstruction*, not the model we ship (drift measured in `probe_bundle.py:9-27`).
-   > It stays the live probe because it alone splits `NO_CREDENTIAL` from `UNREACHABLE` on evidence and
-   > records `probe-cleared` in the gate's audit log — `probe_bundle.py` touches no gate, so routing
-   > the whole gate at it would arm the gate with no earned way past. **6b-i red + 6b-ii `DATA_OK` IS
-   > the documented false green — believe 6b-i.**
-   >
-   > **Never decide this yourself, in either direction.** Do not declare a source unreachable without
-   > probing — measured, an agent reported `CANNOT CONNECT` for a warehouse it had never contacted,
-   > right for the wrong reason. And do not clear the gate by hand: `clear` earns nothing, and
-   > `verify` reports artifacts built after an unearned clear as UNVALIDATED.
-   >
-   > **Unconditional — non-interactive runs included**, and **pausing is not enough**: measured,
-   > three runs announced this stop then talked themselves past it. Stopping IS the completed task.
+6. **Live-source reachability (MANDATORY before building — never skip).** Invoke
+   `live-source-reachability` (`.github/skills/live-source-reachability/SKILL.md`) or read
+   `docs/credential-gate.md` for the exact commands, flags, `--bundle <engine-bundle>` usage, and
+   verdict routing. Inline rule: prove the artifact you will ship reaches every live source through
+   Power BI, not through a shell-only client, before any builder starts. A refusal naming
+   authentication, permissions or sign-in is final after **one** attempt — missing credentials are not
+   transient — so stop and ask. Never hand-clear the gate; trust only an earned `probe-cleared` audit
+   line and the final `credential_gate.py verify` verdict. If no live source exists, record the skip
+   explicitly and continue.
 7. **Delegate to `pbi-migration-validator` FIRST, in triage mode.** This is a change in order from
    the build-era flow, and it is load-bearing: the validator classifies every `viz_fidelity[]` row as
    `fixable` / `accepted-limitation` / `false-claim`, and **both builders consume that
@@ -205,14 +177,16 @@ PBIR files yourself.
    queue), the emitted model path, the active contract (parser specs carry table-calc addressing in
    `worksheets[].encodings`; engine bundles may require handover/context), and the validator's
    model-side findings. Its job is to prove the model loads, author the residual DAX, enrich for AI,
-   and hand back **refreshed and saved**.
+   and hand back **refreshed and saved**. AI enrichment is per-model and happens **before** that
+   sealing refresh; do not defer it to an estate-wide pass after earlier models have been cached.
    - It must land approvals through `--approved-dax`, never by hand-editing `_Measures.tmdl`.
    - **The landing re-run is a BARRIER**: it deletes and recreates the whole bundle, so it must
      happen before any report work begins. Do not run report and model fixes concurrently against one
      bundle.
 9. **Delegate to `pbi-report-builder`** — only AFTER step 8's landing re-run has finished, because
-   that re-run recreates the `.Report` folder and would destroy its work. **Spec+handoff gates (both
-   exit 0):** `python scripts/validate_spec.py <spec>`; `python scripts/check_migration_progress.py
+   that re-run recreates the `.Report` folder and would destroy its work. **Gates:** on parser-path
+   migrations, `python scripts/validate_spec.py <spec>` exits 0; on engine-bundle-only handoff, there
+   may be no spec, so do not fabricate one. Always run `python scripts/check_migration_progress.py
    --bundle <bundle> --handoff`. Exit 1 means
    a model has no `cache.abf`, or one **older** than its TMDL — the report builder would open an
    EMPTY model and trigger its own refresh (minutes, plus a credential prompt on a live source).
@@ -222,11 +196,13 @@ PBIR files yourself.
    the reference bundle. Its edits must land as re-runnable `_build/fix_*.py` scripts run through
    `python scripts/declare_generated_edit.py` (one `--target` per run, from the engine baseline), not
    bundle-only or undeclared edits.
-10. **Delegate to `pbi-migration-validator` again — full sign-off mode**, on a FRESH invocation. First
-   rerun `python scripts/validate_spec.py <spec>`; block on failure. It sees the artifacts, the
-   reference bundle and the triage classifications, but **not the builders' rationale** — and it is
-   told the classifications are **claims to verify, not settled facts**, including the ones an earlier
-   instance of itself produced. A reviewer given the reasoning tends to accept it. Prefer a
+10. **Delegate to `pbi-migration-validator` again — full sign-off mode**, on a FRESH invocation.
+   Rerun `python scripts/validate_spec.py <spec>` only when a parser-path spec exists; for an
+   engine-only bundle, say that gate is not applicable and use `check_unit.py --scope all` plus the
+   handover. It sees the artifacts, the reference bundle and the triage classifications, but **not
+   the builders' rationale** — and it is told the classifications are **claims to verify, not settled
+   facts**, including the ones an earlier instance of itself produced. A reviewer given the reasoning
+   tends to accept it. Prefer a
    multi-model cross-check here (2-3 models in parallel); a discrepancy every model raises is
    high-confidence.
 11. **Route every discrepancy the validator reports back to its owning subagent** — numeric/DAX issues
@@ -261,23 +237,11 @@ PBIR files yourself.
       each subagent reports what it authored versus what the engine did. Read those first: *where the
       time actually went* is a fact, and "what did we learn" written from recollection is how this
       repo has produced conclusions it later had to retract.
-    - **Route each learning to its home** — craft belongs in the skills, not back in a persona, which
-      is what keeps personas under budget and the knowledge portable:
-
-      | learning about | goes to |
-      |---|---|
-      | Every agent | `AGENTS.md` conventions block → then `sync_agent_conventions.py` |
-      | PBIR / visual / Desktop craft | `powerbi-report-gotchas` |
-      | TMDL / DAX / modeling craft | `powerbi-semantic-model-gotchas` |
-      | Refresh / AI readiness | `pbip-model-refresh` / `powerbi-ai-readiness` |
-      | Orchestration or cross-agent process | this persona's `## Gotchas` |
-      | Tableau formula → DAX | `docs/tableau-dax-translation-guide.md` |
-      | A visual encoding that renders | `.github/pbi.kb/visual-cookbook.md` + `visuals/` |
-      | Parser/tooling behaviour | the script itself **plus a regression test** |
-      | Upstream engine behaviour | fresh empty-output run first; then upstream issue + credential-free reproducer |
-
-      If you edit a bundle that is also published, re-run `scripts/build_plugin.py` or preflight flags
-      the drift.
+    - **Route each learning to its home.** Craft belongs in skills/docs/tests, not back in a persona;
+      `docs/INDEX.md#retrospective-targets` owns the destination table. If you edit a published skill
+      bundle, re-run `scripts/build_plugin.py` or preflight flags the drift. The index covers
+      `sync_agent_conventions.py`, `visual-cookbook.md`, and the other targets; keep the
+      **30,000-char** prompt cap by aiming for **net-zero growth**.
     - **Pay for what you add.** GitHub documents a **30,000-char** cap per agent prompt (a hosted run
       may truncate past it). A retrospective is **curation, not accumulation**: merge duplicates,
       delete what a newer tool now catches automatically, generalise two cases into one rule. Aim for
@@ -289,7 +253,8 @@ PBIR files yourself.
       "Nothing worth recording" is a legitimate outcome — say it plainly rather than inventing one.
 15. **Final gate — prove nothing was built behind the credential stop.** For any migration with a live
     source, run `python scripts/credential_gate.py verify <bundle>` — the **`<bundle>`** you passed to
-    `--bundle` in steps 6/6b, where the audit history lives (parser path: migration/spec dir) — and
+    `--bundle` in step 6's reachability commands, where the audit history lives (parser path:
+    migration/spec dir) — and
     paste the verdict. Exit 1 = artifacts exist while the gate was applied, or the override was forged:
     **unvalidated, must not ship**. ⚠️ **Never run `verify` at the ship destination
     `migrations/{workbooks,datasources}/<slug>/fabric/`**: that copy has no `.credential-gate-audit.log`,

--- a/.github/skills/live-source-reachability/SKILL.md
+++ b/.github/skills/live-source-reachability/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: live-source-reachability
+description: Prove a Tableau migration's live database sources are reachable through the Power BI artifact that will ship, and route credential-gate verdicts. Use before building any workbook/datasource that has live sources, when probe_bundle/probe_live_source returns DATA_OK, OPERATOR_REQUIRED, NO_CREDENTIAL, UNREACHABLE, ERROR, or SKIPPED, or when a credential-gate audit/verify decision is needed.
+---
+
+# Live-source reachability and credential-gate routing
+
+Use this before any builder starts on a workbook/datasource with live database sources. The invariant
+is simple: prove the **Power BI artifact you will ship** can reach the source; a Python, SQL client or
+Tableau-only proof does not exercise Power BI Desktop's credential store.
+
+The full lifecycle and audit semantics live in
+[`../../../docs/credential-gate.md`](../../../docs/credential-gate.md). This skill is the compact
+execution route a migrator should invoke instead of carrying the mechanics inline.
+
+## Run order
+
+1. **Classify and arm without opening sockets.**
+
+   ```powershell
+   python scripts\preflight_source_credentials.py --spec <spec>
+   python scripts\preflight_source_credentials.py --bundle <engine-bundle>
+   ```
+
+   Use the form that matches the active contract. Any live database source requires the proof below.
+
+2. **Check the emitted artifact first.**
+
+   ```powershell
+   python scripts\probe_bundle.py <bundle> --check-only --spec <spec>
+   ```
+
+   Non-zero here outranks a later live probe: the model you plan to ship cannot refresh as emitted.
+   Route `M_PARAM_UNDEFINED`, `SOURCE_COLLAPSED`, missing parameter, or missing endpoint evidence to
+   the owner before probing live. On a parser-path migration with no bundle yet, continue to step 3.
+
+3. **Probe through Power BI Desktop.**
+
+   ```powershell
+   python scripts\probe_live_source.py --spec <spec>
+   python scripts\probe_live_source.py --bundle <engine-bundle>
+   ```
+
+   The probe builds a one-table PBIP sandbox, refreshes in Desktop, requires a row back for ordinary
+   tables, records any earned `probe-cleared` audit entry, and refuses to fabricate missing
+   table/column evidence.
+
+## Verdict routing
+
+| Verdict | Meaning | Action |
+|---|---|---|
+| `DATA_OK` | Power BI returned a real row; the probe earns the clear itself. | Continue. |
+| `OPERATOR_REQUIRED` | Custom SQL/cost/modal risk needs a human Desktop refresh. | Hard stop; do not accept SQL-client proof. |
+| `NO_CREDENTIAL` | Power BI lacks or rejects a credential. | Hard stop after one attempt; ask for Desktop sign-in or human build-only authorization. |
+| `UNREACHABLE` | Address/network/spec failure, not a credential wall. | Report the bad address/path; do not send the user to sign in. |
+| `ERROR` | Local tooling/artifact evidence failure. | Stop; fix/reroute the artifact evidence before retrying. |
+| `SKIPPED` | No live source exists. | Record the skip and continue. |
+
+## Rules that prevent false greens
+
+- A credential/sign-in/permission refusal is final after **one** attempt. Retrying does not create a
+  credential.
+- `probe_bundle.py` checks the artifact you ship; `probe_live_source.py` checks a reconstructed
+  one-table probe model. If they disagree, believe the shipped-artifact check.
+- Never clear the gate by hand. `credential_gate.py clear` earns nothing; only a probe-earned
+  `probe-cleared` line or a human `authorize` produces an auditable state.
+- Finish by verifying the same bundle/dir whose audit log was armed:
+
+  ```powershell
+  python scripts\credential_gate.py verify <bundle-or-migration-dir>
+  ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -383,27 +383,30 @@ replace the blunt "never mid-migration" it used to read:
 | Re-running a unit with **substantial hand-authored TMDL/PBIR** on top | ⛔ finish or checkpoint that unit first | **either** diff is large |
 | **Partial** re-run into an **existing** bundle (some workbooks, not all) | ⛔ **never** | `write_engine_receipt` stamps one `engine.version` over the whole bundle, so it would claim a single version for artifacts two builds produced — the #107 shape, and `check_engine_receipts.py` cannot see an intra-bundle mix |
 
-⚠️ **`reports/` is the REPORT baseline only, and a workbook bundle has NO model baseline at all.**
+⚠️ **`reports/` is the REPORT baseline only, and a workbook bundle may have NO paired model baseline.**
 The `reports/`-vs-`pbip/` diff is therefore structurally blind to hand-authored TMDL — measured,
 `reports/` holds **0** `.tmdl` files — so an agent that authored DAX, relationships, RLS or AI
 metadata but left the report alone sees an ~empty diff, reads row 2's "nothing hand-made is lost",
 re-runs, and loses all of it. That is exactly what `pbi-semantic-builder` produces, so it is a
 first-class case, not an edge one.
 
-⚠️ **Do NOT reach for `<bundle>/semantic_models/<WB>.SemanticModel` as the missing baseline.** It is
-not emitted for workbook migrations — measured on a fresh 2.339.0 run, the bundle contains only
-`data`, `handover`, `pbip`, `reports`. That tree is for models **not owned by a single workbook**
+⚠️ **Do NOT reach for `<bundle>/semantic_models/<WB>.SemanticModel` as the missing baseline.** That
+tree is keyed by model, not workbook, and is emitted for models **not owned by a single workbook**
 (published/shared datasources; `bundle_corpus.py:33` — "datasource-only migrations can legitimately
-ship a standalone model there"). And the miss is silent: `git diff --no-index` exits **1** for
+ship a standalone model there"), not as a guaranteed workbook-model pair. The miss is silent:
+`git diff --no-index` exits **1** for
 *"could not access"* exactly as it does for *"they differ"*, so a missing baseline reads as
-"large diff — do not re-run". See #359.
+"large diff — do not re-run". If there is no counterpart, record **BASELINE UNAVAILABLE**, never a
+clean/no-change diff. See #359.
 
 **What actually answers the question, verified:** compare the OLD bundle against a FRESH run of the
-new engine, model to model —
+new engine, model to model — or, when a standalone/shared model counterpart exists, compare by
+`<Model>` name, not `<WB>` name:
 
 ```
-git diff --no-index --stat <bundle>/reports/<WB>.Report               <bundle>/pbip/<WB>/<WB>.Report
-git diff --no-index --stat <old-bundle>/pbip/<WB>/<WB>.SemanticModel  <new-bundle>/pbip/<WB>/<WB>.SemanticModel
+git diff --no-index --stat <bundle>/reports/<WB>.Report                       <bundle>/pbip/<WB>/<WB>.Report
+git diff --no-index --stat <bundle>/semantic_models/<Model>.SemanticModel     <bundle>/pbip/<WB>/<Model>.SemanticModel
+git diff --no-index --stat <old-bundle>/pbip/<WB>/<Model>.SemanticModel       <new-bundle>/pbip/<WB>/<Model>.SemanticModel
 ```
 
 Measured 2.208.0 vs 2.339.0 on Superstore: `13 files changed, 488 insertions(+), 169 deletions(-)`,
@@ -546,6 +549,33 @@ overstated (issue #194). Do not quietly drop this, and do not inflate it.
 > section: the day-before checklist, expected timings, the failure playbook (the `estate_survey.py`
 > site-wide silent sweep, the `exit 3` DoD gate, the storage-decision/union skip), the verification
 > checklist and — importantly — what that checklist does **not** prove.
+
+### Migration cost attribution
+
+Every migrated workbook or datasource **must have its own** `_runs/<NNN>-<slug>/run.json` before
+agentic work starts. Record attribution at dispatch/allocation time, not at completion: a crash after
+spend but before stamping the root makes the spend permanently unattributable.
+
+A dedicated Copilot **session** per migration unit is the reliable attribution anchor; record its
+`session_id` in `run.json` and do **not** mix unrelated questions or other units into that session. If
+unrelated work happens anyway, flag the run as polluted in `run.json`; it remains visible but must not
+be silently averaged into customer budget estimates.
+
+A dispatched `@tableau-migrator` root `agent_id` may be recorded as an additional label under
+`attribution.roots[]`, but it captures only that agent's own calls, never its descendants.
+`parent_tool_call_id` is the agent's own spawning tool call, not a parent-agent id, and no table
+available in one store maps that tool-call id back to its issuing agent (`assistant_usage_events` is
+local-only; `tool_requests` is cloud-only). So a subtree walk is not reconstructible and spend cannot
+be rolled up: issue #364's original premise was right after all, and the session is the only bucket
+that contains a dispatched agent and all of its child agents.
+
+A session with no `run.json` is development work for cost-reporting purposes and is excluded.
+Retroactive attribution is impossible: old units migrated without a dispatch/allocation anchor cannot
+be backfilled honestly.
+
+Report **both** model time and elapsed time. They can differ by a large factor because tool execution
+(dependency sync, Desktop work, test suites, file operations) consumes elapsed time outside model
+calls. A customer estimate that quotes only one is misleading.
 
 ### Gate B — after parse + probe, before building
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -7,11 +7,37 @@ Map of maps for agent-facing knowledge. Start here, then open the matching index
 1. `python scripts/check_unit.py <unit-or-bundle> --scope <model|report|integration|all>` — first status and final gate; direct `check_*.py` gates only isolate one finding.
 2. `python scripts/read_handover.py <bundle> --workbook <name>` — residual work queue and engine-block reason.
 3. `python scripts/credential_gate.py list <estate-root>` — which units are gated, across a whole estate (`--json` for an agent). Exit 1 = still blocked, so it is the resume signal after a human signs in. A credential caches machine-wide, so re-probe the blocked units to earn a `probe-cleared`; never mass-`authorize`, which stamps a build UNVALIDATED permanently. Detail: [`docs/credential-gate.md`](credential-gate.md).
-4. Load the layer gotchas skill before editing: `powerbi-semantic-model-gotchas` for TMDL/DAX, `powerbi-report-gotchas` for PBIR/visuals, `pbip-model-refresh` for cache/refresh, `powerbi-ai-readiness` for Copilot/Q&A metadata.
+4. Load the right skill before acting: `live-source-reachability` for live-source proof and
+   credential-gate routing, `powerbi-semantic-model-gotchas` for TMDL/DAX,
+   `powerbi-report-gotchas` for PBIR/visuals, `pbip-model-refresh` for cache/refresh, and
+   `powerbi-ai-readiness` for Copilot/Q&A metadata.
 
 After a machine-wide Power BI sign-in, resume every still-blocked unit at once with `python scripts/reprobe_blocked.py` (dry-run by default; `--apply` to run). It re-probes each BLOCKED credential-gate unit and lets the gate earn its own `probe-cleared` where the probe now passes — it **never authorizes**, so it is the agent-safe counterpart to the human-only `credential_gate.py authorize`.
 
 Toolkit-maintenance scripts live in `scripts/README.md`, outside the per-unit route.
+
+## Retrospective targets
+
+At the end of a migration, route durable learnings to the smallest permanent home that will be read
+next time. Craft belongs in skills/docs/tests, not back in a persona unless the learning is
+orchestration-specific.
+
+| Learning about | Put it here |
+|---|---|
+| Every agent | `AGENTS.md` conventions block, then run `scripts/sync_agent_conventions.py` |
+| Live-source reachability / credential gates | `.github/skills/live-source-reachability/SKILL.md` or `docs/credential-gate.md` |
+| PBIR / visual / Desktop craft | `.github/skills/powerbi-report-gotchas/SKILL.md` |
+| TMDL / DAX / modeling craft | `.github/skills/powerbi-semantic-model-gotchas/SKILL.md` |
+| Refresh / cache or AI readiness | `.github/skills/pbip-model-refresh/SKILL.md` / `.github/skills/powerbi-ai-readiness/SKILL.md` |
+| Orchestration or cross-agent process | `.github/agents/tableau-migrator.agent.md` `## Gotchas` |
+| Tableau formula → DAX | `docs/tableau-dax-translation-guide.md` |
+| A visual encoding that renders | `.github/pbi.kb/visual-cookbook.md` + `.github/pbi.kb/visuals/` |
+| Parser/tooling behaviour | the script itself plus a regression test |
+| Upstream engine behaviour | fresh empty-output run first; then upstream issue + credential-free reproducer |
+
+If you edit a skill bundle that is also published, re-run `scripts/build_plugin.py` or preflight flags
+the drift. If a learning is one-off or already caught by a gate, say "nothing worth recording" rather
+than inventing durable knowledge.
 
 ## Inclusion rule
 
@@ -198,6 +224,7 @@ migrations/workbooks/README.md
 Reason: `AGENTS.md` indexes repo-local skills; the start-here block names when to invoke the per-layer skills.
 Base: ``
 ```text
+.github/skills/live-source-reachability/SKILL.md
 .github/skills/pbip-model-refresh/SKILL.md
 .github/skills/powerbi-ai-readiness/SKILL.md
 .github/skills/powerbi-report-gotchas/SKILL.md


### PR DESCRIPTION
Closes **#178** and **#179**, and carries point 1 of **#312**.

## #179 — a bundle layout documented as guaranteed that is not

`<bundle>/semantic_models/` was documented as guaranteed in `AGENTS.md`, the runbook and all four personas. It is **keyed by model, not by workbook**, and is not emitted as a guaranteed workbook-model pair.

This had already caused a real defect (#359, fixed in #360): a documented `git diff` command pointed at `<bundle>/semantic_models/<WB>.SemanticModel`, and `git diff --no-index` exits **1** for *"could not access"* exactly as for *"they differ"* — so a missing baseline read as *"large diff, do not re-run"*.

Adds **`BASELINE UNAVAILABLE`** as an explicit third state, so a missing counterpart is recorded rather than mistaken for a clean diff.

## #178 — six agent-instruction defects

All six fixed, none silently omitted — including the persona-documented "primary" DAX-validation path that **cannot execute DAX**.

## #312 point 1 — a false-green signal two personas cited as authoritative

`openability_selfcheck.ok` is `true` on **46 of 61** defective workbooks, `issues[]` empty on 60 of 61, and its `checks` map silently omits checks that did not run. Both persona citations now describe it as what it is: a narrow structural self-check whose map is **not exhaustive**.

Points 2–3 remain open — they need re-measuring against engine bundles that no longer exist on this machine, and the numbers came from engines 2.126–2.208 while we now run 2.339.0. **#312 stays open** deliberately; the commit uses a plain reference, not a closing keyword.

## Persona headroom bought back

`tableau-migrator.agent.md` was at **29,782 / 30,000 (99.3%)** — 218 characters from failing CI. Now **26,472 (88.2%)**.

- **Step 6's live-source mechanics** → new `.github/skills/live-source-reachability/` bundle. The **rule** stays inline: *"MANDATORY before building — never skip"* and *"final after one attempt — missing credentials are not transient"*.
- **Step 14's retrospective targets** → `docs/INDEX.md`. The obligation stays inline.
- **`## Gotchas` untouched** — byte-identical. Absence there is silent and harmful.

The reviewer accounted for **every one of the 39 deleted lines**: each lands in the bundle, in `docs/credential-gate.md`, or is still delivered at the point of use by the tools themselves. **No content loss.**

## A correction I introduced and a reviewer caught

I told this agent that agent-subtree cost attribution was "proven, measured live: 0 of 33,509 candidate links". **That statistic was a tautology** — my query filtered to rows where the parent id was already an agent id, then reported none differed. The blind reviewer caught it, and found the store's shape had *changed on 2026-08-21*: self-links stopped, and 6,528 rows since carry a distinct spawn handle.

The prose is now mechanism-only, and the reviewer verified it independently: `assistant_usage_events` is local-only, `tool_requests` is cloud-only, so the join cannot be made — and five live handles resolve to **0 rows** cross-store, making the claim conservative rather than overstated. The shape moved **again** during review (119 → 124 distinct parents, now including a `call_`-prefixed id), which is exactly why the number was deleted rather than restated.

A stale model-time figure was dropped for the same reason: it was a mid-wave snapshot presented as a total, already off by 2× within six hours.

## Gates
`sync_agent_conventions --check` exit 0 · generated block byte-identical across all four personas · `pylint scripts` **10.00/10 exit 0** · `pytest -k "not upstream_repro_pins"` exit 0, **2173 passed** · all four personas under cap.
