### PR TITLE
Fixes #378: make the workshop-/engagement-/customer- privacy prefixes fire at depth 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,22 +12,43 @@ build/
 # (Learned the hard way: a workshop plan and a prerequisites email were committed and pushed before
 # anyone noticed the repo was public.)
 #
-# `**/` not `/migrations/`: these three were root-anchored at DEPTH 1 (`/migrations/customer-*/`),
-# but the user trees are two levels deep (`migrations/workbooks/<slug>/`,
-# `migrations/datasources/<slug>/`), so prefixing a slug - the documented opt-out for a migration
-# that must stay local - matched NOTHING and tracked the whole unit, `fabric/**` (TMDL partitions
-# with server/database names, M queries, PBIR) and `migration-spec.json` included. Measured before
-# the fix: `migrations/customer-foo/...` IGNORED, `migrations/workbooks/customer-foo/...` NOT
-# IGNORED (issue #378). The identical trap is written up four lines below for `migration-brief.md`;
-# it was fixed there and not generalised to its own neighbours. `**/` matches at every depth, so it
-# subsumes the old depth-1 rules rather than sitting beside them.
+# TWO anchored rules per prefix, covering the two SLUG positions - and nothing else.
 #
-# The trailing `/` is load-bearing: these ignore DIRECTORIES only. Dropping it would also swallow
-# tracked files whose NAME starts with a prefix - `docs/customer-text-exposure.md` is exactly that.
-# Pinned by tests/test_gitignore_privacy_prefixes.py.
-**/workshop-*/
-**/engagement-*/
-**/customer-*/
+# Depth-1 alone was the original bug (#378): the trees AGENTS.md instructs are two levels deep
+# (`migrations/workbooks/<slug>/`, `migrations/datasources/<slug>/`), so prefixing a slug - the
+# documented opt-out for a migration that must stay local - matched NOTHING and tracked the whole
+# unit, `fabric/**` (TMDL partitions with server/database names, M queries, PBIR) and
+# `migration-spec.json` included. Measured: `migrations/customer-foo/...` IGNORED,
+# `migrations/workbooks/customer-foo/...` NOT IGNORED.
+#
+# `**/<prefix>-*/` fixes that and OVERSHOOTS, which is why it is not used here. `**/` matches at
+# every depth, including inside a deliverable that is tracked on purpose. Measured on the first
+# attempt at this fix: an ORDINARY, unprefixed slug whose Fabric artifact is named after the source
+# workbook silently lost the subtree -
+#   migrations/workbooks/shipping-kpis/fabric/customer-insights.SemanticModel/... -> IGNORED
+# and a Tableau workbook called "Customer Insights" produces exactly that name. Silent, because an
+# ignored subtree never enters the index, so no sweep over tracked files can ever see it.
+#
+# `*` cannot span `/`, so `/migrations/*/<prefix>-*/` reaches the slug position and stops there.
+# The tree segment is a WILDCARD rather than an enumerated `workbooks|datasources`: a fixed shape
+# that silently stops matching when the layout gains a level is the exact failure this file has now
+# had three times (#378 here, and the `_harvest` / `_sweep` prefix globs below, both citing #125).
+# A third tree is covered on the day it is created, not on the day someone remembers this file.
+#
+# The trailing `/` is load-bearing too: these match DIRECTORIES only, so a FILE whose name starts
+# with a prefix stays tracked - `migrations/workbooks/customer-notes.md` is not swallowed by
+# `/migrations/*/customer-*`. That the hazard is real is on the record one directory over:
+# `docs/customer-text-exposure.md` IS a tracked `customer-*` file, and the earlier unanchored
+# `**/customer-*` draft of this rule matched it (measured, exit 0). The anchor now keeps `docs/` out
+# of reach, so the slash is what protects the migration trees themselves.
+#
+# All of the above is pinned behaviourally by tests/test_gitignore_privacy_prefixes.py.
+/migrations/workshop-*/
+/migrations/*/workshop-*/
+/migrations/engagement-*/
+/migrations/*/engagement-*/
+/migrations/customer-*/
+/migrations/*/customer-*/
 # `**/` not `/migrations/*/`: the depth-1 rule did NOT cover the path AGENTS.md actually instructs -
 # `migrations/workbooks/<slug>/migration-brief.md` is two levels deep, and `git check-ignore` on that
 # exact documented path returned NOT IGNORED. A brief names the customer, their scope, their people

--- a/.gitignore
+++ b/.gitignore
@@ -11,9 +11,23 @@ build/
 # PUBLIC, and such notes are not toolkit content - they belong in the session workspace, never here.
 # (Learned the hard way: a workshop plan and a prerequisites email were committed and pushed before
 # anyone noticed the repo was public.)
-/migrations/workshop-*/
-/migrations/engagement-*/
-/migrations/customer-*/
+#
+# `**/` not `/migrations/`: these three were root-anchored at DEPTH 1 (`/migrations/customer-*/`),
+# but the user trees are two levels deep (`migrations/workbooks/<slug>/`,
+# `migrations/datasources/<slug>/`), so prefixing a slug - the documented opt-out for a migration
+# that must stay local - matched NOTHING and tracked the whole unit, `fabric/**` (TMDL partitions
+# with server/database names, M queries, PBIR) and `migration-spec.json` included. Measured before
+# the fix: `migrations/customer-foo/...` IGNORED, `migrations/workbooks/customer-foo/...` NOT
+# IGNORED (issue #378). The identical trap is written up four lines below for `migration-brief.md`;
+# it was fixed there and not generalised to its own neighbours. `**/` matches at every depth, so it
+# subsumes the old depth-1 rules rather than sitting beside them.
+#
+# The trailing `/` is load-bearing: these ignore DIRECTORIES only. Dropping it would also swallow
+# tracked files whose NAME starts with a prefix - `docs/customer-text-exposure.md` is exactly that.
+# Pinned by tests/test_gitignore_privacy_prefixes.py.
+**/workshop-*/
+**/engagement-*/
+**/customer-*/
 # `**/` not `/migrations/*/`: the depth-1 rule did NOT cover the path AGENTS.md actually instructs -
 # `migrations/workbooks/<slug>/migration-brief.md` is two levels deep, and `git check-ignore` on that
 # exact documented path returned NOT IGNORED. A brief names the customer, their scope, their people

--- a/tests/test_gitignore_privacy_prefixes.py
+++ b/tests/test_gitignore_privacy_prefixes.py
@@ -12,6 +12,13 @@ The same class of bug had already been found, written up and fixed for `migratio
 lines below in the same file, and was not generalised to its own neighbours. That is why this suite
 exists: it pins the behaviour rather than the prose.
 
+The first attempt at the fix used `**/<prefix>-*/`, which matches at EVERY depth and so reached
+inside deliverables that are tracked on purpose: an ordinary, unprefixed slug whose Fabric artifact
+is named after the source workbook - `fabric/customer-insights.SemanticModel/`, from a Tableau
+workbook called "Customer Insights" - silently lost the subtree. `test_nested_fabric_artifact_*`
+below pins that, and it is the test that could not be written as a sweep over tracked files: an
+ignored subtree never enters the index, so `git ls-files` can never offer it as input.
+
 Everything here is judged by `git check-ignore`'s EXIT CODE (0 = ignored, 1 = not ignored). That
 command prints nothing under `-q`, so a truthiness test on its stdout silently reads every path as
 "not ignored" - a mistake already made once against this very file.
@@ -107,25 +114,89 @@ def test_unprefixed_slug_stays_tracked(tree: str, payload: str) -> None:
     )
 
 
+#: Fabric artifacts are named after the SOURCE WORKBOOK, so a prefix word can legitimately appear
+#: deep inside a deliverable that is tracked on purpose. A Tableau workbook called "Customer
+#: Insights" produces `customer-insights.SemanticModel`; these are not contrived names.
+NESTED_ARTIFACTS = (
+    "fabric/customer-insights.SemanticModel/definition/model.tmdl",
+    "fabric/workshop-summary.Report/definition/report.json",
+    "fabric/engagement-metrics.SemanticModel/definition/tables/Sales.tmdl",
+    # The prefix word can also appear below the artifact root.
+    "fabric/Acme.Report/definition/pages/customer-overview/page.json",
+)
+
+
+@pytest.mark.parametrize("tree", USER_TREES)
+@pytest.mark.parametrize("artifact", NESTED_ARTIFACTS)
+def test_nested_fabric_artifact_named_after_the_workbook_stays_tracked(tree: str, artifact: str) -> None:
+    """The privacy prefixes are reserved in the SLUG position only - not at arbitrary depth.
+
+    An unanchored `**/customer-*/` also matches inside a deliverable, so an ordinary, unprefixed
+    migration whose Fabric artifact happens to be named after a "Customer ..." workbook silently
+    lost that subtree. The failure is invisible to `test_no_tracked_file_is_matched_by_an_exclude_
+    rule`: an ignored subtree never enters the index, so `git ls-files` can never offer it as
+    input. Only a constructed path can catch it, which is what this test is.
+    """
+    path = f"{tree}/shipping-kpis/{artifact}"
+    assert not _is_ignored(path), (
+        f"{path} is ignored - an ordinary slug's deliverable must stay tracked. "
+        f"The prefixes are reserved for the slug position, not every depth. "
+        f"Matched: {_matching_rule(path)}"
+    )
+
+
+@pytest.mark.parametrize("prefix", PRIVACY_PREFIXES)
+def test_prefix_rules_do_not_reach_below_the_slug_position(prefix: str) -> None:
+    """The complement of the test above, stated as the rule shape rather than as example names.
+
+    `*` cannot span `/`, so `/migrations/*/<prefix>-*/` stops at the slug. Anything deeper than the
+    slug is deliverable territory. Guarding both directions is what makes a revert to `**/` fail
+    here rather than merely change behaviour quietly.
+    """
+    slug_position = f"migrations/workbooks/{prefix}acme/fabric/x.tmdl"
+    below_the_slug = f"migrations/workbooks/ordinary/fabric/{prefix}thing.SemanticModel/x.tmdl"
+    assert _is_ignored(slug_position), f"PRIVACY LEAK: {slug_position} is NOT ignored"
+    assert not _is_ignored(below_the_slug), (
+        f"{below_the_slug} is ignored - the rule reaches past the slug position. "
+        f"Matched: {_matching_rule(below_the_slug)}"
+    )
+
+
 def test_prefix_rules_match_directories_only() -> None:
     """The trailing `/` is load-bearing: a FILE whose name starts with a prefix stays tracked.
 
-    `docs/customer-text-exposure.md` is a real committed doc. Dropping the trailing slash from
-    `**/customer-*/` would start matching it (and any future `customer-*.md`), which is how a
-    privacy fix turns into a silent un-tracking of toolkit content.
+    Two independent cases, and they are no longer the same case:
+
+    * `migrations/workbooks/customer-notes.md` is what the ANCHORED rules would swallow if the
+      slash were dropped, and is therefore the live guard.
+    * `docs/customer-text-exposure.md` is a real committed doc and is out of the anchored rules'
+      reach, but it is the measured evidence that the hazard is not theoretical - the earlier
+      unanchored `**/customer-*` draft matched it (exit 0). Kept as a standing check that no future
+      widening puts `docs/` back in range.
     """
     tracked_doc = "docs/customer-text-exposure.md"
     assert (REPO_ROOT / tracked_doc).is_file(), f"{tracked_doc} moved - re-pick a tracked customer-* FILE"
     assert not _is_ignored(tracked_doc), f"{tracked_doc} is ignored. Matched: {_matching_rule(tracked_doc)}"
-    assert not _is_ignored("migrations/workbooks/customer-notes.md")
+    assert not _is_ignored("migrations/workbooks/customer-notes.md"), (
+        "a FILE named customer-* inside a migration tree became ignored - the rules are "
+        "directory-only by design. Matched: "
+        f"{_matching_rule('migrations/workbooks/customer-notes.md')}"
+    )
 
 
 def test_no_tracked_file_is_matched_by_an_exclude_rule() -> None:
-    """Nothing already committed may become ignored - the regression this whole change risks.
+    """Nothing already committed may become ignored - one half of the regression risk.
 
     Sweeps every tracked path through `check-ignore --no-index` in one batch. NUL-separated so a
     path with a space or a newline cannot corrupt the comparison. Exit 1 means "no path matched",
     which is the passing state.
+
+    ⚠️ Read its scope honestly: this gate protects what is ALREADY TRACKED and is structurally
+    blind to the opposite failure - a rule broad enough to stop an artifact from EVER being
+    tracked. Such a subtree never enters the index, so `git ls-files` can never offer it here. That
+    is exactly how the unanchored `**/` draft shipped a green sweep while silently suppressing
+    `fabric/customer-insights.SemanticModel/`. The constructed-path tests above are the other half;
+    neither is sufficient alone.
     """
     tracked = subprocess.run(
         ["git", "ls-files", "-z"],

--- a/tests/test_gitignore_privacy_prefixes.py
+++ b/tests/test_gitignore_privacy_prefixes.py
@@ -1,0 +1,168 @@
+"""Behavioural regression tests for the `workshop-`/`engagement-`/`customer-` privacy prefixes.
+
+THIS REPOSITORY IS PUBLIC. The three prefixes are the documented opt-out an operator uses to keep a
+real customer migration on their own disk: prefix the slug, and the whole unit stays untracked. That
+opt-out was broken. The rules were root-anchored at DEPTH 1 (`/migrations/customer-*/`) while the
+trees `AGENTS.md` instructs are DEPTH 2 (`migrations/workbooks/<slug>/`,
+`migrations/datasources/<slug>/`), so a prefixed slug matched nothing and the entire unit was
+tracked - `fabric/**` (TMDL partitions carrying server and database names, M queries, PBIR) and
+`migration-spec.json` included (issue #378).
+
+The same class of bug had already been found, written up and fixed for `migration-brief.md` four
+lines below in the same file, and was not generalised to its own neighbours. That is why this suite
+exists: it pins the behaviour rather than the prose.
+
+Everything here is judged by `git check-ignore`'s EXIT CODE (0 = ignored, 1 = not ignored). That
+command prints nothing under `-q`, so a truthiness test on its stdout silently reads every path as
+"not ignored" - a mistake already made once against this very file.
+"""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+#: The two user trees `AGENTS.md` instructs operators to create. Both are one level deeper than the
+#: original depth-1 rules assumed, which is the whole defect.
+USER_TREES = ("migrations/workbooks", "migrations/datasources")
+
+PRIVACY_PREFIXES = ("workshop-", "engagement-", "customer-")
+
+#: Deliberately TRACKED payloads for an unprefixed slug - the interaction that makes this fix hard.
+#: Widening the prefix rules must not swallow these, or the worked examples disappear.
+DELIVERABLES = (
+    "fabric/Acme.SemanticModel/definition/tables/Sales.tmdl",
+    "fabric/Acme.Report/definition/report.json",
+    "migration-spec.json",
+)
+
+
+def _is_ignored(path: str) -> bool:
+    """True when git's exclude rules match `path`. Judged by exit code, never by stdout.
+
+    `--no-index` is deliberate. `git check-ignore` consults the index by default and reports an
+    already-TRACKED path as not-ignored whatever the patterns say. Measured on a throwaway repo
+    whose `.gitignore` is just `customer-*/`, with `customer-acme/x.tmdl` committed: default
+    `check-ignore -q` exits **1** (not ignored), `--no-index` exits **0** (ignored). Without the
+    flag, `test_no_tracked_file_is_matched_by_an_exclude_rule` below could not fail even if a rule
+    started matching a committed deliverable - it would be masked by the very tracking it exists to
+    protect.
+    """
+    result = subprocess.run(
+        ["git", "check-ignore", "-q", "--no-index", "--", path],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode in (0, 1), f"git check-ignore failed on {path!r}: {result.stderr.strip()}"
+    return result.returncode == 0
+
+
+def _matching_rule(path: str) -> str:
+    """The `.gitignore:<line>:<pattern>` that decided `path`, for failure messages."""
+    result = subprocess.run(
+        ["git", "check-ignore", "-v", "--no-index", "--", path],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.stdout.strip() or "<no rule matched>"
+
+
+@pytest.mark.parametrize("tree", USER_TREES)
+@pytest.mark.parametrize("prefix", PRIVACY_PREFIXES)
+@pytest.mark.parametrize("payload", DELIVERABLES)
+def test_prefixed_slug_is_ignored_in_the_depth_2_user_trees(tree: str, prefix: str, payload: str) -> None:
+    """The defect itself: the documented opt-out must fire at the depth the docs instruct.
+
+    `fabric/**` and `migration-spec.json` are the tracked-on-purpose deliverables, so they are the
+    exact payloads a prefixed unit must take with it when it opts out.
+    """
+    path = f"{tree}/{prefix}acme/{payload}"
+    assert _is_ignored(path), f"PRIVACY LEAK: {path} is NOT ignored on a public repo"
+
+
+@pytest.mark.parametrize("prefix", PRIVACY_PREFIXES)
+def test_prefixed_slug_is_still_ignored_at_depth_1(prefix: str) -> None:
+    """Do not regress what already worked: the old rules matched `migrations/<prefix>*/`."""
+    path = f"migrations/{prefix}acme/fabric/x.tmdl"
+    assert _is_ignored(path), f"PRIVACY REGRESSION: {path} is NOT ignored"
+
+
+@pytest.mark.parametrize("tree", USER_TREES + ("examples",))
+@pytest.mark.parametrize("payload", DELIVERABLES)
+def test_unprefixed_slug_stays_tracked(tree: str, payload: str) -> None:
+    """The other half of the fix, and the half that is easy to break.
+
+    Migration deliverables are tracked ON PURPOSE - that is how the worked examples in `examples/`
+    exist. A prefix rule broad enough to fire at depth 2 must not also swallow an ordinary slug.
+    """
+    path = f"{tree}/shipping-kpis/{payload}"
+    assert not _is_ignored(path), (
+        f"{path} became ignored - migration deliverables are tracked on purpose. Matched: {_matching_rule(path)}"
+    )
+
+
+def test_prefix_rules_match_directories_only() -> None:
+    """The trailing `/` is load-bearing: a FILE whose name starts with a prefix stays tracked.
+
+    `docs/customer-text-exposure.md` is a real committed doc. Dropping the trailing slash from
+    `**/customer-*/` would start matching it (and any future `customer-*.md`), which is how a
+    privacy fix turns into a silent un-tracking of toolkit content.
+    """
+    tracked_doc = "docs/customer-text-exposure.md"
+    assert (REPO_ROOT / tracked_doc).is_file(), f"{tracked_doc} moved - re-pick a tracked customer-* FILE"
+    assert not _is_ignored(tracked_doc), f"{tracked_doc} is ignored. Matched: {_matching_rule(tracked_doc)}"
+    assert not _is_ignored("migrations/workbooks/customer-notes.md")
+
+
+def test_no_tracked_file_is_matched_by_an_exclude_rule() -> None:
+    """Nothing already committed may become ignored - the regression this whole change risks.
+
+    Sweeps every tracked path through `check-ignore --no-index` in one batch. NUL-separated so a
+    path with a space or a newline cannot corrupt the comparison. Exit 1 means "no path matched",
+    which is the passing state.
+    """
+    tracked = subprocess.run(
+        ["git", "ls-files", "-z"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        check=True,
+    )
+    assert tracked.stdout, "git ls-files returned nothing - wrong cwd?"
+
+    swept = subprocess.run(
+        ["git", "check-ignore", "-z", "--stdin", "--no-index"],
+        cwd=REPO_ROOT,
+        input=tracked.stdout,
+        capture_output=True,
+        check=False,
+    )
+    assert swept.returncode in (0, 1), f"git check-ignore failed: {swept.stderr.decode('utf-8', 'replace')}"
+
+    leaked = [p for p in swept.stdout.decode("utf-8", "replace").split("\0") if p]
+    assert swept.returncode == 1 and not leaked, (
+        "these TRACKED files are now matched by an exclude rule, which un-tracks committed "
+        f"content on the next clone: {leaked}"
+    )
+
+
+def test_this_test_file_is_tracked() -> None:
+    """A gate that reads git-tracked state is inert until the gate itself is committed.
+
+    Doubly true here: the subject under test IS the ignore rules, so a self-ignoring test file
+    would pass locally and never run in CI.
+    """
+    assert not _is_ignored("tests/test_gitignore_privacy_prefixes.py")
+    listed = subprocess.run(
+        ["git", "ls-files", "--", "tests/test_gitignore_privacy_prefixes.py"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert listed.stdout.strip(), "this test file is not tracked - `git add` it or CI will never run it"


### PR DESCRIPTION
## The defect

`.gitignore`'s three privacy-prefix rules were root-anchored at **depth 1** while the user
migration trees `AGENTS.md` instructs are **depth 2**, so prefixing a slug — the documented
opt-out for a migration that must stay local — matched nothing and the whole unit stayed
tracked on a **public** repo, `fabric/**` (TMDL partitions carrying server and database
names, M queries, PBIR) and `migration-spec.json` included.

## The diff

```diff
-/migrations/workshop-*/
-/migrations/engagement-*/
-/migrations/customer-*/
+/migrations/workshop-*/
+/migrations/*/workshop-*/
+/migrations/engagement-*/
+/migrations/*/engagement-*/
+/migrations/customer-*/
+/migrations/*/customer-*/
```

Two anchored rules per prefix, covering the two reserved **slug** positions and nothing
below them, plus a comment recording the measurements and
`tests/test_gitignore_privacy_prefixes.py`.

### Why this form

- **Not depth-1 alone** — that is the reported bug.
- **Not unanchored `**/<prefix>-*/`** — that fixes depth-2 and *overshoots*. Blind review
  caught it with a working reproduction: `**/` matches at every depth, including inside a
  deliverable that is tracked on purpose, so an **ordinary, unprefixed** slug whose Fabric
  artifact is named after the source workbook silently lost the subtree —
  `migrations/workbooks/shipping-kpis/fabric/customer-insights.SemanticModel/…` → exit 0,
  attributed to `**/customer-*/`. A Tableau workbook called *"Customer Insights"* produces
  exactly that name.
- **Not depth-2 alone** — regresses depth-1 (mutation D).
- `*` cannot span `/`, so `/migrations/*/<prefix>-*/` reaches the slug and stops there.
- The tree segment is a **wildcard**, not an enumerated `workbooks|datasources`: a fixed
  shape that stops matching when the layout gains a level is the exact failure this file has
  now had three times (this issue, and the `_harvest` / `_sweep` prefix globs citing #125).
  A third tree is covered the day it is created.
- The **trailing `/` is kept** — the rules match directories only, so a file such as
  `migrations/workbooks/customer-notes.md` stays tracked (mutation C).

## Verified by behaviour, judged by exit code

`git check-ignore -q` prints nothing and signals by exit code, so every check reads
`$LASTEXITCODE` / `returncode` — never stdout. `--no-index` is used throughout: git's
default consults the index and reports an already-tracked path as not-ignored whatever the
patterns say (measured on a throwaway repo with `.gitignore` = `customer-*/` and
`customer-acme/x.tmdl` committed — default exits **1**, `--no-index` exits **0**).

**Slug positions → ignored (exit 0), with rule attribution:**

| path | exit | rule |
|---|---|---|
| `migrations/customer-foo/fabric/x.tmdl` | 0 | `:46 /migrations/customer-*/` |
| `migrations/workshop-foo/anything.json` | 0 | `:42 /migrations/workshop-*/` |
| `migrations/engagement-foo/notes.md` | 0 | `:44 /migrations/engagement-*/` |
| `migrations/workbooks/customer-foo/fabric/x.tmdl` | 0 | `:47 /migrations/*/customer-*/` |
| `migrations/workbooks/customer-foo/migration-spec.json` | 0 | `:47 /migrations/*/customer-*/` |
| `migrations/datasources/customer-foo/fabric/x.tmdl` | 0 | `:47 /migrations/*/customer-*/` |
| `migrations/workbooks/engagement-foo/migration-spec.json` | 0 | `:45 /migrations/*/engagement-*/` |
| `migrations/datasources/engagement-foo/fabric/x.tmdl` | 0 | `:45 /migrations/*/engagement-*/` |
| `migrations/workbooks/workshop-foo/fabric/x.tmdl` | 0 | `:43 /migrations/*/workshop-*/` |
| `migrations/datasources/workshop-foo/migration-spec.json` | 0 | `:43 /migrations/*/workshop-*/` |

**Deliverables → tracked (exit 1):**

| path | exit |
|---|---|
| `…/shipping-kpis/fabric/customer-insights.SemanticModel/definition/model.tmdl` | 1 |
| `…/shipping-kpis/fabric/workshop-summary.Report/definition/report.json` | 1 |
| `…/shipping-kpis/fabric/engagement-metrics.SemanticModel/definition/tables/Sales.tmdl` | 1 |
| `migrations/workbooks/ordinary-slug/fabric/x.tmdl` | 1 |
| `migrations/datasources/ordinary-slug/migration-spec.json` | 1 |
| `examples/shipping-kpis/fabric/x.tmdl` | 1 |
| `docs/customer-text-exposure.md` | 1 |

## The sweep, and its blind spot

`git ls-files | git check-ignore --stdin --no-index` → `matched: []`, **exit 1** across all
1874 tracked paths. Kept, and pinned as a test.

But it is **structurally unable** to catch the overshoot class, and the test now says so in
its own docstring: an ignored subtree never enters the index, so `git ls-files` can never
offer it as input. The sweep protects what is *already tracked*; it cannot protect what a
rule prevents from *ever being* tracked. Only constructed paths can — which is what
`test_nested_fabric_artifact_named_after_the_workbook_stays_tracked` and
`test_prefix_rules_do_not_reach_below_the_slug_position` are.

## Mutations — every test proven able to fail, each by a different mutation

| mutation | result |
|---|---|
| unanchored `**/<prefix>-*/` (the overshoot) | **11 failed** — 8 nested-artifact + 3 below-slug |
| depth-1 only (master semantics) | **21 failed** |
| drop the trailing `/` | **1 failed** — directory-only |
| depth-2 only | **3 failed** — depth-1 guard |

Fixed `.gitignore`: **44 passed**, exit 0.

## Gates

| gate | exit |
|---|---|
| `ruff format --check scripts tests .github/skills` | 0 |
| `ruff check scripts tests .github/skills` | 0 |
| `pylint tests/test_gitignore_privacy_prefixes.py` | 0 (10.00/10) |
| `pytest tests/test_gitignore_privacy_prefixes.py` | 0 (44 passed) |
| affected suites (`…_privacy_prefixes`, `repo_layout`, `harvest_output_guard`, `work_dirs`) | 0 (130 passed) |
| full `pytest` | 3 pre-existing failures in `tests/test_upstream_repro_pins.py` — engine-drift tripwires pinned at `2.260.0` against an installed `2.339.0`; they fail identically on `master` |

## One incidental fix, in scope

`tests/test_harvest_output_guard.py` locates the `_harvest` / `_sweep` comment blocks by
splitting `.gitignore` on those rule strings **literally**. Quoting them verbatim in a
comment earlier in the file hijacks the split and fails that test. Reworded my comment to
avoid the literal strings rather than touch a file outside this change; the brittleness
itself is noted for a separate look.

## Scope

`AGENTS.md` documents this convention and is being edited by other work in flight, so it is
untouched here. Its prose says "prefix the slug" without naming a depth, so it stays
accurate — worth a read once the contending change lands.
