### PR TITLE
Enforce the destructive-re-run barrier before the engine runs (fixes #250)

### DIFF
--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -609,8 +609,15 @@ Reference run ✅ verified from `_convert.log`: `bound=23/38 failed=15 warned=20
 > indeterminate state — never a pass. The first cut reported *clean* through five such routes and a
 > reviewer destroyed a sentinel through each at exit 0. **Bundles built before this shipped have no
 > `engine_output_tree`, so their first destructive re-run will need both flags** — that is the
-> intended cost of not being able to prove what is in them. `--slice-only` never runs the engine and
-> is exempt.
+> intended cost of not being able to prove what is in them, and it is **one-time**: that
+> acknowledged run writes the tree, and the next pristine invocation exits 0 again. `--slice-only`
+> never runs the engine and is exempt.
+>
+> ⚠️ **`_build/` inside a `pbip/<project>/` folder DOES trip the barrier — deliberately.** It is
+> this repo's durable replay-script convention (*"every edit re-runnable from `_build/`"*), so it is
+> exactly where an agent's re-runnable work lives, and it sits inside a directory the engine
+> `rmtree`s. A **bundle-root** `<bundle>/_build/` is outside the destructive roots, is never deleted,
+> and is not guarded. The scope is the folder the engine destroys, not the folder name.
 
 What a bundle contains ✅ verified against the reference bundle by listing it, 2026-08-13:
 

--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -559,6 +559,7 @@ and 2/5 reproduced by running the command:
 | `6` | `EXIT_EMPTY_MODEL` | **live** — a model would open and load **zero rows** (an Import partition over a flat file that never landed) | read `<bundle>/empty-model-check.json`; see the block below |
 | `7` | `EXIT_INVALID_PBIR` | **live** ✅ reproduced — a shipped report FAILS the first-party `powerbi-report-author validate` (measured: `PBIR_ROLE_REQUIRED_MISSING` from a stubbed calc whose projection was dropped) | read `<bundle>/pbir-validity-check.json`; **bind the stub**, do not delete the visual |
 | `8` | `EXIT_BLANK_PLACEHOLDER` | **live** ✅ reproduced — a handover-backed `BLANK()` placeholder is consumed by a report filter or visual field binding | read `<bundle>/blank-placeholder-check.json`; translate the calc or remove the consuming report dependency knowingly |
+| `9` | `EXIT_BUNDLE_REWRITE` | **pre-engine refusal** (#250) — the `--output` bundle already holds work an engine re-run would delete, and/or a **different engine version** built it | land into a FRESH `--output`, or acknowledge with `--accept-bundle-rewrite` / `--accept-engine-version-change`; the acknowledgement is written to `<bundle>/bundle-rewrite-acknowledgement.json` |
 
 ❌ **Correction: exits 5 and 6 are NOT "pending branch only"** — the previous edition said so, and
 §5.1 check 10 was written against the same stale assumption. Both shipped 2026-08-13 (#109, #111).
@@ -593,6 +594,15 @@ Reference run ✅ verified from `_convert.log`: `bound=23/38 failed=15 warned=20
 > and the stale-output guard *exempts* that path — so the most destructive re-run is the one that
 > needs no `--force`. **All DAX approvals land in ONE run; per-workbook agent work starts only
 > afterwards.** ✅ verified from `run_estate.py`'s own docstring.
+>
+> ✅ **This is now ENFORCED, not just documented** (#250). `run_estate.py` re-hashes the target
+> bundle against `engine-output-receipt.json` and `input_manifest.json`'s `generated_artifacts`
+> **before** the engine runs, and **exits 9** naming every file the re-run would destroy. Proceeding
+> anyway needs `--accept-bundle-rewrite`, and the acknowledgement (including the file list) is
+> written to `<bundle>/bundle-rewrite-acknowledgement.json`. A bundle built by a **different engine
+> version** is refused the same way and acknowledged separately with
+> `--accept-engine-version-change` — deliberately two flags, so accepting a known engine bump does
+> not silently waive the destruction guard. `--slice-only` never runs the engine and is exempt.
 
 What a bundle contains ✅ verified against the reference bundle by listing it, 2026-08-13:
 
@@ -607,7 +617,8 @@ What a bundle contains ✅ verified against the reference bundle by listing it, 
 | `data/` | flat-file data landed next to the models that import it (4 folders on the reference bundle) | no |
 | `empty-model-check.json` | the exit-6 verdict: every model, its partitions, and why any of them would load zero rows. **Written on every run, pass or fail** | — |
 | `phase-timings.json` | per-phase elapsed seconds — see the note under §2's table for what it does *not* cover | — |
-| `engine-output-receipt.json` | hashes of the engine's output **and `engine` — what built this bundle** (§1.2) | — |
+| `engine-output-receipt.json` | hashes of the engine's output **and `engine` — what built this bundle** (§1.2). Read back by the pre-engine rewrite barrier (exit 9) to tell engine output from downstream work | — |
+| `bundle-rewrite-acknowledgement.json` | present only when someone knowingly re-ran the engine over downstream work or a different engine version — records when, which flag, and every file destroyed | — |
 | `.credential-gate-audit.log` | append-only audit trail; `credential_gate.py verify` reads it. **This is the non-narrative record** — trust it over any summary, including your own | — |
 | `input_manifest.json`, `source-provenance.json` | what went in, and where upstream it came from | — |
 | `deploy-journal.jsonl` | written by step 6, not step 5: intent-then-outcome per item (§6.1) | — |
@@ -1236,12 +1247,12 @@ Placeholders used in this document — and where the real value lives:
 
 `—` means that script cannot return that exit code.
 
-| script | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 |
-|---|---|---|---|---|---|---|---|---|---|
-| `preflight.ps1` | ready | critical missing | — | — | — | — | — | — | — |
-| `assess_estate.py` | assessed (may be secondary-degraded) | nothing assessed · sign-in refused (raises) | usage | **a PRIMARY listing is incomplete** | — | — | — | — | — |
-| `run_estate.py` | READY | engine failed | usage | **DoD failed** | approval collision | non-canonical engine | **empty model** | **invalid PBIR** | **BLANK() placeholder** |
-| `deploy_estate.py` | all deployed | item failed / refused | preflight | **incomplete by skip** | — | — | — | — | — |
+| script | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 |
+|---|---|---|---|---|---|---|---|---|---|---|
+| `preflight.ps1` | ready | critical missing | — | — | — | — | — | — | — | — |
+| `assess_estate.py` | assessed (may be secondary-degraded) | nothing assessed · sign-in refused (raises) | usage | **a PRIMARY listing is incomplete** | — | — | — | — | — | — |
+| `run_estate.py` | READY | engine failed | usage | **DoD failed** | approval collision | non-canonical engine | **empty model** | **invalid PBIR** | **BLANK() placeholder** | **bundle rewrite refused** |
+| `deploy_estate.py` | all deployed | item failed / refused | preflight | **incomplete by skip** | — | — | — | — | — | — |
 
 One run returns **one** code, in the order collision → DoD → invalid PBIR → BLANK() placeholder →
 empty model — so a bundle can trip a gate the exit code never mentions. Read the log body,

--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -559,7 +559,7 @@ and 2/5 reproduced by running the command:
 | `6` | `EXIT_EMPTY_MODEL` | **live** — a model would open and load **zero rows** (an Import partition over a flat file that never landed) | read `<bundle>/empty-model-check.json`; see the block below |
 | `7` | `EXIT_INVALID_PBIR` | **live** ✅ reproduced — a shipped report FAILS the first-party `powerbi-report-author validate` (measured: `PBIR_ROLE_REQUIRED_MISSING` from a stubbed calc whose projection was dropped) | read `<bundle>/pbir-validity-check.json`; **bind the stub**, do not delete the visual |
 | `8` | `EXIT_BLANK_PLACEHOLDER` | **live** ✅ reproduced — a handover-backed `BLANK()` placeholder is consumed by a report filter or visual field binding | read `<bundle>/blank-placeholder-check.json`; translate the calc or remove the consuming report dependency knowingly |
-| `9` | `EXIT_BUNDLE_REWRITE` | **pre-engine refusal** (#250) — the `--output` bundle already holds work an engine re-run would delete, and/or a **different engine version** built it | land into a FRESH `--output`, or acknowledge with `--accept-bundle-rewrite` / `--accept-engine-version-change`; the acknowledgement is written to `<bundle>/bundle-rewrite-acknowledgement.json` |
+| `9` | `EXIT_BUNDLE_REWRITE` | **pre-engine refusal** (#250) — the `--output` bundle holds work an engine re-run would delete, a **different engine version** built it, **or the barrier cannot assess either question** (missing/empty/truncated baseline, `--slice-only`-backfilled baseline, unreadable engine version) | land into a FRESH `--output`, or acknowledge with `--accept-bundle-rewrite` / `--accept-engine-version-change`; the acknowledgement, the destroyed files **and the coverage gaps** are written to `<bundle>/bundle-rewrite-acknowledgement.json` |
 
 ❌ **Correction: exits 5 and 6 are NOT "pending branch only"** — the previous edition said so, and
 §5.1 check 10 was written against the same stale assumption. Both shipped 2026-08-13 (#109, #111).
@@ -595,14 +595,22 @@ Reference run ✅ verified from `_convert.log`: `bound=23/38 failed=15 warned=20
 > needs no `--force`. **All DAX approvals land in ONE run; per-workbook agent work starts only
 > afterwards.** ✅ verified from `run_estate.py`'s own docstring.
 >
-> ✅ **This is now ENFORCED, not just documented** (#250). `run_estate.py` re-hashes the target
-> bundle against `engine-output-receipt.json` and `input_manifest.json`'s `generated_artifacts`
-> **before** the engine runs, and **exits 9** naming every file the re-run would destroy. Proceeding
-> anyway needs `--accept-bundle-rewrite`, and the acknowledgement (including the file list) is
-> written to `<bundle>/bundle-rewrite-acknowledgement.json`. A bundle built by a **different engine
-> version** is refused the same way and acknowledged separately with
-> `--accept-engine-version-change` — deliberately two flags, so accepting a known engine bump does
-> not silently waive the destruction guard. `--slice-only` never runs the engine and is exempt.
+> ✅ **This is now ENFORCED, not just documented** (#250). Before the engine runs, `run_estate.py`
+> re-hashes **every file in every folder a re-run deletes** (`pbip/`, `semantic_models/`, `reports/`,
+> `data/`) against the `engine_output_tree` baseline in `input_manifest.json`, plus
+> `engine-output-receipt.json` and `generated_artifacts`. It **exits 9** naming what would be
+> destroyed. Proceeding needs `--accept-bundle-rewrite`; a bundle built by a **different engine
+> version** is refused separately and acknowledged with `--accept-engine-version-change` —
+> deliberately two flags, so accepting a known engine bump does not silently waive the destruction
+> guard.
+>
+> ⚠️ **"Cannot assess" blocks too, and that is the point.** A missing, empty, truncated or
+> `--slice-only`-backfilled baseline, or an engine version that cannot be read, is an explicit
+> indeterminate state — never a pass. The first cut reported *clean* through five such routes and a
+> reviewer destroyed a sentinel through each at exit 0. **Bundles built before this shipped have no
+> `engine_output_tree`, so their first destructive re-run will need both flags** — that is the
+> intended cost of not being able to prove what is in them. `--slice-only` never runs the engine and
+> is exempt.
 
 What a bundle contains ✅ verified against the reference bundle by listing it, 2026-08-13:
 
@@ -618,7 +626,8 @@ What a bundle contains ✅ verified against the reference bundle by listing it, 
 | `empty-model-check.json` | the exit-6 verdict: every model, its partitions, and why any of them would load zero rows. **Written on every run, pass or fail** | — |
 | `phase-timings.json` | per-phase elapsed seconds — see the note under §2's table for what it does *not* cover | — |
 | `engine-output-receipt.json` | hashes of the engine's output **and `engine` — what built this bundle** (§1.2). Read back by the pre-engine rewrite barrier (exit 9) to tell engine output from downstream work | — |
-| `bundle-rewrite-acknowledgement.json` | present only when someone knowingly re-ran the engine over downstream work or a different engine version — records when, which flag, and every file destroyed | — |
+| `input_manifest.json` → `engine_output_tree` | the barrier's authoritative baseline: **every** file in every folder a re-run deletes, with no format allowlist (so PBIR JSON and `textscan` extracts under `<project>.Data` are covered, which the receipt's suffix list does not reach). Absent ⇒ the next destructive run is indeterminate and blocks | — |
+| `bundle-rewrite-acknowledgement.json` | present only when someone knowingly re-ran the engine over downstream work, a different engine version, or a bundle that could not be assessed — records when, which flag, every file destroyed, and every coverage gap | — |
 | `.credential-gate-audit.log` | append-only audit trail; `credential_gate.py verify` reads it. **This is the non-narrative record** — trust it over any summary, including your own | — |
 | `input_manifest.json`, `source-provenance.json` | what went in, and where upstream it came from | — |
 | `deploy-journal.jsonl` | written by step 6, not step 5: intent-then-outcome per item (§6.1) | — |

--- a/scripts/run_estate.py
+++ b/scripts/run_estate.py
@@ -87,28 +87,27 @@ needs no `--force`. Hence: all DAX lands in ONE run, and per-workbook work start
 That sentence used to end "this script owns that ordering so no agent has to remember it", which was
 false: it DOCUMENTED the ordering and checked nothing (issue #250). Every gate below runs in phase 2,
 reading the report the engine has already written - including the collision check, the one gate that
-is specifically about `--approved-dax`. A wrong landing was reported *after* it had landed, and a
-landing into a bundle full of hand-authored fix work was not reported at all.
+is specifically about `--approved-dax`. `assess_bundle_rewrite` now runs BEFORE the engine and
+refuses with `EXIT_BUNDLE_REWRITE` on either finding:
 
-`assess_bundle_rewrite` now runs BEFORE the engine and makes it true, refusing with
-`EXIT_BUNDLE_REWRITE` in two cases:
+* **downstream work would be destroyed** - the bundle is re-hashed against the baselines the
+  previous run wrote: `engine_output_tree` in `input_manifest.json` (every file in every folder a
+  re-run deletes, with NO format allowlist), plus the engine receipt and `generated_artifacts`.
+  `--accept-bundle-rewrite` proceeds, and the acknowledgement is recorded in the bundle.
+* **the bundle was built by a DIFFERENT engine version** - 2.113.0 emitted deprecated Bing
+  `shapeMap` visuals and dropped a density-map worksheet entirely where 2.126.0 emitted `azureMap`
+  with a heat layer, and nothing in the output said which ran (#107). Re-running in place silently
+  mixes both. `--accept-engine-version-change` proceeds.
 
-* **downstream work would be destroyed.** Re-hash the bundle against the two baselines the previous
-  run already wrote - `engine-output-receipt.json` (written by every run, read back by nothing until
-  now) and `input_manifest.json`'s `generated_artifacts` - and any file that no longer matches is
-  somebody's work. `--accept-bundle-rewrite` proceeds and the acknowledgement is recorded in the
-  bundle.
-* **the bundle was built by a DIFFERENT engine version.** Two engine versions are not equivalent:
-  2.113.0 emitted deprecated Bing `shapeMap` visuals and dropped a density-map worksheet entirely
-  where 2.126.0 emitted `azureMap` with a heat layer, and nothing in the output said which ran
-  (#107). Re-running into that bundle silently mixes both. `--accept-engine-version-change` proceeds.
+Two SEPARATE flags on purpose: one would mean accepting a known engine bump also silently waives the
+destruction guard for work you did not know was there.
 
-The two acknowledgements are deliberately SEPARATE flags. One flag would mean accepting a known
-engine bump also silently waives the destruction guard for work you did not know was there.
-
-A bundle with neither baseline (pre-receipt, or third-party) warns and proceeds - a missing receipt
-must not brick every older bundle - and `--slice-only` never runs the guard at all, because it never
-runs the engine and therefore destroys nothing.
+**The rule that governs the whole barrier: where it cannot assess, it BLOCKS.** A missing, empty,
+truncated or `--slice-only`-backfilled baseline, or an unreadable engine version, is an explicit
+indeterminate state - never a pass. The first cut of this file reported *clean* on all five of those
+routes and a reviewer destroyed a sentinel through each of them at exit 0. Legacy and third-party
+bundles stay usable through the acknowledgement flags, which is what they are for. `--slice-only`
+alone is genuinely exempt: it never invokes the engine, so it destroys nothing.
 
 (Line numbers are against engine HEAD `81e6164`. They drift on every upstream release - the four
 `rmtree`/guard sites moved ~30 lines between 2.72.0 and 2.78.0 with no behaviour change - so re-derive
@@ -116,6 +115,14 @@ them by symbol, not by number, if they do not match.)
 """
 
 from __future__ import annotations
+
+# The coordinator and its pre-engine barrier are one procedure: the barrier's whole job is to run
+# before `main`'s phase 1, and the docstring above is the measured knowledge that keeps it correct.
+# DEFERRED FIX: extract the barrier (`assess_bundle_rewrite` and its helpers, ~390 lines) into
+# `scripts/bundle_rewrite_guard.py`. Not done here because a new `scripts/*.py` must be classified in
+# `docs/agent-capability-wiring.md` or carry an `internal: true` marker that no script in this repo
+# uses yet - pioneering that mechanism belongs in its own change, not in a security fix.
+# pylint: disable=too-many-lines
 
 import argparse
 import json
@@ -141,7 +148,7 @@ from check_pbir_valid import REPORT_NAME as PBIR_VALID_REPORT
 from check_pbir_valid import render as render_pbir_valid
 from check_pbir_valid import scan as scan_pbir_validity
 from engine_source import EngineNotFoundError, NonCanonicalEngineError, engine_provenance, resolve_engine
-from migration_bundle import ENGINE_RECEIPT, engine_artifact_records, sha256_file, write_engine_receipt
+from migration_bundle import ENGINE_RECEIPT, sha256_file, write_engine_receipt
 
 log = logging.getLogger("run_estate")
 
@@ -161,6 +168,7 @@ EXIT_INVALID_PBIR = 7
 EXIT_BLANK_PLACEHOLDER = 8
 EXIT_BUNDLE_REWRITE = 9
 GENERATED_ARTIFACTS_KEY = "generated_artifacts"
+SLICE_ONLY_COVERAGE = "slice_only_backfill"
 VOLATILE_GENERATED_DIRS = {".pbi"}
 SCRATCH_DIRS = frozenset({"scratch", "_work", "_build", "_probe", "tmp", "temp", "_shots"})
 SCRATCH_INTENTS = frozenset(part.lstrip("._") for part in SCRATCH_DIRS)
@@ -285,7 +293,7 @@ def backfill_slice_only_baseline(bundle: Path, report: dict | None, phases: list
         if isinstance(existing, dict) and GENERATED_ARTIFACTS_KEY in existing:
             return None
     started = time.monotonic()
-    written = write_generated_artifact_manifest(bundle, report, earliest_mtime=None, coverage="slice_only_backfill")
+    written = write_generated_artifact_manifest(bundle, report, earliest_mtime=None, coverage=SLICE_ONLY_COVERAGE)
     phases.append({"phase": "slice_only_baseline_backfill", "elapsed_sec": round(time.monotonic() - started, 1)})
     log.info("GENERATED_ARTIFACTS: backfilled slice-only baseline -> %s", written)
     return written
@@ -469,26 +477,44 @@ def write_receipt_phase(out_dir: Path, phases: list[dict], engine: Path | None =
 
 
 def record_engine_output(out_dir: Path, report: dict | None, phases: list[dict], engine: Path | None = None) -> None:
-    """Baseline the engine's output: generated-artifact hashes, then the receipt over them.
+    """Baseline the engine's output: artifact hashes, the full output tree, then the receipt.
 
     The order is load-bearing and lives HERE rather than in ``main`` so it cannot be separated by an
-    unrelated edit: the manifest UPSERTS into ``input_manifest.json`` and the receipt HASHES that
-    same file, so receipt-first leaves ``input_manifest_sha256`` stale and the credential gate then
-    rejects the bundle the engine just produced - while the run still reports success.
+    unrelated edit: both manifest writes UPSERT into ``input_manifest.json`` and the receipt HASHES
+    that same file, so receipt-first leaves ``input_manifest_sha256`` stale and the credential gate
+    then rejects the bundle the engine just produced - while the run still reports success.
     """
     log.info(
         "GENERATED_ARTIFACTS: hashes -> %s",
         write_generated_artifact_manifest(out_dir, report, phases[0]["started_wall"] - 1),
     )
+    log.info("ENGINE_OUTPUT_TREE: hashes -> %s", write_engine_output_tree(out_dir))
     write_receipt_phase(out_dir, phases, engine)
 
 
 # ---------------------------------------------------------------------------
 # The destructive-re-run barrier (issue #250) - the ONLY pre-engine gate
+#
+# ONE rule governs everything below: where the barrier CANNOT ASSESS something, it must say so and
+# BLOCK. Absence of evidence is not evidence of absence. A guard that reports clean when it cannot
+# see is worse than no guard, because the operator trusts it - and five separate routes into
+# "reported clean, destroyed real work at exit 0" were found in the first cut of this file.
 # ---------------------------------------------------------------------------
 
 BUNDLE_REWRITE_RECORD = "bundle-rewrite-acknowledgement.json"
+ENGINE_TREE_KEY = "engine_output_tree"
 REWRITE_LIST_LIMIT = 12
+
+# Every top-level folder a re-run may delete and rewrite. `migration_bundle.ENGINE_OUTPUT_DIRS` is
+# deliberately NOT reused: it omits `reports/`, and the receipt built from it filters by
+# `ARTIFACT_SUFFIXES`, which is exactly the allowlist that let a hand-authored PBIR file and a
+# `textscan` `.txt` extract go unbaselined and unprotected. The barrier allowlists LOCATIONS, never
+# formats.
+ENGINE_TREE_ROOTS = ("data", "pbip", "reports", "semantic_models")
+
+# What makes a `--output` folder "already an engine bundle" rather than a fresh target. An empty or
+# unrelated folder is NOT one, so a first run into a new folder is never touched by the barrier.
+BUNDLE_MARKERS = ("report.json", "summary.md", "input_manifest.json", BUNDLE_REWRITE_RECORD)
 
 
 class BundleDrift(NamedTuple):
@@ -504,30 +530,40 @@ class BundleDrift(NamedTuple):
         return len(self.modified) + len(self.added) + len(self.missing)
 
 
+class BundleCoverage(NamedTuple):
+    """How much of the bundle the barrier can actually vouch for.
+
+    ``complete`` means a full engine-output tree baseline exists, which is the ONLY thing that makes
+    an ADDED file decidable - without it, a file the engine never wrote is indistinguishable from
+    one it did. ``gaps`` is every reason the assessment is partial; a non-empty ``gaps`` is itself a
+    blocking finding, because "I could not look" must never render as "I looked and it was fine".
+    """
+
+    known: dict[str, str]
+    complete: bool
+    gaps: list[str]
+
+
 class BundleRewriteFindings(NamedTuple):
     """Everything the pre-engine barrier knows about the `--output` folder it is about to rewrite.
 
-    ``applicable`` is False when the question does not arise at all - ``--slice-only`` (no engine, so
-    nothing is destroyed), a `--output` that does not exist yet, or a bundle carrying neither
-    baseline. It is deliberately distinct from "checked and found nothing".
+    ``applicable`` is False only when the question does not arise: ``--slice-only`` (no engine, so
+    nothing is destroyed) or a `--output` that is not an engine bundle yet. It is never False merely
+    because evidence is missing - that case is applicable AND indeterminate, which blocks.
     """
 
     bundle: Path
     applicable: bool
     drift: BundleDrift
+    coverage: BundleCoverage
     recorded_version: str | None
     running_version: str | None
-    warnings: list[str]
     accepted_rewrite: bool
     accepted_version: bool
 
     @property
     def version_changed(self) -> bool:
-        """Whether this run's engine differs from the one that built the bundle.
-
-        Both versions have to be known: an unversioned engine tree or a pre-``engine`` receipt is an
-        absence of evidence, and blocking on it would fail every older bundle for no finding.
-        """
+        """A different engine built this bundle than the one about to rewrite it."""
         return bool(
             self.applicable
             and self.recorded_version
@@ -536,14 +572,23 @@ class BundleRewriteFindings(NamedTuple):
         )
 
     @property
+    def version_indeterminate(self) -> bool:
+        """Either version is unknown, so "did the engine change?" has no answer.
+
+        A truncated receipt used to make this return "no change" and wave the run through - one
+        broken byte disabling the guard. Unknown is now its own blocking state.
+        """
+        return bool(self.applicable and not (self.recorded_version and self.running_version))
+
+    @property
     def blocks_on_downstream(self) -> bool:
-        """Downstream work exists in the bundle and the caller has not accepted losing it."""
-        return bool(self.applicable and self.drift.total and not self.accepted_rewrite)
+        """Work would be destroyed, or the barrier cannot prove that it would not be."""
+        return bool(self.applicable and (self.drift.total or self.coverage.gaps) and not self.accepted_rewrite)
 
     @property
     def blocks_on_engine_version(self) -> bool:
-        """The bundle would be rewritten by a different engine than the one that built it."""
-        return bool(self.version_changed and not self.accepted_version)
+        """The engine differs, or cannot be shown not to differ."""
+        return bool((self.version_changed or self.version_indeterminate) and not self.accepted_version)
 
     @property
     def blocking(self) -> bool:
@@ -552,39 +597,11 @@ class BundleRewriteFindings(NamedTuple):
 
     @property
     def acknowledged(self) -> bool:
-        """Whether a real finding was waived by an explicit flag, and so must be recorded."""
+        """Whether a real finding or a coverage gap was waived by a flag, and so must be recorded."""
         return bool(
-            (self.applicable and self.drift.total and self.accepted_rewrite)
-            or (self.version_changed and self.accepted_version)
+            (self.applicable and (self.drift.total or self.coverage.gaps) and self.accepted_rewrite)
+            or ((self.version_changed or self.version_indeterminate) and self.accepted_version)
         )
-
-
-def _looks_like_bundle(bundle: Path) -> bool:
-    """Whether `--output` already holds engine output, rather than being a fresh folder."""
-    return (bundle / "report.json").is_file() or (bundle / "pbip").is_dir()
-
-
-def read_engine_receipt(bundle: Path) -> tuple[dict | None, str | None]:
-    """Read the receipt the bundle's last run wrote. Returns ``(receipt, warning)``.
-
-    ``write_receipt_phase`` writes this on EVERY run and, until this guard existed, nothing ever read
-    it back. It is the only record of which files the engine itself produced, which is what makes
-    "everything else in here is somebody's downstream work" a decidable question rather than a guess.
-
-    A malformed receipt degrades to ``(None, warning)`` instead of raising: the caller's job is to
-    protect a bundle, and aborting the run because the protection metadata is corrupt would turn a
-    safety feature into an outage.
-    """
-    path = bundle / ENGINE_RECEIPT
-    if not path.is_file():
-        return None, None
-    try:
-        receipt = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as exc:
-        return None, f"{ENGINE_RECEIPT} is unreadable ({type(exc).__name__})"
-    if not isinstance(receipt, dict):
-        return None, f"{ENGINE_RECEIPT} is not a JSON object"
-    return receipt, None
 
 
 def _is_guarded_path(relative: Path) -> bool:
@@ -596,6 +613,78 @@ def _is_guarded_path(relative: Path) -> bool:
     """
     lower = [part.lower() for part in relative.parts]
     return not _is_scratch_path(relative) and not any(part in VOLATILE_GENERATED_DIRS for part in lower)
+
+
+def engine_output_tree_hashes(bundle: Path) -> dict[str, str]:
+    """Hash EVERY file under every folder a re-run may delete, with no format allowlist.
+
+    This is the barrier's authoritative baseline and the reason it can see an added PBIR file or a
+    `textscan` `.txt` extract under `<project>.Data` - neither of which carries a suffix the engine
+    receipt records, and both of which sit inside a directory the engine rmtree()s.
+    """
+    files: dict[str, str] = {}
+    for root_name in ENGINE_TREE_ROOTS:
+        root = bundle / root_name
+        if not root.is_dir():
+            continue
+        for path in sorted(root.rglob("*")):
+            if not path.is_file():
+                continue
+            relative = path.relative_to(bundle)
+            if _is_guarded_path(relative):
+                files[relative.as_posix()] = sha256_file(path)
+    return files
+
+
+def write_engine_output_tree(bundle: Path) -> Path:
+    """Record the complete engine-output tree into ``input_manifest.json``.
+
+    A SEPARATE key from ``generated_artifacts`` on purpose: that one is the tamper-audit baseline of
+    stable *deliverables* an agent may declare edits against, and `check_migration_progress.py`
+    depends on its shape and scope. This one answers a different question - "what was in the
+    directories the next run will delete?" - so it is deliberately wider (flat-file extracts,
+    `<project>.Data`, `reports/`, loose files) and must not be conflated with it.
+
+    Written only on a real engine run. ``--slice-only`` has no engine-run boundary, so it can only
+    hash a working copy that may already contain downstream edits; recording that here would launder
+    those edits into "engine output" and is exactly the hole this key exists to close.
+    """
+    manifest_path = bundle / "input_manifest.json"
+    manifest: dict = {}
+    if manifest_path.is_file():
+        try:
+            loaded = json.loads(manifest_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            loaded = None
+        manifest = loaded if isinstance(loaded, dict) else {"engine_input_manifest": loaded}
+    manifest[ENGINE_TREE_KEY] = {
+        "version": 1,
+        "recorded_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "roots": list(ENGINE_TREE_ROOTS),
+        "files": engine_output_tree_hashes(bundle),
+    }
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    return manifest_path
+
+
+def read_engine_receipt(bundle: Path) -> tuple[dict | None, str | None]:
+    """Read the receipt the bundle's last run wrote. Returns ``(receipt, gap)``.
+
+    ``write_receipt_phase`` writes this on EVERY run and, until this guard existed, nothing ever read
+    it back. A malformed receipt degrades to ``(None, gap)`` rather than raising - but the gap is a
+    BLOCKING finding, not a warning: a corrupt receipt tells you less than no receipt does, and
+    treating it as "no version change" is how one broken byte disabled the version guard entirely.
+    """
+    path = bundle / ENGINE_RECEIPT
+    if not path.is_file():
+        return None, None
+    try:
+        receipt = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return None, f"{ENGINE_RECEIPT} is unreadable ({type(exc).__name__}) - it attests to nothing"
+    if not isinstance(receipt, dict):
+        return None, f"{ENGINE_RECEIPT} is not a JSON object - it attests to nothing"
+    return receipt, None
 
 
 def _receipt_artifact_hashes(receipt: dict | None) -> dict[str, str]:
@@ -610,23 +699,21 @@ def _receipt_artifact_hashes(receipt: dict | None) -> dict[str, str]:
     return hashes
 
 
-def _generated_baseline_hashes(bundle: Path) -> dict[str, str]:
-    """The WIDER baseline: every file under a `*.SemanticModel`/`*.Report` folder, PBIR JSON included.
-
-    The receipt only records `ARTIFACT_SUFFIXES`, so a hand-edited PBIR visual definition - the
-    report builder's entire output - is invisible to it. `write_generated_artifact_manifest` hashes
-    the whole generated tree, so the two baselines together cover both halves of what an agent
-    actually edits: model measures and report visuals.
-    """
-    manifest_path = bundle / "input_manifest.json"
-    if not manifest_path.is_file():
+def _read_manifest(bundle: Path) -> dict:
+    """``input_manifest.json`` as a dict, or empty when absent or unreadable."""
+    path = bundle / "input_manifest.json"
+    if not path.is_file():
         return {}
     try:
-        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        manifest = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         return {}
-    generated = manifest.get(GENERATED_ARTIFACTS_KEY) if isinstance(manifest, dict) else None
-    files = generated.get("files") if isinstance(generated, dict) else None
+    return manifest if isinstance(manifest, dict) else {}
+
+
+def _hash_map(block: object) -> dict[str, str]:
+    """A ``{"files": {path: sha256}}`` block as a clean map, dropping anything malformed."""
+    files = block.get("files") if isinstance(block, dict) else None
     if not isinstance(files, dict):
         return {}
     return {
@@ -636,40 +723,67 @@ def _generated_baseline_hashes(bundle: Path) -> dict[str, str]:
     }
 
 
-def detect_downstream_work(bundle: Path, receipt_hashes: dict[str, str], baseline: dict[str, str]) -> BundleDrift:
+def assess_coverage(bundle: Path, receipt: dict | None, receipt_gap: str | None) -> BundleCoverage:
+    """Work out what the barrier can vouch for, and name every hole in it.
+
+    Three baselines, in descending authority: the complete engine-output tree, the engine receipt,
+    and the generated-artifact manifest. Only the first makes an ADDED file decidable. A
+    ``--slice-only`` backfill is explicitly NOT trusted - it hashes the working copy, downstream
+    edits included, so treating it as engine output blesses exactly the work the barrier protects.
+    """
+    gaps: list[str] = []
+    known: dict[str, str] = {}
+    manifest = _read_manifest(bundle)
+
+    tree = _hash_map(manifest.get(ENGINE_TREE_KEY))
+    known.update(tree)
+    if not tree:
+        gaps.append(
+            f"no usable '{ENGINE_TREE_KEY}' baseline in input_manifest.json - a file the engine never "
+            "wrote cannot be told from one it did, so ADDED downstream work is undetectable here"
+        )
+
+    receipt_hashes = _receipt_artifact_hashes(receipt)
+    known.update(receipt_hashes)
+    if receipt is None:
+        gaps.append(receipt_gap or f"no {ENGINE_RECEIPT} - nothing attests to what the engine produced")
+    elif not receipt_hashes:
+        gaps.append(f"{ENGINE_RECEIPT} lists no usable artifacts - it attests to nothing")
+
+    generated = manifest.get(GENERATED_ARTIFACTS_KEY)
+    coverage = generated.get("coverage") if isinstance(generated, dict) else None
+    if coverage == SLICE_ONLY_COVERAGE:
+        gaps.append(
+            f"'{GENERATED_ARTIFACTS_KEY}' was backfilled by --slice-only from the working copy, so its "
+            "hashes are not proof of engine origin and are not trusted as a baseline here"
+        )
+    else:
+        known.update(_hash_map(generated))
+
+    return BundleCoverage(known, bool(tree), gaps)
+
+
+def detect_downstream_work(bundle: Path, coverage: BundleCoverage) -> BundleDrift:
     """Re-hash the bundle and name every file that is no longer what the engine produced.
 
-    ``added`` is decided from the RECEIPT alone, via ``engine_artifact_records`` - the very function
-    that wrote it - so a pristine bundle reconciles exactly and cannot raise a false alarm. The
-    generated-artifact baseline is mtime-filtered when written, so it is used only for files it
-    already knows about (modified/missing) and never to decide that a file is new.
+    ``added`` is reported ONLY when coverage is complete. With a partial baseline every unrecognised
+    file is ambiguous, so listing some of them would imply the rest had been cleared; the coverage
+    gap blocks instead, which is the honest answer.
     """
+    current = engine_output_tree_hashes(bundle)
     modified: list[str] = []
-    added: list[str] = []
     missing: list[str] = []
-
-    if receipt_hashes:
-        current = {
-            record["path"]: record["sha256"]
-            for record in engine_artifact_records(bundle)
-            if _is_guarded_path(Path(record["path"]))
-        }
-        for path, digest in receipt_hashes.items():
-            if path not in current:
+    for path, digest in coverage.known.items():
+        now = current.get(path)
+        if now is None:
+            candidate = bundle / path
+            if not candidate.is_file():
                 missing.append(path)
-            elif current[path] != digest:
+            elif sha256_file(candidate) != digest:
                 modified.append(path)
-        added = [path for path in current if path not in receipt_hashes]
-
-    for path, digest in baseline.items():
-        if path in receipt_hashes:
-            continue
-        candidate = bundle / path
-        if not candidate.is_file():
-            missing.append(path)
-        elif sha256_file(candidate) != digest:
+        elif now != digest:
             modified.append(path)
-
+    added = [path for path in current if path not in coverage.known] if coverage.complete else []
     return BundleDrift(sorted(set(modified)), sorted(set(added)), sorted(set(missing)))
 
 
@@ -681,6 +795,13 @@ def _engine_versions(receipt: dict | None, engine: Path | None) -> tuple[str | N
     return (recorded if isinstance(recorded, str) else None, running if isinstance(running, str) else None)
 
 
+def _looks_like_bundle(bundle: Path) -> bool:
+    """Whether `--output` already holds engine output, rather than being a fresh target."""
+    return any((bundle / name).is_file() for name in BUNDLE_MARKERS) or any(
+        (bundle / root).is_dir() for root in ENGINE_TREE_ROOTS
+    )
+
+
 def assess_bundle_rewrite(args: argparse.Namespace, engine: Path | None) -> BundleRewriteFindings:
     """Decide, BEFORE the engine runs, whether this run may rewrite `--output`.
 
@@ -689,38 +810,30 @@ def assess_bundle_rewrite(args: argparse.Namespace, engine: Path | None) -> Bund
     points at an existing bundle every single time.
     """
     bundle = Path(args.output)
-    nothing = BundleDrift([], [], [])
     accepted_rewrite = bool(args.accept_bundle_rewrite)
     accepted_version = bool(args.accept_engine_version_change)
-    if args.slice_only or not bundle.is_dir():
-        return BundleRewriteFindings(bundle, False, nothing, None, None, [], accepted_rewrite, accepted_version)
+    if args.slice_only or not bundle.is_dir() or not _looks_like_bundle(bundle):
+        return BundleRewriteFindings(
+            bundle,
+            False,
+            BundleDrift([], [], []),
+            BundleCoverage({}, True, []),
+            None,
+            None,
+            accepted_rewrite,
+            accepted_version,
+        )
 
-    receipt, warning = read_engine_receipt(bundle)
-    warnings = [warning] if warning else []
-    receipt_hashes = _receipt_artifact_hashes(receipt)
-    if receipt is not None and not receipt_hashes:
-        warnings.append(f"{ENGINE_RECEIPT} lists no artifacts - it cannot attest to what the engine produced")
-    baseline = _generated_baseline_hashes(bundle)
+    receipt, receipt_gap = read_engine_receipt(bundle)
+    coverage = assess_coverage(bundle, receipt, receipt_gap)
     recorded_version, running_version = _engine_versions(receipt, engine)
-    if not receipt_hashes and not baseline:
-        if _looks_like_bundle(bundle):
-            warnings.append(
-                f"no usable {ENGINE_RECEIPT} and no generated-artifact baseline in {bundle} - this run "
-                "cannot tell engine output from downstream work, so it is not trying to; anything an "
-                "agent wrote here will be destroyed without being named"
-            )
-        if not recorded_version:
-            return BundleRewriteFindings(
-                bundle, False, nothing, None, None, warnings, accepted_rewrite, accepted_version
-            )
-
     return BundleRewriteFindings(
         bundle,
         True,
-        detect_downstream_work(bundle, receipt_hashes, baseline),
+        detect_downstream_work(bundle, coverage),
+        coverage,
         recorded_version,
         running_version,
-        warnings,
         accepted_rewrite,
         accepted_version,
     )
@@ -735,15 +848,14 @@ def _sample(paths: list[str]) -> str:
     return "\n".join(lines)
 
 
-def print_bundle_rewrite(findings: BundleRewriteFindings) -> None:
-    """Name what a re-run into this `--output` would destroy, and how to proceed deliberately."""
-    for warning in findings.warnings:
-        print(f"BUNDLE_REWRITE: WARN - {warning}")
+def _print_drift(findings: BundleRewriteFindings) -> None:
+    """The downstream-work half of the verdict: what is here that the engine did not put here."""
+    if not findings.drift.total and not findings.coverage.gaps:
+        return
+    verdict = "ACCEPTED" if findings.accepted_rewrite else "REFUSED"
+    print(f"\nESTATE: BUNDLE_REWRITE {verdict} - {findings.bundle}")
     if findings.drift.total:
-        print(
-            f"\nESTATE: BUNDLE_REWRITE {'ACCEPTED' if findings.accepted_rewrite else 'REFUSED'} - "
-            f"{findings.drift.total} file(s) in {findings.bundle} no longer match what the engine produced"
-        )
+        print(f"  {findings.drift.total} file(s) no longer match what the engine produced:")
         for label, paths in (
             ("modified", findings.drift.modified),
             ("added", findings.drift.added),
@@ -752,36 +864,57 @@ def print_bundle_rewrite(findings: BundleRewriteFindings) -> None:
             if paths:
                 print(f"  {label} ({len(paths)}):")
                 print(_sample(paths))
-        print(
-            "  An engine re-run is DELETE-AND-RECREATE, not merge: it rmtree()s the .SemanticModel\n"
-            "  folder, the .pbip project dir and <name>.Report before rewriting them, and the\n"
-            "  engine's own stale-output guard EXEMPTS the --approved-dax landing path. Every file\n"
-            "  listed above would be gone, and no other gate here runs until after that has happened."
-        )
-        if not findings.accepted_rewrite:
-            print("  -> land into a FRESH --output, or pass --accept-bundle-rewrite to proceed knowingly.")
+    for gap in findings.coverage.gaps:
+        print(f"  CANNOT ASSESS: {gap}")
+    print(
+        "  An engine re-run is DELETE-AND-RECREATE, not merge: it rmtree()s the .SemanticModel\n"
+        "  folder, the .pbip project dir and <name>.Report before rewriting them, and the\n"
+        "  engine's own stale-output guard EXEMPTS the --approved-dax landing path. Anything in\n"
+        "  those folders would be gone, and no other gate here runs until after that has happened."
+    )
+    if not findings.accepted_rewrite:
+        print("  -> land into a FRESH --output, or pass --accept-bundle-rewrite to proceed knowingly.")
+
+
+def _print_version(findings: BundleRewriteFindings) -> None:
+    """The engine-identity half: a bundle two engine versions built is two bundles in a trench coat."""
+    if not (findings.version_changed or findings.version_indeterminate):
+        return
+    verdict = "ACCEPTED" if findings.accepted_version else "REFUSED"
     if findings.version_changed:
         print(
-            f"\nESTATE: BUNDLE_REWRITE {'ACCEPTED' if findings.accepted_version else 'REFUSED'} - this "
-            f"bundle was built by engine {findings.recorded_version}, this run would rewrite it with "
-            f"{findings.running_version}"
+            f"\nESTATE: BUNDLE_REWRITE {verdict} - this bundle was built by engine "
+            f"{findings.recorded_version}, this run would rewrite it with {findings.running_version}"
         )
+    else:
         print(
-            "  Two engine versions are not equivalent: 2.113.0 emitted deprecated Bing shapeMap\n"
-            "  visuals and dropped a density-map worksheet entirely where 2.126.0 emitted azureMap\n"
-            "  with a heat layer, and nothing in the output said which one ran (#107). Rewriting in\n"
-            "  place mixes both into one bundle."
+            f"\nESTATE: BUNDLE_REWRITE {verdict} - CANNOT ASSESS the engine version "
+            f"(bundle recorded: {findings.recorded_version or 'unknown'}; this run: "
+            f"{findings.running_version or 'unknown'})"
         )
-        if not findings.accepted_version:
-            print("  -> use a FRESH --output, or pass --accept-engine-version-change to proceed knowingly.")
+    print(
+        "  Two engine versions are not equivalent: 2.113.0 emitted deprecated Bing shapeMap\n"
+        "  visuals and dropped a density-map worksheet entirely where 2.126.0 emitted azureMap\n"
+        "  with a heat layer, and nothing in the output said which one ran (#107). Rewriting in\n"
+        "  place mixes both into one bundle."
+    )
+    if not findings.accepted_version:
+        print("  -> use a FRESH --output, or pass --accept-engine-version-change to proceed knowingly.")
+
+
+def print_bundle_rewrite(findings: BundleRewriteFindings) -> None:
+    """Name what a re-run into this `--output` would destroy, and how to proceed deliberately."""
+    _print_drift(findings)
+    _print_version(findings)
 
 
 def record_bundle_rewrite_acknowledgement(findings: BundleRewriteFindings) -> Path | None:
     """Append the acknowledgement to the bundle, so the ARTIFACT says the loss was deliberate.
 
     Written before the engine runs and at the bundle root, which the engine's `rmtree` sites do not
-    touch, so it survives the rewrite it is describing. Append rather than overwrite: a bundle that
-    has been knowingly rewritten twice should say so twice.
+    touch, so it survives the rewrite it is describing. The coverage gaps are recorded alongside the
+    file list: "these files were destroyed" and "and this much could not be assessed at all" are
+    different admissions, and collapsing them would overstate what the record proves.
     """
     if not findings.acknowledged:
         return None
@@ -801,6 +934,8 @@ def record_bundle_rewrite_acknowledgement(findings: BundleRewriteFindings) -> Pa
             "accepted_engine_version_change": findings.accepted_version,
             "engine_version_recorded": findings.recorded_version,
             "engine_version_running": findings.running_version,
+            "coverage_complete": findings.coverage.complete,
+            "coverage_gaps": findings.coverage.gaps,
             "destroyed": {
                 "modified": findings.drift.modified,
                 "added": findings.drift.added,

--- a/scripts/run_estate.py
+++ b/scripts/run_estate.py
@@ -604,15 +604,26 @@ class BundleRewriteFindings(NamedTuple):
         )
 
 
-def _is_guarded_path(relative: Path) -> bool:
-    """Whether a bundle-relative path is accounted for by the barrier at all.
+def _barrier_covers_path(relative: Path) -> bool:
+    """Whether a bundle-relative path is accounted for by the REWRITE BARRIER.
 
-    ``.pbi`` sidecars and scratch folders are excluded on BOTH sides of every comparison - current
-    disk state and recorded baseline alike - so a Power BI Desktop refresh can never read as
-    downstream work, and a pristine bundle still reconciles exactly.
+    Only Power BI Desktop's `.pbi` sidecars are excluded, so a normal refresh never reads as
+    downstream work. Applied to BOTH sides of every comparison - current disk state and recorded
+    baseline alike - so a pristine bundle still reconciles exactly.
+
+    Deliberately NOT `_is_scratch_path`. That predicate answers a DIFFERENT question - "is this a
+    stable deliverable worth putting in the tamper-audit manifest?" - and reusing it here made one
+    predicate do two jobs and punched a hole straight through the barrier: `_build/` is this repo's
+    durable REPLAY-SCRIPT convention (`AGENTS.md`: "every edit re-runnable from `_build/`"), so
+    `pbip/<project>/_build/replay.py` is precisely where an agent's re-runnable work lives - and it
+    sits inside a directory the engine rmtree()s. Skipping it meant a re-run destroyed the replay
+    script for the very edits it was written to reproduce, at exit 0.
+
+    A bundle-ROOT `_build/` is still unguarded, and correctly so: it is outside `ENGINE_TREE_ROOTS`
+    and therefore outside anything the engine deletes. The scope is the destructive roots, not the
+    folder name.
     """
-    lower = [part.lower() for part in relative.parts]
-    return not _is_scratch_path(relative) and not any(part in VOLATILE_GENERATED_DIRS for part in lower)
+    return not any(part.lower() in VOLATILE_GENERATED_DIRS for part in relative.parts)
 
 
 def engine_output_tree_hashes(bundle: Path) -> dict[str, str]:
@@ -631,7 +642,7 @@ def engine_output_tree_hashes(bundle: Path) -> dict[str, str]:
             if not path.is_file():
                 continue
             relative = path.relative_to(bundle)
-            if _is_guarded_path(relative):
+            if _barrier_covers_path(relative):
                 files[relative.as_posix()] = sha256_file(path)
     return files
 
@@ -694,7 +705,7 @@ def _receipt_artifact_hashes(receipt: dict | None) -> dict[str, str]:
         if not isinstance(record, dict):
             continue
         path, digest = record.get("path"), record.get("sha256")
-        if isinstance(path, str) and isinstance(digest, str) and _is_guarded_path(Path(path)):
+        if isinstance(path, str) and isinstance(digest, str) and _barrier_covers_path(Path(path)):
             hashes[path] = digest
     return hashes
 
@@ -719,7 +730,7 @@ def _hash_map(block: object) -> dict[str, str]:
     return {
         path: digest
         for path, digest in files.items()
-        if isinstance(path, str) and isinstance(digest, str) and _is_guarded_path(Path(path))
+        if isinstance(path, str) and isinstance(digest, str) and _barrier_covers_path(Path(path))
     }
 
 

--- a/scripts/run_estate.py
+++ b/scripts/run_estate.py
@@ -4,6 +4,7 @@ purpose: run the deterministic tier over an ESTATE and turn its output into some
          handover slices, and a phase-timing record.
 usage:   python scripts/run_estate.py --input <folder-of-.twb/.twbx> --output <bundle-dir>
                                       [--approved-dax <file.json>] [--dry-run]
+                                      [--accept-bundle-rewrite] [--accept-engine-version-change]
          python scripts/run_estate.py --slice-only --output <existing-bundle-dir>
 
 The engine is NOT a parameter you normally pass. It resolves to the installed
@@ -82,7 +83,32 @@ A `--approved-dax` re-run is **delete-and-recreate**, not merge: `migrate_estate
 before rewriting them. Nothing a downstream agent wrote into that bundle survives. Worse, the
 stale-output guard (:5040) *exempts* the landing re-run, so the most destructive path is the one that
 needs no `--force`. Hence: all DAX lands in ONE run, and per-workbook work starts only afterwards.
-This script owns that ordering so no agent has to remember it.
+
+That sentence used to end "this script owns that ordering so no agent has to remember it", which was
+false: it DOCUMENTED the ordering and checked nothing (issue #250). Every gate below runs in phase 2,
+reading the report the engine has already written - including the collision check, the one gate that
+is specifically about `--approved-dax`. A wrong landing was reported *after* it had landed, and a
+landing into a bundle full of hand-authored fix work was not reported at all.
+
+`assess_bundle_rewrite` now runs BEFORE the engine and makes it true, refusing with
+`EXIT_BUNDLE_REWRITE` in two cases:
+
+* **downstream work would be destroyed.** Re-hash the bundle against the two baselines the previous
+  run already wrote - `engine-output-receipt.json` (written by every run, read back by nothing until
+  now) and `input_manifest.json`'s `generated_artifacts` - and any file that no longer matches is
+  somebody's work. `--accept-bundle-rewrite` proceeds and the acknowledgement is recorded in the
+  bundle.
+* **the bundle was built by a DIFFERENT engine version.** Two engine versions are not equivalent:
+  2.113.0 emitted deprecated Bing `shapeMap` visuals and dropped a density-map worksheet entirely
+  where 2.126.0 emitted `azureMap` with a heat layer, and nothing in the output said which ran
+  (#107). Re-running into that bundle silently mixes both. `--accept-engine-version-change` proceeds.
+
+The two acknowledgements are deliberately SEPARATE flags. One flag would mean accepting a known
+engine bump also silently waives the destruction guard for work you did not know was there.
+
+A bundle with neither baseline (pre-receipt, or third-party) warns and proceeds - a missing receipt
+must not brick every older bundle - and `--slice-only` never runs the guard at all, because it never
+runs the engine and therefore destroys nothing.
 
 (Line numbers are against engine HEAD `81e6164`. They drift on every upstream release - the four
 `rmtree`/guard sites moved ~30 lines between 2.72.0 and 2.78.0 with no behaviour change - so re-derive
@@ -115,7 +141,7 @@ from check_pbir_valid import REPORT_NAME as PBIR_VALID_REPORT
 from check_pbir_valid import render as render_pbir_valid
 from check_pbir_valid import scan as scan_pbir_validity
 from engine_source import EngineNotFoundError, NonCanonicalEngineError, engine_provenance, resolve_engine
-from migration_bundle import sha256_file, write_engine_receipt
+from migration_bundle import ENGINE_RECEIPT, engine_artifact_records, sha256_file, write_engine_receipt
 
 log = logging.getLogger("run_estate")
 
@@ -133,6 +159,7 @@ EXIT_ENGINE_SOURCE = 5
 EXIT_EMPTY_MODEL = 6
 EXIT_INVALID_PBIR = 7
 EXIT_BLANK_PLACEHOLDER = 8
+EXIT_BUNDLE_REWRITE = 9
 GENERATED_ARTIFACTS_KEY = "generated_artifacts"
 VOLATILE_GENERATED_DIRS = {".pbi"}
 SCRATCH_DIRS = frozenset({"scratch", "_work", "_build", "_probe", "tmp", "temp", "_shots"})
@@ -456,6 +483,336 @@ def record_engine_output(out_dir: Path, report: dict | None, phases: list[dict],
     write_receipt_phase(out_dir, phases, engine)
 
 
+# ---------------------------------------------------------------------------
+# The destructive-re-run barrier (issue #250) - the ONLY pre-engine gate
+# ---------------------------------------------------------------------------
+
+BUNDLE_REWRITE_RECORD = "bundle-rewrite-acknowledgement.json"
+REWRITE_LIST_LIMIT = 12
+
+
+class BundleDrift(NamedTuple):
+    """Files in a bundle that no longer match the baselines its previous run wrote."""
+
+    modified: list[str]
+    added: list[str]
+    missing: list[str]
+
+    @property
+    def total(self) -> int:
+        """How many files are no longer what the engine produced."""
+        return len(self.modified) + len(self.added) + len(self.missing)
+
+
+class BundleRewriteFindings(NamedTuple):
+    """Everything the pre-engine barrier knows about the `--output` folder it is about to rewrite.
+
+    ``applicable`` is False when the question does not arise at all - ``--slice-only`` (no engine, so
+    nothing is destroyed), a `--output` that does not exist yet, or a bundle carrying neither
+    baseline. It is deliberately distinct from "checked and found nothing".
+    """
+
+    bundle: Path
+    applicable: bool
+    drift: BundleDrift
+    recorded_version: str | None
+    running_version: str | None
+    warnings: list[str]
+    accepted_rewrite: bool
+    accepted_version: bool
+
+    @property
+    def version_changed(self) -> bool:
+        """Whether this run's engine differs from the one that built the bundle.
+
+        Both versions have to be known: an unversioned engine tree or a pre-``engine`` receipt is an
+        absence of evidence, and blocking on it would fail every older bundle for no finding.
+        """
+        return bool(
+            self.applicable
+            and self.recorded_version
+            and self.running_version
+            and self.recorded_version != self.running_version
+        )
+
+    @property
+    def blocks_on_downstream(self) -> bool:
+        """Downstream work exists in the bundle and the caller has not accepted losing it."""
+        return bool(self.applicable and self.drift.total and not self.accepted_rewrite)
+
+    @property
+    def blocks_on_engine_version(self) -> bool:
+        """The bundle would be rewritten by a different engine than the one that built it."""
+        return bool(self.version_changed and not self.accepted_version)
+
+    @property
+    def blocking(self) -> bool:
+        """Whether this run must be refused."""
+        return self.blocks_on_downstream or self.blocks_on_engine_version
+
+    @property
+    def acknowledged(self) -> bool:
+        """Whether a real finding was waived by an explicit flag, and so must be recorded."""
+        return bool(
+            (self.applicable and self.drift.total and self.accepted_rewrite)
+            or (self.version_changed and self.accepted_version)
+        )
+
+
+def _looks_like_bundle(bundle: Path) -> bool:
+    """Whether `--output` already holds engine output, rather than being a fresh folder."""
+    return (bundle / "report.json").is_file() or (bundle / "pbip").is_dir()
+
+
+def read_engine_receipt(bundle: Path) -> tuple[dict | None, str | None]:
+    """Read the receipt the bundle's last run wrote. Returns ``(receipt, warning)``.
+
+    ``write_receipt_phase`` writes this on EVERY run and, until this guard existed, nothing ever read
+    it back. It is the only record of which files the engine itself produced, which is what makes
+    "everything else in here is somebody's downstream work" a decidable question rather than a guess.
+
+    A malformed receipt degrades to ``(None, warning)`` instead of raising: the caller's job is to
+    protect a bundle, and aborting the run because the protection metadata is corrupt would turn a
+    safety feature into an outage.
+    """
+    path = bundle / ENGINE_RECEIPT
+    if not path.is_file():
+        return None, None
+    try:
+        receipt = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return None, f"{ENGINE_RECEIPT} is unreadable ({type(exc).__name__})"
+    if not isinstance(receipt, dict):
+        return None, f"{ENGINE_RECEIPT} is not a JSON object"
+    return receipt, None
+
+
+def _is_guarded_path(relative: Path) -> bool:
+    """Whether a bundle-relative path is accounted for by the barrier at all.
+
+    ``.pbi`` sidecars and scratch folders are excluded on BOTH sides of every comparison - current
+    disk state and recorded baseline alike - so a Power BI Desktop refresh can never read as
+    downstream work, and a pristine bundle still reconciles exactly.
+    """
+    lower = [part.lower() for part in relative.parts]
+    return not _is_scratch_path(relative) and not any(part in VOLATILE_GENERATED_DIRS for part in lower)
+
+
+def _receipt_artifact_hashes(receipt: dict | None) -> dict[str, str]:
+    """The receipt's ``artifacts`` list as a path -> sha256 map, ignoring malformed entries."""
+    hashes: dict[str, str] = {}
+    for record in (receipt or {}).get("artifacts") or []:
+        if not isinstance(record, dict):
+            continue
+        path, digest = record.get("path"), record.get("sha256")
+        if isinstance(path, str) and isinstance(digest, str) and _is_guarded_path(Path(path)):
+            hashes[path] = digest
+    return hashes
+
+
+def _generated_baseline_hashes(bundle: Path) -> dict[str, str]:
+    """The WIDER baseline: every file under a `*.SemanticModel`/`*.Report` folder, PBIR JSON included.
+
+    The receipt only records `ARTIFACT_SUFFIXES`, so a hand-edited PBIR visual definition - the
+    report builder's entire output - is invisible to it. `write_generated_artifact_manifest` hashes
+    the whole generated tree, so the two baselines together cover both halves of what an agent
+    actually edits: model measures and report visuals.
+    """
+    manifest_path = bundle / "input_manifest.json"
+    if not manifest_path.is_file():
+        return {}
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    generated = manifest.get(GENERATED_ARTIFACTS_KEY) if isinstance(manifest, dict) else None
+    files = generated.get("files") if isinstance(generated, dict) else None
+    if not isinstance(files, dict):
+        return {}
+    return {
+        path: digest
+        for path, digest in files.items()
+        if isinstance(path, str) and isinstance(digest, str) and _is_guarded_path(Path(path))
+    }
+
+
+def detect_downstream_work(bundle: Path, receipt_hashes: dict[str, str], baseline: dict[str, str]) -> BundleDrift:
+    """Re-hash the bundle and name every file that is no longer what the engine produced.
+
+    ``added`` is decided from the RECEIPT alone, via ``engine_artifact_records`` - the very function
+    that wrote it - so a pristine bundle reconciles exactly and cannot raise a false alarm. The
+    generated-artifact baseline is mtime-filtered when written, so it is used only for files it
+    already knows about (modified/missing) and never to decide that a file is new.
+    """
+    modified: list[str] = []
+    added: list[str] = []
+    missing: list[str] = []
+
+    if receipt_hashes:
+        current = {
+            record["path"]: record["sha256"]
+            for record in engine_artifact_records(bundle)
+            if _is_guarded_path(Path(record["path"]))
+        }
+        for path, digest in receipt_hashes.items():
+            if path not in current:
+                missing.append(path)
+            elif current[path] != digest:
+                modified.append(path)
+        added = [path for path in current if path not in receipt_hashes]
+
+    for path, digest in baseline.items():
+        if path in receipt_hashes:
+            continue
+        candidate = bundle / path
+        if not candidate.is_file():
+            missing.append(path)
+        elif sha256_file(candidate) != digest:
+            modified.append(path)
+
+    return BundleDrift(sorted(set(modified)), sorted(set(added)), sorted(set(missing)))
+
+
+def _engine_versions(receipt: dict | None, engine: Path | None) -> tuple[str | None, str | None]:
+    """(version that built the bundle, version about to rewrite it) - either may be unknown."""
+    block = (receipt or {}).get("engine")
+    recorded = block.get("version") if isinstance(block, dict) else None
+    running = engine_provenance(engine)["version"] if engine is not None else None
+    return (recorded if isinstance(recorded, str) else None, running if isinstance(running, str) else None)
+
+
+def assess_bundle_rewrite(args: argparse.Namespace, engine: Path | None) -> BundleRewriteFindings:
+    """Decide, BEFORE the engine runs, whether this run may rewrite `--output`.
+
+    ``--slice-only`` is exempt by construction, not by exception: it never invokes the engine (see
+    ``resolve_run_engine``), so there is no delete-and-recreate to guard against, and it legitimately
+    points at an existing bundle every single time.
+    """
+    bundle = Path(args.output)
+    nothing = BundleDrift([], [], [])
+    accepted_rewrite = bool(args.accept_bundle_rewrite)
+    accepted_version = bool(args.accept_engine_version_change)
+    if args.slice_only or not bundle.is_dir():
+        return BundleRewriteFindings(bundle, False, nothing, None, None, [], accepted_rewrite, accepted_version)
+
+    receipt, warning = read_engine_receipt(bundle)
+    warnings = [warning] if warning else []
+    receipt_hashes = _receipt_artifact_hashes(receipt)
+    if receipt is not None and not receipt_hashes:
+        warnings.append(f"{ENGINE_RECEIPT} lists no artifacts - it cannot attest to what the engine produced")
+    baseline = _generated_baseline_hashes(bundle)
+    recorded_version, running_version = _engine_versions(receipt, engine)
+    if not receipt_hashes and not baseline:
+        if _looks_like_bundle(bundle):
+            warnings.append(
+                f"no usable {ENGINE_RECEIPT} and no generated-artifact baseline in {bundle} - this run "
+                "cannot tell engine output from downstream work, so it is not trying to; anything an "
+                "agent wrote here will be destroyed without being named"
+            )
+        if not recorded_version:
+            return BundleRewriteFindings(
+                bundle, False, nothing, None, None, warnings, accepted_rewrite, accepted_version
+            )
+
+    return BundleRewriteFindings(
+        bundle,
+        True,
+        detect_downstream_work(bundle, receipt_hashes, baseline),
+        recorded_version,
+        running_version,
+        warnings,
+        accepted_rewrite,
+        accepted_version,
+    )
+
+
+def _sample(paths: list[str]) -> str:
+    """The first few paths, plus an honest count of what was elided."""
+    shown = paths[:REWRITE_LIST_LIMIT]
+    lines = [f"      {path}" for path in shown]
+    if len(paths) > len(shown):
+        lines.append(f"      ... and {len(paths) - len(shown)} more")
+    return "\n".join(lines)
+
+
+def print_bundle_rewrite(findings: BundleRewriteFindings) -> None:
+    """Name what a re-run into this `--output` would destroy, and how to proceed deliberately."""
+    for warning in findings.warnings:
+        print(f"BUNDLE_REWRITE: WARN - {warning}")
+    if findings.drift.total:
+        print(
+            f"\nESTATE: BUNDLE_REWRITE {'ACCEPTED' if findings.accepted_rewrite else 'REFUSED'} - "
+            f"{findings.drift.total} file(s) in {findings.bundle} no longer match what the engine produced"
+        )
+        for label, paths in (
+            ("modified", findings.drift.modified),
+            ("added", findings.drift.added),
+            ("missing", findings.drift.missing),
+        ):
+            if paths:
+                print(f"  {label} ({len(paths)}):")
+                print(_sample(paths))
+        print(
+            "  An engine re-run is DELETE-AND-RECREATE, not merge: it rmtree()s the .SemanticModel\n"
+            "  folder, the .pbip project dir and <name>.Report before rewriting them, and the\n"
+            "  engine's own stale-output guard EXEMPTS the --approved-dax landing path. Every file\n"
+            "  listed above would be gone, and no other gate here runs until after that has happened."
+        )
+        if not findings.accepted_rewrite:
+            print("  -> land into a FRESH --output, or pass --accept-bundle-rewrite to proceed knowingly.")
+    if findings.version_changed:
+        print(
+            f"\nESTATE: BUNDLE_REWRITE {'ACCEPTED' if findings.accepted_version else 'REFUSED'} - this "
+            f"bundle was built by engine {findings.recorded_version}, this run would rewrite it with "
+            f"{findings.running_version}"
+        )
+        print(
+            "  Two engine versions are not equivalent: 2.113.0 emitted deprecated Bing shapeMap\n"
+            "  visuals and dropped a density-map worksheet entirely where 2.126.0 emitted azureMap\n"
+            "  with a heat layer, and nothing in the output said which one ran (#107). Rewriting in\n"
+            "  place mixes both into one bundle."
+        )
+        if not findings.accepted_version:
+            print("  -> use a FRESH --output, or pass --accept-engine-version-change to proceed knowingly.")
+
+
+def record_bundle_rewrite_acknowledgement(findings: BundleRewriteFindings) -> Path | None:
+    """Append the acknowledgement to the bundle, so the ARTIFACT says the loss was deliberate.
+
+    Written before the engine runs and at the bundle root, which the engine's `rmtree` sites do not
+    touch, so it survives the rewrite it is describing. Append rather than overwrite: a bundle that
+    has been knowingly rewritten twice should say so twice.
+    """
+    if not findings.acknowledged:
+        return None
+    path = findings.bundle / BUNDLE_REWRITE_RECORD
+    records = []
+    if path.is_file():
+        try:
+            existing = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            existing = None
+        if isinstance(existing, dict) and isinstance(existing.get("records"), list):
+            records = existing["records"]
+    records.append(
+        {
+            "acknowledged_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+            "accepted_bundle_rewrite": findings.accepted_rewrite,
+            "accepted_engine_version_change": findings.accepted_version,
+            "engine_version_recorded": findings.recorded_version,
+            "engine_version_running": findings.running_version,
+            "destroyed": {
+                "modified": findings.drift.modified,
+                "added": findings.drift.added,
+                "missing": findings.drift.missing,
+            },
+        }
+    )
+    path.write_text(json.dumps({"version": 1, "records": records}, indent=2) + "\n", encoding="utf-8")
+    log.info("BUNDLE_REWRITE: acknowledgement recorded -> %s", path)
+    return path
+
+
 def check_empty_models(out_dir: Path) -> dict:
     """Scan the emitted models for the one failure the engine reports but nothing gates on.
 
@@ -539,6 +896,22 @@ def build_parser() -> argparse.ArgumentParser:
         help="acknowledge a non-plugin --engine; the bundle receipt records the run as non-canonical",
     )
     parser.add_argument("--approved-dax", type=Path, help="landing re-run: {calc name: DAX} JSON")
+    parser.add_argument(
+        "--accept-bundle-rewrite",
+        action="store_true",
+        help=(
+            "acknowledge that this run DESTROYS downstream work already in --output (an engine re-run "
+            "is delete-and-recreate, not merge); the acknowledgement is recorded in the bundle"
+        ),
+    )
+    parser.add_argument(
+        "--accept-engine-version-change",
+        action="store_true",
+        help=(
+            "acknowledge rewriting a bundle that a DIFFERENT engine version built; two versions are "
+            "not equivalent (#107), so the default is to refuse rather than mix them"
+        ),
+    )
     parser.add_argument(
         "--slice-only",
         action="store_true",
@@ -681,9 +1054,19 @@ def main(argv: list[str] | None = None) -> int:
     if engine_code != EXIT_OK:
         return engine_code
 
+    # --- phase 0: the barrier ------------------------------------------------------------------
+    # BEFORE the engine, because every other gate in this file reads output the engine has already
+    # written - which for a landing re-run means reading it out of the crater (issue #250).
+    rewrite = assess_bundle_rewrite(args, engine)
+    print_bundle_rewrite(rewrite)
+    if rewrite.blocking:
+        return EXIT_BUNDLE_REWRITE
+
     if args.dry_run:
         print_dry_run(args, engine)
         return EXIT_OK
+
+    record_bundle_rewrite_acknowledgement(rewrite)
 
     # --- phase 1: the engine ------------------------------------------------------------------
     if not args.slice_only:

--- a/tests/test_run_estate.py
+++ b/tests/test_run_estate.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import sys
 import time
 from pathlib import Path
@@ -739,13 +740,20 @@ def _versioned_engine(root: Path, version: str) -> Path:
 def _bundle_engine(calls: list[Path] | None = None):
     """A stand-in engine emitting a stable, realistic bundle: a model, a PBIR report and a .pbip.
 
-    `calls` is how a test proves the guard is PRE-engine: a refusal must leave it empty. Asserting
-    only on the exit code would still pass if the bundle were destroyed first and refused after.
+    DESTRUCTIVE on purpose. `migrate_estate.py` rmtree()s the `.SemanticModel` folder, the whole
+    `.pbip` project dir and `<name>.Report` before rewriting them, so a stand-in that merely
+    overwrites the files it happens to know about would let a test claim "nothing was destroyed"
+    while a real engine had eaten the sentinel beside them. Wiping `pbip/` first is what lets a test
+    assert on the DISK rather than only on a call log.
+
+    `calls` is how a test proves the guard is PRE-engine: a refusal must leave it empty.
     """
 
     def _fake(_engine: Path, _src: Path, dest: Path, _dax: Path | None) -> tuple[int, str]:
         if calls is not None:
             calls.append(dest)
+        shutil.rmtree(dest / "pbip", ignore_errors=True)
+        shutil.rmtree(dest / "data", ignore_errors=True)
         _write(dest / "report.json", json.dumps(_report()))
         _write(dest / "input_manifest.json", '{"inputs": []}')
         model = dest / "pbip" / "WB" / "WB.SemanticModel"
@@ -754,6 +762,8 @@ def _bundle_engine(calls: list[Path] | None = None):
         report = dest / "pbip" / "WB" / "WB.Report"
         _write(report / "definition.pbir", "{}")
         _write(report / "definition" / "report.json", '{"pages": []}')
+        _write(dest / "pbip" / "WB" / "WB.Data" / "orders.txt", "id,amount\n1,10\n")
+        _write(dest / "data" / "orders.csv", "id,amount\n1,10\n")
         _write(dest / "pbip" / "WB" / "WB.pbip", "{}")
         return 0, ""
 
@@ -762,6 +772,7 @@ def _bundle_engine(calls: list[Path] | None = None):
 
 ORDERS_TMDL = "pbip/WB/WB.SemanticModel/definition/tables/Orders.tmdl"
 REPORT_JSON = "pbip/WB/WB.Report/definition/report.json"
+TEXTSCAN_DATA = "pbip/WB/WB.Data/orders.txt"
 
 
 def _landing_argv(engine: Path, src: Path, out: Path, *extra: str) -> list[str]:
@@ -860,6 +871,87 @@ def test_a_new_artifact_under_pbip_counts_as_downstream_work(tmp_path: Path, mon
     assert calls == []
 
 
+def test_a_newly_authored_pbir_file_is_downstream_work(tmp_path: Path, monkeypatch) -> None:
+    """HIGH 1: PBIR is `.json`, which the engine receipt's suffix allowlist does not record.
+
+    Addition-detection used to run off that allowlist, so a hand-authored page or visual was
+    invisible - while the engine deletes the whole `.Report` directory around it. The barrier now
+    allowlists LOCATIONS, so anything inside a folder the engine rmtree()s is accounted for.
+    """
+    engine, src, out = _first_run(tmp_path, monkeypatch)
+    authored = out / "pbip" / "WB" / "WB.Report" / "definition" / "pages" / "p1" / "visuals" / "v1"
+    sentinel = _write(authored / "visual.json", json.dumps({"name": "v1"}))
+    receipt = json.loads((out / run_estate.ENGINE_RECEIPT).read_text(encoding="utf-8"))
+    assert not any(record["path"].endswith("visual.json") for record in receipt["artifacts"])
+    calls = _relanding(monkeypatch)
+
+    assert run_estate.main(_landing_argv(engine, src, out)) == run_estate.EXIT_BUNDLE_REWRITE
+    assert calls == []
+    assert sentinel.is_file(), "the authored PBIR file was destroyed by a run the barrier let through"
+
+
+def test_a_textscan_extract_beside_the_project_is_downstream_work(tmp_path: Path, monkeypatch) -> None:
+    """HIGH 2: `.txt` is in neither the receipt's suffix list nor the generated-artifact baseline.
+
+    A packaged Tableau `textscan` datasource lands as flat files under `<project>.Data` and `data/`,
+    both of which the engine deletes. Format allowlists cannot cover this; location coverage can.
+    """
+    engine, src, out = _first_run(tmp_path, monkeypatch)
+    receipt = json.loads((out / run_estate.ENGINE_RECEIPT).read_text(encoding="utf-8"))
+    assert TEXTSCAN_DATA not in {record["path"] for record in receipt["artifacts"]}
+    manifest = json.loads((out / "input_manifest.json").read_text(encoding="utf-8"))
+    assert TEXTSCAN_DATA not in manifest[run_estate.GENERATED_ARTIFACTS_KEY]["files"]
+    assert TEXTSCAN_DATA in manifest[run_estate.ENGINE_TREE_KEY]["files"]
+
+    (out / TEXTSCAN_DATA).write_text("id,amount\n1,10\n2,99\n", encoding="utf-8")
+    calls = _relanding(monkeypatch)
+
+    assert run_estate.main(_landing_argv(engine, src, out)) == run_estate.EXIT_BUNDLE_REWRITE
+    assert calls == []
+
+
+def test_a_new_flat_file_under_data_is_downstream_work(tmp_path: Path, monkeypatch) -> None:
+    """The addition shape of the same gap: a landed extract the engine never wrote."""
+    engine, src, out = _first_run(tmp_path, monkeypatch)
+    sentinel = _write(out / "data" / "hand-landed.txt", "id,amount\n7,70\n")
+    calls = _relanding(monkeypatch)
+
+    assert run_estate.main(_landing_argv(engine, src, out)) == run_estate.EXIT_BUNDLE_REWRITE
+    assert calls == []
+    assert sentinel.is_file()
+
+
+def test_a_slice_only_backfill_cannot_bless_downstream_work_as_engine_output(tmp_path: Path, monkeypatch) -> None:
+    """HIGH 5: `--slice-only` hashes the WORKING COPY, downstream edits included.
+
+    It writes that as `generated_artifacts` with `coverage: "slice_only_backfill"`. Trusting it
+    would launder an agent's edits into "engine output" and hand the next destructive run a clean
+    bill of health - one step removed from where the barrier was looking. The marker is now read,
+    the baseline is not trusted, and the bundle stays indeterminate until acknowledged.
+    """
+    _without_pbir_validator(monkeypatch)
+    engine = _versioned_engine(tmp_path / "engine", "2.339.0")
+    out = tmp_path / "bundle"
+    src = tmp_path / "src"
+    src.mkdir()
+    _write(out / "report.json", json.dumps(_report()))
+    sentinel = _write(out / "pbip" / "WB" / "WB.SemanticModel" / "definition" / "tables" / "Hand.tmdl", "table Hand")
+
+    assert run_estate.main(["--output", str(out), "--slice-only"]) == run_estate.EXIT_OK
+    manifest = json.loads((out / "input_manifest.json").read_text(encoding="utf-8"))
+    generated = manifest[run_estate.GENERATED_ARTIFACTS_KEY]
+    assert generated["coverage"] == run_estate.SLICE_ONLY_COVERAGE
+    assert "pbip/WB/WB.SemanticModel/definition/tables/Hand.tmdl" in generated["files"], (
+        "fixture no longer reproduces the laundering shape - the backfill must have hashed the edit"
+    )
+    assert run_estate.ENGINE_TREE_KEY not in manifest, "--slice-only must not write an engine-output tree"
+
+    calls = _relanding(monkeypatch)
+    assert run_estate.main(_landing_argv(engine, src, out)) == run_estate.EXIT_BUNDLE_REWRITE
+    assert calls == []
+    assert sentinel.is_file()
+
+
 def test_a_deleted_engine_artifact_counts_as_downstream_work(tmp_path: Path, monkeypatch) -> None:
     """A bundle missing something the receipt attests to is no longer the bundle that was measured."""
     engine, src, out = _first_run(tmp_path, monkeypatch)
@@ -890,22 +982,89 @@ def test_accepting_the_rewrite_proceeds_and_the_bundle_records_what_was_destroye
     assert ORDERS_TMDL in record["records"][0]["destroyed"]["modified"]
 
 
-def test_a_bundle_with_neither_baseline_warns_instead_of_hard_failing(tmp_path: Path, monkeypatch, capsys) -> None:
-    """DoD 4: a pre-receipt or third-party bundle must not be bricked by the guard."""
+def test_a_bundle_with_no_baseline_blocks_rather_than_reporting_clean(tmp_path: Path, monkeypatch, capsys) -> None:
+    """HIGH 3: a pre-receipt or third-party bundle cannot be assessed, so it must not be waved through.
+
+    The first cut treated "no baseline" as "no drift" and destroyed a sentinel at exit 0, told apart
+    from a real pass only by warning TEXT. Unassessable is now its own blocking state; the flag is
+    how a legacy bundle stays usable, which is exactly what the flag is for.
+    """
     _without_pbir_validator(monkeypatch)
     engine = _versioned_engine(tmp_path / "engine", "2.339.0")
     out = tmp_path / "bundle"
     src = tmp_path / "src"
     src.mkdir()
     _write(out / "report.json", json.dumps(_report()))
-    _write(out / "pbip" / "WB" / "WB.SemanticModel" / "definition" / "tables" / "Orders.tmdl", "table Orders")
+    sentinel = _write(out / "pbip" / "WB" / "WB.SemanticModel" / "definition" / "tables" / "Hand.tmdl", "table Hand")
     calls = _relanding(monkeypatch)
 
-    code = run_estate.main(_landing_argv(engine, src, out))
+    assert run_estate.main(_landing_argv(engine, src, out)) == run_estate.EXIT_BUNDLE_REWRITE
+    assert calls == []
+    assert sentinel.is_file(), "the sentinel was destroyed by a run the barrier let through"
+    assert "CANNOT ASSESS" in capsys.readouterr().out
+
+
+def test_an_unassessable_bundle_is_recoverable_with_both_acknowledgements(tmp_path: Path, monkeypatch) -> None:
+    """The escape hatch has to work, or the barrier bricks every bundle built before it existed."""
+    _without_pbir_validator(monkeypatch)
+    engine = _versioned_engine(tmp_path / "engine", "2.339.0")
+    out = tmp_path / "bundle"
+    src = tmp_path / "src"
+    src.mkdir()
+    _write(out / "report.json", json.dumps(_report()))
+    _write(out / "pbip" / "WB" / "WB.SemanticModel" / "definition" / "tables" / "Hand.tmdl", "table Hand")
+    calls = _relanding(monkeypatch)
+
+    code = run_estate.main(_landing_argv(engine, src, out, "--accept-bundle-rewrite", "--accept-engine-version-change"))
 
     assert code == run_estate.EXIT_OK
     assert calls == [out]
-    assert f"no usable {run_estate.ENGINE_RECEIPT}" in capsys.readouterr().out
+    record = json.loads((out / run_estate.BUNDLE_REWRITE_RECORD).read_text(encoding="utf-8"))
+    assert record["records"][0]["coverage_complete"] is False
+    assert record["records"][0]["coverage_gaps"], "an acknowledgement must record what could not be assessed"
+
+
+def test_emptied_baselines_block_exactly_like_missing_ones(tmp_path: Path, monkeypatch) -> None:
+    """HIGH 3, second shape: `artifacts: []` and `files: {}` attest to nothing.
+
+    They previously behaved identically to a real pass and were distinguished only by warning text,
+    never by exit code - which is the same defect wearing a different hat.
+    """
+    engine, src, out = _first_run(tmp_path, monkeypatch)
+    receipt = json.loads((out / run_estate.ENGINE_RECEIPT).read_text(encoding="utf-8"))
+    receipt["artifacts"] = []
+    (out / run_estate.ENGINE_RECEIPT).write_text(json.dumps(receipt), encoding="utf-8")
+    manifest = json.loads((out / "input_manifest.json").read_text(encoding="utf-8"))
+    manifest[run_estate.GENERATED_ARTIFACTS_KEY]["files"] = {}
+    manifest[run_estate.ENGINE_TREE_KEY]["files"] = {}
+    (out / "input_manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+    sentinel = _write(out / "pbip" / "WB" / "WB.SemanticModel" / "definition" / "tables" / "Hand.tmdl", "table Hand")
+    calls = _relanding(monkeypatch)
+
+    assert run_estate.main(_landing_argv(engine, src, out)) == run_estate.EXIT_BUNDLE_REWRITE
+    assert calls == []
+    assert sentinel.is_file()
+
+
+def test_an_emptied_baseline_does_not_invent_a_file_list(tmp_path: Path, monkeypatch) -> None:
+    """Blocking is right; naming phantom victims is not.
+
+    With no trustworthy baseline every file in the bundle is ambiguous, so listing them as "added"
+    would imply the rest had been cleared. The block comes from the coverage gap alone.
+    """
+    engine, src, out = _first_run(tmp_path, monkeypatch)
+    receipt = json.loads((out / run_estate.ENGINE_RECEIPT).read_text(encoding="utf-8"))
+    receipt["artifacts"] = []
+    (out / run_estate.ENGINE_RECEIPT).write_text(json.dumps(receipt), encoding="utf-8")
+    (out / "input_manifest.json").write_text('{"inputs": []}', encoding="utf-8")
+    _relanding(monkeypatch)
+
+    code = run_estate.main(_landing_argv(engine, src, out, "--accept-bundle-rewrite", "--accept-engine-version-change"))
+
+    assert code == run_estate.EXIT_OK
+    record = json.loads((out / run_estate.BUNDLE_REWRITE_RECORD).read_text(encoding="utf-8"))["records"][0]
+    assert record["destroyed"] == {"modified": [], "added": [], "missing": []}
+    assert record["coverage_gaps"]
 
 
 def test_a_bundle_built_by_a_different_engine_version_is_not_rewritten_by_default(
@@ -971,13 +1130,18 @@ def test_slice_only_still_works_against_a_bundle_full_of_downstream_work(tmp_pat
     """`--slice-only` legitimately points at an EXISTING bundle on every invocation.
 
     It never invokes the engine (see `resolve_run_engine`), so there is no delete-and-recreate to
-    guard against. A barrier that fired here would break the documented re-derivation flow outright.
+    guard against. The call log is the load-bearing assertion and the reason this test was rewritten:
+    asserting only `EXIT_OK` passed even when `--slice-only` was mutated into running the engine,
+    because the exit code cannot tell "skipped the engine" from "ran it and it worked".
     """
     _, _, out = _first_run(tmp_path, monkeypatch)
+    sentinel = _write(out / "pbip" / "WB" / "WB.SemanticModel" / "definition" / "tables" / "Custom.tmdl", "table C")
     (out / ORDERS_TMDL).write_text("table Orders\n\n\tmeasure Sales = 1\n", encoding="utf-8")
-    _write(out / "pbip" / "WB" / "WB.SemanticModel" / "definition" / "tables" / "Custom.tmdl", "table Custom")
+    calls = _relanding(monkeypatch)
 
     assert run_estate.main(["--output", str(out), "--slice-only"]) == run_estate.EXIT_OK
+    assert calls == [], "--slice-only ran the engine, which is the destructive path it exists to avoid"
+    assert sentinel.is_file(), "downstream work was destroyed by a --slice-only run"
     assert not (out / run_estate.BUNDLE_REWRITE_RECORD).exists()
 
 
@@ -998,11 +1162,7 @@ def test_a_desktop_refresh_sidecar_is_not_downstream_work(tmp_path: Path, monkey
 
 
 def test_a_receipt_that_attests_to_nothing_is_not_read_as_a_clean_bundle(tmp_path: Path, monkeypatch, capsys) -> None:
-    """An empty `artifacts` list is an absence of evidence, not evidence of absence.
-
-    Taking it at face value would flip the guard from "refuse" to "silently proceed" on exactly the
-    bundles whose provenance is weakest, and the engine-version half must still bind.
-    """
+    """An empty `artifacts` list is an absence of evidence, not evidence of absence."""
     engine, src, out = _first_run(tmp_path, monkeypatch, version="2.141.0")
     receipt = json.loads((out / run_estate.ENGINE_RECEIPT).read_text(encoding="utf-8"))
     receipt["artifacts"] = []
@@ -1013,22 +1173,119 @@ def test_a_receipt_that_attests_to_nothing_is_not_read_as_a_clean_bundle(tmp_pat
 
     assert run_estate.main(_landing_argv(newer, src, out)) == run_estate.EXIT_BUNDLE_REWRITE
     assert calls == []
-    assert "lists no artifacts" in capsys.readouterr().out
+    assert "lists no usable artifacts" in capsys.readouterr().out
     assert engine != newer
 
 
-def test_a_receipt_that_attests_to_nothing_does_not_invent_a_finding(tmp_path: Path, monkeypatch) -> None:
-    """The other half of DoD 4: unattestable is not the same as dirty.
+def test_a_truncated_receipt_blocks_the_version_guard_rather_than_passing_it(tmp_path: Path, monkeypatch) -> None:
+    """HIGH 4: one broken byte used to disable the engine-version guard entirely.
 
-    Comparing disk against an EMPTY attestation naively reports every file in the bundle as newly
-    added and refuses a run that has nothing wrong with it - a guard that cries wolf gets flagged
-    past, which is the failure mode this whole barrier exists to avoid.
+    A malformed receipt parses to None, `recorded_version` becomes None, and "is it different?"
+    silently answered "no". Unknown is indeterminate now and blocks - and the rewrite flag must not
+    answer it, because "I accept losing my work" says nothing about which engine rebuilds it.
+    """
+    _, src, out = _first_run(tmp_path, monkeypatch, version="2.141.0")
+    receipt_path = out / run_estate.ENGINE_RECEIPT
+    receipt_path.write_text(receipt_path.read_text(encoding="utf-8")[:40], encoding="utf-8")
+    newer = _versioned_engine(tmp_path / "engine2", "2.260.0")
+    calls = _relanding(monkeypatch)
+
+    assert run_estate.main(_landing_argv(newer, src, out)) == run_estate.EXIT_BUNDLE_REWRITE
+    assert run_estate.main(_landing_argv(newer, src, out, "--accept-bundle-rewrite")) == (
+        run_estate.EXIT_BUNDLE_REWRITE
+    )
+    assert calls == []
+
+
+def test_an_engine_tree_with_no_version_is_indeterminate_not_unchanged(tmp_path: Path, monkeypatch) -> None:
+    """The mirror case: if THIS run's engine has no VERSION, nothing can be compared either."""
+    _, src, out = _first_run(tmp_path, monkeypatch, version="2.141.0")
+    nameless = tmp_path / "engine-no-version"
+    (nameless / "skills" / "tableau-migration" / "scripts").mkdir(parents=True)
+    calls = _relanding(monkeypatch)
+
+    assert run_estate.main(_landing_argv(nameless, src, out)) == run_estate.EXIT_BUNDLE_REWRITE
+    assert calls == []
+
+
+def test_a_slice_only_backfill_is_distrusted_even_when_the_other_baselines_look_fine(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Defence in depth for HIGH 5, isolated from the coverage gap that usually fires first.
+
+    In today's flows a `slice_only_backfill` block only ever coexists with a MISSING tree, so the
+    tree gap blocks first and the distrust never gets to speak - which is precisely how a redundant
+    check rots. This constructs the shape directly: a bundle whose tree and receipt are intact, and
+    whose `generated_artifacts` came from a backfill. The backfill's hashes are not evidence of
+    engine origin no matter what sits beside them, so the bundle stays indeterminate.
     """
     engine, src, out = _first_run(tmp_path, monkeypatch)
-    receipt = json.loads((out / run_estate.ENGINE_RECEIPT).read_text(encoding="utf-8"))
-    receipt["artifacts"] = []
-    (out / run_estate.ENGINE_RECEIPT).write_text(json.dumps(receipt), encoding="utf-8")
-    (out / "input_manifest.json").write_text('{"inputs": []}', encoding="utf-8")
+    hand = _write(out / "pbip" / "WB" / "WB.SemanticModel" / "definition" / "tables" / "Hand.tmdl", "table Hand")
+    relative = "pbip/WB/WB.SemanticModel/definition/tables/Hand.tmdl"
+    manifest = json.loads((out / "input_manifest.json").read_text(encoding="utf-8"))
+    manifest[run_estate.ENGINE_TREE_KEY]["files"][relative] = run_estate.sha256_file(hand)
+    manifest[run_estate.GENERATED_ARTIFACTS_KEY] = {
+        "version": 1,
+        "coverage": run_estate.SLICE_ONLY_COVERAGE,
+        "files": {relative: run_estate.sha256_file(hand)},
+    }
+    (out / "input_manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+    calls = _relanding(monkeypatch)
+
+    assert run_estate.main(_landing_argv(engine, src, out)) == run_estate.EXIT_BUNDLE_REWRITE
+    assert calls == []
+
+
+def test_a_legacy_bundle_with_a_receipt_but_no_tree_cannot_clear_an_added_file(tmp_path: Path, monkeypatch) -> None:
+    """The realistic HIGH 1 shape: every bundle built before this barrier existed.
+
+    Its receipt is valid, its generated-artifact baseline is valid, and the engine has not moved -
+    so nothing else raises a finding. Only the missing tree makes an ADDED file undecidable, and
+    only saying so blocks. Suppressing that one gap turns this bundle back into a silent exit 0.
+    """
+    engine, src, out = _first_run(tmp_path, monkeypatch)
+    manifest = json.loads((out / "input_manifest.json").read_text(encoding="utf-8"))
+    del manifest[run_estate.ENGINE_TREE_KEY]
+    (out / "input_manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+    authored = out / "pbip" / "WB" / "WB.Report" / "definition" / "pages" / "p1" / "visuals" / "v1"
+    sentinel = _write(authored / "visual.json", json.dumps({"name": "v1"}))
+    calls = _relanding(monkeypatch)
+
+    assert run_estate.main(_landing_argv(engine, src, out)) == run_estate.EXIT_BUNDLE_REWRITE
+    assert calls == []
+    assert sentinel.is_file()
+
+
+def test_a_corrupt_receipt_still_blocks_when_only_the_version_change_was_accepted(tmp_path: Path, monkeypatch) -> None:
+    """ "I accept a possible engine change" is not "I accept not knowing what is in the bundle".
+
+    With the version half acknowledged, an unreadable receipt is the ONLY remaining finding - so
+    this is what proves the receipt gap carries its own weight rather than riding on the version
+    guard that usually fires alongside it.
+    """
+    engine, src, out = _first_run(tmp_path, monkeypatch)
+    (out / run_estate.ENGINE_RECEIPT).write_text("{ truncated", encoding="utf-8")
+    calls = _relanding(monkeypatch)
+
+    code = run_estate.main(_landing_argv(engine, src, out, "--accept-engine-version-change"))
+
+    assert code == run_estate.EXIT_BUNDLE_REWRITE
+    assert calls == []
+
+
+def test_an_existing_but_non_bundle_output_folder_is_not_treated_as_a_bundle(tmp_path: Path, monkeypatch) -> None:
+    """The over-reach guard: `--output` may legitimately be a folder that simply already exists.
+
+    An operator's scratch directory holds nothing the engine wrote, so there is nothing to protect
+    and blocking would be noise on a first run. "Cannot assess" must block only where the engine has
+    actually been.
+    """
+    _without_pbir_validator(monkeypatch)
+    engine = _versioned_engine(tmp_path / "engine", "2.339.0")
+    out = tmp_path / "bundle"
+    src = tmp_path / "src"
+    src.mkdir()
+    _write(out / "notes.md", "operator scratch, nothing the engine wrote")
     calls = _relanding(monkeypatch)
 
     assert run_estate.main(_landing_argv(engine, src, out)) == run_estate.EXIT_OK

--- a/tests/test_run_estate.py
+++ b/tests/test_run_estate.py
@@ -715,3 +715,335 @@ def test_the_coordinator_never_emits_model_content() -> None:
     body = source.split('"""', 2)[-1]  # skip the module docstring, which explains these very terms
     for forbidden in ("write_model_folder", "write_local_pbip", ".tmdl", "visual.json"):
         assert forbidden not in body, f"coordinator must not emit model content ({forbidden})"
+
+
+# ---------------------------------------------------------------------------
+# issue #250: the destructive-re-run barrier is CHECKED now, not merely documented
+#
+# The docstring claimed "this script owns that ordering so no agent has to remember it" and owned
+# nothing: every gate ran in phase 2, reading output the engine had already written. A landing
+# re-run into a bundle holding ~20 items of hand-authored fix work destroyed all of it with no
+# --force, no prompt and no pre-check. These tests drive `main()` so that a guard moved back after
+# the engine, or quietly turned into an opt-in, fails them.
+# ---------------------------------------------------------------------------
+
+
+def _versioned_engine(root: Path, version: str) -> Path:
+    """An engine tree whose VERSION is what `engine_provenance` reads back off disk."""
+    skill = root / "skills" / "tableau-migration"
+    skill.mkdir(parents=True, exist_ok=True)
+    (skill / "VERSION").write_text(version + "\n", encoding="utf-8")
+    return root
+
+
+def _bundle_engine(calls: list[Path] | None = None):
+    """A stand-in engine emitting a stable, realistic bundle: a model, a PBIR report and a .pbip.
+
+    `calls` is how a test proves the guard is PRE-engine: a refusal must leave it empty. Asserting
+    only on the exit code would still pass if the bundle were destroyed first and refused after.
+    """
+
+    def _fake(_engine: Path, _src: Path, dest: Path, _dax: Path | None) -> tuple[int, str]:
+        if calls is not None:
+            calls.append(dest)
+        _write(dest / "report.json", json.dumps(_report()))
+        _write(dest / "input_manifest.json", '{"inputs": []}')
+        model = dest / "pbip" / "WB" / "WB.SemanticModel"
+        _write(model / "definition.pbism", "{}")
+        _write(model / "definition" / "tables" / "Orders.tmdl", "table Orders")
+        report = dest / "pbip" / "WB" / "WB.Report"
+        _write(report / "definition.pbir", "{}")
+        _write(report / "definition" / "report.json", '{"pages": []}')
+        _write(dest / "pbip" / "WB" / "WB.pbip", "{}")
+        return 0, ""
+
+    return _fake
+
+
+ORDERS_TMDL = "pbip/WB/WB.SemanticModel/definition/tables/Orders.tmdl"
+REPORT_JSON = "pbip/WB/WB.Report/definition/report.json"
+
+
+def _landing_argv(engine: Path, src: Path, out: Path, *extra: str) -> list[str]:
+    return [
+        "--engine",
+        str(engine),
+        "--allow-noncanonical-engine",
+        "--input",
+        str(src),
+        "--output",
+        str(out),
+        *extra,
+    ]
+
+
+def _first_run(tmp_path: Path, monkeypatch, version: str = "2.339.0") -> tuple[Path, Path, Path]:
+    """Build the bundle the way a real run builds it, so both baselines are the real ones."""
+    _without_pbir_validator(monkeypatch)
+    engine = _versioned_engine(tmp_path / "engine", version)
+    out = tmp_path / "bundle"
+    src = tmp_path / "src"
+    src.mkdir(exist_ok=True)
+    monkeypatch.setattr(run_estate, "run_engine", _bundle_engine())
+    assert run_estate.main(_landing_argv(engine, src, out)) == run_estate.EXIT_OK
+    return engine, src, out
+
+
+def _relanding(monkeypatch) -> list[Path]:
+    """Re-arm the stand-in engine for a SECOND run and return the call log."""
+    calls: list[Path] = []
+    monkeypatch.setattr(run_estate, "run_engine", _bundle_engine(calls))
+    return calls
+
+
+def test_a_landing_rerun_into_a_pristine_bundle_still_proceeds(tmp_path: Path, monkeypatch) -> None:
+    """The documented one-run landing flow must survive the guard (issue #250, DoD 2).
+
+    A guard that blocked every re-run would be trivially "safe" and would break the exact workflow
+    the barrier exists to protect. Both baselines are re-hashed here against a bundle nothing has
+    touched, so a false positive fails this test rather than an operator's estate.
+    """
+    engine, src, out = _first_run(tmp_path, monkeypatch)
+    calls = _relanding(monkeypatch)
+    dax = _write(tmp_path / "approved.json", json.dumps({"Rank": "RANKX(...)"}))
+
+    code = run_estate.main(_landing_argv(engine, src, out, "--approved-dax", str(dax)))
+
+    assert code == run_estate.EXIT_OK
+    assert calls == [out], "a pristine bundle must still be re-runnable"
+
+
+def test_hand_authored_work_in_the_bundle_refuses_the_landing_rerun(tmp_path: Path, monkeypatch, capsys) -> None:
+    """The reported case: bulk approved DAX landed into a bundle holding manual fix work.
+
+    The engine's own stale-output guard exempts `--approved-dax`, so nothing upstream refuses this.
+    `calls` is the load-bearing assertion: the refusal has to happen BEFORE the delete-and-recreate,
+    not after it.
+    """
+    engine, src, out = _first_run(tmp_path, monkeypatch)
+    (out / ORDERS_TMDL).write_text("table Orders\n\n\tmeasure Sales = SUM(Orders[Amount])\n", encoding="utf-8")
+    calls = _relanding(monkeypatch)
+    dax = _write(tmp_path / "approved.json", json.dumps({"Rank": "RANKX(...)"}))
+
+    code = run_estate.main(_landing_argv(engine, src, out, "--approved-dax", str(dax)))
+
+    assert code == run_estate.EXIT_BUNDLE_REWRITE
+    assert calls == [], "the engine ran anyway - the barrier must be PRE-engine"
+    assert ORDERS_TMDL in capsys.readouterr().out, "a refusal must name what would be destroyed"
+
+
+def test_a_hand_edited_report_file_is_work_the_receipt_alone_cannot_see(tmp_path: Path, monkeypatch) -> None:
+    """PBIR JSON is outside `ARTIFACT_SUFFIXES`, so the receipt does not record it at all.
+
+    That is why the guard reads the generated-artifact baseline too. The second assertion pins the
+    reason: if the receipt ever did cover these files, this test would be passing for a different
+    reason than it was written for.
+    """
+    engine, src, out = _first_run(tmp_path, monkeypatch)
+    receipt = json.loads((out / run_estate.ENGINE_RECEIPT).read_text(encoding="utf-8"))
+    assert REPORT_JSON not in {record["path"] for record in receipt["artifacts"]}
+
+    (out / REPORT_JSON).write_text('{"pages": [{"name": "p1"}]}', encoding="utf-8")
+    calls = _relanding(monkeypatch)
+
+    assert run_estate.main(_landing_argv(engine, src, out)) == run_estate.EXIT_BUNDLE_REWRITE
+    assert calls == []
+
+
+def test_a_new_artifact_under_pbip_counts_as_downstream_work(tmp_path: Path, monkeypatch) -> None:
+    """An agent-authored model file the engine never wrote is work too, not just an edit."""
+    engine, src, out = _first_run(tmp_path, monkeypatch)
+    _write(out / "pbip" / "WB" / "WB.SemanticModel" / "definition" / "tables" / "Custom.tmdl", "table Custom")
+    calls = _relanding(monkeypatch)
+
+    assert run_estate.main(_landing_argv(engine, src, out)) == run_estate.EXIT_BUNDLE_REWRITE
+    assert calls == []
+
+
+def test_a_deleted_engine_artifact_counts_as_downstream_work(tmp_path: Path, monkeypatch) -> None:
+    """A bundle missing something the receipt attests to is no longer the bundle that was measured."""
+    engine, src, out = _first_run(tmp_path, monkeypatch)
+    (out / ORDERS_TMDL).unlink()
+    calls = _relanding(monkeypatch)
+
+    assert run_estate.main(_landing_argv(engine, src, out)) == run_estate.EXIT_BUNDLE_REWRITE
+    assert calls == []
+
+
+def test_accepting_the_rewrite_proceeds_and_the_bundle_records_what_was_destroyed(tmp_path: Path, monkeypatch) -> None:
+    """DoD 3: the opt-out works, and the ARTIFACT says the loss was deliberate.
+
+    The record is written before the engine runs and lives at the bundle root, which the engine's
+    rmtree sites do not touch - so it survives the rewrite it describes.
+    """
+    engine, src, out = _first_run(tmp_path, monkeypatch)
+    (out / ORDERS_TMDL).write_text("table Orders\n\n\tmeasure Sales = 1\n", encoding="utf-8")
+    calls = _relanding(monkeypatch)
+
+    code = run_estate.main(_landing_argv(engine, src, out, "--accept-bundle-rewrite"))
+
+    assert code == run_estate.EXIT_OK
+    assert calls == [out]
+    record = json.loads((out / run_estate.BUNDLE_REWRITE_RECORD).read_text(encoding="utf-8"))
+    assert len(record["records"]) == 1
+    assert record["records"][0]["accepted_bundle_rewrite"] is True
+    assert ORDERS_TMDL in record["records"][0]["destroyed"]["modified"]
+
+
+def test_a_bundle_with_neither_baseline_warns_instead_of_hard_failing(tmp_path: Path, monkeypatch, capsys) -> None:
+    """DoD 4: a pre-receipt or third-party bundle must not be bricked by the guard."""
+    _without_pbir_validator(monkeypatch)
+    engine = _versioned_engine(tmp_path / "engine", "2.339.0")
+    out = tmp_path / "bundle"
+    src = tmp_path / "src"
+    src.mkdir()
+    _write(out / "report.json", json.dumps(_report()))
+    _write(out / "pbip" / "WB" / "WB.SemanticModel" / "definition" / "tables" / "Orders.tmdl", "table Orders")
+    calls = _relanding(monkeypatch)
+
+    code = run_estate.main(_landing_argv(engine, src, out))
+
+    assert code == run_estate.EXIT_OK
+    assert calls == [out]
+    assert f"no usable {run_estate.ENGINE_RECEIPT}" in capsys.readouterr().out
+
+
+def test_a_bundle_built_by_a_different_engine_version_is_not_rewritten_by_default(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    """2.113.0 and 2.126.0 are not interchangeable (#107) - rewriting in place mixes both."""
+    _, src, out = _first_run(tmp_path, monkeypatch, version="2.141.0")
+    newer = _versioned_engine(tmp_path / "engine2", "2.260.0")
+    calls = _relanding(monkeypatch)
+
+    assert run_estate.main(_landing_argv(newer, src, out)) == run_estate.EXIT_BUNDLE_REWRITE
+    assert calls == []
+    printed = capsys.readouterr().out
+    assert "2.141.0" in printed and "2.260.0" in printed
+
+    assert run_estate.main(_landing_argv(newer, src, out, "--accept-engine-version-change")) == run_estate.EXIT_OK
+    assert calls == [out]
+
+
+def test_the_same_engine_version_is_not_a_finding(tmp_path: Path, monkeypatch) -> None:
+    """The version guard must not fire on the ordinary case, or it is noise that gets flagged away."""
+    engine, src, out = _first_run(tmp_path, monkeypatch, version="2.339.0")
+    same = _versioned_engine(tmp_path / "engine-copy", "2.339.0")
+    calls = _relanding(monkeypatch)
+
+    assert run_estate.main(_landing_argv(same, src, out)) == run_estate.EXIT_OK
+    assert calls == [out]
+    assert engine != same
+
+
+def test_accepting_an_engine_version_change_does_not_waive_the_destruction_guard(tmp_path: Path, monkeypatch) -> None:
+    """The reason these are two flags and not one.
+
+    A single acknowledgement would mean an operator who knows the engine moved silently also waives
+    the guard on downstream work they did not know was there - which moves the failure boundary
+    instead of removing it.
+    """
+    _, src, out = _first_run(tmp_path, monkeypatch, version="2.141.0")
+    (out / ORDERS_TMDL).write_text("table Orders\n\n\tmeasure Sales = 1\n", encoding="utf-8")
+    newer = _versioned_engine(tmp_path / "engine2", "2.260.0")
+    calls = _relanding(monkeypatch)
+
+    assert run_estate.main(_landing_argv(newer, src, out, "--accept-engine-version-change")) == (
+        run_estate.EXIT_BUNDLE_REWRITE
+    )
+    assert calls == []
+
+
+def test_accepting_the_rewrite_does_not_waive_the_engine_version_guard(tmp_path: Path, monkeypatch) -> None:
+    """The mirror image: accepting the loss of work says nothing about mixing engine versions."""
+    _, src, out = _first_run(tmp_path, monkeypatch, version="2.141.0")
+    (out / ORDERS_TMDL).write_text("table Orders\n\n\tmeasure Sales = 1\n", encoding="utf-8")
+    newer = _versioned_engine(tmp_path / "engine2", "2.260.0")
+    calls = _relanding(monkeypatch)
+
+    assert run_estate.main(_landing_argv(newer, src, out, "--accept-bundle-rewrite")) == (
+        run_estate.EXIT_BUNDLE_REWRITE
+    )
+    assert calls == []
+
+
+def test_slice_only_still_works_against_a_bundle_full_of_downstream_work(tmp_path: Path, monkeypatch) -> None:
+    """`--slice-only` legitimately points at an EXISTING bundle on every invocation.
+
+    It never invokes the engine (see `resolve_run_engine`), so there is no delete-and-recreate to
+    guard against. A barrier that fired here would break the documented re-derivation flow outright.
+    """
+    _, _, out = _first_run(tmp_path, monkeypatch)
+    (out / ORDERS_TMDL).write_text("table Orders\n\n\tmeasure Sales = 1\n", encoding="utf-8")
+    _write(out / "pbip" / "WB" / "WB.SemanticModel" / "definition" / "tables" / "Custom.tmdl", "table Custom")
+
+    assert run_estate.main(["--output", str(out), "--slice-only"]) == run_estate.EXIT_OK
+    assert not (out / run_estate.BUNDLE_REWRITE_RECORD).exists()
+
+
+def test_a_desktop_refresh_sidecar_is_not_downstream_work(tmp_path: Path, monkeypatch) -> None:
+    """A normal refresh writes `.pbi/cache.abf`; blocking on that would train operators to flag past it.
+
+    The `.pbi` model file is the sharp case: it carries an artifact suffix the receipt DOES record
+    elsewhere, so only the explicit volatile-folder exclusion keeps it out of the accounting.
+    """
+    engine, src, out = _first_run(tmp_path, monkeypatch)
+    _write(out / "pbip" / "WB" / "WB.SemanticModel" / ".pbi" / "cache.abf", "refresh cache")
+    _write(out / "pbip" / "WB" / "WB.SemanticModel" / ".pbi" / "unapplied" / "Orders.tmdl", "table Orders")
+    _write(out / "pbip" / "WB" / "WB.Report" / ".pbi" / "localSettings.json", "{}")
+    calls = _relanding(monkeypatch)
+
+    assert run_estate.main(_landing_argv(engine, src, out)) == run_estate.EXIT_OK
+    assert calls == [out]
+
+
+def test_a_receipt_that_attests_to_nothing_is_not_read_as_a_clean_bundle(tmp_path: Path, monkeypatch, capsys) -> None:
+    """An empty `artifacts` list is an absence of evidence, not evidence of absence.
+
+    Taking it at face value would flip the guard from "refuse" to "silently proceed" on exactly the
+    bundles whose provenance is weakest, and the engine-version half must still bind.
+    """
+    engine, src, out = _first_run(tmp_path, monkeypatch, version="2.141.0")
+    receipt = json.loads((out / run_estate.ENGINE_RECEIPT).read_text(encoding="utf-8"))
+    receipt["artifacts"] = []
+    (out / run_estate.ENGINE_RECEIPT).write_text(json.dumps(receipt), encoding="utf-8")
+    (out / "input_manifest.json").write_text('{"inputs": []}', encoding="utf-8")
+    newer = _versioned_engine(tmp_path / "engine2", "2.260.0")
+    calls = _relanding(monkeypatch)
+
+    assert run_estate.main(_landing_argv(newer, src, out)) == run_estate.EXIT_BUNDLE_REWRITE
+    assert calls == []
+    assert "lists no artifacts" in capsys.readouterr().out
+    assert engine != newer
+
+
+def test_a_receipt_that_attests_to_nothing_does_not_invent_a_finding(tmp_path: Path, monkeypatch) -> None:
+    """The other half of DoD 4: unattestable is not the same as dirty.
+
+    Comparing disk against an EMPTY attestation naively reports every file in the bundle as newly
+    added and refuses a run that has nothing wrong with it - a guard that cries wolf gets flagged
+    past, which is the failure mode this whole barrier exists to avoid.
+    """
+    engine, src, out = _first_run(tmp_path, monkeypatch)
+    receipt = json.loads((out / run_estate.ENGINE_RECEIPT).read_text(encoding="utf-8"))
+    receipt["artifacts"] = []
+    (out / run_estate.ENGINE_RECEIPT).write_text(json.dumps(receipt), encoding="utf-8")
+    (out / "input_manifest.json").write_text('{"inputs": []}', encoding="utf-8")
+    calls = _relanding(monkeypatch)
+
+    assert run_estate.main(_landing_argv(engine, src, out)) == run_estate.EXIT_OK
+    assert calls == [out]
+
+
+def test_a_dry_run_reports_the_refusal_and_never_writes_an_acknowledgement(tmp_path: Path, monkeypatch) -> None:
+    """`--dry-run` says what WOULD happen, so it must say "this would be refused" - and change nothing."""
+    engine, src, out = _first_run(tmp_path, monkeypatch)
+    (out / ORDERS_TMDL).write_text("table Orders\n\n\tmeasure Sales = 1\n", encoding="utf-8")
+    calls = _relanding(monkeypatch)
+
+    assert run_estate.main(_landing_argv(engine, src, out, "--dry-run")) == run_estate.EXIT_BUNDLE_REWRITE
+    assert run_estate.main(_landing_argv(engine, src, out, "--dry-run", "--accept-bundle-rewrite")) == (
+        run_estate.EXIT_OK
+    )
+    assert calls == []
+    assert not (out / run_estate.BUNDLE_REWRITE_RECORD).exists(), "a dry run must not write into the bundle"

--- a/tests/test_run_estate.py
+++ b/tests/test_run_estate.py
@@ -1161,6 +1161,57 @@ def test_a_desktop_refresh_sidecar_is_not_downstream_work(tmp_path: Path, monkey
     assert calls == [out]
 
 
+def test_a_replay_script_nested_under_a_destructive_root_is_downstream_work(tmp_path: Path, monkeypatch) -> None:
+    """`_build/` is this repo's durable replay-script convention, not scratch.
+
+    AGENTS.md requires "every edit re-runnable from `_build/`", so `pbip/<project>/_build/replay.py`
+    is exactly where an agent's re-runnable work lives - and it sits inside a directory the engine
+    rmtree()s. The barrier used to borrow the generated-artifact manifest's SCRATCH predicate, which
+    answers a different question, and so walked straight past it: a re-run destroyed the replay
+    script for the very edits it reproduces, at exit 0.
+    """
+    engine, src, out = _first_run(tmp_path, monkeypatch)
+    sentinel = _write(out / "pbip" / "WB" / "_build" / "replay.py", "# re-runnable edit for this unit\n")
+    calls = _relanding(monkeypatch)
+
+    assert run_estate.main(_landing_argv(engine, src, out)) == run_estate.EXIT_BUNDLE_REWRITE
+    assert calls == []
+    assert sentinel.is_file(), "the replay script was destroyed by a run the barrier let through"
+
+
+@pytest.mark.parametrize("scratch_dir", sorted(run_estate.SCRATCH_DIRS))
+def test_no_scratch_component_survives_inside_a_destructive_root(tmp_path: Path, monkeypatch, scratch_dir: str) -> None:
+    """`_build` was the reported case; the predicate had excluded the whole set.
+
+    Parametrised over the live constant rather than a copied list, so growing `SCRATCH_DIRS` cannot
+    silently re-open the hole for a name nobody thought to re-test.
+    """
+    engine, src, out = _first_run(tmp_path, monkeypatch)
+    sentinel = _write(out / "pbip" / "WB" / scratch_dir / "work.py", "# agent work\n")
+    calls = _relanding(monkeypatch)
+
+    assert run_estate.main(_landing_argv(engine, src, out)) == run_estate.EXIT_BUNDLE_REWRITE
+    assert calls == []
+    assert sentinel.is_file()
+
+
+def test_a_bundle_root_build_folder_is_not_guarded(tmp_path: Path, monkeypatch) -> None:
+    """The other side of the boundary: the fix must not over-reach into what the engine never deletes.
+
+    `<bundle>/_build/` sits outside `ENGINE_TREE_ROOTS`, survives a re-run untouched, and is where
+    replay scripts for the estate as a whole live. Guarding it would refuse every second run of a
+    bundle whose declared edits were recorded correctly - the scope is the destructive roots, not the
+    folder name.
+    """
+    engine, src, out = _first_run(tmp_path, monkeypatch)
+    sentinel = _write(out / "_build" / "replay.py", "# estate-level re-runnable edit\n")
+    calls = _relanding(monkeypatch)
+
+    assert run_estate.main(_landing_argv(engine, src, out)) == run_estate.EXIT_OK
+    assert calls == [out]
+    assert sentinel.is_file()
+
+
 def test_a_receipt_that_attests_to_nothing_is_not_read_as_a_clean_bundle(tmp_path: Path, monkeypatch, capsys) -> None:
     """An empty `artifacts` list is an absence of evidence, not evidence of absence."""
     engine, src, out = _first_run(tmp_path, monkeypatch, version="2.141.0")


### PR DESCRIPTION
## What

`run_estate.py`'s module docstring claimed **"this script owns that ordering so no agent has to
remember it"**. It owned nothing — it *documented* the ordering and checked nothing.

Every gate in the file runs in **phase 2**, reading output the engine has already written. That
includes `find_approval_collisions`, the one gate specifically about `--approved-dax`: it reported a
wrong-DAX landing *after* it had landed. A landing re-run into a bundle full of hand-authored fix
work was not reported at all — the engine's own stale-output guard **exempts** `--approved-dax`, so
the most destructive path was the one needing no `--force`.

`assess_bundle_rewrite` now runs **before** `run_engine_phase` and makes the claim true.

## The guard

New `EXIT_BUNDLE_REWRITE = 9`, default-on, refusing two conditions with **two separate** opt-outs:

| condition | detection | opt-out |
|---|---|---|
| downstream work would be destroyed | re-hash the bundle against the two baselines the previous run already wrote — `engine-output-receipt.json` and `input_manifest.json`'s `generated_artifacts` | `--accept-bundle-rewrite` |
| a **different engine version** built this bundle | `receipt.engine.version` vs the version resolved for *this* run | `--accept-engine-version-change` |

Both baselines are already written by every run and, until now, **read back by nothing**. The
receipt alone is not enough: it only records `ARTIFACT_SUFFIXES`, so hand-edited PBIR JSON — the
report builder's entire output — is invisible to it. The generated-artifact manifest covers that,
and is mtime-filtered when written, so it is used only for files it already knows about
(modified/missing) and never to decide a file is *new*. `added` is decided from the receipt alone,
via `engine_artifact_records` — the very function that wrote it — so a pristine bundle reconciles
exactly.

**Why two flags and not one:** a single acknowledgement would mean an operator who knows the engine
moved *also* silently waives the destruction guard on work they did not know was there. That is
moving the failure boundary rather than removing it. Two tests pin the separation in both
directions.

Acknowledging appends to `<bundle>/bundle-rewrite-acknowledgement.json` — when, which flag, and
every file destroyed — written before the engine runs, at the bundle root the `rmtree` sites do not
touch, so it survives the rewrite it describes.

**Deliberately not blocked:** a bundle with neither baseline warns and proceeds (a missing receipt
must not brick every older bundle); an empty `artifacts` list is treated as *absence of evidence*
rather than as either a clean bundle or a dirty one; `.pbi` sidecars are excluded on **both** sides
of every comparison so a Desktop refresh is not tampering; and **`--slice-only` never runs the guard
at all**, because it never runs the engine and therefore destroys nothing.

## Verified, by exit code

Real CLI runs against a synthetic bundle, engine 2.339.0 (the installed canonical plugin):

```
run_estate.py --input … --output … --approved-dax … --dry-run          -> exit 9  (names the file)
… --accept-bundle-rewrite --dry-run   (receipt says 2.141.0)           -> exit 9  (version half still binds)
… --accept-bundle-rewrite --accept-engine-version-change --dry-run     -> exit 0  (no acknowledgement written)
run_estate.py --slice-only --output <same modified bundle>             -> exit 0  (ESTATE: READY)
```

Gates: `ruff format`/`ruff check` **0**; `.\.venv\Scripts\python.exe -m pylint scripts` **10.00/10,
exit 0**; `pytest tests/test_run_estate.py` **47 passed, exit 0**; full suite **2360 passed, 3
failed** — the three failures are `tests/test_upstream_repro_pins.py`, reproduced identically on an
unmodified `master` (`git stash`, same three, exit 1) and unrelated to this change.
`scripts/run_estate.py` is **1133 lines** against `max-module-lines = 1200`.

## Mutation-tested

17 mutations applied to `scripts/run_estate.py`, each run against the suite, **all 17 caught**, then
the file restored and the baseline re-run green. Highlights (mutation → test that failed):

- guard never blocks / guard moved after the engine → 9 and 10 tests respectively, including every
  `calls == []` assertion, which is what proves the refusal is *pre*-engine rather than post-crater
- wider generated baseline dropped → `test_a_hand_edited_report_file_is_work_the_receipt_alone_cannot_see`
- `added`/`missing` detection removed → the two tests written for each
- guard blocks whenever a baseline exists (drift-insensitive) → the pristine-re-run, same-version and
  Desktop-sidecar tests, i.e. the **false-positive** guards bite
- the two acknowledgements collapsed into one (both halves) → the two separation tests
- `--slice-only` no longer exempt → `test_slice_only_still_works_against_a_bundle_full_of_downstream_work`
  *and* the pre-existing `test_slice_only_backfill_never_overwrites_an_existing_baseline`
- `.pbi` exclusion removed → the Desktop-sidecar test
- empty attestation compared naively → `test_a_receipt_that_attests_to_nothing_does_not_invent_a_finding`

One mutation was initially scored as caught for the wrong reason (it introduced a `NameError`, so
pytest failed on an error rather than on the assertion). It was rewritten to a semantically valid
form and re-run.

## Engine-version half

The receipt/engine-version guard is a **second, closely related gap in the same file** — the same
neglected artifact and the same pre-engine moment — folded in here rather than split across two
passes over one function. It is **not covered by an existing issue**; raise one if you would rather
it were tracked separately. `scripts/check_engine_receipts.py` (from #246) stays as-is: it is an
advisory, repo-tree-wide preflight sweep against the *installed* engine, whereas this is a binding,
bundle-scoped check against the engine resolved for *this run* (so it also honours `--engine`).

## Docs

`docs/operator-runbook.md` gains the exit-9 row and column (`tests/test_runbook_exit_codes.py` ties
both tables to the `EXIT_*` constants), the acknowledgement file in the bundle-contents table, and
the `--approved-dax` warning block now says the ordering is enforced instead of merely documented.

## What I could not verify

- **No real engine run.** Every `main()` test substitutes `run_engine`; the engine was never invoked
  against a real workbook. What is *not* substituted is the receipt/baseline machinery — those are
  the real `write_engine_receipt` and `write_generated_artifact_manifest` — so "pristine bundle
  reconciles exactly" is measured against real artefact accounting, just not real engine output.
- **Cost on a large estate is unmeasured.** The guard adds roughly one extra hash pass over
  `pbip/`, `semantic_models/` and `data/` (`data/` can hold `.hyper`/`.parquet`). It is the same
  work `write_engine_receipt` already does once per run, so I expect seconds, but I have no
  measurement on a 38-workbook bundle.
- **Whether `powerbi-report-author validate` ever writes inside a report folder.** If it did, it
  would make a subsequent run look dirty. `check_pbir_valid.py` only spawns the CLI and writes its
  own JSON, and the pristine-re-run test passes with the validator patched out — so this is reasoned,
  not observed on a machine with the CLI present.
- **Whether Power BI Desktop ever writes an artifact-suffixed file under `.pbi/`.** The exclusion is
  tested directly with such a file, so the behaviour is pinned either way, but the real-world shape
  is assumed.
