### PR TITLE
Consume the engine's evidence and by_axis coverage signals

### DIFF
--- a/scripts/read_handover.py
+++ b/scripts/read_handover.py
@@ -6,6 +6,9 @@ usage:   python scripts/read_handover.py <bundle-or-handover.json>            # 
          python scripts/read_handover.py <target> --category <category>       # full repair detail
          python scripts/read_handover.py <target> --name '<calc name>'        # one calc, in full
          python scripts/read_handover.py <target> --viz [--severity blocking] # report-side queue
+         python scripts/read_handover.py <target> --fidelity                  # per-visual evidence
+         python scripts/read_handover.py <target> --gate-evidence             # exit 0/1/3 on coverage
+         python scripts/read_handover.py <target> [--oracle <report.json>]    # layout drift by axis
          python scripts/read_handover.py <target> [--workbook <name>] [--json <file>]
 
 Why this exists
@@ -87,6 +90,32 @@ category's guidance - and nothing here validates the DAX you write from it. It a
 model or report on disk: ``check_blank_placeholders.py`` is the gate that catches a stub that
 survived into shipped TMDL, and ``check_field_bindings.py`` the one for PBIR references that
 resolve to nothing.
+
+Coverage vs findings: ``evidence`` (#371) and ``by_axis`` (#372)
+---------------------------------------------------------------
+Two engine signals were emitted for months with no consumer on this side. They answer *coverage*
+questions, which every other field here structurally cannot:
+
+**``viz_fidelity[].evidence``** (engine >= 2.335.0) is present in the handover and is read here.
+``status: rebuilt`` records only that the emitter completed without raising - the engine author is
+explicit that it "is a record that our code ran cleanly - it is not a statement that the emitted
+``visual.json`` renders". ``evidence`` separates those two claims: ``emitted`` (nothing inspected
+the artifact), ``emitted+linted`` (the shipped bytes were linted and no finding names it), and
+``lint_failed`` (a finding does). A row with no ``evidence`` key at all is reported as ``unknown``,
+never folded into ``emitted``. ``--gate-evidence`` turns that into three exit codes, because two
+would force "never examined" to share a code with either a pass or a blocker. ⚠️ ``emitted+linted``
+is **still not a render check** - it means the bytes passed a structural lint and nothing more.
+
+**``summary.placement.by_axis``** (engine >= 2.332.0) is NOT in the handover, and this is the
+measured finding rather than an assumption. It is produced by ``fidelity_oracle.py``, a **separate
+opt-in tool**, into **its own** report (``kind: "tableau-fabric-structural-fidelity"``);
+``migrate_estate.py`` never computes placement at all. Verified against engine 2.339.0: ``by_axis``
+occurs in **zero** JSON files across the whole local corpus, including a fresh 2.339.0 bundle's
+``handover/`` and its estate ``report.json`` (whose ``summary.placement`` is ``null``). So this
+reader finds an oracle report beside the bundle - by ``kind``, never by a filename convention
+nobody writes to - or takes one from ``--oracle``, and otherwise reports **NOT MEASURED**. Absence
+of the block is not absence of drift, and today NOT MEASURED is the honest answer for every bundle
+the deterministic pipeline produces on its own.
 """
 
 from __future__ import annotations
@@ -95,7 +124,7 @@ import argparse
 import json
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, NamedTuple
 
 # One cohesive projection CLI; adding every engine handover signal here keeps drills consistent.
 # pylint: disable=too-many-lines
@@ -209,8 +238,78 @@ PBIP_WARNING_PATTERNS = [
 ]
 
 
+# `viz_fidelity[].evidence` (engine >= 2.335.0). Verified present in a real 2.339.0 slice:
+# `{"evidence": "emitted+linted", "status": "warned", "tier": "degraded", ...}`. It answers a
+# question `status` structurally cannot: `status: rebuilt` records that the EMITTER ran cleanly,
+# never that anything inspected the bytes it wrote. The engine is explicit about the fail-closed
+# rule -- when the lint did not run, every row stays `emitted`, because claiming `emitted+linted`
+# on the strength of "nothing looked and found nothing" is the defect, not the fix.
+EVIDENCE_EMITTED = "emitted"
+EVIDENCE_LINTED = "emitted+linted"
+EVIDENCE_LINT_FAILED = "lint_failed"
+# Not an engine value: our name for a row that carries no `evidence` key at all (a pre-2.335.0
+# bundle). It is deliberately NOT folded into `emitted` - "the emitter ran and nothing looked" and
+# "we cannot tell what happened" are different claims, and only one of them is the engine's.
+EVIDENCE_UNKNOWN = "unknown"
+
+# Loudest first: anything that is not `emitted+linted` outranks it, because the whole point is that
+# an unexamined visual must never sort or read like a verified one.
+EVIDENCE_ORDER = [EVIDENCE_LINT_FAILED, EVIDENCE_EMITTED, EVIDENCE_UNKNOWN, EVIDENCE_LINTED]
+
+EVIDENCE_LABEL = {
+    EVIDENCE_LINT_FAILED: "LINT FAILED - a PBIR lint finding names this visual",
+    EVIDENCE_EMITTED: "NEVER EXAMINED - emitter ran clean; nothing inspected the shipped bytes",
+    EVIDENCE_UNKNOWN: "NOT RECORDED - no evidence key (bundle predates engine 2.335.0)",
+    EVIDENCE_LINTED: "linted - shipped bytes were linted and no finding names it",
+}
+
+# The only value that supports a structural pass. `emitted+linted` is STILL not a render check.
+EVIDENCE_VERIFIED = EVIDENCE_LINTED
+
+FIDELITY_EVIDENCE_NONE = "none"
+FIDELITY_EVIDENCE_MISSING = "not_recorded"
+FIDELITY_EVIDENCE_PRESENT = "present"
+FIDELITY_EVIDENCE_INVALID = "invalid"
+
+# `summary.placement.by_axis` (engine >= 2.332.0). ⚠️ MEASURED, NOT INFERRED: this block is emitted
+# by `fidelity_oracle.py`, a SEPARATE opt-in tool, into ITS report - `migrate_estate.py` never
+# computes placement, so no handover slice and no estate `report.json` carries it. Verified against
+# engine 2.339.0: zero occurrences of `by_axis` in any JSON under `_runs/`. So the honest consumer
+# reads it from a fidelity-oracle report found beside the bundle (or named with `--oracle`), and
+# reports NOT MEASURED - never zero drift - when there is none.
+ORACLE_KIND = "tableau-fabric-structural-fidelity"
+ORACLE_SNIFF_BYTES = 4096
+
+LAYOUT_DRIFT_NOT_MEASURED = "not_measured"
+LAYOUT_DRIFT_AXIS_BLIND = "axis_blind"
+LAYOUT_DRIFT_EXACT = "pixel_exact"
+LAYOUT_DRIFT_PRESENT = "present"
+LAYOUT_DRIFT_INVALID = "invalid"
+
+# The engine's own vocabulary for the signed direction counts, kept verbatim so a reader can move
+# between our line and the oracle's markdown without re-learning which sign means which way.
+AXIS_DIRECTIONS = {"x": ("right", "left"), "y": ("down", "up")}
+
+# Exit codes. Matches the sibling gates in this folder (`check_connection_fidelity.py`,
+# `check_pbir_layout.py`, `check_empty_model.py`): 0 ok, 1 the defect this gate names, 2 usage,
+# 3 "could not verify". 3 exists because #366 shipped a SKIPPED result that read as a pass, which
+# is the same conflation #371 is about - a visual nothing examined is not a visual that passed.
+EXIT_OK = 0
+EXIT_EVIDENCE_BLOCKED = 1
+EXIT_USAGE = 2
+EXIT_NOT_VERIFIED = 3
+
+
 class HandoverError(RuntimeError):
     """A target that cannot be resolved to at least one workbook payload."""
+
+
+class OracleSource(NamedTuple):
+    """A fidelity-oracle report and where it was found, kept together so the numbers are always
+    citable. An empty instance means "no oracle report", which is a first-class answer here."""
+
+    payload: dict | None = None
+    path: Path | None = None
 
 
 # --------------------------------------------------------------------------------------------
@@ -272,6 +371,90 @@ def load_workbooks(target: Path) -> list[tuple[str, dict, Path]]:
         f"{target}: found no handover/*.json slices and no report.json. "
         "Point at a bundle directory, a handover slice, or an estate report.json."
     )
+
+
+def _sniff_oracle(path: Path) -> bool:
+    """Cheap prefix test before paying to parse a file that may be a 347 KB handover slice.
+
+    `kind` is the FIRST key the oracle writes (`_assemble_report` returns it first, and `json.dumps`
+    preserves insertion order), so the marker is at the very start of the file. Reading 4 KB to
+    reject a slice is the difference between scanning a bundle for free and re-parsing every
+    workbook in it.
+    """
+    try:
+        with path.open("rb") as handle:
+            head = handle.read(ORACLE_SNIFF_BYTES)
+    except OSError:
+        return False
+    return ORACLE_KIND.encode("utf-8") in head
+
+
+def _oracle_candidates(directory: Path) -> list[tuple[Path, dict]]:
+    """Every fidelity-oracle report directly inside ``directory``, identified by CONTENT.
+
+    By `kind`, never by filename: `fidelity_oracle.py --out` takes an arbitrary path, so there is
+    no filename convention to rely on and inventing one would only find reports we ourselves wrote.
+    """
+    if not directory.is_dir():
+        return []
+    out: list[tuple[Path, dict]] = []
+    for path in sorted(directory.glob("*.json")):
+        if not _sniff_oracle(path):
+            continue
+        try:
+            payload = _read_json(path)
+        except HandoverError:
+            continue
+        if isinstance(payload, dict) and payload.get("kind") == ORACLE_KIND:
+            out.append((path, payload))
+    return out
+
+
+def find_oracle_report(target: Path, source: Path, wb_name: str, explicit: Path | None = None) -> OracleSource:
+    """Locate the fidelity-oracle report carrying ``summary.placement.by_axis`` for one workbook.
+
+    Returns an :class:`OracleSource`, empty when there is none - which is the answer for every
+    bundle the deterministic pipeline produces today, because the oracle is a separate opt-in tool.
+    An explicit ``--oracle`` wins; otherwise the bundle root, a ``fidelity/`` subfolder and the
+    directory the slice itself came from are scanned, in that order.
+
+    When several reports are found, one whose filename names the workbook wins; a single unnamed
+    candidate is accepted; an ambiguous set is REFUSED (empty) rather than guessed, because
+    attributing another workbook's drift numbers to this one is worse than reporting nothing.
+    """
+    directories: list[Path] = []
+    if explicit is not None:
+        if explicit.is_file():
+            payload = _read_json(explicit)
+            if not (isinstance(payload, dict) and payload.get("kind") == ORACLE_KIND):
+                raise HandoverError(f"{explicit}: not a fidelity-oracle report (expected kind {ORACLE_KIND!r})")
+            return OracleSource(payload, explicit)
+        if not explicit.is_dir():
+            raise HandoverError(f"{explicit} does not exist")
+        directories.append(explicit)
+    else:
+        root = target if target.is_dir() else target.parent
+        directories += [root, root / "fidelity", source.parent]
+
+    seen: set[Path] = set()
+    found: list[tuple[Path, dict]] = []
+    for directory in directories:
+        resolved = directory.resolve() if directory.exists() else directory
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        found += _oracle_candidates(directory)
+
+    if not found:
+        return OracleSource()
+    named = [(p, d) for p, d in found if p.stem.lower() == wb_name.lower()]
+    if not named:
+        named = [(p, d) for p, d in found if wb_name.lower() in p.stem.lower()]
+    if len(named) == 1:
+        return OracleSource(named[0][1], named[0][0])
+    if not named and len(found) == 1:
+        return OracleSource(found[0][1], found[0][0])
+    return OracleSource()
 
 
 def select_workbook(found: list[tuple[str, dict, Path]], wanted: str | None) -> tuple[str, dict, Path]:
@@ -859,41 +1042,60 @@ def _pbip_warning_summary_line(wb: dict) -> str | None:
     return "        pbip warnings: none recorded (key present and empty)"
 
 
-def _report_section(wb: dict) -> list[str]:
+def _fidelity_tier_line(fidelity: list) -> str | None:
+    """The existing tier roll-up, extracted so `_report_section` stays under pylint's local cap."""
+    tiers: dict[str, int] = {}
+    for v in fidelity:
+        if isinstance(v, dict):
+            tiers[v.get("tier") or "?"] = tiers.get(v.get("tier") or "?", 0) + 1
+    if not tiers:
+        return None
+    return "        fidelity: " + " | ".join(f"{k} {n}" for k, n in sorted(tiers.items()))
+
+
+def _severity_line(items: list[dict]) -> str | None:
+    """The existing severity roll-up, extracted for the same reason as `_fidelity_tier_line`."""
+    by_sev = _severity_counts(items)
+    if not by_sev:
+        return None
+    parts = [f"{s} {by_sev[s]}" for s in SEVERITY_ORDER if s in by_sev]
+    parts += [f"{s} {n}" for s, n in sorted(by_sev.items()) if s not in SEVERITY_ORDER]
+    return "        severity: " + " | ".join(parts)
+
+
+def _report_section(wb: dict, oracle: OracleSource | None = None, terse: bool = False) -> list[str]:
+    oracle = oracle or OracleSource()
     items = report_items_of(wb)
     fidelity = wb.get("viz_fidelity") if isinstance(wb.get("viz_fidelity"), list) else []
-    emptied = _emptied_visuals(wb)
     measure_line = _measure_filter_summary_line(wb)
     pbip_line = _pbip_warning_summary_line(wb)
+    drift_lines = _layout_drift_lines(wb, oracle, terse)
 
     if not items and not fidelity and not measure_line and not pbip_line:
-        return ["REPORT: no remediation worklist in this handover.", ""]
+        return ["REPORT: no remediation worklist in this handover.", "", *drift_lines, ""]
 
-    out = []
     summary = worklist_of(wb).get("summary") if isinstance(worklist_of(wb).get("summary"), dict) else {}
-    flagged = summary.get("visuals_flagged", "?")
-    clean = summary.get("visuals_clean", "?")
-    out.append(f"REPORT: {len(items)} remediation item(s), {flagged} visual(s) flagged, {clean} clean")
+    emptied = _emptied_visuals(wb)
+    out = [
+        f"REPORT: {len(items)} remediation item(s), {summary.get('visuals_flagged', '?')} "
+        f"visual(s) flagged, {summary.get('visuals_clean', '?')} clean"
+    ]
 
-    by_sev = _severity_counts(items)
-    if by_sev:
-        parts = [f"{s} {by_sev[s]}" for s in SEVERITY_ORDER if s in by_sev]
-        parts += [f"{s} {n}" for s, n in sorted(by_sev.items()) if s not in SEVERITY_ORDER]
-        out.append("        severity: " + " | ".join(parts))
-
-    if fidelity:
-        tiers: dict[str, int] = {}
-        for v in fidelity:
-            if isinstance(v, dict):
-                tiers[v.get("tier") or "?"] = tiers.get(v.get("tier") or "?", 0) + 1
-        out.append("        fidelity: " + " | ".join(f"{k} {v}" for k, v in sorted(tiers.items())))
-
-    if emptied:
-        out.append(f"        !! {len(emptied)} visual(s) EMPTIED - every field binding was dropped")
-    if measure_line:
-        out.append(measure_line)
-    if pbip_line:
-        out.append(pbip_line)
+    # Evidence sits directly under the tier line, which is where a reader forms the belief "the
+    # visuals were checked". Tiers are a verdict about what the emitter INTENDED; evidence is
+    # whether anything then looked at what it wrote (#371).
+    candidates = [
+        _severity_line(items),
+        _fidelity_tier_line(fidelity) if fidelity else None,
+        _evidence_summary_line(wb, terse),
+        f"        !! {len(emptied)} visual(s) EMPTIED - every field binding was dropped" if emptied else None,
+        measure_line,
+        pbip_line,
+    ]
+    out += [line for line in candidates if line]
+    # Unconditional: "not measured" is the finding here, so it must print exactly when there is no
+    # data, which is precisely when a conditional line would stay silent (#372).
+    out += drift_lines
 
     out += ["", "        next step: --viz    (full worklist)   --viz --severity blocking", ""]
     return out
@@ -1014,8 +1216,296 @@ def _truncation_banner(
     return head + named + [tail_rule]
 
 
+# --------------------------------------------------------------------------------------------
+# Evidence (#371) and layout drift (#372) - two engine signals that had no consumer
+# --------------------------------------------------------------------------------------------
+
+
+def fidelity_evidence_status(wb: dict) -> tuple[str, dict[str, int]]:
+    """COVERAGE, not findings: for each visual, did the structural check actually RUN?
+
+    Returns ``(status, counts)`` where ``counts`` maps each ``evidence`` value to how many visuals
+    carry it. Mirrors `measure_filter_status`/`partitions_needs_review_status`, for the same reason:
+    an absent key is reported as ABSENT, never as a clean zero.
+
+    An unrecognised value (a future engine adds one) is counted under its own name and is therefore
+    NOT verified - only the literal `emitted+linted` is. Failing that way round is the point: a new
+    value must not inherit a pass from a consumer that has never heard of it.
+    """
+    if "viz_fidelity" not in wb:
+        return FIDELITY_EVIDENCE_NONE, {}
+    raw_rows = wb.get("viz_fidelity")
+    if not isinstance(raw_rows, list):
+        return FIDELITY_EVIDENCE_INVALID, {}
+    rows = [r for r in raw_rows if isinstance(r, dict)]
+    if not rows:
+        return FIDELITY_EVIDENCE_NONE, {}
+    counts: dict[str, int] = {}
+    for row in rows:
+        raw = row.get("evidence")
+        value = raw.strip() if isinstance(raw, str) and raw.strip() else EVIDENCE_UNKNOWN
+        counts[value] = counts.get(value, 0) + 1
+    if set(counts) == {EVIDENCE_UNKNOWN}:
+        return FIDELITY_EVIDENCE_MISSING, counts
+    return FIDELITY_EVIDENCE_PRESENT, counts
+
+
+def _evidence_order(counts: dict[str, int]) -> list[str]:
+    """Known values loudest-first, then any value this consumer does not recognise."""
+    known = [v for v in EVIDENCE_ORDER if counts.get(v)]
+    return known + sorted(v for v in counts if v not in EVIDENCE_ORDER)
+
+
+def evidence_gate(wb: dict) -> tuple[int, str]:
+    """Exit code + verdict for `--gate-evidence`. THREE outcomes, never two.
+
+    * ``EXIT_EVIDENCE_BLOCKED`` - a lint finding names at least one visual.
+    * ``EXIT_NOT_VERIFIED``     - no finding, but coverage is incomplete or unknown: a visual left
+      at ``emitted``, a row with no ``evidence`` key, an unrecognised value, an unreadable shape, or
+      no ``viz_fidelity`` at all. This is its OWN state; it is never folded into the pass.
+    * ``EXIT_OK``               - every visual is ``emitted+linted``. Still not a render check.
+    """
+    status, counts = fidelity_evidence_status(wb)
+    if status == FIDELITY_EVIDENCE_INVALID:
+        return (
+            EXIT_NOT_VERIFIED,
+            "EVIDENCE: NOT VERIFIED - viz_fidelity is present but not a list; inspect raw handover",
+        )
+    if status == FIDELITY_EVIDENCE_NONE:
+        return EXIT_NOT_VERIFIED, "EVIDENCE: NOT VERIFIED - no viz_fidelity rows; nothing recorded a per-visual check"
+    if status == FIDELITY_EVIDENCE_MISSING:
+        return EXIT_NOT_VERIFIED, (
+            f"EVIDENCE: NOT VERIFIED - {sum(counts.values())} visual(s), none carries an `evidence` "
+            "key (bundle predates engine 2.335.0); coverage is unknown, not clean"
+        )
+    total = sum(counts.values())
+    verified = counts.get(EVIDENCE_VERIFIED, 0)
+    breakdown = " | ".join(f"{v} {counts[v]}" for v in _evidence_order(counts))
+    if counts.get(EVIDENCE_LINT_FAILED):
+        return EXIT_EVIDENCE_BLOCKED, (
+            f"EVIDENCE: BLOCKED - {counts[EVIDENCE_LINT_FAILED]} of {total} visual(s) are named by a "
+            f"PBIR lint finding ({breakdown})"
+        )
+    if verified != total:
+        return EXIT_NOT_VERIFIED, (
+            f"EVIDENCE: NOT VERIFIED - only {verified} of {total} visual(s) were examined "
+            f"({breakdown}); an unexamined visual is not a verified one"
+        )
+    return EXIT_OK, (
+        f"EVIDENCE: {total} of {total} visual(s) emitted+linted - structural coverage complete "
+        "(NOT a render check; the bytes were linted, not drawn)"
+    )
+
+
+def _evidence_absent_line(status: str, total: int, terse: bool) -> str | None:
+    """The two states where there is no distribution to report: unreadable, or never recorded."""
+    if status == FIDELITY_EVIDENCE_INVALID:
+        if terse:
+            return "        evidence: INVALID SHAPE"
+        return "        evidence: INVALID SHAPE (viz_fidelity present but not a list; inspect raw handover)"
+    if terse:
+        return f"        ?? evidence: NOT RECORDED on {total} visual(s)"
+    return (
+        f"        ?? evidence: NOT RECORDED on any of {total} visual(s) "
+        "(pre-2.335.0 engine) - coverage UNKNOWN, not clean"
+    )
+
+
+def _evidence_summary_line(wb: dict, terse: bool = False) -> str | None:
+    """One line for the default view. Loud unless every visual was actually examined.
+
+    ``terse`` drops the explanation, never the signal: a budget too tight for the prose is still
+    wide enough for the counts, and silently omitting the line is the failure this line prevents.
+    """
+    status, counts = fidelity_evidence_status(wb)
+    if status == FIDELITY_EVIDENCE_NONE:
+        return None
+    total = sum(counts.values())
+    if status in (FIDELITY_EVIDENCE_INVALID, FIDELITY_EVIDENCE_MISSING):
+        return _evidence_absent_line(status, total, terse)
+    verified = counts.get(EVIDENCE_VERIFIED, 0)
+    mark = "!!" if counts.get(EVIDENCE_LINT_FAILED) else ("??" if verified != total else "  ")
+    if terse:
+        return f"        {mark} evidence: {verified}/{total} examined"
+    breakdown = " | ".join(f"{v} {counts[v]}" for v in _evidence_order(counts))
+    return f"        {mark} evidence: {verified}/{total} examined - {breakdown}"
+
+
+def _evidence_legend(counts: dict[str, int]) -> list[str]:
+    """Spell out each value present, so `emitted` is never read as a synonym for "fine"."""
+    return [
+        f"    {v:<14} {counts[v]:>4}  {EVIDENCE_LABEL.get(v, 'UNRECOGNISED VALUE - not verified')}"
+        for v in _evidence_order(counts)
+    ]
+
+
+def placement_block_of(wb: dict, oracle: dict | None) -> dict | None:
+    """The oracle's ``summary.placement``, or an inlined copy should the engine ever emit one.
+
+    The workbook keys are checked FIRST and are forward-compatible only: no engine version emits
+    placement into a handover slice today (measured against 2.339.0). They cost two dict lookups and
+    mean this consumer keeps working if `migrate_estate.py` ever absorbs the oracle rollup.
+    """
+    for key in ("viz_placement", "placement"):
+        candidate = wb.get(key)
+        if isinstance(candidate, dict):
+            return candidate
+    if isinstance(oracle, dict):
+        summary = oracle.get("summary")
+        if isinstance(summary, dict) and isinstance(summary.get("placement"), dict):
+            return summary["placement"]
+    return None
+
+
+def layout_drift_status(wb: dict, oracle: dict | None = None) -> tuple[str, dict]:
+    """Per-axis layout drift, distinguishing "measured, no drift" from "never measured".
+
+    Five states, because collapsing any two of them recreates the axis-blind failure this block was
+    built to fix:
+
+    * ``LAYOUT_DRIFT_NOT_MEASURED`` - no placement rollup anywhere. Absence of the block is NOT
+      absence of drift, and today this is the answer for every deterministic-pipeline bundle.
+    * ``LAYOUT_DRIFT_AXIS_BLIND``   - a placement rollup with no usable ``by_axis`` (a pre-2.332.0
+      oracle report, or one with no zone->visual deltas). Per-axis drift is UNKNOWN.
+    * ``LAYOUT_DRIFT_INVALID``      - ``by_axis`` present but not an object of axis records.
+    * ``LAYOUT_DRIFT_EXACT``        - measured, every evaluated pair exact on every axis.
+    * ``LAYOUT_DRIFT_PRESENT``      - measured, with drift. ``payload["axes"]`` carries both axes and
+      ``payload["worst"]`` the ``(name, stats)`` pair to lead with.
+    """
+    placement = placement_block_of(wb, oracle)
+    if placement is None:
+        return LAYOUT_DRIFT_NOT_MEASURED, {}
+    by_axis = placement.get("by_axis")
+    if by_axis is None:
+        return LAYOUT_DRIFT_AXIS_BLIND, {"placement": placement}
+    if not isinstance(by_axis, dict):
+        return LAYOUT_DRIFT_INVALID, {"placement": placement}
+    axes = {name: stats for name, stats in by_axis.items() if isinstance(stats, dict)}
+    if not axes:
+        status = LAYOUT_DRIFT_AXIS_BLIND if not by_axis else LAYOUT_DRIFT_INVALID
+        return status, {"placement": placement}
+    payload = {"placement": placement, "axes": axes, "worst": _worst_axis(axes)}
+    if all(_num(s.get("exact")) == _num(s.get("evaluated")) for s in axes.values()):
+        return LAYOUT_DRIFT_EXACT, payload
+    return LAYOUT_DRIFT_PRESENT, payload
+
+
+def _num(value: Any) -> float | None:
+    """Numeric coercion that refuses bools, so a stray `true` cannot pose as a pixel count."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value)
+
+
+def _worst_axis(axes: dict[str, dict]) -> tuple[str, dict] | None:
+    """The axis to lead with: largest worst-case absolute error, mean breaking the tie."""
+    scored = [(name, stats) for name, stats in axes.items() if _num(stats.get("worst_abs_px")) is not None]
+    if not scored:
+        return None
+    return max(
+        scored, key=lambda pair: (_num(pair[1].get("worst_abs_px")) or 0.0, _num(pair[1].get("mean_abs_px")) or 0.0)
+    )
+
+
+def _axis_phrase(name: str, stats: dict) -> str:
+    """One axis, WITH ITS SIGN. `+108px down` and `-56px up` are different defects; the absolute
+    value that collapses them is exactly what made `max_edge_px` unable to answer the question."""
+    positive, negative = AXIS_DIRECTIONS.get(name.lower(), ("+", "-"))
+    signed = _num(stats.get("mean_signed_px"))
+    signed_txt = f"{signed:+g}px" if signed is not None else "?px"
+    return (
+        f"{name.upper()} {stats.get('exact', '?')}/{stats.get('evaluated', '?')} exact, "
+        f"worst {stats.get('worst_abs_px', '?')}px, median {stats.get('median_abs_px', '?')}px, "
+        f"signed {signed_txt} ({stats.get('positive', '?')} {positive} / {stats.get('negative', '?')} {negative})"
+    )
+
+
+def _terse_drift_line(status: str, payload: dict) -> str:
+    """The compressed form, deliberately tiny. Never drops the signal - a budget too tight for the
+    prose is still wide enough for the verdict, and omitting the line is exactly the failure the
+    line exists to prevent. Bounded in bytes so the fallback cannot itself overrun the cap.
+    """
+    if status == LAYOUT_DRIFT_NOT_MEASURED:
+        return "        ?? drift: NOT MEASURED (--oracle)"
+    if status == LAYOUT_DRIFT_AXIS_BLIND:
+        return "        ?? drift: PER-AXIS UNKNOWN"
+    if status == LAYOUT_DRIFT_EXACT:
+        return "        drift: MEASURED, pixel-exact"
+    worst = payload.get("worst")
+    if not worst:
+        return "        !! drift: MEASURED, worst axis unknown"
+    signed = _num(worst[1].get("mean_signed_px"))
+    signed_txt = f"{signed:+g}" if signed is not None else "?"
+    return f"        !! drift: worst {worst[0].upper()} {worst[1].get('worst_abs_px', '?')}px {signed_txt}px"
+
+
+def _layout_drift_summary_line(wb: dict, oracle: dict | None = None, terse: bool = False) -> str:
+    """One line per workbook - the triage #372 asks for, ahead of anyone opening the report.
+
+    BOTH axes always appear together in the full form. The engine's own rollup test pins that rule
+    ("a consumer comparing axes must never get one of them; that reads as 'the other is fine'"), and
+    it applies just as hard one layer up.
+    """
+    status, payload = layout_drift_status(wb, oracle)
+    if status == LAYOUT_DRIFT_INVALID:
+        return "        layout drift: INVALID SHAPE (by_axis is not an object of axis records)"
+    if terse:
+        return _terse_drift_line(status, payload)
+    if status == LAYOUT_DRIFT_NOT_MEASURED:
+        return (
+            "        ?? layout drift: NOT MEASURED - no oracle placement rollup here "
+            "(run fidelity_oracle.py or pass --oracle); absence is not zero drift"
+        )
+    if status == LAYOUT_DRIFT_AXIS_BLIND:
+        placement = payload.get("placement") or {}
+        return (
+            "        ?? layout drift: PER-AXIS UNKNOWN - placement measured but carries no by_axis "
+            f"(pre-2.332.0); axis-blind worst edge {placement.get('worst_max_edge_px', '?')}px"
+        )
+    axes = payload["axes"]
+    worst = payload["worst"]
+    if status == LAYOUT_DRIFT_EXACT:
+        detail = " | ".join(
+            f"{n.upper()} {s.get('exact', '?')}/{s.get('evaluated', '?')}" for n, s in sorted(axes.items())
+        )
+        return f"        layout drift: MEASURED, pixel-exact on every axis ({detail})"
+    lead = _axis_phrase(*worst) if worst else "worst axis unknown"
+    rest = " | ".join(
+        f"{n.upper()} {s.get('exact', '?')}/{s.get('evaluated', '?')} exact, worst {s.get('worst_abs_px', '?')}px"
+        for n, s in sorted(axes.items())
+        if not worst or n != worst[0]
+    )
+    tail = f" | {rest}" if rest else ""
+    return f"        !! layout drift: MEASURED, worst {lead}{tail}"
+
+
+def _clip_tail(text: str, limit: int = 88) -> str:
+    """Clip from the LEFT, keeping the tail. A path clipped from the right loses its filename -
+    which is the only part that identifies which report the numbers came from."""
+    return text if len(text) <= limit else "..." + text[-(limit - 3) :]
+
+
+def _layout_drift_lines(wb: dict, oracle: OracleSource, terse: bool = False) -> list[str]:
+    """The drift verdict plus, when a number was measured, WHERE it came from.
+
+    Provenance is emitted here rather than printed alongside the render because ``--max-bytes`` is a
+    strict cap on everything a run prints: a line printed outside the budgeted body made the cap a
+    suggestion (measured - 1632 bytes emitted under a 1500-byte cap, with no truncation banner).
+
+    Under ``terse`` the citation collapses onto the verdict line and the filename is clipped, so the
+    pair stays inside a fixed byte ceiling however long the oracle's path happens to be.
+    """
+    verdict = _layout_drift_summary_line(wb, oracle.payload, terse)
+    if oracle.path is None:
+        return [verdict]
+    if terse:
+        return [f"{verdict} [{_clip_tail(oracle.path.name, 24)}]"]
+    return [verdict, f"           measured from: {_clip_tail(str(oracle.path))}"]
+
+
 def _fidelity_counts(wb: dict) -> list[str]:
-    """Tier counts only - cheap enough to always print, so `--viz` never hides that this exists."""
+    """Tier counts plus the evidence distribution - cheap enough to always print, so no view can
+    hide either that visual fidelity exists or that some of it was never examined."""
     rows = [v for v in (wb.get("viz_fidelity") or []) if isinstance(v, dict)]
     if not rows:
         return []
@@ -1028,6 +1518,11 @@ def _fidelity_counts(wb: dict) -> list[str]:
     ]
     if flagged:
         out.append(f"    {flagged} visual(s) recorded a fidelity reason - see --fidelity for each")
+    status, counts = fidelity_evidence_status(wb)
+    if status in (FIDELITY_EVIDENCE_PRESENT, FIDELITY_EVIDENCE_MISSING):
+        verified = counts.get(EVIDENCE_VERIFIED, 0)
+        out.append(f"--- EVIDENCE (engine >= 2.335.0): {verified}/{sum(counts.values())} visual(s) examined")
+        out += _evidence_legend(counts)
     return out + [""]
 
 
@@ -1049,8 +1544,13 @@ def _fidelity_groups(rows: list[dict]) -> list[tuple[str, list[dict]]]:
 
 
 def _fidelity_row(v: dict) -> str:
+    """Per-visual line. `evidence` sits beside `status` deliberately: `status: rebuilt` records that
+    the EMITTER ran, and the two are read together or the first is over-read (#371)."""
+    raw = v.get("evidence")
+    evidence = raw.strip() if isinstance(raw, str) and raw.strip() else EVIDENCE_UNKNOWN
+    mark = "  " if evidence == EVIDENCE_VERIFIED else "!!"
     return (
-        f"    {str(v.get('status') or '?'):<22} {v.get('worksheet') or '?'}"
+        f"    {mark} {str(v.get('status') or '?'):<22} {evidence:<14} {v.get('worksheet') or '?'}"
         f" ({v.get('visual_type') or '?'}, tier {v.get('tier') or '?'})"
     )
 
@@ -1225,18 +1725,29 @@ no target_table, no guidance. It is enough to REPORT a stub and structurally ins
 REPAIR one, so this tool always works from `requests[]`."""
 
 
-def render_default(wb_name: str, wb: dict, target: Path, max_bytes: int) -> str:
+def render_default(wb_name: str, wb: dict, target: Path, max_bytes: int, oracle: OracleSource | None = None) -> str:
     """The landing view: both queues at a glance, plus which list the detail came from.
 
     Budgeted too. The cascadable list is the one unbounded thing here - it names every stub that
     depends on another stub - so the fixed tail (the report section and the `needs_review` note) is
     costed first and the cascade list gets whatever is left.
+
+    TWO PASSES, because the tail grew. `_model_section` emits an unbudgeted head (the title, the
+    source line, the coverage line and the category table), so a tail that alone approaches the cap
+    can push the total over it - and at `MIN_MAX_BYTES` the added evidence and drift lines did
+    exactly that, firing the `HARD CAP` net this module treats as a budgeting DEFECT rather than a
+    pass. When the full assembly does not fit, the tail is rebuilt terse; the two new signals are
+    compressed, never dropped.
     """
-    reqs = requests_of(wb)
-    report = _report_section(wb)
-    tail_cost = sum(_blen(x) + 1 for x in report) + _blen(NEEDS_REVIEW_NOTE) + 1
-    out = _model_section(wb_name, wb, reqs, target, max_bytes - tail_cost)
-    return "\n".join(out + report + [NEEDS_REVIEW_NOTE])
+
+    def _assemble(terse: bool) -> str:
+        report = _report_section(wb, oracle, terse)
+        tail_cost = sum(_blen(x) + 1 for x in report) + _blen(NEEDS_REVIEW_NOTE) + 1
+        out = _model_section(wb_name, wb, requests_of(wb), target, max_bytes - tail_cost)
+        return "\n".join(out + report + [NEEDS_REVIEW_NOTE])
+
+    full = _assemble(False)
+    return full if _blen(full) <= max_bytes else _assemble(True)
 
 
 def _list_row(name: str, wb: dict) -> tuple[str, int, int, int, int, int, bool, int, bool, int, bool]:
@@ -1333,6 +1844,36 @@ def _partition_review_estate_lines(found: list[tuple[str, dict, Path]]) -> list[
     return out + [""]
 
 
+def _evidence_estate_lines(found: list[tuple[str, dict, Path]]) -> list[str]:
+    """Estate totals for `--list`: how much of the estate's visual surface was actually examined.
+
+    Named per workbook, not just totalled: "38 of 40 examined" estate-wide hides that all 2 gaps sit
+    in one report. Workbooks with nothing examined are listed first for the same reason.
+    """
+    counts: dict[str, int] = {}
+    unexamined: list[tuple[str, int, int]] = []
+    for name, wb, _ in found:
+        status, wb_counts = fidelity_evidence_status(wb)
+        if status in (FIDELITY_EVIDENCE_NONE, FIDELITY_EVIDENCE_INVALID):
+            continue
+        for value, n in wb_counts.items():
+            counts[value] = counts.get(value, 0) + n
+        total = sum(wb_counts.values())
+        verified = wb_counts.get(EVIDENCE_VERIFIED, 0)
+        if verified != total:
+            unexamined.append((name, verified, total))
+    if not counts:
+        return ["Visual evidence: NOT RECORDED anywhere in this estate (no viz_fidelity rows).", ""]
+    total = sum(counts.values())
+    out = [
+        f"Visual evidence: {counts.get(EVIDENCE_VERIFIED, 0)}/{total} visual(s) examined "
+        f"({' | '.join(f'{v} {counts[v]}' for v in _evidence_order(counts))})",
+    ]
+    for name, verified, wb_total in sorted(unexamined, key=lambda t: (t[1] - t[2], t[0].lower())):
+        out.append(f"    !! {_clip(name, 52):<52} {verified}/{wb_total} examined")
+    return out + [""]
+
+
 def render_list(found: list[tuple[str, dict, Path]], max_bytes: int) -> str:
     """Every workbook in a bundle, ranked by urgency, with the size of both its queues.
 
@@ -1350,6 +1891,7 @@ def render_list(found: list[tuple[str, dict, Path]], max_bytes: int) -> str:
     ]
     out += _pbip_warning_estate_lines(found)
     out += _partition_review_estate_lines(found)
+    out += _evidence_estate_lines(found)
     # Partition scaffolds rank FIRST: unlike a stub calc or a dropped visual binding, an unresolved
     # M partition means the table has ZERO rows -- and it carries a named manual completion step
     # the engine already wrote down (issue #326).
@@ -1359,12 +1901,31 @@ def render_list(found: list[tuple[str, dict, Path]], max_bytes: int) -> str:
     return "\n".join(out + _fit_lines([_list_line(r) for r in ranked], budget, more))
 
 
-def build_json(wb_name: str, wb: dict, category: str | None) -> dict:
+def _layout_drift_json(wb: dict, oracle: OracleSource) -> dict:
+    """Machine-readable drift. ``status`` is always present, so a consumer that never looks at the
+    numbers still cannot mistake "not measured" for "measured, no drift"."""
+    status, payload = layout_drift_status(wb, oracle.payload)
+    worst = payload.get("worst")
+    return {
+        "status": status,
+        "measured": status in (LAYOUT_DRIFT_EXACT, LAYOUT_DRIFT_PRESENT),
+        "by_axis": payload.get("axes"),
+        "worst_axis": worst[0] if worst else None,
+        "worst_axis_stats": worst[1] if worst else None,
+        "placement": payload.get("placement"),
+        "measured_from": str(oracle.path) if oracle.path is not None else None,
+    }
+
+
+def build_json(wb_name: str, wb: dict, category: str | None, oracle: OracleSource | None = None) -> dict:
     """Machine-readable form: guidance hoisted out of the requests, so it appears once."""
+    oracle = oracle or OracleSource()
     reqs = requests_of(wb)
     if category:
         reqs = [r for r in reqs if (r.get("category") or "uncategorised") == category]
     slim = [{k: v for k, v in r.items() if k != "category_guidance"} for r in reqs]
+    evidence_status, evidence_counts = fidelity_evidence_status(wb)
+    gate_code, gate_verdict = evidence_gate(wb)
     return {
         "workbook": wb_name,
         "guidance": guidance_by_category(requests_of(wb)),
@@ -1383,6 +1944,20 @@ def build_json(wb_name: str, wb: dict, category: str | None) -> dict:
         else PARTITION_REVIEW_MISSING,
         "partitions_needs_review_groups": _partition_review_groups(partitions_needs_review_status(wb)[1]),
         "viz_fidelity": [v for v in (wb.get("viz_fidelity") or []) if isinstance(v, dict)],
+        "viz_fidelity_evidence": {
+            "status": evidence_status,
+            "counts": evidence_counts,
+            "total": sum(evidence_counts.values()),
+            # Named explicitly rather than left for the consumer to derive: deriving it means
+            # deciding which values count as verified, and that decision is what #371 is about.
+            "verified": evidence_counts.get(EVIDENCE_VERIFIED, 0),
+            "never_examined": evidence_counts.get(EVIDENCE_EMITTED, 0),
+            "lint_failed": evidence_counts.get(EVIDENCE_LINT_FAILED, 0),
+            "unknown": evidence_counts.get(EVIDENCE_UNKNOWN, 0),
+            "gate_exit_code": gate_code,
+            "gate_verdict": gate_verdict,
+        },
+        "layout_drift": _layout_drift_json(wb, oracle),
     }
 
 
@@ -1411,6 +1986,22 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "carries deferral reasons that appear in no remediation item)",
     )
     p.add_argument("--severity", help="with --viz: blocking | high | medium | low (no effect on other views)")
+    p.add_argument(
+        "--oracle",
+        type=Path,
+        metavar="PATH",
+        help="fidelity-oracle report (or a directory holding one) carrying summary.placement.by_axis. "
+        "The layout-drift measurement lives in fidelity_oracle.py's report, NOT in the handover, so "
+        "without one this reports NOT MEASURED. Auto-detected by kind in the bundle root, "
+        "<bundle>/fidelity/ and beside the slice",
+    )
+    p.add_argument(
+        "--gate-evidence",
+        action="store_true",
+        help="exit by viz_fidelity[].evidence instead of always 0: "
+        f"{EXIT_OK} every visual emitted+linted, {EXIT_EVIDENCE_BLOCKED} a lint finding names one, "
+        f"{EXIT_NOT_VERIFIED} coverage incomplete or unknown (an unexamined visual is NOT a pass)",
+    )
     p.add_argument("--list", action="store_true", help="list workbooks in the target and exit")
     p.add_argument("--json", type=Path, metavar="FILE", help="also write a machine-readable form")
     p.add_argument(
@@ -1440,19 +2031,31 @@ def _force_utf8_stdout() -> None:
                 pass
 
 
-def _render(args: argparse.Namespace, wb_name: str, wb: dict, source: Path, budget: int) -> str:
-    """Pick the view. Every one of these is capped; `--name` is handled by the caller."""
+def _render(
+    args: argparse.Namespace, selected: tuple[str, dict, Path], budget: int, oracle: OracleSource | None = None
+) -> str:
+    """Pick the view. Every one of these is capped; `--name` is handled by the caller.
+
+    ``selected`` is `select_workbook`'s own ``(name, payload, source)`` triple, kept whole rather
+    than splatted into three parameters.
+    """
+    wb_name, wb, source = selected
     if args.viz:
         return render_viz(wb_name, wb, args.severity, args.category, budget)
     if args.category:
         return render_category(wb_name, requests_of(wb), args.category, budget)
     if args.fidelity:
         return render_fidelity(wb_name, wb, budget)
-    return render_default(wb_name, wb, source, budget)
+    return render_default(wb_name, wb, source, budget, oracle)
 
 
 def main(argv: list[str] | None = None) -> int:
-    """Exit 0 on a rendered queue, 2 on an unresolvable target or a cap too small to honour."""
+    """Exit 0 on a rendered queue, 2 on an unresolvable target or a cap too small to honour.
+
+    With ``--gate-evidence`` the exit code instead reports coverage: 0 / 1 / 3 per `evidence_gate`.
+    Opt-in on purpose - every existing caller of this reader keeps getting 0 on a rendered queue,
+    and nothing here starts failing a pipeline because a reader learned to have an opinion.
+    """
     _force_utf8_stdout()
     args = parse_args(argv)
     if args.max_bytes < MIN_MAX_BYTES:
@@ -1463,7 +2066,7 @@ def main(argv: list[str] | None = None) -> int:
             "reporting that the cap held is worse than this error.",
             file=sys.stderr,
         )
-        return 2
+        return EXIT_USAGE
 
     # `print` appends a newline and that newline is output too, so a renderer gets one byte less
     # than the caller asked for. `--json` prints a confirmation, which is output as well.
@@ -1474,22 +2077,30 @@ def main(argv: list[str] | None = None) -> int:
         found = load_workbooks(args.target)
         if args.list:
             print(_capped(render_list(found, budget), budget))
-            return 0
-        wb_name, wb, source = select_workbook(found, args.workbook)
+            return EXIT_OK
+        selected = select_workbook(found, args.workbook)
+        wb_name, wb, source = selected
+        oracle = find_oracle_report(args.target, source, wb_name, args.oracle)
     except HandoverError as exc:
         print(f"read_handover: {exc}", file=sys.stderr)
-        return 2
+        return EXIT_USAGE
 
     if args.name:
         print(render_named(wb_name, requests_of(wb), args.name, budget))
     else:
-        print(_capped(_render(args, wb_name, wb, source, budget), budget))
+        print(_capped(_render(args, selected, budget, oracle), budget))
 
     if args.json:
         args.json.parent.mkdir(parents=True, exist_ok=True)
-        args.json.write_text(json.dumps(build_json(wb_name, wb, args.category), indent=2) + "\n", encoding="utf-8")
+        payload = build_json(wb_name, wb, args.category, oracle)
+        args.json.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
         print(json_notice)
-    return 0
+
+    if args.gate_evidence:
+        code, verdict = evidence_gate(wb)
+        print(verdict, file=sys.stderr)
+        return code
+    return EXIT_OK
 
 
 if __name__ == "__main__":

--- a/scripts/read_handover.py
+++ b/scripts/read_handover.py
@@ -329,6 +329,33 @@ class OracleSource(NamedTuple):
     path: Path | None = None
 
 
+class WorkbookCensus(NamedTuple):
+    """What the target DECLARED, kept beside what could actually be parsed.
+
+    ⚠️ These are two different numbers and conflating them re-opened a fixed defect. The oracle's
+    unmatched-singleton fallback is only safe when the target provably holds ONE workbook, and it
+    was gated on ``len(parsed)`` - so a two-slice bundle with one CORRUPT slice reported a count of
+    1 and handed the readable workbook the other one's measurements. A parse failure must never
+    shrink a denominator into a permissive path; that is the same shape as unreadable
+    ``viz_fidelity`` rows vanishing from the evidence denominator, one level up.
+
+    ``declared`` counts workbook-like inputs the target announced; ``unreadable`` counts how many of
+    those could not be turned into a workbook. A stray non-workbook JSON beside the slices is
+    neither - it was never a workbook and skipping it is correct.
+    """
+
+    workbooks: list[tuple[str, dict, Path]]
+    declared: int = 0
+    unreadable: int = 0
+    unreadable_sources: tuple[Path, ...] = ()
+
+    @property
+    def provably_single(self) -> bool:
+        """One workbook declared, one parsed, nothing unaccounted for. The ONLY state in which an
+        arbitrarily-named oracle report can be attributed without a name match."""
+        return self.declared == 1 and self.unreadable == 0 and len(self.workbooks) == 1
+
+
 # --------------------------------------------------------------------------------------------
 # Loading
 # --------------------------------------------------------------------------------------------
@@ -341,53 +368,116 @@ def _read_json(path: Path) -> Any:
         raise HandoverError(f"{path} is not valid JSON: {exc}") from exc
 
 
+def _census_from_payload(payload: Any, source: Path) -> tuple[list[tuple[str, dict, Path]], int, int]:
+    """``(workbooks, declared, unreadable)`` for ONE payload.
+
+    The three outcomes are deliberately distinct:
+
+    * a slice or report that yields workbooks - declared and parsed;
+    * a payload that DECLARES ``workbook``/``workbooks`` but cannot honour it (a non-object entry
+      inside ``workbooks[]``, or ``{"workbook": 42}``) - declared and **unreadable**;
+    * a stray JSON that is not workbook-like at all - **neither**, because it was never a workbook
+      and counting it would refuse the oracle fallback on every bundle that has a `report.json`
+      or an oracle report sitting beside the slices.
+    """
+    if isinstance(payload, dict) and isinstance(payload.get("workbooks"), list):
+        rows = payload["workbooks"]
+        out = [(wb.get("name") or f"workbook[{i}]", wb, source) for i, wb in enumerate(rows) if isinstance(wb, dict)]
+        return out, len(rows), len(rows) - len(out)
+    if isinstance(payload, dict) and isinstance(payload.get("workbook"), dict):
+        wb = payload["workbook"]
+        return [(wb.get("name") or source.stem, wb, source)], 1, 0
+    if isinstance(payload, dict) and ("workbook" in payload or "workbooks" in payload):
+        return [], 1, 1
+    return [], 0, 0
+
+
 def _workbooks_from_payload(payload: Any, source: Path) -> list[tuple[str, dict, Path]]:
     """Accept either a handover slice (``{estate, workbook}``) or an estate ``report.json``."""
     if not isinstance(payload, dict):
         raise HandoverError(f"{source}: expected a JSON object at the top level")
-
-    if isinstance(payload.get("workbook"), dict):
-        wb = payload["workbook"]
-        return [(wb.get("name") or source.stem, wb, source)]
-
-    if isinstance(payload.get("workbooks"), list):
-        out = []
-        for i, wb in enumerate(payload["workbooks"]):
-            if isinstance(wb, dict):
-                out.append((wb.get("name") or f"workbook[{i}]", wb, source))
-        return out
-
-    raise HandoverError(f"{source}: no 'workbook' or 'workbooks' key - is this a handover slice or a report.json?")
+    workbooks, declared, _ = _census_from_payload(payload, source)
+    if not declared:
+        raise HandoverError(f"{source}: no 'workbook' or 'workbooks' key - is this a handover slice or a report.json?")
+    return workbooks
 
 
-def load_workbooks(target: Path) -> list[tuple[str, dict, Path]]:
-    """Resolve a file or bundle directory to ``(name, workbook_payload, source_path)`` triples."""
+def _census_from_slices(slices: list[Path]) -> WorkbookCensus:
+    """Census a ``handover/`` directory. Unparseable bytes count as UNREADABLE, never as absent.
+
+    Fail-closed on purpose: a file that will not parse cannot be classified, so it *might* be a
+    workbook. Assuming otherwise is exactly the undercount that unlocked wrong-oracle attribution.
+    """
+    workbooks: list[tuple[str, dict, Path]] = []
+    declared = unreadable = 0
+    bad: list[Path] = []
+    for path in slices:
+        try:
+            payload = _read_json(path)
+        except HandoverError:
+            declared += 1
+            unreadable += 1
+            bad.append(path)
+            continue
+        found, n_declared, n_unreadable = _census_from_payload(payload, path)
+        workbooks += found
+        declared += n_declared
+        unreadable += n_unreadable
+        if n_unreadable:
+            bad.append(path)
+    return WorkbookCensus(workbooks, declared, unreadable, tuple(bad))
+
+
+def load_workbook_census(target: Path) -> WorkbookCensus:
+    """Resolve a file or bundle directory to workbooks PLUS the census they came from.
+
+    `load_workbooks` is the thin list-only wrapper over this; anything that makes a decision from
+    "how many workbooks are there" must use the census, because the list alone cannot distinguish
+    "one workbook" from "one workbook and one that failed to parse".
+    """
     if not target.exists():
         raise HandoverError(f"{target} does not exist")
 
     if target.is_file():
-        return _workbooks_from_payload(_read_json(target), target)
+        return WorkbookCensus(*_as_census(_read_json(target), target))
 
     handover_dir = target / "handover" if (target / "handover").is_dir() else target
     slices = sorted(p for p in handover_dir.glob("*.json"))
-    if slices:
-        found: list[tuple[str, dict, Path]] = []
-        for path in slices:
-            try:
-                found.extend(_workbooks_from_payload(_read_json(path), path))
-            except HandoverError:
-                continue  # a stray JSON file in the folder is not an error
-        if found:
-            return found
+    pending = _census_from_slices(slices) if slices else WorkbookCensus([])
+    if pending.workbooks:
+        return pending
 
     report = target / "report.json"
     if report.is_file():
-        return _workbooks_from_payload(_read_json(report), report)
+        workbooks, declared, unreadable, bad = _as_census(_read_json(report), report)
+        # Slice failures are CARRIED, not discarded: falling through to `report.json` because no
+        # slice parsed must not erase the fact that slices existed and could not be read.
+        return WorkbookCensus(
+            workbooks,
+            declared + pending.declared,
+            unreadable + pending.unreadable,
+            tuple(bad) + pending.unreadable_sources,
+        )
 
     raise HandoverError(
         f"{target}: found no handover/*.json slices and no report.json. "
         "Point at a bundle directory, a handover slice, or an estate report.json."
     )
+
+
+def _as_census(payload: Any, source: Path) -> tuple[list[tuple[str, dict, Path]], int, int, tuple[Path, ...]]:
+    """Census one explicitly-named file, raising the usual error when it is not workbook-like."""
+    if not isinstance(payload, dict):
+        raise HandoverError(f"{source}: expected a JSON object at the top level")
+    workbooks, declared, unreadable = _census_from_payload(payload, source)
+    if not declared:
+        raise HandoverError(f"{source}: no 'workbook' or 'workbooks' key - is this a handover slice or a report.json?")
+    return workbooks, declared, unreadable, ((source,) if unreadable else ())
+
+
+def load_workbooks(target: Path) -> list[tuple[str, dict, Path]]:
+    """Resolve a file or bundle directory to ``(name, workbook_payload, source_path)`` triples."""
+    return load_workbook_census(target).workbooks
 
 
 def _sniff_oracle(path: Path) -> bool:
@@ -428,7 +518,7 @@ def _oracle_candidates(directory: Path) -> list[tuple[Path, dict]]:
 
 
 def find_oracle_report(
-    target: Path, source: Path, wb_name: str, explicit: Path | None = None, workbook_count: int = 1
+    target: Path, source: Path, wb_name: str, explicit: Path | None = None, census: WorkbookCensus | None = None
 ) -> OracleSource:
     """Locate the fidelity-oracle report carrying ``summary.placement.by_axis`` for one workbook.
 
@@ -437,12 +527,19 @@ def find_oracle_report(
     An explicit ``--oracle`` wins; otherwise the bundle root, a ``fidelity/`` subfolder and the
     directory the slice itself came from are scanned, in that order.
 
-    ⚠️ ``workbook_count`` is load-bearing, not decoration. A report whose filename names the
-    workbook always wins. An arbitrarily-named SINGLE candidate is accepted **only when the target
-    holds one workbook**: in a multi-workbook bundle where the oracle was run for A alone, the old
-    unconditional singleton fallback handed A's numbers to B - and a pixel-exact A made an entirely
-    unmeasured B read as verified. Ambiguity is refused rather than guessed, because attributing
-    another workbook's measurements to this one is worse than reporting nothing.
+    ⚠️ ``census`` is load-bearing, not decoration. A report whose filename names the workbook always
+    wins. An arbitrarily-named SINGLE candidate is accepted **only when the target is PROVABLY a
+    single-workbook input** - one declared, one parsed, nothing unreadable. Two defects live here:
+
+    * the original fallback was unconditional, so in a multi-workbook bundle where the oracle ran
+      for A alone, B got A's numbers and a pixel-exact A made an unmeasured B read as verified;
+    * gating it on the number of PARSED workbooks re-opened the same hole, because a corrupt slice
+      is silently skipped - a two-slice bundle with one unreadable slice counted 1 and satisfied
+      the guard. Hence the census rather than ``len(found)``.
+
+    ``census=None`` means "provenance unknown", and is treated conservatively: no unmatched
+    singleton. Ambiguity is refused rather than guessed, because attributing another workbook's
+    measurements to this one is worse than reporting nothing.
 
     The real fix belongs upstream: the oracle report should carry the workbook identity it measured,
     so this is an identity check rather than a filename inference. Filed as the successor to #182.
@@ -477,7 +574,7 @@ def find_oracle_report(
         named = [(p, d) for p, d in found if wb_name.lower() in p.stem.lower()]
     if len(named) == 1:
         return OracleSource(named[0][1], named[0][0])
-    if not named and len(found) == 1 and workbook_count == 1:
+    if not named and len(found) == 1 and census is not None and census.provably_single:
         return OracleSource(found[0][1], found[0][0])
     return OracleSource()
 
@@ -2261,6 +2358,26 @@ def _render(
     return render_default(wb_name, wb, source, budget, oracle)
 
 
+def _warn_unreadable(census: WorkbookCensus) -> None:
+    """Say out loud that part of the input could not be read.
+
+    On stderr, so it is outside the `--max-bytes` budget that governs the rendered body and cannot
+    be truncated away. Silently skipping a corrupt slice is the same failure as silently skipping an
+    unreadable `viz_fidelity` row: the reader looks complete because the thing it could not read
+    left no trace.
+    """
+    if not census.unreadable:
+        return
+    names = ", ".join(str(p) for p in census.unreadable_sources[:5])
+    more = f" (+{len(census.unreadable_sources) - 5} more)" if len(census.unreadable_sources) > 5 else ""
+    print(
+        f"read_handover: WARNING - {census.unreadable} of {census.declared} declared workbook "
+        f"input(s) could not be read: {names}{more}. They are missing from every count below, and "
+        "an unmatched fidelity-oracle report will NOT be attributed while any input is unreadable.",
+        file=sys.stderr,
+    )
+
+
 def main(argv: list[str] | None = None) -> int:
     """Exit 0 on a rendered queue, 2 on an unresolvable target or a cap too small to honour.
 
@@ -2286,13 +2403,15 @@ def main(argv: list[str] | None = None) -> int:
     budget = args.max_bytes - 1 - (_blen(json_notice) + 1 if json_notice else 0)
 
     try:
-        found = load_workbooks(args.target)
+        census = load_workbook_census(args.target)
+        found = census.workbooks
+        _warn_unreadable(census)
         if args.list:
             print(_capped(render_list(found, budget), budget))
             return EXIT_OK
         selected = select_workbook(found, args.workbook)
         wb_name, wb, source = selected
-        oracle = find_oracle_report(args.target, source, wb_name, args.oracle, len(found))
+        oracle = find_oracle_report(args.target, source, wb_name, args.oracle, census)
     except HandoverError as exc:
         print(f"read_handover: {exc}", file=sys.stderr)
         return EXIT_USAGE

--- a/scripts/read_handover.py
+++ b/scripts/read_handover.py
@@ -122,6 +122,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import sys
 from pathlib import Path
 from typing import Any, NamedTuple
@@ -251,13 +252,17 @@ EVIDENCE_LINT_FAILED = "lint_failed"
 # bundle). It is deliberately NOT folded into `emitted` - "the emitter ran and nothing looked" and
 # "we cannot tell what happened" are different claims, and only one of them is the engine's.
 EVIDENCE_UNKNOWN = "unknown"
+# Also not an engine value: a `viz_fidelity[]` entry that is not an object at all. It stays in the
+# DENOMINATOR - dropping it made a 2-row list report "1 of 1 complete" and exit 0.
+EVIDENCE_UNREADABLE = "unreadable_row"
 
 # Loudest first: anything that is not `emitted+linted` outranks it, because the whole point is that
 # an unexamined visual must never sort or read like a verified one.
-EVIDENCE_ORDER = [EVIDENCE_LINT_FAILED, EVIDENCE_EMITTED, EVIDENCE_UNKNOWN, EVIDENCE_LINTED]
+EVIDENCE_ORDER = [EVIDENCE_LINT_FAILED, EVIDENCE_UNREADABLE, EVIDENCE_EMITTED, EVIDENCE_UNKNOWN, EVIDENCE_LINTED]
 
 EVIDENCE_LABEL = {
     EVIDENCE_LINT_FAILED: "LINT FAILED - a PBIR lint finding names this visual",
+    EVIDENCE_UNREADABLE: "UNREADABLE - the row is not an object; it cannot be assessed at all",
     EVIDENCE_EMITTED: "NEVER EXAMINED - emitter ran clean; nothing inspected the shipped bytes",
     EVIDENCE_UNKNOWN: "NOT RECORDED - no evidence key (bundle predates engine 2.335.0)",
     EVIDENCE_LINTED: "linted - shipped bytes were linted and no finding names it",
@@ -283,8 +288,20 @@ ORACLE_SNIFF_BYTES = 4096
 LAYOUT_DRIFT_NOT_MEASURED = "not_measured"
 LAYOUT_DRIFT_AXIS_BLIND = "axis_blind"
 LAYOUT_DRIFT_EXACT = "pixel_exact"
+LAYOUT_DRIFT_EDGE_ONLY = "edge_or_size_drift"
 LAYOUT_DRIFT_PRESENT = "present"
 LAYOUT_DRIFT_INVALID = "invalid"
+
+# The states in which a per-axis number was genuinely produced. `EDGE_ONLY` belongs here: the axes
+# WERE measured; it is the far edges the axis rollup cannot see.
+LAYOUT_DRIFT_MEASURED = (LAYOUT_DRIFT_EXACT, LAYOUT_DRIFT_EDGE_ONLY, LAYOUT_DRIFT_PRESENT)
+
+# Byte ceiling for the compressed drift line. Bytes, not characters: `--max-bytes` is a byte cap,
+# and a 24-CHARACTER clip of a CJK filename measured 101 bytes against a bound believed to be ~70.
+# The value is the previous EFFECTIVE width, now enforced in the right unit rather than assumed -
+# raising it is not free, because `render_default`'s terse pass is what keeps the floor cap
+# honourable and this line is part of its fixed tail.
+TERSE_DRIFT_LINE_MAX_BYTES = 72
 
 # The engine's own vocabulary for the signed direction counts, kept verbatim so a reader can move
 # between our line and the oracle's markdown without re-learning which sign means which way.
@@ -410,7 +427,9 @@ def _oracle_candidates(directory: Path) -> list[tuple[Path, dict]]:
     return out
 
 
-def find_oracle_report(target: Path, source: Path, wb_name: str, explicit: Path | None = None) -> OracleSource:
+def find_oracle_report(
+    target: Path, source: Path, wb_name: str, explicit: Path | None = None, workbook_count: int = 1
+) -> OracleSource:
     """Locate the fidelity-oracle report carrying ``summary.placement.by_axis`` for one workbook.
 
     Returns an :class:`OracleSource`, empty when there is none - which is the answer for every
@@ -418,9 +437,15 @@ def find_oracle_report(target: Path, source: Path, wb_name: str, explicit: Path 
     An explicit ``--oracle`` wins; otherwise the bundle root, a ``fidelity/`` subfolder and the
     directory the slice itself came from are scanned, in that order.
 
-    When several reports are found, one whose filename names the workbook wins; a single unnamed
-    candidate is accepted; an ambiguous set is REFUSED (empty) rather than guessed, because
-    attributing another workbook's drift numbers to this one is worse than reporting nothing.
+    ⚠️ ``workbook_count`` is load-bearing, not decoration. A report whose filename names the
+    workbook always wins. An arbitrarily-named SINGLE candidate is accepted **only when the target
+    holds one workbook**: in a multi-workbook bundle where the oracle was run for A alone, the old
+    unconditional singleton fallback handed A's numbers to B - and a pixel-exact A made an entirely
+    unmeasured B read as verified. Ambiguity is refused rather than guessed, because attributing
+    another workbook's measurements to this one is worse than reporting nothing.
+
+    The real fix belongs upstream: the oracle report should carry the workbook identity it measured,
+    so this is an identity check rather than a filename inference. Filed as the successor to #182.
     """
     directories: list[Path] = []
     if explicit is not None:
@@ -452,7 +477,7 @@ def find_oracle_report(target: Path, source: Path, wb_name: str, explicit: Path 
         named = [(p, d) for p, d in found if wb_name.lower() in p.stem.lower()]
     if len(named) == 1:
         return OracleSource(named[0][1], named[0][0])
-    if not named and len(found) == 1:
+    if not named and len(found) == 1 and workbook_count == 1:
         return OracleSource(found[0][1], found[0][0])
     return OracleSource()
 
@@ -1231,17 +1256,26 @@ def fidelity_evidence_status(wb: dict) -> tuple[str, dict[str, int]]:
     An unrecognised value (a future engine adds one) is counted under its own name and is therefore
     NOT verified - only the literal `emitted+linted` is. Failing that way round is the point: a new
     value must not inherit a pass from a consumer that has never heard of it.
+
+    ⚠️ EVERY ROW COUNTS, including one that is not an object. Filtering unreadable rows out before
+    counting made the denominator describe the rows this function could parse rather than the
+    visuals the engine emitted: ``[{"evidence": "emitted+linted"}, 42]`` reported *"1 of 1 visual(s)
+    emitted+linted - structural coverage complete"* and exited 0, with two visuals in and one out.
+    That is the same collapse this whole module exists to prevent, one level down - a row nothing
+    could assess is not a row that passed - so an unreadable row gets its own bucket instead.
     """
     if "viz_fidelity" not in wb:
         return FIDELITY_EVIDENCE_NONE, {}
     raw_rows = wb.get("viz_fidelity")
     if not isinstance(raw_rows, list):
         return FIDELITY_EVIDENCE_INVALID, {}
-    rows = [r for r in raw_rows if isinstance(r, dict)]
-    if not rows:
+    if not raw_rows:
         return FIDELITY_EVIDENCE_NONE, {}
     counts: dict[str, int] = {}
-    for row in rows:
+    for row in raw_rows:
+        if not isinstance(row, dict):
+            counts[EVIDENCE_UNREADABLE] = counts.get(EVIDENCE_UNREADABLE, 0) + 1
+            continue
         raw = row.get("evidence")
         value = raw.strip() if isinstance(raw, str) and raw.strip() else EVIDENCE_UNKNOWN
         counts[value] = counts.get(value, 0) + 1
@@ -1357,44 +1391,118 @@ def placement_block_of(wb: dict, oracle: dict | None) -> dict | None:
     return None
 
 
+def _num(value: Any) -> float | None:
+    """Numeric coercion that refuses bools and non-finite values.
+
+    Refusing bools stops a stray ``true`` posing as a pixel count; refusing ``nan``/``inf`` stops a
+    corrupt number surviving a comparison it should fail. ``nan != nan`` would have made an axis
+    look drifted; ``None == None`` made a MISSING one look exact, which is worse.
+    """
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    value = float(value)
+    return value if math.isfinite(value) else None
+
+
+# The engine derives both axes from the same `delta_px` dicts, so `_placement_rollup` emits them
+# together or not at all - its own test asserts exactly that. One axis alone is therefore a
+# malformed rollup, and reading it as "the other is fine" is the failure `by_axis` was built to fix.
+EXPECTED_AXES = ("x", "y")
+
+# Every axis record must carry these, finite and non-negative, before any comparison is made.
+AXIS_MAGNITUDE_KEYS = ("median_abs_px", "mean_abs_px", "worst_abs_px")
+
+
+def _valid_axis(stats: Any) -> bool:
+    """Whether an axis record can be compared at all. Anything unassessable is NOT exact.
+
+    Guards the trap directly: ``_num(missing) == _num(missing)`` is ``None == None`` -> True, so an
+    EMPTY axis record used to satisfy "exact == evaluated" and report ``pixel_exact``. Measured:
+    ``{"x": {}, "y": {}}`` returned ``pixel_exact`` with ``measured: true``.
+    """
+    if not isinstance(stats, dict):
+        return False
+    evaluated, exact = _num(stats.get("evaluated")), _num(stats.get("exact"))
+    if evaluated is None or exact is None or evaluated < 0 or not 0 <= exact <= evaluated:
+        return False
+    if _num(stats.get("mean_signed_px")) is None:
+        return False
+    return all((_num(stats.get(k)) or 0.0) >= 0 and _num(stats.get(k)) is not None for k in AXIS_MAGNITUDE_KEYS)
+
+
+def _placement_pixel_exact(placement: dict) -> bool | None:
+    """Whether the ENCLOSING rollup calls itself pixel-exact. ``None`` when it does not say.
+
+    ``by_axis`` measures ``left``/``top`` only, while the rollup around it also weighs the right and
+    bottom edges and size drift. Measured against engine 2.339.0: a visual whose origin is perfect
+    but whose far edges are 100 px out yields ``verdict: "drifted"``, ``worst_max_edge_px: 100.0`` -
+    and reading only ``by_axis`` reported ``pixel_exact`` with ``measured: true``. The engine's own
+    verdict is authoritative here; ours is a per-axis refinement of it, never a replacement.
+    """
+    verdict = placement.get("verdict")
+    if isinstance(verdict, str):
+        return verdict == "pixel-exact"
+    evaluated, exact = _num(placement.get("evaluated")), _num(placement.get("pixel_exact"))
+    if evaluated is None or exact is None:
+        return None
+    return exact == evaluated
+
+
+def _by_axis_status(placement: dict) -> str | None:
+    """Whether ``by_axis`` is usable at all. Returns a terminal status, or ``None`` to continue.
+
+    Split out of `layout_drift_status` so the shape rules read as one list, and so the caller stays
+    under pylint's return-statement ceiling.
+    """
+    by_axis = placement.get("by_axis")
+    if by_axis is None or (isinstance(by_axis, dict) and not by_axis):
+        return LAYOUT_DRIFT_AXIS_BLIND
+    if not isinstance(by_axis, dict):
+        return LAYOUT_DRIFT_INVALID
+    if any(axis not in by_axis for axis in EXPECTED_AXES):
+        return LAYOUT_DRIFT_INVALID
+    if not all(_valid_axis(stats) for stats in by_axis.values()):
+        return LAYOUT_DRIFT_INVALID
+    return None
+
+
 def layout_drift_status(wb: dict, oracle: dict | None = None) -> tuple[str, dict]:
     """Per-axis layout drift, distinguishing "measured, no drift" from "never measured".
 
-    Five states, because collapsing any two of them recreates the axis-blind failure this block was
+    Six states, because collapsing any two of them recreates the axis-blind failure this block was
     built to fix:
 
     * ``LAYOUT_DRIFT_NOT_MEASURED`` - no placement rollup anywhere. Absence of the block is NOT
       absence of drift, and today this is the answer for every deterministic-pipeline bundle.
-    * ``LAYOUT_DRIFT_AXIS_BLIND``   - a placement rollup with no usable ``by_axis`` (a pre-2.332.0
-      oracle report, or one with no zone->visual deltas). Per-axis drift is UNKNOWN.
-    * ``LAYOUT_DRIFT_INVALID``      - ``by_axis`` present but not an object of axis records.
-    * ``LAYOUT_DRIFT_EXACT``        - measured, every evaluated pair exact on every axis.
-    * ``LAYOUT_DRIFT_PRESENT``      - measured, with drift. ``payload["axes"]`` carries both axes and
-      ``payload["worst"]`` the ``(name, stats)`` pair to lead with.
+    * ``LAYOUT_DRIFT_AXIS_BLIND``   - a placement rollup with no ``by_axis`` (a pre-2.332.0 oracle
+      report, or one with no zone->visual deltas). Per-axis drift is UNKNOWN.
+    * ``LAYOUT_DRIFT_INVALID``      - ``by_axis`` is not an object of two comparable axis records:
+      a missing axis, a non-object record, a non-finite or out-of-range count, or an enclosing
+      rollup that never states its own verdict. Unassessable, therefore not a pass.
+    * ``LAYOUT_DRIFT_EXACT``        - origins exact on every axis AND the enclosing rollup agrees it
+      is pixel-exact.
+    * ``LAYOUT_DRIFT_EDGE_ONLY``    - origins exact on every axis but the enclosing rollup is not
+      pixel-exact: the far edges or the SIZE drifted. ``by_axis`` structurally cannot see this, so
+      it is reported rather than absorbed into either neighbour.
+    * ``LAYOUT_DRIFT_PRESENT``      - measured, with origin drift. ``payload["axes"]`` carries both
+      axes and ``payload["worst"]`` the ``(name, stats)`` pair to lead with.
     """
     placement = placement_block_of(wb, oracle)
     if placement is None:
         return LAYOUT_DRIFT_NOT_MEASURED, {}
-    by_axis = placement.get("by_axis")
-    if by_axis is None:
-        return LAYOUT_DRIFT_AXIS_BLIND, {"placement": placement}
-    if not isinstance(by_axis, dict):
-        return LAYOUT_DRIFT_INVALID, {"placement": placement}
-    axes = {name: stats for name, stats in by_axis.items() if isinstance(stats, dict)}
-    if not axes:
-        status = LAYOUT_DRIFT_AXIS_BLIND if not by_axis else LAYOUT_DRIFT_INVALID
-        return status, {"placement": placement}
+    shape = _by_axis_status(placement)
+    if shape is not None:
+        return shape, {"placement": placement}
+    axes = dict(placement["by_axis"])
     payload = {"placement": placement, "axes": axes, "worst": _worst_axis(axes)}
-    if all(_num(s.get("exact")) == _num(s.get("evaluated")) for s in axes.values()):
-        return LAYOUT_DRIFT_EXACT, payload
-    return LAYOUT_DRIFT_PRESENT, payload
-
-
-def _num(value: Any) -> float | None:
-    """Numeric coercion that refuses bools, so a stray `true` cannot pose as a pixel count."""
-    if isinstance(value, bool) or not isinstance(value, (int, float)):
-        return None
-    return float(value)
+    if not all(_num(s.get("exact")) == _num(s.get("evaluated")) for s in axes.values()):
+        return LAYOUT_DRIFT_PRESENT, payload
+    enclosing = _placement_pixel_exact(placement)
+    if enclosing is None:
+        # Origins are exact but nothing corroborates the edges or the size. "Cannot assess" is its
+        # own answer; claiming pixel-exact on it is the collapse this function guards against.
+        return LAYOUT_DRIFT_INVALID, {"placement": placement}
+    return (LAYOUT_DRIFT_EXACT if enclosing else LAYOUT_DRIFT_EDGE_ONLY), payload
 
 
 def _worst_axis(axes: dict[str, dict]) -> tuple[str, dict] | None:
@@ -1431,6 +1539,8 @@ def _terse_drift_line(status: str, payload: dict) -> str:
         return "        ?? drift: PER-AXIS UNKNOWN"
     if status == LAYOUT_DRIFT_EXACT:
         return "        drift: MEASURED, pixel-exact"
+    if status == LAYOUT_DRIFT_EDGE_ONLY:
+        return "        !! drift: origins exact, EDGE/SIZE drift"
     worst = payload.get("worst")
     if not worst:
         return "        !! drift: MEASURED, worst axis unknown"
@@ -1439,18 +1549,28 @@ def _terse_drift_line(status: str, payload: dict) -> str:
     return f"        !! drift: worst {worst[0].upper()} {worst[1].get('worst_abs_px', '?')}px {signed_txt}px"
 
 
-def _layout_drift_summary_line(wb: dict, oracle: dict | None = None, terse: bool = False) -> str:
-    """One line per workbook - the triage #372 asks for, ahead of anyone opening the report.
+def _edge_only_line(placement: dict, axes: dict[str, dict]) -> str:
+    """Origins land pixel-perfect, yet the enclosing rollup does not call itself pixel-exact.
 
-    BOTH axes always appear together in the full form. The engine's own rollup test pins that rule
-    ("a consumer comparing axes must never get one of them; that reads as 'the other is fine'"), and
-    it applies just as hard one layer up.
+    Named rather than absorbed, because `by_axis` measures ``left``/``top`` only: it structurally
+    cannot see a far-edge or SIZE mismatch, which is precisely the customer-reported shape in #372
+    (visuals compressed to ~34-48% of intended height with their origins in the right place).
     """
-    status, payload = layout_drift_status(wb, oracle)
+    detail = " | ".join(f"{n.upper()} {s.get('exact', '?')}/{s.get('evaluated', '?')}" for n, s in sorted(axes.items()))
+    return (
+        f"        !! layout drift: origins pixel-exact ({detail}) but the rollup reports "
+        f"{placement.get('verdict', '?')!s} - EDGE or SIZE drift that by_axis cannot see; "
+        f"worst edge {placement.get('worst_max_edge_px', '?')}px"
+    )
+
+
+def _unmeasured_drift_line(status: str, payload: dict) -> str | None:
+    """The full-form lines for the states that carry no per-axis numbers. ``None`` to continue."""
     if status == LAYOUT_DRIFT_INVALID:
-        return "        layout drift: INVALID SHAPE (by_axis is not an object of axis records)"
-    if terse:
-        return _terse_drift_line(status, payload)
+        return (
+            "        ?? layout drift: NOT ASSESSABLE - by_axis is not two comparable axis records, "
+            "or the rollup states no verdict; treated as unknown, never as no drift"
+        )
     if status == LAYOUT_DRIFT_NOT_MEASURED:
         return (
             "        ?? layout drift: NOT MEASURED - no oracle placement rollup here "
@@ -1462,8 +1582,26 @@ def _layout_drift_summary_line(wb: dict, oracle: dict | None = None, terse: bool
             "        ?? layout drift: PER-AXIS UNKNOWN - placement measured but carries no by_axis "
             f"(pre-2.332.0); axis-blind worst edge {placement.get('worst_max_edge_px', '?')}px"
         )
+    return None
+
+
+def _layout_drift_summary_line(wb: dict, oracle: dict | None = None, terse: bool = False) -> str:
+    """One line per workbook - the triage #372 asks for, ahead of anyone opening the report.
+
+    BOTH axes always appear together in the full form. The engine's own rollup test pins that rule
+    ("a consumer comparing axes must never get one of them; that reads as 'the other is fine'"), and
+    it applies just as hard one layer up.
+    """
+    status, payload = layout_drift_status(wb, oracle)
+    if terse and status != LAYOUT_DRIFT_INVALID:
+        return _terse_drift_line(status, payload)
+    unmeasured = _unmeasured_drift_line(status, payload)
+    if unmeasured is not None:
+        return unmeasured
     axes = payload["axes"]
     worst = payload["worst"]
+    if status == LAYOUT_DRIFT_EDGE_ONLY:
+        return _edge_only_line(payload["placement"], axes)
     if status == LAYOUT_DRIFT_EXACT:
         detail = " | ".join(
             f"{n.upper()} {s.get('exact', '?')}/{s.get('evaluated', '?')}" for n, s in sorted(axes.items())
@@ -1480,9 +1618,27 @@ def _layout_drift_summary_line(wb: dict, oracle: dict | None = None, terse: bool
 
 
 def _clip_tail(text: str, limit: int = 88) -> str:
-    """Clip from the LEFT, keeping the tail. A path clipped from the right loses its filename -
-    which is the only part that identifies which report the numbers came from."""
-    return text if len(text) <= limit else "..." + text[-(limit - 3) :]
+    """Clip from the LEFT by BYTES, keeping the tail.
+
+    Two things, both load-bearing. Clipping from the RIGHT loses the filename, which is the only
+    part identifying which report the numbers came from. And the limit is a BYTE limit because
+    ``--max-bytes`` is a byte cap: a 24-CHARACTER clip of a CJK filename measured 101 bytes against
+    a bound the code believed was ~70, and pushed the whole render past the cap. ``errors="ignore"``
+    drops a code point the cut landed inside, so the result is never mojibake.
+    """
+    raw = text.encode("utf-8")
+    if len(raw) <= limit:
+        return text
+    return "..." + raw[-(limit - 3) :].decode("utf-8", errors="ignore")
+
+
+def _clip_head(text: str, limit: int) -> str:
+    """Clip from the RIGHT by BYTES, keeping the head. The mirror of `_clip_tail`, for text whose
+    MEANING is at the front (a verdict) rather than at the end (a path)."""
+    raw = text.encode("utf-8")
+    if len(raw) <= limit:
+        return text
+    return raw[: limit - 3].decode("utf-8", errors="ignore") + "..."
 
 
 def _layout_drift_lines(wb: dict, oracle: OracleSource, terse: bool = False) -> list[str]:
@@ -1492,15 +1648,24 @@ def _layout_drift_lines(wb: dict, oracle: OracleSource, terse: bool = False) -> 
     strict cap on everything a run prints: a line printed outside the budgeted body made the cap a
     suggestion (measured - 1632 bytes emitted under a 1500-byte cap, with no truncation banner).
 
-    Under ``terse`` the citation collapses onto the verdict line and the filename is clipped, so the
-    pair stays inside a fixed byte ceiling however long the oracle's path happens to be.
+    Under ``terse`` the citation collapses onto the verdict line and is byte-clipped to fit, and the
+    whole line is then clamped to ``TERSE_DRIFT_LINE_MAX_BYTES``. The clamp is NOT redundant: the
+    verdict alone can exceed the ceiling on extreme input (a long axis name, a huge pixel value), so
+    a bound enforced only on the citation is a bound that holds for well-behaved data and no other.
     """
     verdict = _layout_drift_summary_line(wb, oracle.payload, terse)
-    if oracle.path is None:
-        return [verdict]
-    if terse:
-        return [f"{verdict} [{_clip_tail(oracle.path.name, 24)}]"]
-    return [verdict, f"           measured from: {_clip_tail(str(oracle.path))}"]
+    if not terse:
+        if oracle.path is None:
+            return [verdict]
+        return [verdict, f"           measured from: {_clip_tail(str(oracle.path))}"]
+    line = verdict
+    if oracle.path is not None:
+        # Below ~4 bytes a citation is "...", which identifies nothing; the VERDICT is the signal
+        # and the citation is its provenance, so this is the one place dropping it is right.
+        room = TERSE_DRIFT_LINE_MAX_BYTES - _blen(verdict) - len(" []")
+        if room >= 4:
+            line = f"{verdict} [{_clip_tail(oracle.path.name, room)}]"
+    return [_clip_head(line, TERSE_DRIFT_LINE_MAX_BYTES)]
 
 
 def _fidelity_counts(wb: dict) -> list[str]:
@@ -1844,34 +2009,75 @@ def _partition_review_estate_lines(found: list[tuple[str, dict, Path]]) -> list[
     return out + [""]
 
 
-def _evidence_estate_lines(found: list[tuple[str, dict, Path]]) -> list[str]:
-    """Estate totals for `--list`: how much of the estate's visual surface was actually examined.
+def _evidence_estate_tally(found: list[tuple[str, dict, Path]]) -> tuple[dict[str, int], list[str], list[str]]:
+    """Roll the per-workbook evidence up, keeping the unassessable workbooks VISIBLE.
 
-    Named per workbook, not just totalled: "38 of 40 examined" estate-wide hides that all 2 gaps sit
-    in one report. Workbooks with nothing examined are listed first for the same reason.
+    Returns ``(counts, gap_labels, unassessable_names)``. A workbook with no ``viz_fidelity`` or an
+    unreadable one contributes nothing to ``counts``, so it must be NAMED instead: skipping it
+    silently is how a mixed estate claimed full coverage while a workbook in the very same list was
+    never assessed at all.
     """
     counts: dict[str, int] = {}
-    unexamined: list[tuple[str, int, int]] = []
+    gaps: list[tuple[str, int, int]] = []
+    unassessable: list[str] = []
     for name, wb, _ in found:
         status, wb_counts = fidelity_evidence_status(wb)
         if status in (FIDELITY_EVIDENCE_NONE, FIDELITY_EVIDENCE_INVALID):
+            unassessable.append(name)
             continue
         for value, n in wb_counts.items():
             counts[value] = counts.get(value, 0) + n
         total = sum(wb_counts.values())
         verified = wb_counts.get(EVIDENCE_VERIFIED, 0)
         if verified != total:
-            unexamined.append((name, verified, total))
-    if not counts:
-        return ["Visual evidence: NOT RECORDED anywhere in this estate (no viz_fidelity rows).", ""]
-    total = sum(counts.values())
-    out = [
-        f"Visual evidence: {counts.get(EVIDENCE_VERIFIED, 0)}/{total} visual(s) examined "
-        f"({' | '.join(f'{v} {counts[v]}' for v in _evidence_order(counts))})",
+            gaps.append((name, verified, total))
+    labels = [
+        f"    !! {_clip(n, 52):<52} {v}/{t} examined"
+        for n, v, t in sorted(gaps, key=lambda g: (g[1] - g[2], g[0].lower()))
     ]
-    for name, verified, wb_total in sorted(unexamined, key=lambda t: (t[1] - t[2], t[0].lower())):
-        out.append(f"    !! {_clip(name, 52):<52} {verified}/{wb_total} examined")
-    return out + [""]
+    return counts, labels, sorted(unassessable)
+
+
+def _evidence_estate_lines(found: list[tuple[str, dict, Path]], budget: int) -> list[str]:
+    """Estate totals for `--list`: how much of the estate's visual surface was actually examined.
+
+    Named per workbook, not just totalled: "38 of 40 examined" estate-wide hides that all 2 gaps sit
+    in one report. Workbooks with nothing examined are listed first for the same reason.
+
+    BUDGETED, like every other section in this module. It was not, and one unconditional line per
+    workbook is unbounded in the estate's width: at `MIN_MAX_BYTES` a 30-workbook estate fired
+    `HARD CAP` and cut 18 of the 30 signals with no omission line and exit 0. A dropped signal under
+    budget pressure is a silent false-clean - the exact failure this section exists to prevent - so
+    the omission line is reserved BEFORE any workbook is named, and the estate totals always
+    survive.
+    """
+    counts, labels, unassessable = _evidence_estate_tally(found)
+    head: list[str] = []
+    if counts:
+        total = sum(counts.values())
+        head.append(
+            f"Visual evidence: {counts.get(EVIDENCE_VERIFIED, 0)}/{total} visual(s) examined "
+            f"({' | '.join(f'{v} {counts[v]}' for v in _evidence_order(counts))})"
+        )
+        # Named ONLY when the estate is MIXED. When nothing was assessable the headline below
+        # already says so and naming every workbook is noise; when SOME were, silence about the
+        # rest is what let a "1/1 examined" total sit above two workbooks nobody assessed.
+        if unassessable:
+            head.append(
+                f"    ?? {len(unassessable)} workbook(s) NOT ASSESSABLE (no viz_fidelity, or an "
+                "unreadable one) - they are NOT in the total above"
+            )
+            labels = [f"    ?? {_clip(n, 52):<52} not assessable" for n in unassessable] + labels
+    else:
+        head.append(
+            f"Visual evidence: NOT RECORDED anywhere in this estate - none of {len(found)} "
+            "workbook(s) carries viz_fidelity rows; coverage is unknown, not zero"
+        )
+    if not labels:
+        return head + [""]
+    more = "    ... and {n} more workbook(s) not named here; raise --max-bytes or use --json"
+    remaining = budget - sum(_blen(x) + 1 for x in head) - 1
+    return head + _fit_lines(labels, remaining, more) + [""]
 
 
 def render_list(found: list[tuple[str, dict, Path]], max_bytes: int) -> str:
@@ -1891,7 +2097,10 @@ def render_list(found: list[tuple[str, dict, Path]], max_bytes: int) -> str:
     ]
     out += _pbip_warning_estate_lines(found)
     out += _partition_review_estate_lines(found)
-    out += _evidence_estate_lines(found)
+    # Half the remaining budget, so a wide estate cannot spend the whole cap naming unexamined
+    # workbooks and leave the ranked queue below with nothing. Both sections then omit-and-count.
+    spent = sum(_blen(x) + 1 for x in out)
+    out += _evidence_estate_lines(found, max(0, (max_bytes - spent) // 2))
     # Partition scaffolds rank FIRST: unlike a stub calc or a dropped visual binding, an unresolved
     # M partition means the table has ZERO rows -- and it carries a named manual completion step
     # the engine already wrote down (issue #326).
@@ -1908,7 +2117,10 @@ def _layout_drift_json(wb: dict, oracle: OracleSource) -> dict:
     worst = payload.get("worst")
     return {
         "status": status,
-        "measured": status in (LAYOUT_DRIFT_EXACT, LAYOUT_DRIFT_PRESENT),
+        "measured": status in LAYOUT_DRIFT_MEASURED,
+        "origins_pixel_exact": status == LAYOUT_DRIFT_EXACT,
+        "edge_or_size_drift": status == LAYOUT_DRIFT_EDGE_ONLY,
+        "enclosing_verdict": (payload.get("placement") or {}).get("verdict"),
         "by_axis": payload.get("axes"),
         "worst_axis": worst[0] if worst else None,
         "worst_axis_stats": worst[1] if worst else None,
@@ -2080,7 +2292,7 @@ def main(argv: list[str] | None = None) -> int:
             return EXIT_OK
         selected = select_workbook(found, args.workbook)
         wb_name, wb, source = selected
-        oracle = find_oracle_report(args.target, source, wb_name, args.oracle)
+        oracle = find_oracle_report(args.target, source, wb_name, args.oracle, len(found))
     except HandoverError as exc:
         print(f"read_handover: {exc}", file=sys.stderr)
         return EXIT_USAGE

--- a/tests/fixtures/handover-2.339.0-evidence.json
+++ b/tests/fixtures/handover-2.339.0-evidence.json
@@ -1,0 +1,420 @@
+{
+  "estate": {
+    "tool": "migrate_estate",
+    "generated_at": "2026-08-29T16:57:35Z",
+    "source": {
+      "kind": "LocalFilesSource",
+      "root": "_runs\\coldrun\\input"
+    },
+    "pending_gates": [
+      {
+        "count": 4,
+        "gate": "second_compiler",
+        "offer": "OFFER the LLM-assisted second compiler for 4 stubbed calculation(s) before declaring the migration done -- present them and run only on an explicit GO. The per-calc work order (formula, resolved fields, target table, category) is repair-queue.json. If declined, the deterministic result ships as-is (each stub keeps its preserved TableauFormula and a TranslationStubReason annotation naming why it stubbed).",
+        "runbook": "resources/second-compiler.md",
+        "skill_step": 3,
+        "trigger": "summary.needs_review_total",
+        "work_order": "repair-queue.json"
+      },
+      {
+        "count": 3,
+        "gate": "dashboard_audit",
+        "offer": "OFFER the LLM-assisted Tier-3 dashboard audit for 3 warned visual(s) before declaring the migration done -- present them and run only on an explicit GO. If declined, the deterministic rebuild ships as-is (every faithfully-bound visual intact). OFFER THE FORMATTING TOUCH-UP IN THE SAME BREATH -- the two are independent, so the user may take either, both or neither: \"Do you want the adjudication report, as well as a formatting touch-up?\"",
+        "runbook": "resources/dashboard-audit.md",
+        "skill_step": 5,
+        "trigger": "summary.visuals_warned"
+      },
+      {
+        "count": 1,
+        "gate": "layout_polish",
+        "offer": "OFFER the Tier-3 FORMATTING TOUCH-UP alongside the adjudication report -- run only on an explicit GO. It normalises each page's control bands (uniform card size, aligned rows, even gutters, no band drawn over the content below) against the source layout, and keeps a page's new geometry ONLY when the measured defect count falls. Geometry only: no binding, no number, nothing but position rects. Run: py -3.11 \"$SKILL\\scripts\\polish_layout.py\" \"<...>.Report\" (add --dry-run to measure first).",
+        "runbook": "resources/dashboard-audit.md",
+        "skill_step": 5,
+        "trigger": "summary.workbooks_pbip_built"
+      }
+    ],
+    "definition_of_done_status": "failed"
+  },
+  "workbook": {
+    "binding_signal": {
+      "connection_class": "sqlproxy",
+      "kind": "published",
+      "note": "published datasource 'Meridian Sales (Live Snowflake)' with no view-local calc dependencies -- candidate to rebind to the migrated published model (pending estate catalog match)",
+      "primary_datasource": "Meridian Sales (Live Snowflake)",
+      "published_ds_name": "Meridian Sales (Live Snowflake)",
+      "recommendation": "candidate_rebind_to_published",
+      "secondary_datasources": [],
+      "secondary_published_datasources": [],
+      "view_local_calcs": []
+    },
+    "bound_datasource": "Meridian Sales (Live Snowflake)",
+    "bound_model": "Meridian Sales (Live Snowflake)",
+    "bound_via": "published_catalog_match:Meridian Sales (Live Snowflake)",
+    "column_prune": null,
+    "column_rebind": {
+      "count": 3
+    },
+    "date_rebind": {
+      "active_keys": [
+        "ORDER_DATE"
+      ],
+      "date_table": "Date"
+    },
+    "embedded_datasources": [
+      {
+        "caption": "Meridian Sales (Live Snowflake)",
+        "connection_class": "sqlproxy",
+        "connections": [],
+        "label": "Meridian Sales (Live Snowflake)",
+        "named_connection_count": 1,
+        "table_count": 1
+      }
+    ],
+    "field_rebind": {
+      "count": 28,
+      "model_table": "FACT_ORDERS"
+    },
+    "measure_rebind": {
+      "count": 3
+    },
+    "model_facts": {
+      "column_count": 14,
+      "connector": "Snowflake.Databases",
+      "storage_mode": "DirectQuery",
+      "table_count": 4
+    },
+    "model_translation_handoff": {
+      "needs_review": [
+        {
+          "blocked_by": [],
+          "category": "unresolved_reference",
+          "fallback_reason": "cross-table terms (fields span multiple tables)",
+          "has_suggestion": false,
+          "name": "Regional Revenue (FIXED)",
+          "role": "measure"
+        },
+        {
+          "blocked_by": [],
+          "category": "unsupported_other",
+          "fallback_reason": "unsupported function ISMEMBEROF",
+          "has_suggestion": false,
+          "name": "Is My Region",
+          "role": "dimension"
+        }
+      ],
+      "partial_fidelity": [],
+      "requests": [
+        {
+          "blocked_by": [],
+          "category": "unresolved_reference",
+          "category_guidance": "A referenced field, dimension, or calc could not be bound (unresolved/ambiguous name, terms spanning multiple tables, or an unsupported field type). Resolve the binding yourself: choose the correct 'Table'[Column] qualifier or the relationship path, and if it points at another stubbed calc, author that calc's DAX first. Then write the faithful expression using the resolved model identifiers and validate it (check_candidate_dax, plus the reconciliation oracle when data is landed). Resolving the reference does not re-invoke Tier 0 -- once it binds, YOU author the DAX.",
+          "fallback_reason": "cross-table terms (fields span multiple tables)",
+          "fields": [
+            {
+              "caption": "DIM_CUSTOMER_REGION",
+              "column": "REGION",
+              "kind": "field",
+              "table": "DIM_CUSTOMER",
+              "type": "string"
+            },
+            {
+              "caption": "FACT_ORDERS_TOTAL_PRICE",
+              "column": "TOTAL_PRICE",
+              "kind": "field",
+              "table": "FACT_ORDERS",
+              "type": "double"
+            }
+          ],
+          "formula": "{ FIXED [DIM_CUSTOMER_REGION] : SUM([FACT_ORDERS_TOTAL_PRICE]) }",
+          "has_suggestion": false,
+          "name": "Regional Revenue (FIXED)",
+          "role": "measure",
+          "target_table": "_Measures"
+        },
+        {
+          "blocked_by": [],
+          "category": "unsupported_other",
+          "category_guidance": "Not matched to a specific category. A faithful DAX form may still exist (for example CORR/COVAR/COVARP via a VAR/RETURN closed form, or an aggregate the deterministic tier has not yet wired). Assess the formula, author a candidate at the right grain, and validate (oracle when data is landed) before proposing it; otherwise keep the stub.",
+          "fallback_reason": "unsupported function ISMEMBEROF",
+          "fields": [
+            {
+              "caption": "DIM_CUSTOMER_REGION",
+              "column": "REGION",
+              "kind": "field",
+              "table": "DIM_CUSTOMER",
+              "type": "string"
+            }
+          ],
+          "formula": "ISMEMBEROF('Meridian - EMEA') AND [DIM_CUSTOMER_REGION] = 'EUROPE'",
+          "has_suggestion": false,
+          "name": "Is My Region",
+          "role": "dimension",
+          "target_table": "FACT_ORDERS"
+        }
+      ],
+      "summary": {
+        "assisted_approved": 0,
+        "assisted_suggested": 0,
+        "blocked_by_unmigrated_calc": 0,
+        "categories": {
+          "unresolved_reference": 1,
+          "unsupported_other": 1
+        },
+        "coverage_pct": 60.0,
+        "live": 3,
+        "needs_review": 2,
+        "partial_fidelity": 0,
+        "stub": 2,
+        "total": 5,
+        "translated": 3
+      },
+      "triage": {
+        "cascadable": [],
+        "irreducible": {
+          "lod": [
+            {
+              "category": "unresolved_reference",
+              "name": "Regional Revenue (FIXED)",
+              "role": "measure"
+            }
+          ],
+          "other": [
+            {
+              "category": "unsupported_other",
+              "name": "Is My Region",
+              "role": "dimension"
+            }
+          ]
+        },
+        "summary": {
+          "cascadable": 0,
+          "irreducible": 2,
+          "shapes": {
+            "lod": 1,
+            "other": 1
+          }
+        }
+      }
+    },
+    "name": "Meridian Revenue by Region",
+    "note": null,
+    "openability_selfcheck": {
+      "checks": {
+        "bare_column_references_qualified": true,
+        "compatibility_level_current": true,
+        "dax_functions_exist": true,
+        "dax_references_resolve": true,
+        "local_source_paths": true,
+        "m_parameters_defined": true,
+        "measure_value_path_not_blank": true,
+        "no_duplicate_columns": true,
+        "relationship_columns_exist": true,
+        "tmdl_wellformed": true,
+        "typed_columns_declared": true,
+        "unambiguous_relationship_paths": true,
+        "wrapper_keeps_base_format_string": true
+      },
+      "issues": [],
+      "not_evaluated": [
+        {
+          "check": "endpoints_distinct",
+          "reason": "the source declares a single upstream, so endpoints cannot collapse onto each other"
+        }
+      ],
+      "ok": true,
+      "reference_case_mismatches": []
+    },
+    "output_folder": "reports/Meridian Revenue by Region.Report",
+    "pbip_entity_binding_mismatches": [
+      {
+        "column": "Region",
+        "entity": "FACT_ORDERS",
+        "owned_by": [
+          "dim_customer"
+        ],
+        "part": "definition/pages/page-ws-Revenuebb7d27f78/visuals/v-RevenuebyRegio864a62f6/visual.json"
+      },
+      {
+        "column": "Calendar_Year",
+        "entity": "FACT_ORDERS",
+        "owned_by": [
+          "dim_date"
+        ],
+        "part": "definition/pages/page-ws-RevenueTfd9cb617/visuals/v-RevenueTrend1626f5ae/visual.json"
+      }
+    ],
+    "pbip_folder": "pbip/Meridian Revenue by Region/Meridian Revenue by Region.pbip",
+    "pbip_page_count": 3,
+    "pbip_ref_drops": [
+      {
+        "dropped": [
+          "Y:column 'Regional_Revenue__FIXED'"
+        ],
+        "emptied": true,
+        "visual": "v-RegionalSharea1c2c884"
+      }
+    ],
+    "pbip_status": "built",
+    "pbip_warnings": [
+      "manual attention required: table 'DIM_CUSTOMER' landed with NO relationship to any other table -- a measure broken down by its columns returns the whole table's GRAND TOTAL identically for every member, and no structural gate can see that. The source declared no join for it, so none was invented.",
+      "manual attention required: table 'DIM_DATE' landed with NO relationship to any other table -- a measure broken down by its columns returns the whole table's GRAND TOTAL identically for every member, and no structural gate can see that. The source declared no join for it, so none was invented.",
+      "manual attention required: visual 'v-RegionalSharea1c2c884' dropped 1 reference(s) the model did not emit: Y:column 'Regional_Revenue__FIXED' (visual emptied)",
+      "manual attention required: binding 'FACT_ORDERS'[Region] names a table that does not own that column -- it lives on dim_customer. Power BI reports Missing_References once real data lands; while the partition is a stub it renders empty either way",
+      "manual attention required: binding 'FACT_ORDERS'[Calendar_Year] names a table that does not own that column -- it lives on dim_date. Power BI reports Missing_References once real data lands; while the partition is a stub it renders empty either way",
+      "manual attention required: 2 visual field reference(s) name a model object that does not exist -- those visuals render EMPTY and report no error; first: PBIR_VISUAL_REF_MISSING: definition/pages/page-ws-RevenueTfd9cb617/visuals/v-RevenueTrend1626f5ae/visual.json binds column 'Calendar_Year' on table 'FACT_ORDERS', which the model does not contain -- the visual renders EMPTY and validation reports no error"
+    ],
+    "remediation_worklist": {
+      "items": [
+        {
+          "category": "field_binding",
+          "id": "wl-0002",
+          "page": "page-ws-Regional05286155",
+          "page_display": "Regional Share",
+          "reason": "field 'Regional Revenue (FIXED)' bound by caption fallback (no datasource metadata); verify it matches model table/column names",
+          "remediation": "Bind the field to the matching model table/column; verify the caption maps to a real column name.",
+          "scope": "worksheet",
+          "severity": "high",
+          "source": "warning",
+          "visual": "v-RegionalSharea1c2c884",
+          "visual_type": "clusteredColumnChart",
+          "worksheet": "Regional Share"
+        },
+        {
+          "category": "field_binding",
+          "id": "wl-0003",
+          "page": "page-ws-Regional05286155",
+          "page_display": "Regional Share",
+          "reason": "field 'Nation' bound by caption fallback (no datasource metadata); verify it matches model table/column names",
+          "remediation": "Bind the field to the matching model table/column; verify the caption maps to a real column name.",
+          "scope": "worksheet",
+          "severity": "high",
+          "source": "warning",
+          "visual": "v-RegionalSharea1c2c884",
+          "visual_type": "clusteredColumnChart",
+          "worksheet": "Regional Share"
+        },
+        {
+          "category": "field_binding",
+          "id": "wl-0001",
+          "page": "page-ws-RevenueTfd9cb617",
+          "page_display": "Revenue Trend",
+          "reason": "field 'Calendar Year' bound by caption fallback (no datasource metadata); verify it matches model table/column names",
+          "remediation": "Bind the field to the matching model table/column; verify the caption maps to a real column name.",
+          "scope": "worksheet",
+          "severity": "high",
+          "source": "warning",
+          "visual": "v-RevenueTrend1626f5ae",
+          "visual_type": "lineChart",
+          "worksheet": "Revenue Trend"
+        },
+        {
+          "category": "field_binding",
+          "id": "wl-0000",
+          "page": "page-ws-Revenuebb7d27f78",
+          "page_display": "Revenue by Region",
+          "reason": "field 'Region' bound by caption fallback (no datasource metadata); verify it matches model table/column names",
+          "remediation": "Bind the field to the matching model table/column; verify the caption maps to a real column name.",
+          "scope": "worksheet",
+          "severity": "high",
+          "source": "warning",
+          "visual": "v-RevenuebyRegio864a62f6",
+          "visual_type": "clusteredColumnChart",
+          "worksheet": "Revenue by Region"
+        }
+      ],
+      "kind": "tableau-fabric-remediation-worklist",
+      "summary": {
+        "by_category": {
+          "field_binding": 4
+        },
+        "by_severity": {
+          "high": 4
+        },
+        "items_total": 4,
+        "unattached_items": 0,
+        "visuals_clean": 0,
+        "visuals_flagged": 3,
+        "visuals_total": 3
+      },
+      "version": 1,
+      "visuals": [
+        {
+          "confidence": "high",
+          "item_ids": [
+            "wl-0000"
+          ],
+          "page": "page-ws-Revenuebb7d27f78",
+          "page_display": "Revenue by Region",
+          "status": "needs_attention",
+          "visual": "v-RevenuebyRegio864a62f6",
+          "visual_type": "clusteredColumnChart",
+          "worksheet": "Revenue by Region"
+        },
+        {
+          "confidence": "high",
+          "item_ids": [
+            "wl-0001"
+          ],
+          "page": "page-ws-RevenueTfd9cb617",
+          "page_display": "Revenue Trend",
+          "status": "needs_attention",
+          "visual": "v-RevenueTrend1626f5ae",
+          "visual_type": "lineChart",
+          "worksheet": "Revenue Trend"
+        },
+        {
+          "confidence": "high",
+          "item_ids": [
+            "wl-0002",
+            "wl-0003"
+          ],
+          "page": "page-ws-Regional05286155",
+          "page_display": "Regional Share",
+          "status": "needs_attention",
+          "visual": "v-RegionalSharea1c2c884",
+          "visual_type": "clusteredColumnChart",
+          "worksheet": "Regional Share"
+        }
+      ]
+    },
+    "source_id": "_runs\\coldrun\\input\\Meridian Revenue by Region.twb",
+    "viz_dangling_bindings": {
+      "count": 2,
+      "problems": [
+        "PBIR_VISUAL_REF_MISSING: definition/pages/page-ws-RevenueTfd9cb617/visuals/v-RevenueTrend1626f5ae/visual.json binds column 'Calendar_Year' on table 'FACT_ORDERS', which the model does not contain -- the visual renders EMPTY and validation reports no error",
+        "PBIR_VISUAL_REF_MISSING: definition/pages/page-ws-Revenuebb7d27f78/visuals/v-RevenuebyRegio864a62f6/visual.json binds column 'Region' on table 'FACT_ORDERS', which the model does not contain -- the visual renders EMPTY and validation reports no error"
+      ]
+    },
+    "viz_fidelity": [
+      {
+        "evidence": "emitted+linted",
+        "reason": "manual attention required: field 'Region' bound by caption fallback (no datasource metadata); verify it matches model table/column names",
+        "status": "warned",
+        "tier": "degraded",
+        "visual_type": "column",
+        "worksheet": "Revenue by Region"
+      },
+      {
+        "evidence": "emitted+linted",
+        "reason": "manual attention required: field 'Calendar Year' bound by caption fallback (no datasource metadata); verify it matches model table/column names",
+        "status": "warned",
+        "tier": "degraded",
+        "visual_type": "line",
+        "worksheet": "Revenue Trend"
+      },
+      {
+        "additional_reasons": [
+          "manual attention required: field 'Nation' bound by caption fallback (no datasource metadata); verify it matches model table/column names"
+        ],
+        "evidence": "emitted+linted",
+        "reason": "manual attention required: field 'Regional Revenue (FIXED)' bound by caption fallback (no datasource metadata); verify it matches model table/column names",
+        "status": "warned",
+        "tier": "degraded",
+        "visual_type": "column",
+        "worksheet": "Regional Share"
+      }
+    ],
+    "viz_implicit_row_count": 0,
+    "viz_status": "built"
+  }
+}

--- a/tests/fixtures/oracle-2.339.0-drifted.json
+++ b/tests/fixtures/oracle-2.339.0-drifted.json
@@ -1,0 +1,57 @@
+{
+  "kind": "tableau-fabric-structural-fidelity",
+  "version": 2,
+  "advisory": true,
+  "summary": {
+    "aggregate_score": 0.91,
+    "aggregate_band": "faithful",
+    "mean_visual_score": 0.91,
+    "worst_visual_score": 0.84,
+    "coverage": 1.0,
+    "source_worksheets": 3,
+    "matched_visuals": 3,
+    "unmatched_worksheets": [],
+    "extra_visuals": 0,
+    "slicers": 0,
+    "remodel_rename_suspected": 0,
+    "fields_alias_resolved": 0,
+    "placement": {
+      "evaluated": 3,
+      "pixel_exact": 0,
+      "within_tolerance": 1,
+      "drifted": 2,
+      "worst_max_edge_px": 108.0,
+      "mean_max_edge_px": 76.4,
+      "worst_worksheet": "Revenue by Region",
+      "verdict": "drifted",
+      "by_axis": {
+        "x": {
+          "evaluated": 3,
+          "exact": 3,
+          "median_abs_px": 0.0,
+          "mean_abs_px": 0.0,
+          "worst_abs_px": 0.0,
+          "mean_signed_px": 0.0,
+          "positive": 0,
+          "negative": 0
+        },
+        "y": {
+          "evaluated": 3,
+          "exact": 0,
+          "median_abs_px": 65.0,
+          "mean_abs_px": 76.4,
+          "worst_abs_px": 108.0,
+          "mean_signed_px": 38.93,
+          "positive": 2,
+          "negative": 1
+        }
+      }
+    },
+    "dashboard_objects": 0
+  },
+  "visuals": [],
+  "slicers": [],
+  "extra_visuals_detail": [],
+  "dashboard_objects_detail": [],
+  "notes": []
+}

--- a/tests/fixtures/oracle-2.339.0-edge-size-drift.json
+++ b/tests/fixtures/oracle-2.339.0-edge-size-drift.json
@@ -1,0 +1,57 @@
+{
+  "kind": "tableau-fabric-structural-fidelity",
+  "version": 2,
+  "advisory": true,
+  "summary": {
+    "aggregate_score": 0.88,
+    "aggregate_band": "faithful",
+    "mean_visual_score": 0.88,
+    "worst_visual_score": 0.8,
+    "coverage": 1.0,
+    "source_worksheets": 2,
+    "matched_visuals": 2,
+    "unmatched_worksheets": [],
+    "extra_visuals": 0,
+    "slicers": 0,
+    "remodel_rename_suspected": 0,
+    "fields_alias_resolved": 0,
+    "placement": {
+      "evaluated": 2,
+      "pixel_exact": 0,
+      "within_tolerance": 0,
+      "drifted": 2,
+      "worst_max_edge_px": 240.0,
+      "mean_max_edge_px": 170.0,
+      "worst_worksheet": "Revenue Trend",
+      "verdict": "drifted",
+      "by_axis": {
+        "x": {
+          "evaluated": 2,
+          "exact": 2,
+          "median_abs_px": 0.0,
+          "mean_abs_px": 0.0,
+          "worst_abs_px": 0.0,
+          "mean_signed_px": 0.0,
+          "positive": 0,
+          "negative": 0
+        },
+        "y": {
+          "evaluated": 2,
+          "exact": 2,
+          "median_abs_px": 0.0,
+          "mean_abs_px": 0.0,
+          "worst_abs_px": 0.0,
+          "mean_signed_px": 0.0,
+          "positive": 0,
+          "negative": 0
+        }
+      }
+    },
+    "dashboard_objects": 0
+  },
+  "visuals": [],
+  "slicers": [],
+  "extra_visuals_detail": [],
+  "dashboard_objects_detail": [],
+  "notes": []
+}

--- a/tests/fixtures/oracle-2.339.0-pixel-exact.json
+++ b/tests/fixtures/oracle-2.339.0-pixel-exact.json
@@ -1,0 +1,57 @@
+{
+  "kind": "tableau-fabric-structural-fidelity",
+  "version": 2,
+  "advisory": true,
+  "summary": {
+    "aggregate_score": 0.91,
+    "aggregate_band": "faithful",
+    "mean_visual_score": 0.91,
+    "worst_visual_score": 0.84,
+    "coverage": 1.0,
+    "source_worksheets": 2,
+    "matched_visuals": 2,
+    "unmatched_worksheets": [],
+    "extra_visuals": 0,
+    "slicers": 0,
+    "remodel_rename_suspected": 0,
+    "fields_alias_resolved": 0,
+    "placement": {
+      "evaluated": 2,
+      "pixel_exact": 2,
+      "within_tolerance": 2,
+      "drifted": 0,
+      "worst_max_edge_px": 0.0,
+      "mean_max_edge_px": 0.0,
+      "worst_worksheet": "A",
+      "verdict": "pixel-exact",
+      "by_axis": {
+        "x": {
+          "evaluated": 2,
+          "exact": 2,
+          "median_abs_px": 0.0,
+          "mean_abs_px": 0.0,
+          "worst_abs_px": 0.0,
+          "mean_signed_px": 0.0,
+          "positive": 0,
+          "negative": 0
+        },
+        "y": {
+          "evaluated": 2,
+          "exact": 2,
+          "median_abs_px": 0.0,
+          "mean_abs_px": 0.0,
+          "worst_abs_px": 0.0,
+          "mean_signed_px": 0.0,
+          "positive": 0,
+          "negative": 0
+        }
+      }
+    },
+    "dashboard_objects": 0
+  },
+  "visuals": [],
+  "slicers": [],
+  "extra_visuals_detail": [],
+  "dashboard_objects_detail": [],
+  "notes": []
+}

--- a/tests/fixtures/oracle-pre-2.332.0-axis-blind.json
+++ b/tests/fixtures/oracle-pre-2.332.0-axis-blind.json
@@ -1,0 +1,35 @@
+{
+  "kind": "tableau-fabric-structural-fidelity",
+  "version": 2,
+  "advisory": true,
+  "summary": {
+    "aggregate_score": 0.91,
+    "aggregate_band": "faithful",
+    "mean_visual_score": 0.91,
+    "worst_visual_score": 0.84,
+    "coverage": 1.0,
+    "source_worksheets": 3,
+    "matched_visuals": 3,
+    "unmatched_worksheets": [],
+    "extra_visuals": 0,
+    "slicers": 0,
+    "remodel_rename_suspected": 0,
+    "fields_alias_resolved": 0,
+    "placement": {
+      "evaluated": 3,
+      "pixel_exact": 0,
+      "within_tolerance": 1,
+      "drifted": 2,
+      "worst_max_edge_px": 108.0,
+      "mean_max_edge_px": 76.4,
+      "worst_worksheet": "Revenue by Region",
+      "verdict": "drifted"
+    },
+    "dashboard_objects": 0
+  },
+  "visuals": [],
+  "slicers": [],
+  "extra_visuals_detail": [],
+  "dashboard_objects_detail": [],
+  "notes": []
+}

--- a/tests/test_read_handover.py
+++ b/tests/test_read_handover.py
@@ -363,10 +363,18 @@ def test_a_pathological_workbook_name_cannot_spend_the_whole_cap_on_a_heading(tm
 
 
 def test_list_view_honours_the_cap(tmp_path, capsys):
-    """Kills: `--list` rows emitted unbudgeted - a wide estate is the one that overflows."""
+    """Kills: `--list` rows emitted unbudgeted - a wide estate is the one that overflows.
+
+    ⚠️ The fixtures carry `viz_fidelity` DELIBERATELY. Without it this test was vacuous for the
+    estate evidence section (#371): that section only emits per-workbook lines for workbooks whose
+    visuals were not all examined, so a fixture with no `viz_fidelity` never reached it and the
+    section was unbudgeted for weeks under a test that claimed to cover this view. A test whose
+    fixture cannot reach the code it names is worse than no test.
+    """
     (tmp_path / "handover").mkdir()
     for i in range(300):
         wb = make_workbook([make_request("A")], name=f"Workbook_{i:03d}_{'L' * 40}")
+        wb["viz_fidelity"] = [{"evidence": "emitted", "status": "rebuilt", "worksheet": f"Sheet {i}"}]
         write_slice(tmp_path / "handover", wb, f"W{i:03d}.json")
 
     _, out = run([str(tmp_path), "--list", "--max-bytes", "4000"], capsys)
@@ -374,6 +382,30 @@ def test_list_view_honours_the_cap(tmp_path, capsys):
     assert_within_cap(out, 4000)
     assert "300 workbook(s)" in out, "the total must survive even when most rows do not"
     assert "more workbook(s) not listed here" in out
+
+
+def test_list_view_honours_the_floor_cap_with_an_unexamined_estate(tmp_path, capsys):
+    """Kills: the estate evidence section emitting one unconditional line per workbook.
+
+    The narrow case the 300-workbook test above cannot reach, because at 4,000 bytes there is slack.
+    At `MIN_MAX_BYTES` a 30-workbook estate where every workbook has unexamined visuals fired
+    `HARD CAP` and silently cut 18 of the 30 signals with no omitted-count line and exit 0 - a
+    dropped signal under budget pressure is a silent false-clean, which is the exact failure the
+    evidence section exists to prevent.
+    """
+    (tmp_path / "handover").mkdir()
+    for i in range(30):
+        wb = make_workbook([], name=f"Workbook-{i:02d}")
+        wb["viz_fidelity"] = [{"evidence": "emitted", "status": "rebuilt", "worksheet": "Sheet"}]
+        write_slice(tmp_path / "handover", wb, f"W{i:02d}.json")
+
+    _, out = run([str(tmp_path), "--list", "--max-bytes", str(rh.MIN_MAX_BYTES)], capsys)
+
+    assert_within_cap(out, rh.MIN_MAX_BYTES)
+    assert "Visual evidence:" in out, "the estate coverage total must survive any cap"
+    named = out.count("examined\n")
+    assert named < 30, "fixture too small to force an omission; raise the workbook count"
+    assert "not named here" in out, "every workbook cut from the evidence section must be COUNTED"
 
 
 def test_default_max_bytes_is_the_size_an_agent_read_tool_accepts(tmp_path, capsys):

--- a/tests/test_read_handover_evidence.py
+++ b/tests/test_read_handover_evidence.py
@@ -862,6 +862,225 @@ def test_a_name_matched_report_still_wins_in_a_multi_workbook_bundle(tmp_path):
     assert "NOT MEASURED" in run_cli(str(root), "--workbook", "Workbook B").stdout
 
 
+def test_a_corrupt_slice_does_not_shrink_the_census_into_the_singleton_path(tmp_path):
+    """HIGH (round 2). The singleton-oracle guard was gated on the number of PARSED workbooks, and
+    `load_workbooks` silently skips a slice it cannot read - so a two-slice bundle with ONE corrupt
+    slice counted 1, satisfied the guard, and handed the readable workbook the other one's
+    measurements.
+
+    Measured before the fix: ``HANDOVER_SLICES=2  LOADED=1`` ->
+    ``drift: MEASURED, pixel-exact [measured-run.json]``, exit 0.
+
+    This is the round-1 HIGH 1 defect recurring one level up: a parse failure silently shrinks a
+    denominator and unlocks a permissive path.
+
+    Mutation killed: gate on ``len(found)`` (or on ``census.workbooks``) instead of the census.
+    """
+    root = tmp_path / "bundle"
+    (root / "handover").mkdir(parents=True)
+    (root / "handover" / "Workbook A.json").write_text(
+        json.dumps({"estate": {}, "workbook": {"name": "Workbook A", "viz_fidelity": []}}), encoding="utf-8"
+    )
+    (root / "handover" / "Workbook B.json").write_text("{ this is not valid json", encoding="utf-8")
+    (root / "measured-run.json").write_text(ORACLE_EXACT.read_text(encoding="utf-8"), encoding="utf-8")
+
+    census = rh.load_workbook_census(root)
+    assert census.declared == 2, "the CORRUPT slice must still be declared"
+    assert len(census.workbooks) == 1
+    assert census.unreadable == 1
+    assert census.provably_single is False
+
+    proc = run_cli(str(root))
+    assert proc.returncode == rh.EXIT_OK
+    assert "NOT MEASURED" in proc.stdout
+    assert "pixel-exact" not in proc.stdout, "another workbook's measurement must not land here"
+    assert not cites_oracle(proc.stdout)
+
+
+def test_a_malformed_estate_entry_does_not_shrink_the_census(tmp_path):
+    """The same undercount through the other input shape: `report.json`'s `workbooks[]` with a
+    non-object entry. The DECLARED list is the census; parse results reconcile against it.
+
+    Mutation killed: count only the entries that survive the `isinstance(wb, dict)` filter.
+    """
+    root = tmp_path / "bundle"
+    root.mkdir(parents=True)
+    (root / "report.json").write_text(
+        json.dumps({"workbooks": [{"name": "Workbook A", "viz_fidelity": []}, 42]}), encoding="utf-8"
+    )
+    (root / "measured-run.json").write_text(ORACLE_EXACT.read_text(encoding="utf-8"), encoding="utf-8")
+
+    census = rh.load_workbook_census(root)
+    assert (census.declared, len(census.workbooks), census.unreadable) == (2, 1, 1)
+    assert census.provably_single is False
+
+    proc = run_cli(str(root))
+    assert "NOT MEASURED" in proc.stdout
+    assert "pixel-exact" not in proc.stdout
+
+
+def test_a_genuine_single_workbook_target_is_not_over_refused(tmp_path):
+    """The narrowing must not swallow the case the fallback legitimately serves.
+
+    Mutation killed: refuse the singleton whenever ANY json in the bundle fails to yield a workbook
+    - which would over-refuse on every bundle that has an oracle report or a report.json beside the
+    slices.
+    """
+    root = bundle(tmp_path, real_workbook(), ORACLE_DRIFTED, oracle_name="measured-run.json")
+    census = rh.load_workbook_census(root)
+    assert census.provably_single is True
+    proc = run_cli(str(root))
+    assert "worst Y" in proc.stdout
+    assert cites_oracle(proc.stdout)
+
+
+def test_a_stray_non_workbook_json_beside_the_slices_is_not_unreadable(tmp_path):
+    """A file that was never a workbook is neither declared nor unreadable.
+
+    The oracle report itself commonly sits next to the slices, and counting it as a failed workbook
+    would disable the fallback on exactly the bundles that have something to attribute.
+
+    Mutation killed: treat every non-workbook JSON as an unreadable workbook.
+    """
+    root = bundle(tmp_path, real_workbook())
+    (root / "handover" / "an-oracle-report.json").write_text(
+        ORACLE_DRIFTED.read_text(encoding="utf-8"), encoding="utf-8"
+    )
+    census = rh.load_workbook_census(root)
+    assert (census.declared, census.unreadable) == (1, 0)
+    assert census.provably_single is True
+    assert "worst Y" in run_cli(str(root)).stdout
+
+
+@pytest.mark.parametrize(
+    "payload, expected",
+    [
+        ({"workbook": {"name": "A"}}, (1, 1, 0)),
+        ({"workbooks": [{"name": "A"}, {"name": "B"}]}, (2, 2, 0)),
+        ({"workbooks": [{"name": "A"}, 42, None]}, (3, 1, 2)),
+        ({"workbooks": []}, (0, 0, 0)),
+        ({"workbook": 42}, (1, 0, 1)),
+        ({"workbooks": "nope"}, (1, 0, 1)),
+        ({"kind": "tableau-fabric-structural-fidelity"}, (0, 0, 0)),
+        ({}, (0, 0, 0)),
+        ([1, 2], (0, 0, 0)),
+    ],
+)
+def test_the_census_classifies_every_payload_shape(payload, expected):
+    """Declared / parsed / unreadable, enumerated. A payload that DECLARES a workbook key it cannot
+    honour is unreadable; one that never claimed to be a workbook is a stray.
+
+    Mutation killed: collapse "declared but unreadable" into "stray", which is precisely the
+    undercount.
+    """
+    workbooks, declared, unreadable = rh._census_from_payload(payload, Path("x.json"))
+    assert (declared, len(workbooks), unreadable) == expected
+
+
+def test_slice_failures_survive_the_fallthrough_to_report_json(tmp_path):
+    """When NO slice parses, the reader falls through to `report.json` - and must not forget that
+    slices existed and could not be read.
+
+    Mutation killed: build the report.json census fresh, discarding the pending slice failures.
+    """
+    root = tmp_path / "bundle"
+    (root / "handover").mkdir(parents=True)
+    (root / "handover" / "broken.json").write_text("{{{", encoding="utf-8")
+    (root / "report.json").write_text(
+        json.dumps({"workbooks": [{"name": "Only One", "viz_fidelity": []}]}), encoding="utf-8"
+    )
+    (root / "measured-run.json").write_text(ORACLE_EXACT.read_text(encoding="utf-8"), encoding="utf-8")
+
+    census = rh.load_workbook_census(root)
+    assert census.unreadable == 1, "the unreadable slice must survive the fallthrough"
+    assert census.provably_single is False
+    assert "NOT MEASURED" in run_cli(str(root)).stdout
+
+
+def test_an_unreadable_input_is_announced_on_stderr(tmp_path):
+    """Silently skipping a corrupt slice is the same failure as silently skipping an unreadable
+    row: the reader looks complete because what it could not read left no trace.
+
+    stderr, so the warning is outside the `--max-bytes` budget and cannot be truncated away.
+
+    Mutation killed: drop the warning, or emit it on stdout where the cap can cut it.
+    """
+    root = tmp_path / "bundle"
+    (root / "handover").mkdir(parents=True)
+    (root / "handover" / "Good.json").write_text(
+        json.dumps({"estate": {}, "workbook": {"name": "Good", "viz_fidelity": []}}), encoding="utf-8"
+    )
+    (root / "handover" / "Broken.json").write_text("nope", encoding="utf-8")
+    proc = run_cli(str(root), "--workbook", "Good", "--max-bytes", str(rh.MIN_MAX_BYTES))
+    assert proc.returncode == rh.EXIT_OK
+    assert "could not be read" in proc.stderr
+    assert "Broken.json" in proc.stderr
+    assert "1 of 2" in proc.stderr
+    assert len(proc.stdout.encode("utf-8")) <= rh.MIN_MAX_BYTES
+
+
+def test_load_workbooks_still_returns_only_the_list(tmp_path):
+    """Backwards compatibility: the census is additive, not a breaking change to the loader."""
+    root = bundle(tmp_path, real_workbook())
+    found = rh.load_workbooks(root)
+    assert isinstance(found, list) and len(found) == 1
+    assert found[0][0] == WB_NAME
+    assert found == rh.load_workbook_census(root).workbooks
+
+
+def test_find_oracle_report_refuses_an_unmatched_singleton_without_a_census(tmp_path):
+    """`census=None` means provenance unknown, and unknown is not permission.
+
+    Mutation killed: default the census to a permissive "single workbook" when the caller omits it.
+    """
+    root = bundle(tmp_path, real_workbook(), ORACLE_DRIFTED, oracle_name="measured-run.json")
+    source = root / "handover" / f"{WB_NAME}.json"
+    assert rh.find_oracle_report(root, source, WB_NAME).payload is None
+    assert rh.find_oracle_report(root, source, WB_NAME, None, rh.load_workbook_census(root)).payload is not None
+
+
+@pytest.mark.parametrize(
+    "declared, workbooks, unreadable, expected, why",
+    [
+        (1, 1, 0, True, "one declared, one parsed, nothing lost"),
+        (2, 1, 1, False, "the classic: a corrupt slice shrank the parsed count"),
+        (1, 1, 1, False, "unreadable is never compatible with a proof"),
+        (0, 1, 0, False, "a workbook nothing declared is not a provable census"),
+        (2, 2, 0, False, "two workbooks"),
+        (0, 0, 0, False, "nothing at all"),
+        # The clause that today looks redundant, pinned as an INDEPENDENT requirement. It is the
+        # only one that refuses a census where the declared list is larger than the parsed list
+        # WITHOUT anything being marked unreadable - the shape a future loader would produce the
+        # moment it deduplicates (two slices naming the same workbook -> declared 2, parsed 1,
+        # unreadable 0). `provably_single` must not become true by arithmetic coincidence.
+        (2, 1, 0, False, "declared > parsed with nothing flagged unreadable is NOT a proof"),
+    ],
+)
+def test_provably_single_requires_all_three_conditions(declared, workbooks, unreadable, expected, why):
+    """Mutation killed: drop any one of `declared == 1`, `unreadable == 0`, `len(workbooks) == 1`.
+
+    Each is asserted against a census that isolates it, so no clause survives on the strength of
+    another one happening to imply it on today's inputs.
+    """
+    census = rh.WorkbookCensus([(f"W{i}", {}, Path(f"w{i}.json")) for i in range(workbooks)], declared, unreadable, ())
+    assert census.provably_single is expected, why
+
+
+def test_the_loader_keeps_declared_equal_to_parsed_plus_unreadable(tmp_path):
+    """The invariant that makes `declared == 1` look redundant, asserted rather than assumed - so a
+    future loader path that breaks it is caught here instead of silently widening the guard."""
+    root = tmp_path / "bundle"
+    (root / "handover").mkdir(parents=True)
+    (root / "handover" / "Good.json").write_text(
+        json.dumps({"estate": {}, "workbook": {"name": "Good"}}), encoding="utf-8"
+    )
+    (root / "handover" / "Broken.json").write_text("{{{", encoding="utf-8")
+    (root / "handover" / "Stray.json").write_text(json.dumps({"kind": "something-else"}), encoding="utf-8")
+    census = rh.load_workbook_census(root)
+    assert census.declared == len(census.workbooks) + census.unreadable
+    assert (census.declared, len(census.workbooks), census.unreadable) == (2, 1, 1)
+
+
 def test_the_estate_evidence_section_is_budgeted(tmp_path):
     """MEDIUM 4. One unconditional line per workbook is unbounded in the estate's width. At
     ``MIN_MAX_BYTES`` a 30-workbook estate fired ``HARD CAP``, cut 18 of the 30 signals with no

--- a/tests/test_read_handover_evidence.py
+++ b/tests/test_read_handover_evidence.py
@@ -1,0 +1,620 @@
+"""Tests for the two engine signals `read_handover.py` had no consumer for: #371 and #372.
+
+Both issues are about COVERAGE rather than findings, so every test here is written against the same
+one-sentence requirement: **absent evidence must never render, sort, or exit like verified
+evidence.** A test that merely proves a value is printed does not defend that; each test below
+therefore contrasts the absent case with the verified case, or asserts an exit code.
+
+Fixture provenance, which is load-bearing:
+
+* ``handover-2.339.0-evidence.json`` is the **unmodified** handover slice engine 2.339.0 wrote for
+  ``Meridian Revenue by Region`` (copied byte-for-byte out of a real bundle). Its three
+  ``viz_fidelity[]`` rows genuinely carry ``"evidence": "emitted+linted"``. Nothing here invents the
+  handover shape.
+* ``oracle-2.339.0-drifted.json`` / ``-pixel-exact.json`` / ``oracle-pre-2.332.0-axis-blind.json``
+  carry a ``summary.placement`` block produced by calling the installed engine's own
+  ``fidelity_oracle._placement_rollup`` - so ``by_axis`` is the engine's arithmetic, not a
+  hand-typed guess at it. The drifted one encodes the shape upstream #169 was built to express: X
+  pixel-perfect, Y drifting in BOTH directions (2 down / 1 up, signed mean +38.93 px).
+
+⚠️ MEASURED FINDING, and the reason the #372 tests look the way they do: ``by_axis`` is **not** in
+the handover. It is emitted by ``fidelity_oracle.py``, a separate opt-in tool, into its own report;
+``migrate_estate.py`` never computes placement. Verified against engine 2.339.0 - ``by_axis`` occurs
+in **zero** JSON files across the local corpus, and the estate ``report.json``'s
+``summary.placement`` is ``null``. So the honest consumer finds an oracle report beside the bundle,
+and reports NOT MEASURED otherwise - which is today's answer for every deterministic-tier bundle.
+
+No network, no Power BI Desktop, no engine at test time: the engine was used to BUILD the fixtures,
+never to run them.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+FIXTURES = ROOT / "tests" / "fixtures"
+sys.path.insert(0, str(SCRIPTS))
+
+import read_handover as rh  # noqa: E402  # pylint: disable=wrong-import-position
+
+REAL_SLICE = FIXTURES / "handover-2.339.0-evidence.json"
+ORACLE_DRIFTED = FIXTURES / "oracle-2.339.0-drifted.json"
+ORACLE_EXACT = FIXTURES / "oracle-2.339.0-pixel-exact.json"
+ORACLE_AXIS_BLIND = FIXTURES / "oracle-pre-2.332.0-axis-blind.json"
+
+WB_NAME = "Meridian Revenue by Region"
+
+
+def real_workbook() -> dict:
+    """The real 2.339.0 workbook payload, fresh each call so a test cannot mutate its neighbour."""
+    return json.loads(REAL_SLICE.read_text(encoding="utf-8"))["workbook"]
+
+
+def with_evidence(*values: str | None) -> dict:
+    """The real payload with its `viz_fidelity[]` evidence values replaced.
+
+    Derived from the REAL slice rather than hand-built, so every other key a renderer touches
+    (`status`, `tier`, `reason`, `worksheet`, `visual_type`) is the engine's own. `None` DELETES the
+    key, which is how a pre-2.335.0 bundle actually looks - not `"evidence": null`.
+    """
+    wb = real_workbook()
+    rows = wb["viz_fidelity"]
+    assert len(rows) == len(values), "the real slice has 3 rows; pass exactly that many values"
+    for row, value in zip(rows, values):
+        if value is None:
+            row.pop("evidence", None)
+        else:
+            row["evidence"] = value
+    return wb
+
+
+def bundle(tmp_path: Path, wb: dict, oracle: Path | None = None, oracle_name: str | None = None) -> Path:
+    """A bundle laid out the way the engine lays one out: `<bundle>/handover/<workbook>.json`."""
+    root = tmp_path / "bundle"
+    (root / "handover").mkdir(parents=True, exist_ok=True)
+    payload = {"estate": {"tool": "migrate_estate"}, "workbook": wb}
+    (root / "handover" / f"{wb.get('name') or WB_NAME}.json").write_text(json.dumps(payload), encoding="utf-8")
+    if oracle is not None:
+        (root / (oracle_name or f"{wb.get('name') or WB_NAME}.json")).write_text(
+            oracle.read_text(encoding="utf-8"), encoding="utf-8"
+        )
+    return root
+
+
+def cites_oracle(stdout: str) -> bool:
+    """True when the drift numbers carry a citation, in either the full or the compressed form.
+
+    Deliberately form-agnostic: which form `render_default` picks depends on the byte budget, and a
+    test that pinned one form would be asserting the budget rather than the citation. The FORMS
+    themselves are pinned directly on `_layout_drift_lines` below.
+    """
+    return "measured from:" in stdout or ".json]" in stdout
+
+
+def run_cli(*args: str) -> subprocess.CompletedProcess:
+    cmd = [sys.executable, str(SCRIPTS / "read_handover.py"), *args]
+    return subprocess.run(cmd, capture_output=True, check=False, text=True, encoding="utf-8")
+
+
+# =============================================================================================
+# #371 - viz_fidelity[].evidence
+# =============================================================================================
+
+
+def test_the_real_2339_slice_actually_carries_evidence():
+    """Ground truth. If the engine ever stops emitting this, every test below is theatre, so pin the
+    fixture's real content rather than trusting the issue text that described it."""
+    rows = real_workbook()["viz_fidelity"]
+    assert [r["evidence"] for r in rows] == ["emitted+linted"] * 3
+    status, counts = rh.fidelity_evidence_status(real_workbook())
+    assert status == rh.FIDELITY_EVIDENCE_PRESENT
+    assert counts == {"emitted+linted": 3}
+
+
+def test_an_unexamined_visual_does_not_render_like_a_verified_one():
+    """THE REQUIREMENT, stated as a contrast rather than as a presence check.
+
+    Mutation killed: make `_evidence_summary_line` ignore which value it saw (e.g. always print the
+    total as verified). Both lines become identical and this fails.
+    """
+    verified = rh._evidence_summary_line(with_evidence("emitted+linted", "emitted+linted", "emitted+linted"))
+    unexamined = rh._evidence_summary_line(with_evidence("emitted", "emitted+linted", "emitted+linted"))
+    assert verified != unexamined
+    assert "3/3" in verified and "!!" not in verified
+    assert "2/3" in unexamined and "??" in unexamined
+    assert "emitted 1" in unexamined
+
+
+def test_a_never_examined_visual_does_not_pass_the_gate():
+    """`emitted` means the emitter ran and NOTHING inspected the artifact. Judged by exit code.
+
+    Mutation killed: treat `emitted` as a pass (or as a blocker). Either collapse changes this code.
+    """
+    code, verdict = rh.evidence_gate(with_evidence("emitted", "emitted+linted", "emitted+linted"))
+    assert code == rh.EXIT_NOT_VERIFIED
+    assert code != rh.EXIT_OK and code != rh.EXIT_EVIDENCE_BLOCKED
+    assert "NOT VERIFIED" in verdict
+
+
+def test_a_lint_failed_visual_blocks():
+    """Mutation killed: route `lint_failed` to the not-verified code. 1 and 3 are different answers."""
+    code, verdict = rh.evidence_gate(with_evidence("lint_failed", "emitted+linted", "emitted+linted"))
+    assert code == rh.EXIT_EVIDENCE_BLOCKED
+    assert "BLOCKED" in verdict
+
+
+def test_only_a_fully_linted_workbook_passes():
+    code, verdict = rh.evidence_gate(real_workbook())
+    assert code == rh.EXIT_OK
+    assert "3 of 3" in verdict
+    # ...and it still refuses to call that a render check.
+    assert "NOT a render check" in verdict
+
+
+def test_a_lint_failure_outranks_an_unexamined_visual():
+    """A workbook with both must report the blocker, not the softer state."""
+    code, _ = rh.evidence_gate(with_evidence("lint_failed", "emitted", "emitted+linted"))
+    assert code == rh.EXIT_EVIDENCE_BLOCKED
+
+
+def test_a_pre_2335_bundle_reports_unknown_rather_than_clean():
+    """AC3 of #371. Deleting the key is how a real pre-2.335.0 slice looks.
+
+    Mutation killed: default a missing `evidence` to `emitted+linted`, or to `emitted`. The first
+    flips the exit code to 0; the second makes the status PRESENT and loses the NOT RECORDED wording.
+    """
+    wb = with_evidence(None, None, None)
+    status, counts = rh.fidelity_evidence_status(wb)
+    assert status == rh.FIDELITY_EVIDENCE_MISSING
+    assert counts == {rh.EVIDENCE_UNKNOWN: 3}
+    code, verdict = rh.evidence_gate(wb)
+    assert code == rh.EXIT_NOT_VERIFIED
+    assert "NOT VERIFIED" in verdict and "2.335.0" in verdict
+    assert "NOT RECORDED" in rh._evidence_summary_line(wb)
+
+
+def test_a_partially_annotated_bundle_counts_the_missing_rows_as_unknown():
+    """The engine annotates all-or-nothing, but a hand-edited or merged slice may not.
+
+    Mutation killed: drop rows with no `evidence` from the distribution. Total would fall to 2 and
+    the gate would see a complete set.
+    """
+    wb = with_evidence("emitted+linted", None, "emitted+linted")
+    status, counts = rh.fidelity_evidence_status(wb)
+    assert status == rh.FIDELITY_EVIDENCE_PRESENT
+    assert counts == {"emitted+linted": 2, rh.EVIDENCE_UNKNOWN: 1}
+    assert rh.evidence_gate(wb)[0] == rh.EXIT_NOT_VERIFIED
+
+
+def test_an_unrecognised_future_value_is_not_verified():
+    """Fail-closed on a value this consumer has never heard of.
+
+    Mutation killed: treat "anything that is not lint_failed" as a pass. A future
+    `emitted+rendered` would then silently inherit a green from a consumer that cannot judge it.
+    """
+    wb = with_evidence("emitted+rendered", "emitted+linted", "emitted+linted")
+    code, verdict = rh.evidence_gate(wb)
+    assert code == rh.EXIT_NOT_VERIFIED
+    assert "emitted+rendered 1" in verdict
+
+
+@pytest.mark.parametrize(
+    "payload, expected",
+    [
+        ({}, rh.FIDELITY_EVIDENCE_NONE),
+        ({"viz_fidelity": []}, rh.FIDELITY_EVIDENCE_NONE),
+        ({"viz_fidelity": {}}, rh.FIDELITY_EVIDENCE_INVALID),
+        ({"viz_fidelity": "rebuilt"}, rh.FIDELITY_EVIDENCE_INVALID),
+    ],
+)
+def test_absent_or_malformed_viz_fidelity_never_reports_as_verified(payload, expected):
+    """Mutation killed: return NONE for a malformed shape, or let either state exit 0."""
+    status, _ = rh.fidelity_evidence_status(payload)
+    assert status == expected
+    assert rh.evidence_gate(payload)[0] == rh.EXIT_NOT_VERIFIED
+
+
+def test_the_fidelity_view_prints_evidence_beside_status(tmp_path):
+    """`status: warned/rebuilt` records that the EMITTER ran; the two must be read together.
+
+    Mutation killed: revert `_fidelity_row` to status-only. The value disappears from the view.
+    """
+    root = bundle(tmp_path, real_workbook())
+    proc = run_cli(str(root), "--fidelity")
+    assert proc.returncode == rh.EXIT_OK
+    assert proc.stdout.count("emitted+linted") >= 3
+    assert "EVIDENCE (engine >= 2.335.0): 3/3 visual(s) examined" in proc.stdout
+
+
+def test_the_fidelity_view_spells_out_what_emitted_means(tmp_path):
+    """A bare count of `emitted` is not legible; the legend is what makes it a finding.
+
+    Mutation killed: drop `_evidence_legend` from `_fidelity_counts`.
+    """
+    root = bundle(tmp_path, with_evidence("emitted", "emitted", "emitted+linted"))
+    proc = run_cli(str(root), "--fidelity")
+    assert "NEVER EXAMINED" in proc.stdout
+    assert "1/3 visual(s) examined" in proc.stdout
+
+
+def test_the_gate_is_opt_in(tmp_path):
+    """Every existing caller keeps getting 0 on a rendered queue.
+
+    Mutation killed: make the gate unconditional. A reader that starts failing pipelines because it
+    learned to have an opinion is a breaking change, not a feature.
+    """
+    root = bundle(tmp_path, with_evidence("lint_failed", "emitted", "emitted"))
+    assert run_cli(str(root)).returncode == rh.EXIT_OK
+    assert run_cli(str(root), "--gate-evidence").returncode == rh.EXIT_EVIDENCE_BLOCKED
+
+
+def test_the_gate_exit_codes_end_to_end(tmp_path):
+    """The three states, through the real CLI, judged by exit code and nothing else."""
+    cases = [
+        (("emitted+linted", "emitted+linted", "emitted+linted"), rh.EXIT_OK),
+        (("emitted", "emitted+linted", "emitted+linted"), rh.EXIT_NOT_VERIFIED),
+        (("lint_failed", "emitted+linted", "emitted+linted"), rh.EXIT_EVIDENCE_BLOCKED),
+        ((None, None, None), rh.EXIT_NOT_VERIFIED),
+    ]
+    for i, (values, expected) in enumerate(cases):
+        root = bundle(tmp_path / f"case{i}", with_evidence(*values))
+        assert run_cli(str(root), "--gate-evidence").returncode == expected, values
+
+
+def test_the_json_form_names_verified_never_leaving_it_to_be_derived(tmp_path):
+    """Mutation killed: emit only `counts` and let the consumer decide what counts as verified -
+    which is precisely the decision #371 exists to make once, here."""
+    out = tmp_path / "out.json"
+    root = bundle(tmp_path, with_evidence("emitted", "lint_failed", "emitted+linted"))
+    assert run_cli(str(root), "--json", str(out)).returncode == rh.EXIT_OK
+    block = json.loads(out.read_text(encoding="utf-8"))["viz_fidelity_evidence"]
+    assert block["status"] == rh.FIDELITY_EVIDENCE_PRESENT
+    assert block["verified"] == 1
+    assert block["never_examined"] == 1
+    assert block["lint_failed"] == 1
+    assert block["total"] == 3
+    assert block["gate_exit_code"] == rh.EXIT_EVIDENCE_BLOCKED
+
+
+def test_the_estate_list_names_which_workbook_has_unexamined_visuals(tmp_path):
+    """ "38 of 40 examined" estate-wide hides that both gaps sit in one report.
+
+    Mutation killed: report only the estate total and drop the per-workbook lines.
+    """
+    root = tmp_path / "bundle"
+    (root / "handover").mkdir(parents=True)
+    clean = real_workbook()
+    clean["name"] = "Clean Workbook"
+    dirty = with_evidence("emitted", "emitted", "emitted+linted")
+    dirty["name"] = "Unexamined Workbook"
+    for wb in (clean, dirty):
+        (root / "handover" / f"{wb['name']}.json").write_text(
+            json.dumps({"estate": {}, "workbook": wb}), encoding="utf-8"
+        )
+    proc = run_cli(str(root), "--list")
+    assert proc.returncode == rh.EXIT_OK
+    assert "Unexamined Workbook" in proc.stdout
+    assert "1/3 examined" in proc.stdout
+    # The clean one is NOT listed as a gap - otherwise the list is noise rather than triage.
+    assert "Clean Workbook" not in proc.stdout.split("Visual evidence:")[1].split("\n\n")[0]
+
+
+# =============================================================================================
+# #372 - summary.placement.by_axis
+# =============================================================================================
+
+
+def test_by_axis_is_absent_from_the_real_2339_handover():
+    """CONTRADICTS the premise that the handover reader can just read `by_axis` off the slice.
+
+    This is the measured finding behind the whole #372 design: the block lives in the fidelity
+    oracle's report, not in anything `migrate_estate.py` writes. If a future engine inlines it, this
+    test fails and the consumer should be simplified - which is exactly the signal wanted.
+    """
+    assert "by_axis" not in REAL_SLICE.read_text(encoding="utf-8")
+    status, payload = rh.layout_drift_status(real_workbook())
+    assert status == rh.LAYOUT_DRIFT_NOT_MEASURED
+    assert payload == {}
+
+
+def test_not_measured_is_reported_as_such_and_not_as_zero_drift():
+    """AC2/AC3 of #372. Absence of the block is not absence of drift.
+
+    Mutation killed: return a zeroed `by_axis` when there is none, or stay silent. The first makes
+    the line read "pixel-exact"; the second removes it from the default view entirely.
+    """
+    line = rh._layout_drift_summary_line(real_workbook())
+    assert "NOT MEASURED" in line
+    assert "pixel-exact" not in line
+    assert line != rh._layout_drift_summary_line({}, json.loads(ORACLE_EXACT.read_text(encoding="utf-8")))
+
+
+def test_measured_no_drift_is_distinguishable_from_never_measured():
+    """AC3 of #372, stated as the contrast it actually is."""
+    oracle = json.loads(ORACLE_EXACT.read_text(encoding="utf-8"))
+    measured, _ = rh.layout_drift_status({}, oracle)
+    never, _ = rh.layout_drift_status({}, None)
+    assert measured == rh.LAYOUT_DRIFT_EXACT
+    assert never == rh.LAYOUT_DRIFT_NOT_MEASURED
+    assert measured != never
+    assert "MEASURED, pixel-exact" in rh._layout_drift_summary_line({}, oracle)
+
+
+def test_the_worst_axis_its_sign_and_its_exact_count_are_reported():
+    """AC1 of #372, against a `by_axis` block the ENGINE computed.
+
+    The fixture encodes upstream #169's reported shape: X pixel-perfect, Y drifting both ways.
+
+    Mutation killed: rank the worst axis by mean instead of worst, collapse the sign to an absolute
+    value, or drop the direction counts. The corpus evidence in #372 is explicit that collapsing the
+    sign is what made the previous metric useless.
+    """
+    oracle = json.loads(ORACLE_DRIFTED.read_text(encoding="utf-8"))
+    status, payload = rh.layout_drift_status({}, oracle)
+    assert status == rh.LAYOUT_DRIFT_PRESENT
+    assert payload["worst"][0] == "y"
+    line = rh._layout_drift_summary_line({}, oracle)
+    assert "worst Y" in line
+    assert "0/3 exact" in line
+    assert "+38.93px" in line
+    assert "(2 down / 1 up)" in line
+    # BOTH axes, always - one axis alone reads as "the other is fine".
+    assert "X 3/3 exact" in line
+
+
+def test_the_sign_survives_a_mirrored_population():
+    """Two populations with IDENTICAL magnitudes and opposite directions must not read the same.
+
+    Mutation killed: report `mean_abs_px` in place of `mean_signed_px`. Both lines become equal.
+    """
+    oracle = json.loads(ORACLE_DRIFTED.read_text(encoding="utf-8"))
+    mirrored = json.loads(ORACLE_DRIFTED.read_text(encoding="utf-8"))
+    stats = mirrored["summary"]["placement"]["by_axis"]["y"]
+    stats["mean_signed_px"] = -stats["mean_signed_px"]
+    stats["positive"], stats["negative"] = stats["negative"], stats["positive"]
+    assert rh._layout_drift_summary_line({}, oracle) != rh._layout_drift_summary_line({}, mirrored)
+    assert "-38.93px" in rh._layout_drift_summary_line({}, mirrored)
+    assert "(1 down / 2 up)" in rh._layout_drift_summary_line({}, mirrored)
+
+
+def test_an_asymmetric_drift_names_the_axis_that_actually_drifted():
+    """Transpose the fixture's axes; the verdict must follow the data, not the alphabet.
+
+    Mutation killed: hard-code `y` as the worst axis, which the drifted fixture alone cannot catch.
+    """
+    swapped = json.loads(ORACLE_DRIFTED.read_text(encoding="utf-8"))
+    by_axis = swapped["summary"]["placement"]["by_axis"]
+    by_axis["x"], by_axis["y"] = by_axis["y"], by_axis["x"]
+    status, payload = rh.layout_drift_status({}, swapped)
+    assert status == rh.LAYOUT_DRIFT_PRESENT
+    assert payload["worst"][0] == "x"
+    line = rh._layout_drift_summary_line({}, swapped)
+    assert "worst X" in line
+    # X's direction words differ from Y's; using Y's would be a silent mislabel.
+    assert "(2 right / 1 left)" in line
+
+
+def test_a_pre_2332_oracle_report_reports_per_axis_unknown_not_zero():
+    """AC2 of #372: a report from before the block existed is UNKNOWN, never "no drift".
+
+    Mutation killed: treat a missing `by_axis` as an empty measurement. The status collapses to
+    EXACT and the workbook reads as pixel-perfect on the strength of a field nobody emitted.
+    """
+    oracle = json.loads(ORACLE_AXIS_BLIND.read_text(encoding="utf-8"))
+    assert "by_axis" not in oracle["summary"]["placement"]
+    status, payload = rh.layout_drift_status({}, oracle)
+    assert status == rh.LAYOUT_DRIFT_AXIS_BLIND
+    line = rh._layout_drift_summary_line({}, oracle)
+    assert "PER-AXIS UNKNOWN" in line
+    # The axis-blind number it DOES have is still surfaced, so the reader is not left with nothing.
+    assert "108.0px" in line
+    assert payload["placement"]["verdict"] == "drifted"
+
+
+@pytest.mark.parametrize("by_axis", [[], "x", 5])
+def test_a_malformed_by_axis_is_invalid_not_measured(by_axis):
+    """Mutation killed: `or {}` a malformed block into an empty one, which reads as no drift."""
+    oracle = {"kind": rh.ORACLE_KIND, "summary": {"placement": {"by_axis": by_axis}}}
+    status, _ = rh.layout_drift_status({}, oracle)
+    assert status == rh.LAYOUT_DRIFT_INVALID
+    assert "INVALID SHAPE" in rh._layout_drift_summary_line({}, oracle)
+
+
+def test_the_oracle_is_found_by_kind_not_by_filename(tmp_path):
+    """`fidelity_oracle.py --out` takes an arbitrary path, so there is no filename to key on.
+
+    Mutation killed: match on a filename convention. The report below is called `anything.json`.
+    """
+    root = bundle(tmp_path, real_workbook(), ORACLE_DRIFTED, oracle_name="anything.json")
+    proc = run_cli(str(root))
+    assert proc.returncode == rh.EXIT_OK
+    assert "worst Y" in proc.stdout
+    assert "anything.json" in proc.stdout  # provenance is cited
+
+
+def test_the_cited_path_keeps_its_filename_when_clipped():
+    """A path clipped from the RIGHT loses the only part that identifies the report.
+
+    Mutation killed: clip with `_clip` (head-preserving) instead of `_clip_tail`.
+    """
+    long_path = "C:\\" + ("a" * 200) + "\\oracle-report.json"
+    clipped = rh._clip_tail(long_path)
+    assert clipped.endswith("oracle-report.json")
+    assert len(clipped) <= 88
+
+
+def test_a_name_matched_oracle_wins_over_a_stranger(tmp_path):
+    """Two reports, one named for this workbook: attributing the other one's pixels here would be a
+    confident wrong answer, which is worse than no answer.
+
+    Mutation killed: take the first candidate found.
+    """
+    root = bundle(tmp_path, real_workbook(), ORACLE_EXACT, oracle_name=f"{WB_NAME}.json")
+    (root / "aaa-other-workbook.json").write_text(ORACLE_DRIFTED.read_text(encoding="utf-8"), encoding="utf-8")
+    proc = run_cli(str(root))
+    assert "MEASURED, pixel-exact" in proc.stdout
+    assert "worst Y" not in proc.stdout
+
+
+def test_an_ambiguous_set_of_oracle_reports_is_refused(tmp_path):
+    """Mutation killed: fall back to "any candidate" when none names the workbook."""
+    root = bundle(tmp_path, real_workbook(), ORACLE_DRIFTED, oracle_name="one.json")
+    (root / "two.json").write_text(ORACLE_EXACT.read_text(encoding="utf-8"), encoding="utf-8")
+    proc = run_cli(str(root))
+    assert "NOT MEASURED" in proc.stdout
+    assert "measured from" not in proc.stdout
+
+
+def test_an_explicit_oracle_flag_refuses_a_file_that_is_not_an_oracle_report(tmp_path):
+    """Pointing `--oracle` at the handover slice by mistake must fail loudly, not silently report
+    NOT MEASURED - the user asserted the file exists, so silence would hide a typo.
+
+    Mutation killed: swallow the mismatch and return `(None, None)`. Exit becomes 0.
+    """
+    root = bundle(tmp_path, real_workbook())
+    proc = run_cli(str(root), "--oracle", str(REAL_SLICE))
+    assert proc.returncode == rh.EXIT_USAGE
+    assert "not a fidelity-oracle report" in proc.stderr
+
+
+def test_an_explicit_oracle_flag_beats_auto_discovery(tmp_path):
+    root = bundle(tmp_path, real_workbook(), ORACLE_EXACT, oracle_name=f"{WB_NAME}.json")
+    proc = run_cli(str(root), "--oracle", str(ORACLE_DRIFTED))
+    assert "worst Y" in proc.stdout
+    assert "pixel-exact" not in proc.stdout
+
+
+def test_the_oracle_is_found_in_a_fidelity_subfolder(tmp_path):
+    root = bundle(tmp_path, real_workbook())
+    (root / "fidelity").mkdir()
+    (root / "fidelity" / "report.json").write_text(ORACLE_DRIFTED.read_text(encoding="utf-8"), encoding="utf-8")
+    assert "worst Y" in run_cli(str(root)).stdout
+
+
+def test_the_json_form_carries_the_drift_status_even_when_unmeasured(tmp_path):
+    """A consumer that never reads the numbers still cannot mistake absence for a clean measurement.
+
+    Mutation killed: omit `layout_drift` when there is no oracle, or set `measured: true` regardless.
+    """
+    out = tmp_path / "out.json"
+    root = bundle(tmp_path, real_workbook())
+    assert run_cli(str(root), "--json", str(out)).returncode == rh.EXIT_OK
+    block = json.loads(out.read_text(encoding="utf-8"))["layout_drift"]
+    assert block["status"] == rh.LAYOUT_DRIFT_NOT_MEASURED
+    assert block["measured"] is False
+    assert block["by_axis"] is None
+    assert block["worst_axis"] is None
+
+
+def test_the_json_form_carries_the_full_by_axis_block_when_measured(tmp_path):
+    out = tmp_path / "out.json"
+    root = bundle(tmp_path, real_workbook(), ORACLE_DRIFTED)
+    assert run_cli(str(root), "--json", str(out)).returncode == rh.EXIT_OK
+    block = json.loads(out.read_text(encoding="utf-8"))["layout_drift"]
+    assert block["measured"] is True
+    assert block["worst_axis"] == "y"
+    assert block["worst_axis_stats"]["mean_signed_px"] == 38.93
+    assert set(block["by_axis"]) == {"x", "y"}
+    assert block["measured_from"].endswith(".json")
+
+
+def test_the_provenance_line_is_inside_the_byte_cap(tmp_path):
+    """REGRESSION, and a defect this file's own docstring calls out: `--max-bytes` is a STRICT cap
+    on everything a run prints. The first version printed `measured from:` AFTER `_capped()`, so a
+    1500-byte cap emitted 1632 bytes with no truncation banner and reported success.
+
+    Mutation killed: move the provenance line back out of the budgeted body.
+    """
+    root = bundle(tmp_path, real_workbook(), ORACLE_DRIFTED)
+    for cap in (rh.MIN_MAX_BYTES, 2000, 20_000):
+        proc = run_cli(str(root), "--max-bytes", str(cap))
+        assert proc.returncode == rh.EXIT_OK, cap
+        assert len(proc.stdout.encode("utf-8")) <= cap, cap
+        assert cites_oracle(proc.stdout), cap
+
+
+def test_both_citation_forms_name_the_report_and_stay_bounded():
+    """The two forms, pinned directly so the CLI tests above can stay form-agnostic.
+
+    Mutation killed: emit the citation only in the full form. The terse pass would then silently
+    strip provenance from every number it prints, exactly when the reader can least afford it.
+    """
+    oracle = rh.OracleSource(
+        json.loads(ORACLE_DRIFTED.read_text(encoding="utf-8")),
+        Path("C:/" + "d" * 120) / (("z" * 90) + ".json"),
+    )
+    full = rh._layout_drift_lines({}, oracle, terse=False)
+    terse = rh._layout_drift_lines({}, oracle, terse=True)
+    assert len(full) == 2 and "measured from:" in full[1]
+    assert full[1].rstrip().endswith(".json")  # clipped from the LEFT, filename intact
+    assert len(terse) == 1 and terse[0].endswith("]")
+    assert sum(len(x) for x in terse) < sum(len(x) for x in full)
+    # Bounded whatever the path: a fallback that can itself overrun the cap is not a fallback.
+    assert len(terse[0]) <= 100
+    assert "z" * 90 not in terse[0]
+
+
+def test_an_inlined_placement_block_would_be_preferred_over_the_oracle():
+    """Forward compatibility, asserted rather than merely commented: if `migrate_estate.py` ever
+    absorbs the rollup, the handover wins and the separate report stops being needed."""
+    wb = real_workbook()
+    wb["viz_placement"] = json.loads(ORACLE_DRIFTED.read_text(encoding="utf-8"))["summary"]["placement"]
+    status, payload = rh.layout_drift_status(wb, json.loads(ORACLE_EXACT.read_text(encoding="utf-8")))
+    assert status == rh.LAYOUT_DRIFT_PRESENT
+    assert payload["worst"][0] == "y"
+
+
+# =============================================================================================
+# Budget - the two new lines must not break the cap this module treats as a defect
+# =============================================================================================
+
+
+def test_the_new_lines_do_not_fire_the_hard_cap_at_the_minimum(tmp_path):
+    """REGRESSION. The first version of these lines added ~185 bytes to `render_default`'s fixed
+    tail and fired `HARD CAP` at `--max-bytes 1500` - which this module's own docstring calls a
+    budgeting DEFECT rather than a pass.
+
+    Mutation killed: remove the terse second pass from `render_default`.
+    """
+    root = bundle(tmp_path, real_workbook(), ORACLE_DRIFTED)
+    for cap in (rh.MIN_MAX_BYTES, 1600, 2000, 20_000):
+        proc = run_cli(str(root), "--max-bytes", str(cap))
+        assert proc.returncode == rh.EXIT_OK, cap
+        assert "HARD CAP" not in proc.stdout, cap
+        assert len(proc.stdout.encode("utf-8")) <= cap, cap
+
+
+def test_the_terse_form_compresses_but_never_drops_either_signal(tmp_path):
+    """A budget too tight for the prose is still wide enough for the verdict AND its citation.
+
+    Mutation killed: drop the lines (or the provenance) instead of shortening them when the cap is
+    tight. Absence rendering as silence is the exact failure both issues are about.
+    """
+    wb = with_evidence("emitted", "emitted", "emitted+linted")
+    root = bundle(tmp_path, wb, ORACLE_DRIFTED)
+    proc = run_cli(str(root), "--max-bytes", str(rh.MIN_MAX_BYTES))
+    assert proc.returncode == rh.EXIT_OK
+    assert "HARD CAP" not in proc.stdout
+    assert "evidence: 1/3 examined" in proc.stdout
+    assert "worst Y" in proc.stdout
+    assert "+38.93px" in proc.stdout
+    assert cites_oracle(proc.stdout)  # the citation survives compression
+
+
+def test_the_terse_form_stays_bounded_however_long_the_oracle_path_is(tmp_path):
+    """Mutation killed: interpolate the raw filename into the terse line. A long report name would
+    then push the compressed fallback back over the cap - a fallback that can overrun is not one.
+    """
+    root = bundle(tmp_path, real_workbook(), ORACLE_DRIFTED, oracle_name=("z" * 90) + ".json")
+    proc = run_cli(str(root), "--max-bytes", str(rh.MIN_MAX_BYTES))
+    assert proc.returncode == rh.EXIT_OK
+    assert "HARD CAP" not in proc.stdout
+    assert len(proc.stdout.encode("utf-8")) <= rh.MIN_MAX_BYTES
+    assert "z" * 90 not in proc.stdout

--- a/tests/test_read_handover_evidence.py
+++ b/tests/test_read_handover_evidence.py
@@ -48,8 +48,22 @@ REAL_SLICE = FIXTURES / "handover-2.339.0-evidence.json"
 ORACLE_DRIFTED = FIXTURES / "oracle-2.339.0-drifted.json"
 ORACLE_EXACT = FIXTURES / "oracle-2.339.0-pixel-exact.json"
 ORACLE_AXIS_BLIND = FIXTURES / "oracle-pre-2.332.0-axis-blind.json"
+ORACLE_EDGE_DRIFT = FIXTURES / "oracle-2.339.0-edge-size-drift.json"
 
 WB_NAME = "Meridian Revenue by Region"
+
+# A minimal axis record that IS assessable, used as the baseline the malformed cases mutate one
+# field of. Taken from the shape the engine's `_axis_rollup` actually returns.
+_AXIS_OK = {
+    "evaluated": 2,
+    "exact": 2,
+    "median_abs_px": 0.0,
+    "mean_abs_px": 0.0,
+    "worst_abs_px": 0.0,
+    "mean_signed_px": 0.0,
+    "positive": 0,
+    "negative": 0,
+}
 
 
 def real_workbook() -> dict:
@@ -101,6 +115,11 @@ def cites_oracle(stdout: str) -> bool:
 def run_cli(*args: str) -> subprocess.CompletedProcess:
     cmd = [sys.executable, str(SCRIPTS / "read_handover.py"), *args]
     return subprocess.run(cmd, capture_output=True, check=False, text=True, encoding="utf-8")
+
+
+def _blen(text: str) -> int:
+    """Byte length, the unit `--max-bytes` is actually enforced in."""
+    return len(text.encode("utf-8"))
 
 
 # =============================================================================================
@@ -424,7 +443,7 @@ def test_a_malformed_by_axis_is_invalid_not_measured(by_axis):
     oracle = {"kind": rh.ORACLE_KIND, "summary": {"placement": {"by_axis": by_axis}}}
     status, _ = rh.layout_drift_status({}, oracle)
     assert status == rh.LAYOUT_DRIFT_INVALID
-    assert "INVALID SHAPE" in rh._layout_drift_summary_line({}, oracle)
+    assert "NOT ASSESSABLE" in rh._layout_drift_summary_line({}, oracle)
 
 
 def test_the_oracle_is_found_by_kind_not_by_filename(tmp_path):
@@ -555,13 +574,81 @@ def test_both_citation_forms_name_the_report_and_stay_bounded():
     assert len(full) == 2 and "measured from:" in full[1]
     assert full[1].rstrip().endswith(".json")  # clipped from the LEFT, filename intact
     assert len(terse) == 1 and terse[0].endswith("]")
-    assert sum(len(x) for x in terse) < sum(len(x) for x in full)
+    assert sum(_blen(x) for x in terse) < sum(_blen(x) for x in full)
     # Bounded whatever the path: a fallback that can itself overrun the cap is not a fallback.
-    assert len(terse[0]) <= 100
+    # Measured in BYTES, because that is the unit `--max-bytes` is enforced in.
+    assert _blen(terse[0]) <= rh.TERSE_DRIFT_LINE_MAX_BYTES
+    assert _blen(full[1]) <= 88 + len("           measured from: ")
     assert "z" * 90 not in terse[0]
 
 
-def test_an_inlined_placement_block_would_be_preferred_over_the_oracle():
+def test_the_terse_line_is_bounded_even_when_the_VERDICT_alone_overflows():
+    """The bound must hold for ANY input, not just well-behaved data.
+
+    The citation-side clip cannot help here: an extra axis with a long name (a future engine could
+    add one) or an extreme pixel value pushes the VERDICT itself past the ceiling before any
+    provenance is appended. A bound enforced only on the citation is a bound that holds for the
+    inputs you thought of.
+
+    Mutation killed: remove the final `_clip_head` clamp from `_layout_drift_lines`.
+    """
+    long_axis = "diagonal_" + ("v" * 40)
+    axes = {
+        "x": _AXIS_OK,
+        "y": _AXIS_OK,
+        long_axis: {**_AXIS_OK, "exact": 0, "worst_abs_px": 12345678901234.5, "mean_signed_px": -98765432109876.5},
+    }
+    oracle = {"kind": rh.ORACLE_KIND, "summary": {"placement": {"verdict": "drifted", "by_axis": axes}}}
+    verdict = rh._layout_drift_summary_line({}, oracle, terse=True)
+    assert _blen(verdict) > rh.TERSE_DRIFT_LINE_MAX_BYTES, "fixture too tame to exercise the clamp"
+
+    for path in (None, Path("report.json")):
+        line = rh._layout_drift_lines({}, rh.OracleSource(oracle, path), terse=True)
+        assert len(line) == 1
+        assert _blen(line[0]) <= rh.TERSE_DRIFT_LINE_MAX_BYTES, path
+        assert "drift" in line[0], "the verdict's meaning lives at the FRONT and must survive"
+        assert "\ufffd" not in line[0]
+
+
+def test_the_terse_citation_is_dropped_only_when_there_is_no_room_for_one():
+    """Ordering of sacrifice, stated as a test: the VERDICT is the signal and the citation is its
+    provenance, so when the ceiling cannot hold both, the citation goes - never the verdict.
+
+    ⚠️ The fixture is TUNED to land in the guard's observable window (0 <= room < 4) and ASSERTS
+    that it did. The first version used a fixture with plenty of room, so the branch it names never
+    ran and the mutation escaped: a conditional assertion inside an untaken branch is a test that
+    cannot fail, which is the thing this whole review pass is about.
+
+    Mutation killed: append a citation regardless of whether there is room for a meaningful one.
+    Without the guard a 3-byte allowance yields `[eport.json]` - a citation that looks like a
+    filename and names a file which does not exist. A wrong citation is worse than none.
+    """
+    axis = "y" + "Q" * 30  # tuned so the terse verdict is 66 bytes -> room == 3
+    axes = {
+        "x": _AXIS_OK,
+        "y": _AXIS_OK,
+        axis: {**_AXIS_OK, "exact": 0, "worst_abs_px": 1.0, "mean_signed_px": -1.0},
+    }
+    oracle = {"kind": rh.ORACLE_KIND, "summary": {"placement": {"verdict": "drifted", "by_axis": axes}}}
+    verdict = rh._layout_drift_summary_line({}, oracle, terse=True)
+    room = rh.TERSE_DRIFT_LINE_MAX_BYTES - _blen(verdict) - len(" []")
+    assert 0 <= room < 4, f"fixture must land in the guard's window; room={room}"
+
+    line = rh._layout_drift_lines({}, rh.OracleSource(oracle, Path("report.json")), terse=True)[0]
+    assert line == verdict, "with no room for a real citation, the verdict must survive UNTOUCHED"
+    assert _blen(line) <= rh.TERSE_DRIFT_LINE_MAX_BYTES
+    assert "[" not in line, "a truncated citation naming a nonexistent file is worse than none"
+
+
+def test_a_citation_is_still_emitted_whenever_there_IS_room():
+    """The other side of the same guard, so "drop it" cannot quietly become the default.
+
+    Mutation killed: raise the room threshold until the citation is never emitted at all.
+    """
+    oracle = rh.OracleSource(json.loads(ORACLE_DRIFTED.read_text(encoding="utf-8")), Path("report.json"))
+    line = rh._layout_drift_lines({}, oracle, terse=True)[0]
+    assert line.endswith("]") and ".json]" in line
+
     """Forward compatibility, asserted rather than merely commented: if `migrate_estate.py` ever
     absorbs the rollup, the handover wins and the separate report stops being needed."""
     wb = real_workbook()
@@ -572,8 +659,230 @@ def test_an_inlined_placement_block_would_be_preferred_over_the_oracle():
 
 
 # =============================================================================================
-# Budget - the two new lines must not break the cap this module treats as a defect
+# Review pass: malformed or unassessable input must never collapse into the CLEAN bucket
+#
+# One root cause wearing five faces. It is the same failure #371 exists to prevent - "an unexamined
+# visual is indistinguishable from a verified one" - reappearing at the level of this module's own
+# parsing. Wherever the reader cannot assess something, that is its own state, never a pass.
 # =============================================================================================
+
+
+def test_an_unreadable_row_stays_in_the_denominator():
+    """HIGH 1. Filtering non-object rows out before counting made the denominator describe the rows
+    the parser could read, not the visuals the engine emitted.
+
+    Measured on the first version: ``[{"evidence": "emitted+linted"}, 42]`` reported
+    *"1 of 1 visual(s) emitted+linted - structural coverage complete"* and exited **0**. Two
+    visuals in, one out, and the one nobody could read vanished into a clean bill of health.
+
+    Mutation killed: drop non-dict rows before counting, or bucket them as ``emitted+linted``.
+    """
+    wb = {"viz_fidelity": [{"evidence": "emitted+linted"}, 42]}
+    status, counts = rh.fidelity_evidence_status(wb)
+    assert status == rh.FIDELITY_EVIDENCE_PRESENT
+    assert sum(counts.values()) == 2, "the denominator must be every ROW, not every readable row"
+    assert counts[rh.EVIDENCE_UNREADABLE] == 1
+    code, verdict = rh.evidence_gate(wb)
+    assert code == rh.EXIT_NOT_VERIFIED
+    assert "1 of 2" in verdict
+    assert "1 of 1" not in verdict, "a 2-row input can never report a 1-row denominator"
+
+
+@pytest.mark.parametrize("junk", [42, "rebuilt", None, [], ["nested"]])
+def test_no_shape_of_unreadable_row_can_produce_a_pass(junk):
+    """The same hole probed across every JSON type a row could arrive as.
+
+    Mutation killed: special-case one type (e.g. skip ``None``) and let it fall out of the count.
+    """
+    wb = {"viz_fidelity": [{"evidence": "emitted+linted"}, junk]}
+    _, counts = rh.fidelity_evidence_status(wb)
+    assert sum(counts.values()) == 2
+    assert rh.evidence_gate(wb)[0] == rh.EXIT_NOT_VERIFIED
+
+
+def test_an_all_unreadable_workbook_is_not_a_pass():
+    wb = {"viz_fidelity": [1, 2, 3]}
+    status, counts = rh.fidelity_evidence_status(wb)
+    assert status == rh.FIDELITY_EVIDENCE_PRESENT
+    assert counts == {rh.EVIDENCE_UNREADABLE: 3}
+    assert rh.evidence_gate(wb)[0] == rh.EXIT_NOT_VERIFIED
+
+
+def test_a_mixed_estate_never_claims_coverage_it_did_not_assess(tmp_path):
+    """HIGH 1, estate half. A workbook with no ``viz_fidelity`` (or an unreadable one) contributes
+    nothing to the totals, so it was skipped silently - while still appearing in the ordinary
+    workbook list below. The estate then read "1/1 examined": complete coverage, next to two
+    workbooks nobody assessed at all.
+
+    Mutation killed: `continue` past NONE/INVALID workbooks without naming them.
+    """
+    root = tmp_path / "bundle"
+    (root / "handover").mkdir(parents=True)
+    payloads = {
+        "Clean": {"viz_fidelity": [{"evidence": "emitted+linted", "worksheet": "w"}]},
+        "Unreadable": {"viz_fidelity": {}},
+        "NoRows": {},
+    }
+    for name, extra in payloads.items():
+        wb = {"name": name, **extra}
+        (root / "handover" / f"{name}.json").write_text(json.dumps({"estate": {}, "workbook": wb}), encoding="utf-8")
+    proc = run_cli(str(root), "--list")
+    assert proc.returncode == rh.EXIT_OK
+    assert "NOT ASSESSABLE" in proc.stdout
+    assert "2 workbook(s) NOT ASSESSABLE" in proc.stdout
+    for name in ("Unreadable", "NoRows"):
+        assert f"?? {name}" in proc.stdout, f"{name} must be NAMED, not merely counted"
+    assert "NOT in the total above" in proc.stdout, "the total must disclaim what it excludes"
+
+
+def test_the_engine_verdict_overrules_a_by_axis_that_looks_exact():
+    """HIGH 2. ``by_axis`` measures ``left``/``top`` ONLY; the rollup around it also weighs the far
+    edges and SIZE. A visual whose origin is perfect but whose size is wrong is therefore invisible
+    to the axis records - and that is the exact customer shape in #372 (visuals compressed to
+    ~34-48% of intended height, origins in the right place).
+
+    The fixture is the ENGINE's own ``_placement_rollup`` output: both axes report ``2/2 exact`` at
+    ``0.0px``, while the enclosing verdict is ``drifted`` with ``worst_max_edge_px: 240.0``. Reading
+    only ``by_axis`` reported ``pixel_exact`` with ``measured: true``.
+
+    Mutation killed: decide exactness from the axis records alone.
+    """
+    oracle = json.loads(ORACLE_EDGE_DRIFT.read_text(encoding="utf-8"))
+    placement = oracle["summary"]["placement"]
+    # Pin the trap in the fixture itself, so a regenerated fixture that lost it fails loudly.
+    assert placement["verdict"] == "drifted"
+    assert all(a["exact"] == a["evaluated"] for a in placement["by_axis"].values())
+    assert all(a["worst_abs_px"] == 0.0 for a in placement["by_axis"].values())
+
+    status, _ = rh.layout_drift_status({}, oracle)
+    assert status == rh.LAYOUT_DRIFT_EDGE_ONLY
+    assert status != rh.LAYOUT_DRIFT_EXACT
+    line = rh._layout_drift_summary_line({}, oracle)
+    assert "EDGE or SIZE drift" in line
+    assert "240.0px" in line
+    assert "!!" in line, "a size defect the axes cannot see must be loud, not quiet"
+
+
+def test_the_edge_only_state_is_distinct_in_json():
+    """A machine consumer must be able to tell the three measured states apart without prose."""
+    edge = rh._layout_drift_json({}, rh.OracleSource(json.loads(ORACLE_EDGE_DRIFT.read_text(encoding="utf-8"))))
+    exact = rh._layout_drift_json({}, rh.OracleSource(json.loads(ORACLE_EXACT.read_text(encoding="utf-8"))))
+    assert edge["status"] != exact["status"]
+    assert edge["measured"] is True and exact["measured"] is True
+    assert edge["origins_pixel_exact"] is False, "origins are exact but the VISUAL is not"
+    assert exact["origins_pixel_exact"] is True
+    assert edge["edge_or_size_drift"] is True and exact["edge_or_size_drift"] is False
+    assert edge["enclosing_verdict"] == "drifted"
+
+
+@pytest.mark.parametrize(
+    "by_axis, why",
+    [
+        ({"x": {}, "y": {}}, "empty records: _num(missing) == _num(missing) is None == None -> True"),
+        ({"x": _AXIS_OK, "y": "bad"}, "one axis unreadable; reading only the other says 'fine'"),
+        ({"x": _AXIS_OK}, "a single axis is a malformed rollup - the engine emits both or neither"),
+        ({"y": _AXIS_OK}, "same, mirrored"),
+        ({"x": _AXIS_OK, "y": {**_AXIS_OK, "evaluated": float("nan")}}, "non-finite count"),
+        ({"x": _AXIS_OK, "y": {**_AXIS_OK, "evaluated": float("inf")}}, "infinite count"),
+        ({"x": _AXIS_OK, "y": {**_AXIS_OK, "exact": 5}}, "exact exceeds evaluated"),
+        ({"x": _AXIS_OK, "y": {**_AXIS_OK, "evaluated": -1, "exact": -1}}, "negative counts"),
+        ({"x": _AXIS_OK, "y": {**_AXIS_OK, "worst_abs_px": -3.0}}, "negative magnitude"),
+        ({"x": _AXIS_OK, "y": {**_AXIS_OK, "exact": True, "evaluated": True}}, "bools posing as counts"),
+        ({"x": _AXIS_OK, "y": {**_AXIS_OK, "mean_signed_px": "0"}}, "a string posing as a number"),
+    ],
+)
+def test_an_unassessable_axis_record_is_never_exact(by_axis, why):
+    """HIGH 2, second half. ``None == None`` is ``True``, so a MISSING count satisfied
+    ``exact == evaluated`` and reported ``pixel_exact`` with ``measured: true``.
+
+    Mutation killed: compare counts without validating them first; or accept one axis.
+    """
+    oracle = {"kind": rh.ORACLE_KIND, "summary": {"placement": {"verdict": "pixel-exact", "by_axis": by_axis}}}
+    status, _ = rh.layout_drift_status({}, oracle)
+    assert status == rh.LAYOUT_DRIFT_INVALID, why
+    assert status != rh.LAYOUT_DRIFT_EXACT
+    assert rh._layout_drift_json({}, rh.OracleSource(oracle))["measured"] is False
+    assert "NOT ASSESSABLE" in rh._layout_drift_summary_line({}, oracle)
+
+
+def test_valid_axes_with_no_enclosing_verdict_are_not_called_exact():
+    """Origins exact, but nothing corroborates the edges or the size: that is unassessable, not a
+    pass. A rollup without a verdict is not one the engine wrote.
+
+    Mutation killed: default a missing enclosing verdict to pixel-exact.
+    """
+    oracle = {"kind": rh.ORACLE_KIND, "summary": {"placement": {"by_axis": {"x": _AXIS_OK, "y": _AXIS_OK}}}}
+    assert rh.layout_drift_status({}, oracle)[0] == rh.LAYOUT_DRIFT_INVALID
+
+
+def test_a_lone_oracle_is_not_attributed_across_a_multi_workbook_bundle(tmp_path):
+    """HIGH 3. The singleton fallback accepted an arbitrarily-named report unconditionally, so in a
+    bundle where the oracle ran for A only, B was handed A's measurements - and a pixel-exact A made
+    an entirely unmeasured B read as verified.
+
+    Mutation killed: accept a lone unmatched candidate regardless of how many workbooks exist.
+    """
+    root = tmp_path / "bundle"
+    (root / "handover").mkdir(parents=True)
+    for name in ("Workbook A", "Workbook B"):
+        (root / "handover" / f"{name}.json").write_text(
+            json.dumps({"estate": {}, "workbook": {"name": name, "viz_fidelity": []}}), encoding="utf-8"
+        )
+    (root / "measured-run.json").write_text(ORACLE_EXACT.read_text(encoding="utf-8"), encoding="utf-8")
+
+    proc = run_cli(str(root), "--workbook", "Workbook B")
+    assert proc.returncode == rh.EXIT_OK
+    assert "NOT MEASURED" in proc.stdout
+    assert "pixel-exact" not in proc.stdout, "another workbook's measurement must not land here"
+    assert not cites_oracle(proc.stdout)
+
+
+def test_a_single_workbook_target_still_accepts_an_arbitrarily_named_report(tmp_path):
+    """The narrowing must not become a refusal to work: with one workbook there is nothing to
+    confuse it with, which is the case the singleton fallback legitimately serves.
+
+    Mutation killed: refuse the singleton unconditionally.
+    """
+    root = bundle(tmp_path, real_workbook(), ORACLE_DRIFTED, oracle_name="measured-run.json")
+    proc = run_cli(str(root))
+    assert "worst Y" in proc.stdout
+    assert cites_oracle(proc.stdout)
+
+
+def test_a_name_matched_report_still_wins_in_a_multi_workbook_bundle(tmp_path):
+    """...and the workbook that WAS measured must still get its numbers."""
+    root = tmp_path / "bundle"
+    (root / "handover").mkdir(parents=True)
+    for name in ("Workbook A", "Workbook B"):
+        (root / "handover" / f"{name}.json").write_text(
+            json.dumps({"estate": {}, "workbook": {"name": name, "viz_fidelity": []}}), encoding="utf-8"
+        )
+    (root / "Workbook A.json").write_text(ORACLE_DRIFTED.read_text(encoding="utf-8"), encoding="utf-8")
+    assert "worst Y" in run_cli(str(root), "--workbook", "Workbook A").stdout
+    assert "NOT MEASURED" in run_cli(str(root), "--workbook", "Workbook B").stdout
+
+
+def test_the_estate_evidence_section_is_budgeted(tmp_path):
+    """MEDIUM 4. One unconditional line per workbook is unbounded in the estate's width. At
+    ``MIN_MAX_BYTES`` a 30-workbook estate fired ``HARD CAP``, cut 18 of the 30 signals with no
+    omitted-count line, and exited 0 - a dropped signal under budget pressure is a silent
+    false-clean, which is the failure this section exists to prevent.
+
+    Mutation killed: remove the budget/reserve and emit every workbook line unconditionally.
+    """
+    root = tmp_path / "bundle"
+    (root / "handover").mkdir(parents=True)
+    for i in range(30):
+        wb = {"name": f"Workbook-{i:02d}", "viz_fidelity": [{"evidence": "emitted", "worksheet": "w"}]}
+        (root / "handover" / f"{wb['name']}.json").write_text(
+            json.dumps({"estate": {}, "workbook": wb}), encoding="utf-8"
+        )
+    proc = run_cli(str(root), "--list", "--max-bytes", str(rh.MIN_MAX_BYTES))
+    assert proc.returncode == rh.EXIT_OK
+    assert "HARD CAP" not in proc.stdout
+    assert len(proc.stdout.encode("utf-8")) <= rh.MIN_MAX_BYTES
+    assert "Visual evidence: 0/30" in proc.stdout, "the estate total must survive any cap"
+    assert "not named here" in proc.stdout, "everything cut must be COUNTED"
 
 
 def test_the_new_lines_do_not_fire_the_hard_cap_at_the_minimum(tmp_path):
@@ -611,6 +920,10 @@ def test_the_terse_form_compresses_but_never_drops_either_signal(tmp_path):
 def test_the_terse_form_stays_bounded_however_long_the_oracle_path_is(tmp_path):
     """Mutation killed: interpolate the raw filename into the terse line. A long report name would
     then push the compressed fallback back over the cap - a fallback that can overrun is not one.
+
+    ⚠️ ASCII ONLY here, on purpose, and it is NOT sufficient by itself: where one character is one
+    byte, a character-counting clip looks byte-bounded. The multibyte case below is the one that
+    can actually fail, and it did.
     """
     root = bundle(tmp_path, real_workbook(), ORACLE_DRIFTED, oracle_name=("z" * 90) + ".json")
     proc = run_cli(str(root), "--max-bytes", str(rh.MIN_MAX_BYTES))
@@ -618,3 +931,41 @@ def test_the_terse_form_stays_bounded_however_long_the_oracle_path_is(tmp_path):
     assert "HARD CAP" not in proc.stdout
     assert len(proc.stdout.encode("utf-8")) <= rh.MIN_MAX_BYTES
     assert "z" * 90 not in proc.stdout
+
+
+@pytest.mark.parametrize(
+    "glyph, width",
+    [("\u732b", 3), ("\U0001f4c8", 4)],  # CJK ideograph (3 bytes), emoji (4 bytes)
+)
+def test_the_terse_citation_is_bounded_in_BYTES_not_characters(tmp_path, glyph, width):
+    """`--max-bytes` counts BYTES; the first version of the terse citation clipped CHARACTERS.
+
+    Measured on the shipped code before this fix: a 90-glyph CJK filename produced a 69-character
+    terse line that was 101 BYTES - a 46% overrun of a bound the code believed it was enforcing -
+    and pushed the whole render past the cap. The ASCII test above could not see it because there
+    character count and byte count coincide.
+
+    Mutation killed: clip the citation with a character-counting helper.
+    """
+    name = (glyph * 90) + ".json"
+    root = bundle(tmp_path, real_workbook(), ORACLE_DRIFTED, oracle_name=name)
+    proc = run_cli(str(root), "--max-bytes", str(rh.MIN_MAX_BYTES))
+    assert proc.returncode == rh.EXIT_OK
+    assert "HARD CAP" not in proc.stdout
+    assert len(proc.stdout.encode("utf-8")) <= rh.MIN_MAX_BYTES
+    # The unit the bound is expressed in, asserted directly rather than via the render.
+    oracle = rh.OracleSource(json.loads(ORACLE_DRIFTED.read_text(encoding="utf-8")), Path(name))
+    terse = rh._layout_drift_lines({}, oracle, terse=True)
+    assert len(terse) == 1
+    assert _blen(terse[0]) <= rh.TERSE_DRIFT_LINE_MAX_BYTES
+    # BOTH halves are required, and asserting only the first is what let a mutation escape: a
+    # character-counting clip produces an over-long candidate, the byte guard then discards the
+    # whole citation, and the line is comfortably "bounded" - by having silently dropped the
+    # provenance. A bound honoured by deleting the signal is the failure this file is about.
+    assert terse[0].endswith("]"), "the citation must SURVIVE the clip, not be dropped to satisfy it"
+    assert ".json]" in terse[0], "and it must still identify the report"
+    assert glyph * 90 not in terse[0]
+    # ...and the clip must not have produced mojibake by splitting a code point.
+    assert terse[0] == terse[0].encode("utf-8").decode("utf-8")
+    assert "\ufffd" not in terse[0]
+    assert width in (3, 4)  # pins that this case really is multibyte


### PR DESCRIPTION
Closes #371 and #372. They are two halves of one gap - engine signals we requested upstream, then never read - and they share a file, so they land together.

## What the engine actually emits (the most important thing here)

**#371 - `viz_fidelity[].evidence` IS in the handover.** Verified against a real 2.339.0 bundle (`_runs/coldrun-2.339.0-20260829/bundle`, `engine.version: 2.339.0`):

```json
{
  "evidence": "emitted+linted",
  "reason": "manual attention required: field 'Region' bound by caption fallback ...",
  "status": "warned",
  "tier": "degraded",
  "visual_type": "column",
  "worksheet": "Revenue by Region"
}
```

**#372 - `by_axis` is NOT in the handover, and this contradicts the framing the issue implies.** It is emitted by `fidelity_oracle.py`, a **separate opt-in tool**, into **its own** report (`kind: "tableau-fabric-structural-fidelity"`), at `summary.placement.by_axis`. `migrate_estate.py` never computes placement at all - `grep placement migrate_estate.py` returns one unrelated line.

Measured, not inferred:
- `by_axis` occurs in **zero** JSON files across the entire local corpus (`_runs/`), including the fresh 2.339.0 bundle's `handover/`;
- that bundle's estate `report.json` has `summary.placement: null`;
- `by_axis` also appeared **nowhere in this repo** before this PR - including `read_handover.py`, which the brief believed mentioned it.

So the consumer reads it from an oracle report found **by `kind`** (not by an invented filename convention nobody writes to) beside the bundle, in `<bundle>/fidelity/`, or from `--oracle` - and otherwise reports **NOT MEASURED**, which is today's honest answer for every bundle the deterministic pipeline produces on its own.

## The surface

Chosen to match this file's established tri-state convention (`measure_filter_status` / `pbip_warning_status` / `partitions_needs_review_status`), because the requirement is identical: **absent evidence must never render like verified evidence.**

Default view, against the real 2.339.0 bundle:

```
        fidelity: degraded 3
           evidence: 3/3 examined - emitted+linted 3
        ?? layout drift: NOT MEASURED - no oracle placement rollup here (run fidelity_oracle.py or pass --oracle); absence is not zero drift
```

With an oracle report present:

```
        !! layout drift: MEASURED, worst Y 0/3 exact, worst 108.0px, median 65.0px, signed +38.93px (2 down / 1 up) | X 3/3 exact, worst 0.0px
           measured from: ...\bundle\Meridian Revenue by Region.json
```

Both axes always appear together - the engine's own rollup test pins that rule (*"a consumer comparing axes must never get one of them; that reads as 'the other is fine'"*), and it applies just as hard one layer up. The **sign** is kept, because #372's corpus figures are explicit that collapsing it is what made the previous metric useless.

## Exit codes

New **opt-in** `--gate-evidence`, following the sibling gates in `scripts/` (`check_connection_fidelity.py`, `check_pbir_layout.py`, `check_empty_model.py`):

| code | meaning |
|---|---|
| 0 | every visual `emitted+linted` - the only value supporting a structural pass |
| 1 | a PBIR lint finding names at least one visual |
| 2 | usage (unchanged) |
| 3 | **NOT VERIFIED** - an `emitted` visual, a row with no `evidence` key, an unrecognised value, an unreadable shape, or no `viz_fidelity` at all |

Three codes rather than two, because "never examined" must not share a code with either a pass or a blocker - the #366 conflation #371 explicitly cites. An unrecognised future value fails **closed**: it does not inherit a pass from a consumer that has never heard of it.

Opt-in on purpose: without the flag every existing caller still gets 0 on a rendered queue. `check_unit.py` (AC2 of #371) is owned by another agent in this wave and is untouched here; `evidence_gate()` and `build_json()`'s `viz_fidelity_evidence` block are the seam it can call.

## Two defects the tests found, not review

1. The added lines pushed `render_default`'s fixed tail past `MIN_MAX_BYTES` and fired the `HARD CAP` net this module's own docstring calls *"a budgeting defect rather than a pass"*. `render_default` now measures the assembly and rebuilds the tail terse if it does not fit - the signals **compress, never drop**.
2. The provenance line was first printed **outside** `_capped()`: 1632 bytes emitted under a 1500-byte cap, no truncation banner, exit 0. It is budgeted content now.

## Evidence

Fixtures are derived from the real thing, never hand-typed:
- `handover-2.339.0-evidence.json` is the **unmodified** slice engine 2.339.0 wrote;
- every `by_axis` block was produced by calling the installed engine's own `fidelity_oracle._placement_rollup`.

| gate | exit |
|---|---|
| `ruff format --check scripts tests .github/skills` | 0 |
| `ruff check scripts tests .github/skills` | 0 |
| `.venv\Scripts\python.exe -m pylint scripts` | **0** (10.00/10) |
| `pytest tests/test_read_handover.py tests/test_read_handover_evidence.py` | 0 (127 passed) |
| full `pytest -q` | 3 pre-existing failures in `test_upstream_repro_pins.py`, **confirmed identical on stashed master** (they pin an older engine version) |

**Mutation testing: 22 applied, 22 caught, 0 escaped.** A perfect first result deserves suspicion, so the harness was itself sanity-checked with two controls: a no-op comment change **escaped** (exit 0 - proving the harness can report an escape) and an injected `SyntaxError` was **not** scored as caught (no `N failed` match - proving a collection error cannot masquerade as coverage). Representative kills:

| mutation | caught by |
|---|---|
| `emitted` counted as verified | `test_a_never_examined_visual_does_not_pass_the_gate` |
| missing `evidence` key defaults to `emitted+linted` | `test_a_pre_2335_bundle_reports_unknown_rather_than_clean` |
| `lint_failed` routed to NOT_VERIFIED | `test_a_lint_failed_visual_blocks` |
| absent placement reported as pixel-exact | `test_not_measured_is_reported_as_such_and_not_as_zero_drift` |
| missing `by_axis` treated as measured-no-drift | `test_a_pre_2332_oracle_report_reports_per_axis_unknown_not_zero` |
| signed drift collapsed to an absolute value | `test_the_sign_survives_a_mirrored_population` |
| worst axis hard-coded to `y` | `test_an_asymmetric_drift_names_the_axis_that_actually_drifted` |
| terse fallback removed | `test_the_new_lines_do_not_fire_the_hard_cap_at_the_minimum` |
| ambiguous oracle set guessed rather than refused | `test_an_ambiguous_set_of_oracle_reports_is_refused` |

## What I could NOT verify

- **The upstream question `Yarbrdab000/tableau-fabric-skills#173` is waiting on** - whether *Scatter by Hour* comes back `lint_failed` - is now **answerable** but is not answered here: that dashboard is not in this repo. The reader is the missing instrument, not the measurement.
- **No real `by_axis` from an end-to-end oracle run.** `fidelity_oracle.py` needs a `.twb` plus a built `.Report`, and no bundle on disk has an oracle report beside it. The rollup arithmetic is the engine's own (called directly); the *pairing* that feeds it is untested by me.
- **The corpus is one workbook.** `_runs/tableau-estate` holds only `assets/` and `seeds/` - no bundle - so multi-workbook behaviour is exercised on synthesised estates rather than a real 34-workbook one.
- **`emitted+linted` is still not a render check**, and nothing here changes that. It buys one honest tier, exactly as #371 says.


---

## Review pass 2 — five findings, one root cause

The blind review named it exactly: **malformed or unassessable input collapsed into the CLEAN bucket.** That is the failure this PR exists to prevent — *"an unexamined visual is indistinguishable from a verified one"* — reappearing one level down, inside the reader's own parsing. All five reproduced verbatim before the fix and are gated now.

### The two vacuous tests, fixed first

| test | why it could not fail | now |
|---|---|---|
| `test_read_handover.py::test_list_view_honours_the_cap` | 300 workbooks with **no `viz_fidelity`**, so the estate evidence section never executed | fixtures carry `viz_fidelity`; a second test drives 30 unexamined workbooks at `MIN_MAX_BYTES` |
| `test_read_handover_evidence.py` terse bound | **ASCII only**, where character count and byte count coincide | parametrised over a 3-byte CJK glyph and a 4-byte emoji |

Both **fail against the pre-fix code** — verified before touching the implementation.

### HIGH 1 — malformed rows dropped from the denominator

`[{"evidence": "emitted+linted"}, 42]` reported *"1 of 1 visual(s) emitted+linted — structural coverage complete"*, **exit 0**. Two visuals in, one out.

Every row now counts; a non-object row gets its own `unreadable_row` bucket and is never verified → `1 of 2`, **exit 3**. At estate level, workbooks with no `viz_fidelity` (or an unreadable one) are **counted and named**, and the total disclaims them (*"they are NOT in the total above"*) — but only when the estate is genuinely **mixed**, since naming all 30 of a wholly-unassessed estate is noise the headline already covers.

### HIGH 2 — engine says `drifted`, reader said `pixel_exact`

`by_axis` measures `left`/`top` only; the enclosing rollup also weighs the far edges and **size**. New fixture, produced by engine 2.339.0's own `_placement_rollup`:

``````
by_axis: x 2/2 exact @ 0.0px | y 2/2 exact @ 0.0px
verdict: "drifted"   worst_max_edge_px: 240.0
``````

Exactness is now reconciled with the enclosing verdict, and a sixth state — **`LAYOUT_DRIFT_EDGE_ONLY`** — reports origins-exact-but-edges-drifted rather than folding it into either neighbour. That *is* the customer shape in #372 (visuals compressed to ~34–48% of intended height with their origins correct). JSON gains `origins_pixel_exact`, `edge_or_size_drift` and `enclosing_verdict`.

And the `None == None` trap: axis records are validated **before** any comparison (both expected axes present, finite numerics, `0 <= exact <= evaluated`, non-negative magnitudes, bools refused). All 11 malformed shapes now return `INVALID`, `measured: false`.

### HIGH 3 — a lone oracle attributed to the wrong workbook

Selecting `Workbook A.json` for `Workbook B` made a pixel-exact A read as a verified B. The singleton fallback now requires `workbook_count == 1`; name-matching still wins, and single-workbook targets are unaffected.

> **Noted for #182's successor:** the real fix is workbook identity **inside** the oracle report rather than inferred from filenames. Filename inference is a heuristic and is documented as one at `find_oracle_report`.

### MEDIUM 4 — estate evidence section unbudgeted

30 unexamined workbooks at `MIN_MAX_BYTES`: `HARD CAP`, 18 of 30 signals cut, no omission line, **exit 0**. Now budgeted to half the remaining cap, reserving the omitted-count line **first**; the estate totals always survive. Measured after: 1349 B, no `HARD CAP`, `... and 25 more workbook(s) not named here`.

### MEDIUM 5 — characters vs bytes

A 90-glyph CJK filename produced a 69-**character** line measuring **101 bytes**. Clipping is byte-based and code-point-safe now (no mojibake), and the whole terse line is clamped — because the **verdict alone** can overflow on extreme input, so a bound enforced only on the citation holds for well-behaved data and nothing else.

## Mutation campaign — 41/41 caught, 0 escaped

Extended from 22 to 41 with entries for all five findings. **Two escaped on the first pass, and both were real gaps I would have shipped:**

- **M39** — the byte-ceiling guard was **masking** the character-clip bug by silently *dropping the citation* to satisfy the bound. The test asserted the line was short; it did not assert the citation survived. A bound honoured by deleting the signal is the failure this PR is about.
- **M41** — the "is there room for a citation" branch was **never taken by its own fixture** (`room` was comfortably large). A conditional assertion inside an untaken branch is a test that cannot fail. The fixture is now tuned to land in the window `0 <= room < 4` and **asserts that it did**.

Both produced additional tests rather than a shrug. Harness controls re-verified: a no-op comment change **escapes**; an injected `SyntaxError` is classified `collection-error` and **not** scored as caught.

## Gates

| gate | result |
|---|---|
| `ruff format --check` / `ruff check` (scripts, tests, .github/skills) | exit **0** |
| `.venv\Scripts\python.exe -m pylint scripts` | exit **0**, 10.00/10 |
| targeted `pytest` (both read_handover files) | exit **0**, 157 passed |
| full `pytest -q` | 2419 passed; the same **3 pre-existing** `test_upstream_repro_pins.py` failures, confirmed identical on stashed master |
| mutation set (41 + 2 controls) | 41 caught / **0 escaped** |

Reviewer's own gate list, re-verified end to end: malformed rows counted (`1 of 1` impossible from 2 rows) · engine `drifted` → never `pixel_exact` · `None == None` cannot mean exact · multi-workbook + unmatched singleton → refused · 30-workbook estate at the floor → no `HARD CAP`, omission line survives · multibyte filename at the floor → no `HARD CAP` · both vacuous tests fail under mutation.

## Still not verified

Unchanged from the first pass, and the review's own unverified items are accepted as stated: no genuine pre-2.335.0 bundle exists in the corpus (its case is exercised by stripping `evidence` keys from the byte-identical 2.339.0 fixture); no end-to-end `fidelity_oracle.py` run (the rollup arithmetic is the engine's, called directly — the *pairing* that feeds it is untested by me); the corpus is one workbook.


---

## Review pass 3 — the census

One HIGH, and it was **my own round-1 HIGH 1 recurring one level up**: a parse failure silently shrinking a denominator and unlocking a permissive path.

### The defect

`workbook_count` was `len(found)` — only successfully **parsed** workbooks. `load_workbooks` silently skips a slice it cannot read, so:

``````
HANDOVER_SLICES=2   LOADED=1
drift: MEASURED, pixel-exact [measured-run.json]
OBSERVED_EXIT=0
``````

The round-2 fix was correct; **its input was not**. Same undercount through the other input shape — an estate `report.json` whose `workbooks[]` holds a malformed non-object entry (`DECLARED=2  LOADED=1`).

### The fix — declared census, reconciled against parse results

`WorkbookCensus(workbooks, declared, unreadable, unreadable_sources)`, with `load_workbook_census` as the single source of truth and `load_workbooks` reduced to a list-only wrapper (backwards compatible; only one caller existed).

| input | declared | unreadable | rationale |
|---|---|---|---|
| slice that yields a workbook | 1 | 0 | |
| **unparseable bytes** | 1 | 1 | **fail-closed** — cannot be classified, so it might be a workbook |
| `{"workbook": 42}`, `{"workbooks": "nope"}` | 1 | 1 | declares a key it cannot honour |
| `workbooks: [A, 42, null]` | 3 | 2 | the **declared list** is the census |
| stray non-workbook JSON (an oracle report, a `report.json`) | **0** | **0** | it was never a workbook — counting it would refuse the fallback on every bundle that has something to attribute |

`provably_single` requires **all three**: `declared == 1`, `parsed == 1`, `unreadable == 0`. Slice failures are **carried** through the fallthrough to `report.json` rather than discarded. `census=None` means provenance unknown — which is not permission.

Unreadable inputs are now announced **on stderr**, outside the `--max-bytes` budget so the warning cannot be truncated away. Silently skipping a corrupt slice is the same failure as silently skipping an unreadable row: the reader looks complete because what it could not read left no trace.

### Gates, measured

| gate | result |
|---|---|
| 2 slices, 1 corrupt, 1 unmatched oracle | `declared=2 parsed=1 unreadable=1 provably_single=False` → **NOT MEASURED**, stderr warns |
| estate `workbooks[]` with a malformed entry | `declared=2 parsed=1 unreadable=1` → **NOT MEASURED** |
| genuine single-workbook target | `provably_single=True` → singleton **still accepted** (not over-refused) |
| stray oracle report inside `handover/` | `declared=1 unreadable=0` → still accepted |

### Mutation set — 51 entries, 51 caught, 0 escaped

Ten new entries cover the census. **M45 escaped on the first pass and is worth naming:** `provably_single`'s `declared == 1` clause is *arithmetically implied* by the other two on today's inputs (`declared == parsed + unreadable` always holds), so no test could kill it. Rather than delete a guard or ship an undefended clause, it is now pinned as an **independent requirement** — it is the only clause that would refuse a census from a future loader that **deduplicates** workbooks (two slices naming the same workbook → `declared 2, parsed 1, unreadable 0`) — and the loader's `declared == parsed + unreadable` invariant is **asserted** rather than assumed, so a future path that breaks it fails here instead of silently widening the guard.

Controls re-verified: no-op **escapes**; injected `SyntaxError` → `collection-error`, **not** scored as caught.

| gate | result |
|---|---|
| `ruff format --check` / `ruff check` | exit **0** |
| `pylint scripts` (venv interpreter) | exit **0**, 10.00/10 |
| targeted `pytest` (both read_handover files) | exit **0**, 183 passed |
| full `pytest -q` | 2444 passed; the same **3 pre-existing** `test_upstream_repro_pins.py` failures, previously confirmed identical on stashed master |
| mutation set (51 + 2 controls) | **51 caught / 0 escaped** |
