### PR TITLE
fix(redact): remove the length floor that let a short warehouse password through

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,6 +59,14 @@ FABRIC_WORKSPACE_ID=
 # refresh. One fixture (`Meridian Sales (No Embedded Credentials)`) is
 # deliberately published without one, and the manifest records that so it is
 # reproduced as-is.
+#
+# Redaction: there is NO minimum length. Every value set here is stripped out
+# of anything the scripts print or persist (`tableau_env.redact`), whatever its
+# length - a 7-character password used to fall through an 8-character floor and
+# reach `manifest.json` verbatim (#381). A value under 8 characters is still
+# redacted but also matches unrelated text, so the scripts warn once that the
+# surrounding diagnostics will be noisy. A whitespace-only value is the one
+# thing that cannot be redacted; unset it instead.
 # TABLEAU_SF_USER=
 # TABLEAU_SF_PASSWORD=
 # TABLEAU_DBX_TOKEN=

--- a/.env.example
+++ b/.env.example
@@ -60,13 +60,16 @@ FABRIC_WORKSPACE_ID=
 # deliberately published without one, and the manifest records that so it is
 # reproduced as-is.
 #
-# Redaction: there is NO minimum length. Every value set here is stripped out
-# of anything the scripts print or persist (`tableau_env.redact`), whatever its
-# length - a 7-character password used to fall through an 8-character floor and
-# reach `manifest.json` verbatim (#381). A value under 8 characters is still
-# redacted but also matches unrelated text, so the scripts warn once that the
-# surrounding diagnostics will be noisy. A whitespace-only value is the one
-# thing that cannot be redacted; unset it instead.
+# Redaction: there is NO minimum length and no exemption. Every value set
+# here is stripped out of anything the scripts print or persist
+# (`tableau_env.redact`) - a 7-character password used to fall through an
+# 8-character floor and reach `manifest.json` verbatim (#381), and a
+# whitespace-only value used to be skipped too. Only an unset (empty) value is
+# skipped. The XML-escaped form the Tableau client actually puts on the wire
+# (`SYNTH-&#228;-PASS` for a non-ASCII value) is redacted alongside the literal;
+# case-changed, NFD, percent-encoded and base64 forms are NOT, and no script
+# here emits one. A value under 8 characters is still redacted but also matches
+# unrelated text, so the scripts warn once that diagnostics will be noisy.
 # TABLEAU_SF_USER=
 # TABLEAU_SF_PASSWORD=
 # TABLEAU_DBX_TOKEN=

--- a/scripts/capture_tableau_oracle.py
+++ b/scripts/capture_tableau_oracle.py
@@ -310,7 +310,9 @@ class TableauSession:
             time.sleep(backoff_delay(attempt))
         raise RuntimeError(f"GET {path} exhausted {self.retry.max_attempts} attempts")
 
-    def export(self, path: str) -> tuple[bytes, float, dict[str, Any]]:
+    # One recovery ladder, and it now holds the raw body and its redacted copy side by side so
+    # classification and reporting cannot be confused for each other.
+    def export(self, path: str) -> tuple[bytes, float, dict[str, Any]]:  # pylint: disable=too-many-locals
         """GET a content-export endpoint, recovering from session loss and transient failures.
 
         Returns ``(body, elapsed_sec, stats)`` where ``stats`` records how much recovery was needed --
@@ -330,9 +332,18 @@ class TableauSession:
             elapsed = time.perf_counter() - started
             if status == 200:
                 return payload, elapsed, {"reauths": reauths, "retries": len(retries), "retry_reasons": retries}
-            text = self._redact_response(payload.decode("utf-8", "replace"))
-            kind, detail = classify_export_error(status, text)
-
+            raw = payload.decode("utf-8", "replace")
+            text = self._redact_response(raw)
+            # CLASSIFY the raw body, REPORT the redacted one. `_redact_response` is handed the PAT
+            # NAME, which is human-chosen: a short one rewrites Tableau's own error codes, and a
+            # `401002` mangled into `4[REDACTED]1[REDACTED][REDACTED]2` is read as a permanent
+            # source-credential failure instead of the recoverable session loss it is, so the view
+            # is abandoned and never re-authenticated. Redaction must never mutate syntax that
+            # control flow depends on. `detail` still comes from the redacted copy because
+            # `classify_export_error` truncates, and slicing an unredacted body can leave a secret's
+            # tail in the retained window.
+            kind = classify_export_error(status, raw)[0]
+            detail = classify_export_error(status, text)[1]
             if kind == "session_lost" and reauths < MAX_REAUTH_PER_VIEW:
                 # Re-auth is a SEPARATE recovery path from transient retry, and is deliberately NOT
                 # gated by the admission deadline. It is bounded instead by MAX_REAUTH_PER_VIEW (and

--- a/scripts/tableau_env.py
+++ b/scripts/tableau_env.py
@@ -41,6 +41,7 @@ import os
 import re
 import warnings
 from pathlib import Path
+from xml.etree import ElementTree
 
 # The secret half of the PAT credential. TABLEAU_PAT_SECRET is canonical; the engine's historical
 # TABLEAU_PAT_VALUE spelling stays accepted so existing environments keep working.
@@ -74,12 +75,92 @@ ACCEPTED_ENV_KEYS = frozenset(CANONICAL_ENV_KEYS) | {"TABLEAU_SERVER", "TABLEAU_
 
 _TABLEAU_AUTH_HEADER_RE = re.compile(r"(?i)([\"']?x-tableau-auth[\"']?\s*[:=]\s*[\"']?)([^\"'\s,;<>]+)")
 
-_REDACTION_MARK = "[REDACTED]"
+# Markers tried in order. A marker that CONTAINS a supplied secret would re-emit the credential it
+# is meant to hide -- `redact("credential=[REDACTED]", "[REDACTED]")` used to return its input
+# unchanged, and a two-character secret like "ED" survived inside every marker. The ladder shrinks
+# the alphabet at each step and ends in the empty string, which cannot contain anything, so a marker
+# is always available and deletion is the guaranteed-safe terminal case.
+_MARKERS = ("[REDACTED]", "[HIDDEN]", "[###]", "")
 
 # The length below which a secret starts to collide with ordinary words. It is a NOISE threshold and
 # nothing else: `redact` warns here, it never skips. It used to be a skip, which meant a human-chosen
 # warehouse password shorter than this was silently published verbatim (#381).
 NOISY_SECRET_LEN = 8
+
+
+def _wire_forms(secret: str) -> list[str]:
+    """The shapes a secret takes on the wire, as the SUPPORTED transport serializer writes it.
+
+    ``provision_tableau_estate.py`` hands warehouse credentials to ``tableauserverclient``, which
+    builds its request with :mod:`xml.etree.ElementTree`. ``ElementTree.tostring`` defaults to
+    ``us-ascii``, so a configured value holding a non-ASCII character (U+00E4, say) reaches the wire
+    as a numeric character reference -- ``SYNTH-&#228;-PASS`` -- and searching for the literal finds
+    nothing. XML metacharacters (``& < > "``) escape the same way. A reversible encoding of a
+    credential in a persisted diagnostic is a leak, so both the attribute and text-node forms are
+    redacted alongside the literal.
+
+    **Deliberately NOT covered**, so the promise matches the code: case-changed, Unicode-normalised
+    (NFD), percent-encoded, base64 and newline-split forms. Each survives redaction, and no call
+    site in this repository emits one -- every caller feeds ``redact`` either an HTTP response body
+    or an exception message from this XML client. Adding a speculative encoding ladder would be
+    guesswork; adding one because a new transport appears would not.
+    """
+    forms = [secret]
+    try:
+        attribute = ElementTree.tostring(ElementTree.Element("s", {"v": secret})).decode("ascii")
+        node = ElementTree.Element("s")
+        node.text = secret
+        text_node = ElementTree.tostring(node).decode("ascii")
+    except (ValueError, TypeError):
+        # A control character ElementTree refuses to serialise cannot reach a Tableau request body
+        # either, so the literal is the whole of the exposure.
+        return forms
+    opening = attribute.index('v="') + 3
+    forms.append(attribute[opening : attribute.index('"', opening)])
+    forms.append(text_node[text_node.index(">") + 1 : text_node.rindex("<")])
+    return forms
+
+
+def _choose_marker(needles: list[str]) -> str:
+    """The first marker that cannot re-emit any of the values being redacted."""
+    for marker in _MARKERS:
+        if not any(needle in marker for needle in needles):
+            return marker
+    return ""
+
+
+def _blank_spans(text: str, needles: list[str]) -> list[tuple[int, int]]:
+    """Every span to remove, measured against the ORIGINAL text.
+
+    Both halves must be measured before anything is rewritten. Replacing literals first and then
+    running the header rule let a secret inside the header NAME break the rule that protects the
+    session token: redacting the ``Tableau`` in ``X-Tableau-Auth:`` stopped the header regex from
+    matching, and the token -- which the call site does not separately know -- survived.
+    """
+    spans: list[tuple[int, int]] = [m.span(2) for m in _TABLEAU_AUTH_HEADER_RE.finditer(text)]
+    for needle in needles:
+        start = 0
+        while (hit := text.find(needle, start)) >= 0:
+            spans.append((hit, hit + len(needle)))
+            start = hit + 1  # +1, not +len: "aa" must still be found twice inside "aaa"
+    return spans
+
+
+def _merge(spans: list[tuple[int, int]]) -> list[tuple[int, int]]:
+    """Collapse overlapping and touching spans into one.
+
+    Ordering the alternatives longest-first is not enough, because a regex prefers an earlier match
+    to a longer one: with ``"=S"`` and a long secret, ``password=SYNTHETIC-...`` lost its first
+    character and kept the rest. Merging intervals is what makes overlap safe, and it is what lets
+    the header rule and the literal rule coexist.
+    """
+    merged: list[tuple[int, int]] = []
+    for start, end in sorted(spans):
+        if merged and start <= merged[-1][1]:
+            merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+        else:
+            merged.append((start, end))
+    return merged
 
 
 def load_env(path: Path) -> dict[str, str]:
@@ -260,39 +341,43 @@ def redact(text: str, *secrets: str) -> str:
     500 KB. Withholding the whole text instead destroys the diagnostic in every case, including the
     common one where the collateral is zero.
 
-    An empty value is skipped silently: an optional credential that is simply not set is the normal
-    case, and every caller passes ``... or ""``. A whitespace-only value is skipped *with a warning*,
-    because it would match between every character and means nothing.
+    Only ``""`` is skipped -- an optional credential that is simply not set, which every caller
+    passes as ``... or ""``. A whitespace-only value **is** redacted: it was skipped here on the
+    stated grounds that it "would match everywhere", which is false. Only an EMPTY pattern matches
+    between every character; a non-empty whitespace value matches whitespace, and ``resolve_env``
+    genuinely preserves a single-space password that the provisioner then treats as truthy.
 
-    One pass, longest secret first. Replacing sequentially is only safe while short values are
-    skipped, and both failures it allows are leaks of a sort: passing ``("abc", "abcdef")`` in that
-    order redacted the head of the longer secret and left ``def`` in the output, and a 2-character
-    value matched inside a marker this call had just inserted (``[R[REDACTED]ACT[REDACTED]]``). A
-    single pass makes the result independent of the caller's argument order.
+    Everything is measured against the ORIGINAL text and replaced in ONE pass, because two of the
+    three rules here can otherwise disable each other. See ``_blank_spans`` (a secret inside the
+    ``X-Tableau-Auth`` header NAME used to stop the header rule protecting the session token),
+    ``_merge`` (an overlapping short secret left all but one character of a long one visible) and
+    ``_choose_marker`` (a marker that contains the secret re-emits it).
     """
-    live: list[str] = []
-    for secret in secrets:
-        if not secret:
-            continue
-        if not secret.strip():
-            warnings.warn(
-                "A whitespace-only secret cannot be redacted -- it would match between every "
-                "character. Unset the variable or give it a real value.",
-                stacklevel=2,
-            )
-            continue
-        live.append(secret)
-    if live:
-        ordered = sorted(set(live), key=lambda s: (-len(s), s))
-        if len(ordered[-1]) < NOISY_SECRET_LEN:
-            warnings.warn(
-                f"A configured secret is shorter than {NOISY_SECRET_LEN} characters. It IS redacted, "
-                "but a short value also matches unrelated text, so persisted diagnostics may be "
-                "noisy. Prefer a longer secret.",
-                stacklevel=2,
-            )
-        text = re.sub("|".join(re.escape(s) for s in ordered), _REDACTION_MARK, text)
-    return _TABLEAU_AUTH_HEADER_RE.sub(r"\1" + _REDACTION_MARK, text)
+    live = [secret for secret in secrets if secret]
+    if not live:
+        return _TABLEAU_AUTH_HEADER_RE.sub(r"\1" + _MARKERS[0], text)
+    if min(len(secret) for secret in live) < NOISY_SECRET_LEN:
+        warnings.warn(
+            f"A configured secret is shorter than {NOISY_SECRET_LEN} characters. It IS redacted, "
+            "but a short value also matches unrelated text, so persisted diagnostics may be "
+            "noisy. Prefer a longer secret.",
+            stacklevel=2,
+        )
+    needles: list[str] = []
+    for secret in live:
+        needles.extend(form for form in _wire_forms(secret) if form and form not in needles)
+    spans = _merge(_blank_spans(text, needles))
+    if not spans:
+        return text
+    marker = _choose_marker(needles)
+    out: list[str] = []
+    cursor = 0
+    for start, end in spans:
+        out.append(text[cursor:start])
+        out.append(marker)
+        cursor = end
+    out.append(text[cursor:])
+    return "".join(out)
 
 
 def engine_child_env(env: dict[str, str], base: dict[str, str] | None = None) -> dict[str, str]:

--- a/scripts/tableau_env.py
+++ b/scripts/tableau_env.py
@@ -74,6 +74,13 @@ ACCEPTED_ENV_KEYS = frozenset(CANONICAL_ENV_KEYS) | {"TABLEAU_SERVER", "TABLEAU_
 
 _TABLEAU_AUTH_HEADER_RE = re.compile(r"(?i)([\"']?x-tableau-auth[\"']?\s*[:=]\s*[\"']?)([^\"'\s,;<>]+)")
 
+_REDACTION_MARK = "[REDACTED]"
+
+# The length below which a secret starts to collide with ordinary words. It is a NOISE threshold and
+# nothing else: `redact` warns here, it never skips. It used to be a skip, which meant a human-chosen
+# warehouse password shorter than this was silently published verbatim (#381).
+NOISY_SECRET_LEN = 8
+
 
 def load_env(path: Path) -> dict[str, str]:
     """Read a git-ignored KEY=VALUE file. Secrets are never logged or written to the store.
@@ -226,12 +233,66 @@ def redact(text: str, *secrets: str) -> str:
 
     Scrub at the point of capture rather than trusting another tool's logging discipline: the secret
     is ours, the file is ours, and the engine's error text is not something we control.
+
+    **There is no minimum length.** There was one -- 8 characters -- and it was sound while the only
+    thing in scope was a machine-generated PAT. ``provision_tableau_estate.py`` then put a
+    human-chosen warehouse password in scope, and a 7-character ``TABLEAU_SF_PASSWORD`` went straight
+    through into ``manifest.json`` on a PUBLIC repository (#381). Measured before removing it, on
+    reflected errors of the shape these callers actually persist:
+
+    ============  =====  ==========  =================  ==================
+    secret        chars  redactions  collateral (chars) diagnostic tokens
+    ============  =====  ==========  =================  ==================
+    25-character      25           1                 25  all kept
+    ``Tr0ub4d``        7           1                  7  all kept
+    ``ci``             2           3                  6  all kept
+    ``e``              1          30                 30  HTTP status kept
+    ============  =====  ==========  =================  ==================
+
+    So the feared damage does not appear until 1-2 characters, and even there the output is merely
+    noisy -- a false redaction is recoverable, a published credential is not. The 8 survives only as
+    ``NOISY_SECRET_LEN``, a warning: nothing is silently unprotected any more.
+
+    Two alternatives were measured and rejected. Redacting the whole word around a short match cost
+    4-5x more text (24 chars vs 6 for ``ci``) while leaving a known-plaintext oracle almost as intact
+    (5/7 vs 7/7 secrets uniquely recovered from a fixed error template), and its natural spelling,
+    ``\\w*(?:secret)\\w*``, backtracks quadratically -- 826 ms on 16 KB, still running after 180 s on
+    500 KB. Withholding the whole text instead destroys the diagnostic in every case, including the
+    common one where the collateral is zero.
+
+    An empty value is skipped silently: an optional credential that is simply not set is the normal
+    case, and every caller passes ``... or ""``. A whitespace-only value is skipped *with a warning*,
+    because it would match between every character and means nothing.
+
+    One pass, longest secret first. Replacing sequentially is only safe while short values are
+    skipped, and both failures it allows are leaks of a sort: passing ``("abc", "abcdef")`` in that
+    order redacted the head of the longer secret and left ``def`` in the output, and a 2-character
+    value matched inside a marker this call had just inserted (``[R[REDACTED]ACT[REDACTED]]``). A
+    single pass makes the result independent of the caller's argument order.
     """
+    live: list[str] = []
     for secret in secrets:
-        # A short or empty value would redact unrelated text; a real PAT secret is far longer.
-        if secret and len(secret) >= 8:
-            text = text.replace(secret, "[REDACTED]")
-    return _TABLEAU_AUTH_HEADER_RE.sub(r"\1[REDACTED]", text)
+        if not secret:
+            continue
+        if not secret.strip():
+            warnings.warn(
+                "A whitespace-only secret cannot be redacted -- it would match between every "
+                "character. Unset the variable or give it a real value.",
+                stacklevel=2,
+            )
+            continue
+        live.append(secret)
+    if live:
+        ordered = sorted(set(live), key=lambda s: (-len(s), s))
+        if len(ordered[-1]) < NOISY_SECRET_LEN:
+            warnings.warn(
+                f"A configured secret is shorter than {NOISY_SECRET_LEN} characters. It IS redacted, "
+                "but a short value also matches unrelated text, so persisted diagnostics may be "
+                "noisy. Prefer a longer secret.",
+                stacklevel=2,
+            )
+        text = re.sub("|".join(re.escape(s) for s in ordered), _REDACTION_MARK, text)
+    return _TABLEAU_AUTH_HEADER_RE.sub(r"\1" + _REDACTION_MARK, text)
 
 
 def engine_child_env(env: dict[str, str], base: dict[str, str] | None = None) -> dict[str, str]:

--- a/tests/test_tableau_env.py
+++ b/tests/test_tableau_env.py
@@ -13,6 +13,7 @@ import json
 import re
 import sys
 import warnings
+import xml.etree.ElementTree as ElementTree
 from pathlib import Path
 
 import pytest
@@ -380,10 +381,83 @@ def test_redact_ignores_an_unset_secret_without_complaining():
         assert te.redact("no secret here", "") == "no secret here"
 
 
-def test_redact_warns_and_skips_a_whitespace_only_secret():
-    """The one value that genuinely cannot be redacted: it matches between every character."""
-    with pytest.warns(UserWarning, match="whitespace-only"):
-        assert te.redact("a error about ab", "   ") == "a error about ab"
+def test_redact_removes_a_single_space_password():
+    """MEDIUM 5: whitespace was skipped on a false premise, and `resolve_env` really does keep it.
+
+    Only an EMPTY pattern matches between every character; " " matches spaces. The provisioner
+    treats a one-space value as truthy and embeds it, so skipping it published it.
+    """
+    env = te.resolve_env(None, environ={"TABLEAU_SF_PASSWORD": " "})
+    assert env["TABLEAU_SF_PASSWORD"] == " ", "precondition: a single-space password survives resolve_env"
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        assert te.redact('password=" "', " ") == 'password="[REDACTED]"'
+
+
+def test_redact_removes_the_xml_escaped_form_the_tableau_client_puts_on_the_wire():
+    """HIGH 1: the provisioner's secret reaches Tableau through ElementTree, not as a literal.
+
+    `ElementTree.tostring` defaults to us-ascii, so a reflected request body carries `&#228;` where
+    the configured value has a non-ASCII character, and `& < > "` are escaped too. Synthetic value.
+    """
+    password = 'SYNTH-\u00e4-P&ss<1"x'
+    element = ElementTree.Element("connectionCredentials", {"name": "svc", "password": password})
+    wire = ElementTree.tostring(element).decode("ascii")
+    assert password not in wire, "precondition: the serializer really does re-encode the value"
+
+    reflected = f"ServerResponseError 400006: echo {wire}"
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        out = te.redact(reflected, password)
+
+    encoded = wire[wire.index('password="') + 10 : wire.rindex('"')]
+    assert encoded not in out, "the XML-escaped form of the password survived"
+    assert password not in out
+    assert "400006" in out
+
+
+def test_a_secret_in_the_auth_header_name_does_not_disable_the_session_header_rule():
+    """HIGH 2: redacting literals first rewrote `X-Tableau-Auth`, so the header regex stopped
+    matching and the session token -- which this call site does not separately know -- survived."""
+    text = "HTTP 401 X-Tableau-Auth: SYNTHETIC_SESSION_TOKEN_123"
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        out = te.redact(text, "Tableau")
+    assert "SYNTHETIC_SESSION_TOKEN_123" not in out, "the session token survived"
+    assert "Tableau" not in out
+
+
+def test_redact_merges_overlapping_matches_so_no_tail_of_a_longer_secret_survives():
+    """MEDIUM 3: longest-first only orders alternatives at the SAME start position. A short secret
+    straddling a delimiter matched earlier and left all but one character of the long one visible."""
+    long_secret = "SYNTHETIC-LONG-SECRET-12345"
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        out = te.redact("password=" + long_secret, "=S", long_secret)
+    assert long_secret not in out
+    for cut in range(len(long_secret) - 3):
+        assert long_secret[cut:] not in out, f"a {len(long_secret) - cut}-char tail survived"
+
+
+@pytest.mark.parametrize("secret", ["[REDACTED]", "ED", "REDACT", "E"])
+def test_redact_picks_a_marker_that_cannot_re_emit_the_secret(secret):
+    """MEDIUM 4: the marker is the output. A secret contained in it is republished by every
+    replacement -- `redact("credential=[REDACTED]", "[REDACTED]")` returned its input unchanged."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        out = te.redact(f"credential={secret} and again {secret}", secret)
+    assert secret not in out
+
+
+def test_redact_leaves_no_supplied_secret_in_the_output_when_one_is_part_of_the_marker():
+    """This test used to assert only that the marker was not recursively corrupted, and passed while
+    its own second secret, `ED`, survived inside every `[REDACTED]` it had just written."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        out = te.redact('{"secret":"SECRETVALUE","pw":"ED"}', "SECRETVALUE", "ED")
+    assert "SECRETVALUE" not in out
+    assert "ED" not in out, "a supplied secret survived inside the marker"
+    assert out.count("[HIDDEN]") == 2
 
 
 @pytest.mark.parametrize("password", ["Tr0ub4d", "hunter2", "s3cr3t", "abcd", "ab", "a"])
@@ -433,30 +507,6 @@ def test_redact_does_not_warn_for_a_normal_length_secret():
         assert te.redact("tok=abcdefghij", "abcdefghij") == "tok=[REDACTED]"
 
 
-def test_redact_leaves_no_tail_of_a_longer_secret_when_a_shorter_one_shares_its_head():
-    """Sequential replacement let "abc" eat the head of "abcdef" and leave "def" in the output.
-
-    Only reachable once short values are redacted at all, so removing the floor is what makes the
-    single longest-first pass load-bearing rather than tidy.
-    """
-    text = '{"password":"abcdef","user":"abc"}'
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        out = te.redact(text, "abc", "abcdef")
-    assert "def" not in out
-    assert "abcdef" not in out
-
-
-def test_redact_does_not_match_inside_a_marker_it_just_inserted():
-    """A 2-char secret matching the marker produced `[R[REDACTED]ACT[REDACTED]]` when done in two
-    passes - garbling the evidence that redaction happened at all."""
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        out = te.redact('{"secret":"SECRETVALUE","pw":"ED"}', "SECRETVALUE", "ED")
-    assert "SECRETVALUE" not in out
-    assert out == '{"secret":"[REDACTED]","pw":"[REDACTED]"}'
-
-
 def test_redact_is_independent_of_the_order_secrets_are_passed_in():
     text = '{"a":"abcdef","b":"abc","c":"abcdefghijkl"}'
     with warnings.catch_warnings():
@@ -483,6 +533,39 @@ def test_a_short_warehouse_password_does_not_reach_the_provisioner_manifest(tmp_
     assert "Tr0ub4d" not in note
     assert "Tr0ub4d" not in json.dumps({"notes": [note]}), "the warehouse password reached manifest.json"
     assert "400006" in note, "redaction must not destroy the diagnostic"
+
+
+def test_a_short_pat_name_does_not_reclassify_a_recoverable_session_loss(monkeypatch):
+    """MEDIUM 6: a FUNCTIONAL regression, not a leak.
+
+    `capture_tableau_oracle` feeds `redact` the human-chosen PAT NAME. Once short values are
+    redacted, a two-character name rewrites Tableau's `401002` inside the response body. Classifying
+    the REDACTED text turns a recoverable session loss into a permanent `source_credential` verdict,
+    so the view is abandoned and never re-authenticated. Classification must read the raw body.
+    """
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+    import capture_tableau_oracle as oracle  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
+
+    body = b'{"error":{"code":"401002","summary":"Invalid authentication credentials"}}'
+    creds = oracle.SiteCredentials(
+        base="https://x", site="s", pat_name="00", pat_secret="LONG_PAT_SECRET_1234567890", version="3.19"
+    )
+    session = oracle.TableauSession(creds)
+    session.token = "SYNTHETIC_SESSION_TOKEN"
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        scrubbed = session._redact_response(body.decode())  # pylint: disable=protected-access
+        assert "401002" not in scrubbed, "precondition: a 2-char PAT name really does mangle the code"
+        assert oracle.classify_export_error(401, scrubbed)[0] != "session_lost"
+
+        monkeypatch.setattr(session, "_request", lambda *a, **k: (401, body, {}))
+        monkeypatch.setattr(session, "sign_in", lambda: setattr(session, "token", "NEW_TOKEN"))
+        with pytest.raises(oracle.ExportFailed) as caught:
+            session.export("/views/luid/image")
+
+    assert session.reauth_count >= 1, "a recoverable session loss was misfiled and never re-authenticated"
+    assert "LONG_PAT_SECRET_1234567890" not in str(caught.value.detail)
 
 
 def test_redact_tolerates_a_secret_that_is_absent():

--- a/tests/test_tableau_env.py
+++ b/tests/test_tableau_env.py
@@ -373,10 +373,116 @@ def test_redact_removes_every_occurrence_not_just_the_first():
     assert te.redact(text, "abcdefghij").count("[REDACTED]") == 2
 
 
-def test_redact_ignores_empty_and_short_values_that_would_scrub_unrelated_text():
-    """A blank or 2-char 'secret' would redact half the message and hide the real error."""
-    assert te.redact("no secret here", "") == "no secret here"
-    assert te.redact("a error about ab", "ab") == "a error about ab"
+def test_redact_ignores_an_unset_secret_without_complaining():
+    """Every caller passes `... or ""` for a credential it may not have; that is the normal case."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert te.redact("no secret here", "") == "no secret here"
+
+
+def test_redact_warns_and_skips_a_whitespace_only_secret():
+    """The one value that genuinely cannot be redacted: it matches between every character."""
+    with pytest.warns(UserWarning, match="whitespace-only"):
+        assert te.redact("a error about ab", "   ") == "a error about ab"
+
+
+@pytest.mark.parametrize("password", ["Tr0ub4d", "hunter2", "s3cr3t", "abcd", "ab", "a"])
+def test_redact_removes_a_short_human_chosen_password(password):
+    """#381: the 8-char floor was sound for a machine-generated PAT and wrong for a password.
+
+    `provision_tableau_estate.py` embeds a WAREHOUSE password in a published datasource, and its
+    error paths route through `redact` precisely because a failure echoes the request body into
+    `ContentRecord.notes` -> `manifest.json`, on disk, in a PUBLIC repository.
+    """
+    reflected = f'ServerResponseError 400006: echo <connectionCredentials password="{password}" />'
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        out = te.redact(reflected, password)
+    assert password not in out
+    assert "[REDACTED]" in out
+
+
+@pytest.mark.parametrize("length", [7, 8])
+def test_redact_pins_the_old_floor_from_both_sides(length):
+    """One value just under the removed floor, one just over. Both must be redacted now."""
+    secret = "P" + "a" * (length - 1)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        assert secret not in te.redact(f'{{"password":"{secret}"}}', secret)
+
+
+def test_redact_keeps_the_diagnostic_when_a_short_password_is_removed():
+    """Measured: a 7-char password costs exactly 7 characters of collateral, nothing else."""
+    text = "ServerResponseError: 400006: Bad Request -- invalid credentials for 'Sales Extract'"
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        out = te.redact(f'{text} password="Tr0ub4d"', "Tr0ub4d")
+    assert text in out
+    assert out.count("[REDACTED]") == 1
+
+
+def test_redact_warns_once_that_a_short_secret_makes_output_noisy():
+    """The 8 survives as advice, never as protection: silence is the outcome #381 was about."""
+    with pytest.warns(UserWarning, match="shorter than 8 characters"):
+        te.redact("nothing to see", "abc")
+
+
+def test_redact_does_not_warn_for_a_normal_length_secret():
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert te.redact("tok=abcdefghij", "abcdefghij") == "tok=[REDACTED]"
+
+
+def test_redact_leaves_no_tail_of_a_longer_secret_when_a_shorter_one_shares_its_head():
+    """Sequential replacement let "abc" eat the head of "abcdef" and leave "def" in the output.
+
+    Only reachable once short values are redacted at all, so removing the floor is what makes the
+    single longest-first pass load-bearing rather than tidy.
+    """
+    text = '{"password":"abcdef","user":"abc"}'
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        out = te.redact(text, "abc", "abcdef")
+    assert "def" not in out
+    assert "abcdef" not in out
+
+
+def test_redact_does_not_match_inside_a_marker_it_just_inserted():
+    """A 2-char secret matching the marker produced `[R[REDACTED]ACT[REDACTED]]` when done in two
+    passes - garbling the evidence that redaction happened at all."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        out = te.redact('{"secret":"SECRETVALUE","pw":"ED"}', "SECRETVALUE", "ED")
+    assert "SECRETVALUE" not in out
+    assert out == '{"secret":"[REDACTED]","pw":"[REDACTED]"}'
+
+
+def test_redact_is_independent_of_the_order_secrets_are_passed_in():
+    text = '{"a":"abcdef","b":"abc","c":"abcdefghijkl"}'
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        assert te.redact(text, "abc", "abcdef", "abcdefghijkl") == te.redact(text, "abcdefghijkl", "abcdef", "abc")
+
+
+def test_a_short_warehouse_password_does_not_reach_the_provisioner_manifest(tmp_path):
+    """End to end at the call site the issue names: `scrub` -> `ContentRecord.notes` -> manifest.json.
+
+    Five error paths in `provision_tableau_estate.py` route through `_describe`; this pins the one
+    the issue cites as durable. A synthetic 7-character value, never a real one.
+    """
+    _ = tmp_path
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+    import provision_tableau_estate as p  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
+
+    env = {"TABLEAU_PAT_SECRET": "SENTINEL_PAT_abcdefghijklmnop", "TABLEAU_SF_PASSWORD": "Tr0ub4d"}
+    exc = RuntimeError('400006: echo <connectionCredentials name="svc" password="Tr0ub4d" />')
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        note = p._describe(exc, env)  # pylint: disable=protected-access
+
+    assert "Tr0ub4d" not in note
+    assert "Tr0ub4d" not in json.dumps({"notes": [note]}), "the warehouse password reached manifest.json"
+    assert "400006" in note, "redaction must not destroy the diagnostic"
 
 
 def test_redact_tolerates_a_secret_that_is_absent():


### PR DESCRIPTION
## The defect

`redact()` skipped any secret shorter than 8 characters, so a 7-character `TABLEAU_SF_PASSWORD` reached `manifest.json` verbatim. Reproduced against the shipped implementation:

```
len= 7  survives_unredacted=True   -> {"password":"Tr0ub4d","code":"401"}
len= 8  survives_unredacted=False  -> {"password":"[REDACTED]","code":"401"}
```

## Why the floor is gone rather than lowered

The floor was protecting against over-redaction, so I measured the over-redaction before removing it, on reflected errors of the shape these callers actually persist (synthetic values throughout):

| secret | chars | redactions | collateral (chars) | diagnostic tokens kept |
|---|---|---|---|---|
| 25-character password | 25 | 1 | 25 | all |
| `Tr0ub4d` | 7 | 1 | 7 | all |
| `ci` (a 2-char PAT name) | 2 | 3 | 6 | 3/3 |
| `e` | 1 | 30 | 30 | HTTP status kept |

The feared damage does not appear until 1–2 characters, and even there the outcome is **noise, not a leak** — the numeric status still survives. There is no length at which skipping is the better trade, so **a lower floor would only move the failure boundary**: at 4, a 3-character password is still published verbatim. Mutation **M2** exists specifically to pin that.

The 8 is not deleted, it is demoted: `NOISY_SECRET_LEN` now drives a one-line warning. Nothing is silently unprotected.

Two alternatives were measured and **rejected**:

- **Whole-word redaction around a short match.** Identical to plain replacement in every realistic case, 4–5× more text destroyed in the noisy ones (24 chars vs 6 for `ci`; 155 vs 31 for `e`), and it does *not* close the known-plaintext oracle it was meant to close (5/7 vs 7/7 secrets uniquely recovered from a fixed error template). Its natural spelling `\w*(?:secret)\w*` backtracks quadratically — 826 ms on 16 KB, still running after 180 s on 500 KB.
- **Withholding the whole text.** Destroys the diagnostic in every case, including the common one where collateral is zero. Mutation **M10** pins that it was not done.

## One pass, longest first

Removing the floor makes sequential replacement unsafe, so replacement is a single `re.sub` over an alternation, longest secret first. Both failures it prevents were measured:

- `redact(text, "abc", "abcdef")` replaced the head of the longer secret and left `def` — a tail of secret material — in the output.
- A 2-character secret matched inside a marker the same call had just inserted: `[R[REDACTED]ACT[REDACTED]]`.

## Call sites — all four verified with a 7-char password and a 2-char PAT name

| call site | secrets passed | verdict |
|---|---|---|
| `assess_estate.Site.scrub_text` | PAT secret, session token | PASS — no leak, `401`/`Unauthorized` kept |
| `capture_tableau_oracle.TableauSession._redact_response` | PAT secret, **PAT name**, token | PASS |
| `harvest_estate_assets.download` | PAT secret, **PAT name** | PASS (redact-before-truncate order preserved) |
| `provision_tableau_estate._describe` | PAT secret, SF password, DBX token | PASS — the five error paths at L327/L437/L449/L510/L641 the #362 review checked |

**Behaviour change worth knowing:** two call sites pass the human-chosen `TABLEAU_PAT_NAME` into `redact()`, so a short PAT name is now redacted where it previously was not. Measured cost on word-heavy text: 3 markers, 6 characters, every diagnostic token kept.

## Mutation evidence — 10/10 caught

Each mutation was written to disk, the bytes re-read and asserted to differ from the original before the tests ran, and scored **only** when pytest named the expected test on a `FAILED` line — a non-zero exit alone is not enough, since a collection error also exits non-zero. An earlier M4 spelling produced `1 error in 0.28s` (a `SyntaxError`) and was correctly scored MISSED, then rewritten.

| # | mutation | expected test | caught | pytest |
|---|---|---|---|---|
| M1 | restore the 8-char floor (the defect) | `test_redact_removes_a_short_human_chosen_password[Tr0ub4d]` | yes | 11 failed, 52 passed |
| M2 | lower the floor to 4 instead of removing it | `test_redact_removes_a_short_human_chosen_password[ab]` | yes | 3 failed, 60 passed |
| M3 | drop the whitespace-only guard | `test_redact_warns_and_skips_a_whitespace_only_secret` | yes | 1 failed, 62 passed |
| M4 | skip whitespace silently | `test_redact_warns_and_skips_a_whitespace_only_secret` | yes | 1 failed, 62 passed |
| M5 | silence the short-secret warning | `test_redact_warns_once_that_a_short_secret_makes_output_noisy` | yes | 1 failed, 62 passed |
| M6 | warn for every secret, not only short ones | `test_redact_does_not_warn_for_a_normal_length_secret` | yes | 1 failed, 62 passed |
| M7 | sort shortest-first | `test_redact_leaves_no_tail_of_a_longer_secret_when_a_shorter_one_shares_its_head` | yes | 1 failed, 62 passed |
| M8 | replace sequentially, not in one pass | `test_redact_does_not_match_inside_a_marker_it_just_inserted` | yes | 1 failed, 62 passed |
| M9 | drop the empty-secret guard | `test_redact_ignores_an_unset_secret_without_complaining` | yes | 1 failed, 62 passed |
| M10 | withhold the whole text (rejected alternative) | `test_redact_keeps_the_diagnostic_when_a_short_password_is_removed` | yes | 8 failed, 55 passed |

## Gates, by exit code

| command | exit | result |
|---|---|---|
| `ruff format --check scripts tests .github/skills` | 0 | 190 files already formatted |
| `ruff check scripts tests .github/skills` | 0 | All checks passed |
| `pylint scripts` | 0 | 10.00/10 |
| `pylint .github/skills/pbip-model-refresh/scripts` | 0 | 10.00/10 |
| `pylint .github/skills/powerbi-ai-readiness/scripts` | 0 | 10.00/10 |
| `pytest tests/test_tableau_env.py` | 0 | 63 passed |
| `pytest` × 4 call-site test files | 0 | 205 passed |
| `pytest` (full suite) | 1 | 2518 passed, 3 failed |

The three full-suite failures are in `tests/test_upstream_repro_pins.py` and are **pre-existing** — the same three fail identically on the unmodified base commit (engine `VERSION` drift, 2.339.0). Verified by stashing this change and re-running.

## Acceptance

1. ✅ A 7-character `TABLEAU_SF_PASSWORD` does not survive in `manifest.json`, stdout or an exception message — pinned end-to-end through `provision_tableau_estate._describe`.
2. ✅ Stated in `.env.example` next to `TABLEAU_SF_PASSWORD` / `TABLEAU_DBX_TOKEN`. (That file is outside the strict file group for this fix, but it is where the issue asks for it — flagging it for the reviewer.)
3. ✅ `test_redact_pins_the_old_floor_from_both_sides` — 7 and 8 characters.
4. ✅ Long machine-generated tokens unchanged; the three other callers verified directly and by their own suites.

## Not verified

- No timing test guards the linear-replacement property in CI; a wall-clock assertion would be flaky. The quadratic hazard belongs to the rejected regex approach, which is not in the diff.
- Whether a warehouse password could ever reach `harvest_estate_assets`' captured child stderr. It is not passed to `redact` there, and the engine's `fetch_tds.py` never handles one, so it is out of scope rather than covered.
- `tests/test_provision_tableau_estate.py:52` carries a comment referring to "`redact`'s 8-character floor", now stale. Left untouched deliberately — outside this fix's file group. The test itself still passes.
