### PR TITLE
fix(harvest): judge every form of --out, and never anchor git through a junction

### DIFF
--- a/scripts/harvest_estate_assets.py
+++ b/scripts/harvest_estate_assets.py
@@ -15,6 +15,14 @@ their names, and THIS REPO IS PUBLIC, so when the target sits inside a git work 
 refuses to start unless git already ignores it -- see `unignored_output_paths` below. A target
 outside any work tree is fine and runs unguarded.
 
+What the guard does and does not cover (issue #374). It judges BOTH the path git's own working-tree
+walk would see (`--out` made absolute, nothing expanded or followed) AND the path the bytes actually
+land on (`~` expanded, every junction/symlink followed), refuses if EITHER is committable, and the
+run then writes to the second one -- so the path that was checked is the path that is written. It
+does NOT detect an `--out` that names a junction's TARGET directly: the write lands outside the
+checkout, but a junction elsewhere in the checkout still exposes it to `git add -A`. Finding that
+needs reparse-point enumeration of the whole checkout and is deliberately out of scope.
+
 Why this exists
 ---------------
 Both tiers are normally exercised on whatever workbook is in front of us, which selects for the
@@ -115,8 +123,65 @@ def _existing_ancestor(path: Path) -> Path | None:
     return next((p for p in (path, *path.parents) if p.is_dir()), None)
 
 
+def _is_relative_to(path: Path, parent: Path) -> bool:
+    """Lexical containment, the same question git's working-tree walk asks."""
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True
+
+
+def _resolved(path: Path) -> Path:
+    """`path` with `~` expanded and every junction/symlink followed. Isolated so the guard has one
+    place to fail closed when a path cannot be resolved at all."""
+    return path.expanduser().resolve()
+
+
+def _containing_worktree_root(out: Path, anchor: Path) -> Path | None:
+    """Root of the work tree that LEXICALLY contains `out`, or None when no work tree does.
+
+    Not simply `git rev-parse` at `anchor`, because `anchor` can be reached through a junction and
+    the answer is then about somewhere else entirely (issue #374). Measured on Windows with
+    `mklink /J <repo>\\linkdir <outside>`: `git rev-parse --is-inside-work-tree` run with
+    cwd=`<repo>\\linkdir` exits 128 "not a git repository" -- the OS resolved the junction for the
+    child process's cwd -- so a guard anchored there concludes "outside any work tree" and passes,
+    while `git add -A` at `<repo>` happily stages `linkdir/sweepout/...`. Asked from `<repo>` the
+    same git answers `check-ignore` exit 1, correctly. POSIX has the identical hole via a symlink.
+
+    So walk the LEXICAL ancestors and take the first work tree whose root actually contains `out` as
+    a string. Anchoring at `Path.cwd()` closes the measured case too and is what #322 did; the walk
+    is a superset - it also holds when the script is invoked from outside the checkout entirely.
+
+    The containment test is not decoration: a checkout REACHED through a junction reports a
+    toplevel that does not contain the lexical path, and asking that repo anyway yields
+    "outside repository" (exit 128) -> an unprovable answer -> a refusal for a perfectly ignored
+    output. Such a repo cannot see this path form, so it is not asked; the resolved form covers it.
+    """
+    for candidate in (anchor, *anchor.parents):
+        probe = _git(["rev-parse", "--show-toplevel"], candidate)
+        if probe is None:
+            # git being un-runnable is not evidence that no repository is here, so look for the
+            # checkout directly rather than letting a missing binary quietly disable the guard.
+            if any((parent / ".git").exists() for parent in (anchor, *anchor.parents)):
+                raise OutputPathNotIgnoredError(
+                    f"cannot run git, but {out} is inside a .git checkout, so it cannot be proven ignored"
+                )
+            return None
+        if probe.returncode != 0:
+            continue  # not a work tree here; a junction may have hidden the real one further up
+        root = Path(probe.stdout.strip())
+        if _is_relative_to(out, root):
+            return root
+    return None
+
+
 def unignored_output_paths(out: Path, artifacts: Sequence[str] = OUTPUT_ARTIFACTS) -> list[Path]:
     """Which artifacts under `out` git would offer to commit. Empty list means safe to write.
+
+    `out` is judged EXACTLY as given (made absolute, nothing expanded or followed): the caller
+    decides which form of the path to ask about, because the forms disagree and both matter - see
+    `refuse_unignored_output`, which asks about all of them.
 
     Two measured details decide this implementation, and getting either wrong yields a guard that
     silently always passes - worse than no guard, because it also reassures:
@@ -133,27 +198,19 @@ def unignored_output_paths(out: Path, artifacts: Sequence[str] = OUTPUT_ARTIFACT
     Raises `OutputPathNotIgnoredError` when git is present but cannot answer, or is absent while a
     `.git` checkout is in scope: an unprovable path is treated as unsafe, never as safe.
     """
-    out = out.expanduser().resolve()
+    out = out.absolute()
     anchor = _existing_ancestor(out)
     if anchor is None:  # pragma: no cover - a drive/filesystem root always exists
         return []
 
-    inside = _git(["rev-parse", "--is-inside-work-tree"], anchor)
-    if inside is None:
-        # git being un-runnable is not evidence that no repository is here, so look for the checkout
-        # directly rather than letting a missing binary quietly disable the guard.
-        if any((parent / ".git").exists() for parent in (anchor, *anchor.parents)):
-            raise OutputPathNotIgnoredError(
-                f"cannot run git, but {out} is inside a .git checkout, so it cannot be proven ignored"
-            )
-        return []
-    if inside.returncode != 0 or inside.stdout.strip() != "true":
+    root = _containing_worktree_root(out, anchor)
+    if root is None:
         return []  # outside any work tree: nothing here can be committed by accident
 
     unignored: list[Path] = []
     for artifact in artifacts:
         target = out / artifact
-        probe = _git(["check-ignore", "-q", "--", str(target)], anchor)
+        probe = _git(["check-ignore", "-q", "--", str(target)], root)
         # 0 = ignored, 1 = not ignored, anything else (128, or no git) = no answer, so do not guess.
         if probe is None or probe.returncode not in (0, 1):
             detail = "git could not be run" if probe is None else (probe.stderr.strip() or f"exit {probe.returncode}")
@@ -161,6 +218,33 @@ def unignored_output_paths(out: Path, artifacts: Sequence[str] = OUTPUT_ARTIFACT
         if probe.returncode == 1:
             unignored.append(target)
     return unignored
+
+
+def output_path_forms(out: Path) -> list[Path]:
+    """Every form of `--out` that must pass before customer content is written (issue #374).
+
+    A guard that judges one form while the writer uses another proves nothing. Both of these are
+    real, and each catches what the other cannot:
+
+    * **lexical** - `out.absolute()`, nothing expanded or followed. This is the string git's own
+      working-tree walk sees, so it is the honest answer to "would `git add -A` stage this?" for an
+      `--out` that traverses a junction OUT of the checkout, and for a literal `~` (measured: from
+      cmd.exe, a quoted PowerShell argument, or any programmatic call, `~` reaches argv unexpanded,
+      and `Path("~/x").absolute()` is `<cwd>/~/x` - inside the checkout, unignored).
+    * **resolved** - `~` expanded and every junction/symlink followed. This is where the bytes land,
+      and it is what catches an `--out` that looks external but is a junction pointing INTO the
+      checkout (measured: already refused before this function existed, precisely because the guard
+      resolved - which is why the resolved form is kept rather than replaced).
+
+    An unresolvable path raises rather than degrading to the lexical form alone: a form we cannot
+    compute is a question we cannot answer, and unanswerable means unsafe.
+    """
+    lexical = out.absolute()
+    try:
+        resolved = _resolved(out)
+    except (OSError, RuntimeError, ValueError) as exc:
+        raise OutputPathNotIgnoredError(f"cannot resolve {out}, so it cannot be proven ignored: {exc}") from exc
+    return list(dict.fromkeys((lexical, resolved)))
 
 
 def refuse_unignored_output(
@@ -172,12 +256,18 @@ def refuse_unignored_output(
 ) -> bool:
     """True when the run must STOP before downloading anything. Logs the reason either way.
 
+    Takes `--out` AS THE OPERATOR GAVE IT, not a pre-normalised copy: normalising before the call
+    discards the very form that catches a literal `~` (issue #374). Every form from
+    `output_path_forms` must pass; the caller then writes to the resolved one.
+
     `artifacts` and `hint` exist so a second tool that downloads customer content can reuse this one
     implementation rather than growing a near-copy that drifts. Pass the FILES that tool writes: the
     probe must name a file, never a bare directory (see `unignored_output_paths`).
     """
     try:
-        unignored = unignored_output_paths(out, artifacts)
+        unignored = list(
+            dict.fromkeys(path for form in output_path_forms(out) for path in unignored_output_paths(form, artifacts))
+        )
     except OutputPathNotIgnoredError as exc:
         message = str(exc)
     else:
@@ -559,9 +649,14 @@ def main() -> int:  # pylint: disable=too-many-locals,too-many-statements  # one
 
     logging.basicConfig(level=logging.INFO, format="%(message)s")
     # Before the engine, the .env, the database and above all the download: a customer's workbooks
-    # must never land somewhere this PUBLIC repo would commit them (issue #125).
+    # must never land somewhere this PUBLIC repo would commit them (issue #125). The guard is given
+    # `--out` RAW, so it can judge the literal argv form as well as the resolved one; the write then
+    # uses the resolved form, which the guard has just passed. Checking one form and writing another
+    # is the whole of issue #374 -- measured: `--out ~/sweep` from cmd.exe was judged as
+    # `%USERPROFILE%\sweep` (outside any work tree, so allowed) and written to `<checkout>\~\sweep`.
     if refuse_unignored_output(args.out, args.allow_unignored_out):
         return 2
+    args.out = _resolved(args.out)
     # One resolver, no fallback: the installed plugin is the single canonical engine (issue #107).
     try:
         scripts = engine_scripts_dir()

--- a/scripts/harvest_estate_assets.py
+++ b/scripts/harvest_estate_assets.py
@@ -138,16 +138,26 @@ def _resolved(path: Path) -> Path:
     return path.expanduser().resolve()
 
 
-def _same_dir(a: Path, b: Path) -> bool:
-    """Do these two spellings name the SAME directory on disk? Never a string comparison."""
+def _same_dir(a: Path, b: Path) -> bool | None:
+    """Do these two spellings name the SAME directory on disk? Never a string comparison.
+
+    Three-valued on purpose. `None` means the FILESYSTEM could not answer - a permission failure, a
+    disconnected share - which is not the same as "no", and collapsing it to `False` is how an
+    unignored in-repository output was allowed through: with every comparison erroring, containment
+    looked disproven rather than unproven and the guard proceeded (measured: `main()` exit 0, a
+    customer workbook name written to `parse-sweep.json`, `git status` staging it).
+    """
     try:
         return os.path.samefile(a, b)
     except OSError:
-        return False
+        return None
 
 
-def _identity_relative(node: Path, root: Path) -> list[str] | None:
-    """Segments from `root` down to `node` by FILE IDENTITY, or None when `root` does not hold it.
+def _identity_relative(node: Path, root: Path) -> tuple[list[str] | None, bool]:
+    """`(segments from root down to node, every comparison answered)` - by FILE IDENTITY, not text.
+
+    The second element is what separates "walked the whole ancestry and this really is not inside
+    `root`" from "could not tell". Only the first is safe to act on.
 
     Windows can spell one directory several ways that are not lexically relative to each other, and
     both `absolute()` and `resolve()` preserve every one of them, so comparing `--out` against
@@ -164,11 +174,15 @@ def _identity_relative(node: Path, root: Path) -> list[str] | None:
     """
     segments: list[str] = []
     current = node
+    answered = True
     while True:
-        if _same_dir(current, root):
-            return list(reversed(segments))
+        same = _same_dir(current, root)
+        if same is None:
+            answered = False
+        elif same:
+            return list(reversed(segments)), answered
         if current.parent == current:
-            return None
+            return None, answered
         segments.append(current.name)
         current = current.parent
 
@@ -184,19 +198,28 @@ def _canonical_probe_target(out: Path) -> tuple[Path, Path] | None:
     stages `linkdir/sweepout/...`. Asked from `<repo>` the same git answers correctly.
 
     Containment is then decided by `_identity_relative`, never by path spelling, and the probe is
-    rebuilt from the ROOT's own spelling so git is asked about a path it can actually see.
+    rebuilt from the ROOT's own spelling so git is asked about a path it can actually see. That
+    rebuild is load-bearing: with `subst Z: <repo>`, `rev-parse` at `Z:\\` reports the long
+    `C:\\...` toplevel and `check-ignore` answers the canonical path (exit 0) while refusing the
+    `Z:\\` spelling outright (exit 128) - so probing what the caller typed would refuse a plainly
+    ignored output.
 
-    Fails closed on a broken repository. A `.git` entry whose directory yields no work-tree root
-    means git could not answer, not that there is nothing here: an ancestor with `.git` present and
-    `rev-parse` failing (a dubious-ownership refusal over UNC, a stale gitdir pointer, a damaged
-    config) previously skipped `check-ignore` altogether and permitted a write inside a known
-    checkout. Unanswerable is unsafe - the same rule the `check-ignore` probe already follows.
+    EVERY unanswerable probe here is a refusal, not a shrug. Three of them were fail-open:
+
+    * a `.git` entry found with `exists()`, which FOLLOWS a reparse point - a dangling `.git`
+      junction reported absent while `rev-parse` failed, so the broken checkout was skipped and an
+      unignored output was written and staged. `os.path.lexists` asks about the ENTRY.
+    * an identity comparison that errored, collapsed to "not contained" (see `_same_dir`).
+    * an ancestry with no examinable directory at all - a nonexistent drive, a disconnected share -
+      where nothing could be looked at and the run proceeded anyway.
     """
     lexical = _lexical(out)
     tail: list[str] = []
     node = lexical
+    examined = False
     while True:
         if node.is_dir():
+            examined = True
             probe = _git(["rev-parse", "--show-toplevel"], node)
             root = (
                 Path(probe.stdout.strip())
@@ -204,20 +227,30 @@ def _canonical_probe_target(out: Path) -> tuple[Path, Path] | None:
                 else None
             )
             if root is None:
-                if (node / ".git").exists():
+                if os.path.lexists(node / ".git"):
                     detail = "git could not be run" if probe is None else (probe.stderr.strip() or "no work tree")
                     raise OutputPathNotIgnoredError(
                         f"{node} holds a .git entry but git could not identify a work tree there "
                         f"({detail}), so {lexical} cannot be proven ignored"
                     )
             else:
-                relative = _identity_relative(node, root)
+                relative, answered = _identity_relative(node, root)
                 if relative is not None:
                     return root, root.joinpath(*relative, *reversed(tail))
+                if not answered:
+                    raise OutputPathNotIgnoredError(
+                        f"the filesystem could not say whether {node} lies inside the work tree at "
+                        f"{root}, so {lexical} cannot be proven ignored"
+                    )
         if node.parent == node:
-            return None
+            break
         tail.append(node.name)
         node = node.parent
+    if not examined:
+        raise OutputPathNotIgnoredError(
+            f"no directory in the ancestry of {lexical} could be examined, so it cannot be proven ignored"
+        )
+    return None
 
 
 def unignored_output_paths(out: Path, artifacts: Sequence[str] = OUTPUT_ARTIFACTS) -> list[Path]:

--- a/scripts/harvest_estate_assets.py
+++ b/scripts/harvest_estate_assets.py
@@ -52,6 +52,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import sqlite3
 import subprocess
 import sys
@@ -118,18 +119,17 @@ def _git(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str] | None:
         return None
 
 
-def _existing_ancestor(path: Path) -> Path | None:
-    """Nearest existing directory at or above `path` - git needs a real directory to run in."""
-    return next((p for p in (path, *path.parents) if p.is_dir()), None)
+def _lexical(path: Path) -> Path:
+    """`path` made absolute with `.`/`..` collapsed TEXTUALLY, following no junction or symlink.
 
-
-def _is_relative_to(path: Path, parent: Path) -> bool:
-    """Lexical containment, the same question git's working-tree walk asks."""
-    try:
-        path.relative_to(parent)
-    except ValueError:
-        return False
-    return True
+    `Path.absolute()` keeps `..` verbatim (measured on Python 3.11.9 and 3.13.2, Windows), and a
+    surviving `..` then rides into `git check-ignore`, which answers about a directory the operator
+    never named: `<repo>\\..\\outside\\out` still passes a `relative_to(<repo>)` test, so the
+    documented "point --out outside the checkout" remedy was refused in its most natural relative
+    spelling. `os.path.abspath` collapses it the way git itself does - and only textually, because
+    `resolve()` here would dereference the junction and re-open the hole below.
+    """
+    return Path(os.path.abspath(path))
 
 
 def _resolved(path: Path) -> Path:
@@ -138,52 +138,97 @@ def _resolved(path: Path) -> Path:
     return path.expanduser().resolve()
 
 
-def _containing_worktree_root(out: Path, anchor: Path) -> Path | None:
-    """Root of the work tree that LEXICALLY contains `out`, or None when no work tree does.
+def _same_dir(a: Path, b: Path) -> bool:
+    """Do these two spellings name the SAME directory on disk? Never a string comparison."""
+    try:
+        return os.path.samefile(a, b)
+    except OSError:
+        return False
 
-    Not simply `git rev-parse` at `anchor`, because `anchor` can be reached through a junction and
-    the answer is then about somewhere else entirely (issue #374). Measured on Windows with
-    `mklink /J <repo>\\linkdir <outside>`: `git rev-parse --is-inside-work-tree` run with
-    cwd=`<repo>\\linkdir` exits 128 "not a git repository" -- the OS resolved the junction for the
-    child process's cwd -- so a guard anchored there concludes "outside any work tree" and passes,
-    while `git add -A` at `<repo>` happily stages `linkdir/sweepout/...`. Asked from `<repo>` the
-    same git answers `check-ignore` exit 1, correctly. POSIX has the identical hole via a symlink.
 
-    So walk the LEXICAL ancestors and take the first work tree whose root actually contains `out` as
-    a string. Anchoring at `Path.cwd()` closes the measured case too and is what #322 did; the walk
-    is a superset - it also holds when the script is invoked from outside the checkout entirely.
+def _identity_relative(node: Path, root: Path) -> list[str] | None:
+    """Segments from `root` down to `node` by FILE IDENTITY, or None when `root` does not hold it.
 
-    The containment test is not decoration: a checkout REACHED through a junction reports a
-    toplevel that does not contain the lexical path, and asking that repo anyway yields
-    "outside repository" (exit 128) -> an unprovable answer -> a refusal for a perfectly ignored
-    output. Such a repo cannot see this path form, so it is not asked; the resolved form covers it.
+    Windows can spell one directory several ways that are not lexically relative to each other, and
+    both `absolute()` and `resolve()` preserve every one of them, so comparing `--out` against
+    `git rev-parse --show-toplevel` as TEXT let three spellings write into the checkout unrefused
+    while the plain spelling of the same target was correctly refused:
+
+        \\\\?\\<repo>\\leak                     extended-length prefix
+        \\\\localhost\\c$\\...\\<repo>\\leak       UNC admin-share alias
+        <8.3 repo>\\link-out\\leak             8.3 short name PLUS an outbound junction
+
+    The third defeats the obvious fix: 8.3 alone is expanded by `resolve()` and caught, but combined
+    with a junction the lexical form stays short and the resolved form lands outside, so BOTH forms
+    pass. `os.path.samefile` answers the question the spellings obscure.
     """
-    for candidate in (anchor, *anchor.parents):
-        probe = _git(["rev-parse", "--show-toplevel"], candidate)
-        if probe is None:
-            # git being un-runnable is not evidence that no repository is here, so look for the
-            # checkout directly rather than letting a missing binary quietly disable the guard.
-            if any((parent / ".git").exists() for parent in (anchor, *anchor.parents)):
-                raise OutputPathNotIgnoredError(
-                    f"cannot run git, but {out} is inside a .git checkout, so it cannot be proven ignored"
-                )
+    segments: list[str] = []
+    current = node
+    while True:
+        if _same_dir(current, root):
+            return list(reversed(segments))
+        if current.parent == current:
             return None
-        if probe.returncode != 0:
-            continue  # not a work tree here; a junction may have hidden the real one further up
-        root = Path(probe.stdout.strip())
-        if _is_relative_to(out, root):
-            return root
-    return None
+        segments.append(current.name)
+        current = current.parent
+
+
+def _canonical_probe_target(out: Path) -> tuple[Path, Path] | None:
+    """`(work tree root, out re-spelled beneath it)`, or None when no work tree holds `out`.
+
+    Walks the LEXICAL ancestors, because an existing ancestor can be reached through a junction and
+    `git rev-parse` run there answers about somewhere else entirely (issue #374). Measured on Windows
+    with `mklink /J <repo>\\linkdir <outside>`: `rev-parse` with cwd=`<repo>\\linkdir` exits 128 "not
+    a git repository" -- the OS resolved the junction for the child process's cwd -- so a guard
+    anchored there concludes "outside any work tree" and passes, while `git add -A` at `<repo>`
+    stages `linkdir/sweepout/...`. Asked from `<repo>` the same git answers correctly.
+
+    Containment is then decided by `_identity_relative`, never by path spelling, and the probe is
+    rebuilt from the ROOT's own spelling so git is asked about a path it can actually see.
+
+    Fails closed on a broken repository. A `.git` entry whose directory yields no work-tree root
+    means git could not answer, not that there is nothing here: an ancestor with `.git` present and
+    `rev-parse` failing (a dubious-ownership refusal over UNC, a stale gitdir pointer, a damaged
+    config) previously skipped `check-ignore` altogether and permitted a write inside a known
+    checkout. Unanswerable is unsafe - the same rule the `check-ignore` probe already follows.
+    """
+    lexical = _lexical(out)
+    tail: list[str] = []
+    node = lexical
+    while True:
+        if node.is_dir():
+            probe = _git(["rev-parse", "--show-toplevel"], node)
+            root = (
+                Path(probe.stdout.strip())
+                if probe is not None and probe.returncode == 0 and probe.stdout.strip()
+                else None
+            )
+            if root is None:
+                if (node / ".git").exists():
+                    detail = "git could not be run" if probe is None else (probe.stderr.strip() or "no work tree")
+                    raise OutputPathNotIgnoredError(
+                        f"{node} holds a .git entry but git could not identify a work tree there "
+                        f"({detail}), so {lexical} cannot be proven ignored"
+                    )
+            else:
+                relative = _identity_relative(node, root)
+                if relative is not None:
+                    return root, root.joinpath(*relative, *reversed(tail))
+        if node.parent == node:
+            return None
+        tail.append(node.name)
+        node = node.parent
 
 
 def unignored_output_paths(out: Path, artifacts: Sequence[str] = OUTPUT_ARTIFACTS) -> list[Path]:
     """Which artifacts under `out` git would offer to commit. Empty list means safe to write.
 
-    `out` is judged EXACTLY as given (made absolute, nothing expanded or followed): the caller
-    decides which form of the path to ask about, because the forms disagree and both matter - see
-    `refuse_unignored_output`, which asks about all of them.
+    `out` is judged EXACTLY as given, beyond collapsing `.`/`..`: the caller decides which form of
+    the path to ask about, because the forms disagree and both matter - see `refuse_unignored_output`,
+    which asks about all of them. The returned paths are the CANONICAL spelling git was asked about,
+    which is the one that says where the bytes would actually be staged from.
 
-    Two measured details decide this implementation, and getting either wrong yields a guard that
+    Two measured details decide the probe itself, and getting either wrong yields a guard that
     silently always passes - worse than no guard, because it also reassures:
 
     * **Ask about paths INSIDE `out`, never `out` itself.** `/_sweep*/` is a directory-only pattern,
@@ -195,21 +240,18 @@ def unignored_output_paths(out: Path, artifacts: Sequence[str] = OUTPUT_ARTIFACT
       `git check-ignore -- 'zzz_not_ignored/'` exits 0 reporting an EMPTY matched pattern: with a
       trailing slash EVERY path looks ignored.
 
-    Raises `OutputPathNotIgnoredError` when git is present but cannot answer, or is absent while a
-    `.git` checkout is in scope: an unprovable path is treated as unsafe, never as safe.
+    Raises `OutputPathNotIgnoredError` when git is present but cannot answer, is absent while a
+    `.git` checkout is in scope, or finds a `.git` it cannot read: an unprovable path is treated as
+    unsafe, never as safe.
     """
-    out = out.absolute()
-    anchor = _existing_ancestor(out)
-    if anchor is None:  # pragma: no cover - a drive/filesystem root always exists
-        return []
-
-    root = _containing_worktree_root(out, anchor)
-    if root is None:
+    found = _canonical_probe_target(out)
+    if found is None:
         return []  # outside any work tree: nothing here can be committed by accident
+    root, base = found
 
     unignored: list[Path] = []
     for artifact in artifacts:
-        target = out / artifact
+        target = base / artifact
         probe = _git(["check-ignore", "-q", "--", str(target)], root)
         # 0 = ignored, 1 = not ignored, anything else (128, or no git) = no answer, so do not guess.
         if probe is None or probe.returncode not in (0, 1):
@@ -226,11 +268,11 @@ def output_path_forms(out: Path) -> list[Path]:
     A guard that judges one form while the writer uses another proves nothing. Both of these are
     real, and each catches what the other cannot:
 
-    * **lexical** - `out.absolute()`, nothing expanded or followed. This is the string git's own
+    * **lexical** - absolute, `.`/`..` collapsed, nothing dereferenced. This is the string git's own
       working-tree walk sees, so it is the honest answer to "would `git add -A` stage this?" for an
       `--out` that traverses a junction OUT of the checkout, and for a literal `~` (measured: from
       cmd.exe, a quoted PowerShell argument, or any programmatic call, `~` reaches argv unexpanded,
-      and `Path("~/x").absolute()` is `<cwd>/~/x` - inside the checkout, unignored).
+      and its absolute form is `<cwd>/~/x` - inside the checkout, unignored).
     * **resolved** - `~` expanded and every junction/symlink followed. This is where the bytes land,
       and it is what catches an `--out` that looks external but is a junction pointing INTO the
       checkout (measured: already refused before this function existed, precisely because the guard
@@ -239,7 +281,7 @@ def output_path_forms(out: Path) -> list[Path]:
     An unresolvable path raises rather than degrading to the lexical form alone: a form we cannot
     compute is a question we cannot answer, and unanswerable means unsafe.
     """
-    lexical = out.absolute()
+    lexical = _lexical(out)
     try:
         resolved = _resolved(out)
     except (OSError, RuntimeError, ValueError) as exc:

--- a/tests/test_harvest_output_guard.py
+++ b/tests/test_harvest_output_guard.py
@@ -18,9 +18,11 @@ No customer data is used or created anywhere below: every fixture is an empty te
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -69,11 +71,17 @@ def repo_fixture(tmp_path: Path) -> Path:
     `test_the_trailing_slash_trap_is_real_and_the_guard_avoids_it`), so a subset would have proved
     something about a file nobody has.
     """
-    _git(["init", "-q"], tmp_path)
+    return _init_repo(tmp_path)
+
+
+def _init_repo(path: Path) -> Path:
+    """`path` as a git checkout carrying this repo's REAL .gitignore, byte for byte."""
+    path.mkdir(parents=True, exist_ok=True)
+    _git(["init", "-q"], path)
     ignore_text = (REPO_ROOT / ".gitignore").read_bytes()
     assert b"/_sweep" in ignore_text and b"/_harvest" in ignore_text, "no harvest rules - fixture proves nothing"
-    (tmp_path / ".gitignore").write_bytes(ignore_text)
-    return tmp_path
+    (path / ".gitignore").write_bytes(ignore_text)
+    return path
 
 
 # --------------------------------------------------------------------------- the ignore rules
@@ -239,3 +247,272 @@ def test_cli_exits_nonzero_before_touching_anything(repo: Path) -> None:
     assert result.returncode != 0, f"the CLI accepted an unignored --out:\n{result.stdout}\n{result.stderr}"
     assert "REFUSING" in (result.stdout + result.stderr)
     assert not (repo / "leaky").exists(), "the refusal ran too late - it already created --out"
+
+
+# --------------------------------------------------------------------------- issue #374
+#
+# The guard judged ONE form of `--out` (`expanduser().resolve()`) while `main` wrote to the RAW
+# argument, and it anchored git at the nearest EXISTING ancestor of that resolved path - which a
+# junction can move outside the checkout entirely. Two consequences, both measured before the fix:
+#
+#   --out ~/sweep       judged as %USERPROFILE%\sweep (outside any work tree -> allowed),
+#                       written to <checkout>\~\sweep  -- unignored, stageable
+#   --out linkdir\x     (linkdir is a junction to somewhere outside) judged from the junction
+#                       TARGET, where `git rev-parse` exits 128 -> "outside any work tree" -> allowed,
+#                       while `git add -A` at the checkout staged 'linkdir/x/assets/...' (Windows;
+#                       on POSIX git stages the symlink entry instead - see the control below)
+#
+# Every test below therefore asserts TWICE: first that the question the OLD guard asked returns
+# "safe" for this fixture, then that the guard refuses anyway. Without the first assertion a test
+# that never exercised the defect would still pass - the failure shape called out in the review of
+# PR #362, where harvest's default artifact names happened to be unignored under an unignored --out.
+
+
+def _link_dir(link: Path, target: Path) -> None:
+    """A directory link needing no elevation: an NTFS junction on Windows, a symlink elsewhere.
+
+    A junction, not a symlink, on Windows deliberately: `New-Item -ItemType SymbolicLink` needs
+    elevation (or Developer Mode) while `mklink /J` never does, so the Windows half of this coverage
+    would otherwise silently skip on most machines - and Windows is where the defect was found.
+    """
+    if sys.platform == "win32":
+        made = subprocess.run(
+            ["cmd", "/c", "mklink", "/J", str(link), str(target)], capture_output=True, text=True, check=False
+        )
+        if made.returncode != 0:
+            pytest.skip(f"could not create an NTFS junction: {made.stdout.strip()} {made.stderr.strip()}")
+    else:
+        os.symlink(target, link, target_is_directory=True)
+
+
+def _unlink_dir(link: Path) -> None:
+    """Remove the LINK, never what it points at - a leaked link into a checkout is the very harm."""
+    if not os.path.lexists(link):
+        return
+    try:
+        os.rmdir(link) if sys.platform == "win32" else link.unlink()
+    except OSError:  # pragma: no cover - best effort teardown
+        pass
+
+
+@pytest.fixture(name="lab")
+def lab_fixture(tmp_path: Path):
+    """A checkout, a directory outside it, and three links between them.
+
+    * `repo`        - a checkout with the REAL `.gitignore` (acceptance criterion 4)
+    * `outside`     - a plain directory, in no work tree
+    * `junction_out`- `<repo>/linkdir` -> `outside`:      inside the checkout, resolves out of it
+    * `junction_in` - `<outside>/backdoor` -> `<repo>/leaky`: outside the checkout, resolves into it
+    * `linked_repo` - `<tmp>/linkrepo` -> `<repo>`:       the checkout itself reached through a link
+    """
+    if _git(["rev-parse", "--is-inside-work-tree"], tmp_path).stdout.strip() == "true":
+        pytest.skip("pytest tmp_path is itself inside a git work tree on this machine")
+    repo = _init_repo(tmp_path / "repo")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (repo / "leaky").mkdir()
+    links = SimpleNamespace(
+        junction_out=repo / "linkdir", junction_in=outside / "backdoor", linked_repo=tmp_path / "linkrepo"
+    )
+    _link_dir(links.junction_out, outside)
+    _link_dir(links.junction_in, repo / "leaky")
+    _link_dir(links.linked_repo, repo)
+    yield SimpleNamespace(repo=repo, outside=outside, **vars(links))
+    for link in vars(links).values():
+        _unlink_dir(link)
+
+
+def test_the_link_leak_is_real_on_this_platform(lab) -> None:
+    """The control the rest of this section rests on: what does `git add -A` actually do with it?
+
+    The two platforms differ and the difference is the point. An NTFS junction is a directory to
+    git's working-tree walk, so it descends and stages the customer `.twbx` itself - that is the
+    leak issue #374 is about. A POSIX symlink is staged as a link object; git does not walk into it,
+    so the workbooks stay out of the index while the link entry - which names the path - still lands.
+    Asserted, not assumed, so a change in either platform's behaviour shows up here rather than
+    quietly making the refusals below pointless.
+    """
+    landed = lab.junction_out / "sweepout" / "assets"
+    landed.mkdir(parents=True)
+    (landed / "harvested-workbook.twbx").write_text("customer content", encoding="utf-8")
+    assert (lab.outside / "sweepout" / "assets" / "harvested-workbook.twbx").exists(), "the link is not a link"
+
+    staged = _git(["add", "-A", "--dry-run"], lab.repo).stdout.replace("\\", "/")
+    if sys.platform == "win32":
+        assert "linkdir/sweepout/assets/harvested-workbook.twbx" in staged, (
+            f"git no longer walks into an NTFS junction; the leak may be gone:\n{staged}"
+        )
+    else:
+        # Measured on git 2.43.0 (Ubuntu): the whole output is `add '.gitignore'` + `add 'linkdir'`.
+        assert "linkdir" in staged, f"git staged nothing for the symlink at all:\n{staged}"
+        assert "linkdir/sweepout" not in staged, f"git now walks into a POSIX symlink:\n{staged}"
+
+
+def test_a_junction_leading_out_of_the_checkout_is_refused(lab) -> None:
+    """`--out` inside the checkout whose link resolves outside it. Acceptance criterion 2."""
+    out = lab.junction_out / "sweepout"
+
+    old_question = h.unignored_output_paths(out.expanduser().resolve())
+    assert old_question == [], (
+        "fixture proves nothing: the OLD guard's single resolved form already refused this, so this "
+        f"test would pass without the fix ({old_question})"
+    )
+    assert h.refuse_unignored_output(out, allow_unignored=False) is True
+
+
+def test_a_junction_leading_out_is_refused_even_from_outside_the_checkout(lab, monkeypatch) -> None:
+    """Anchoring at `Path.cwd()` fixes the common case; the lexical-ancestor walk fixes all of them.
+
+    An operator can perfectly well run this script from anywhere - `python <repo>/scripts/... --out
+    <repo>/linkdir/x` - and a cwd-derived anchor then has nothing to say.
+    """
+    monkeypatch.chdir(lab.outside)
+    out = lab.junction_out / "sweepout"
+    assert h.unignored_output_paths(out.expanduser().resolve()) == [], "fixture proves nothing"
+    assert h.refuse_unignored_output(out, allow_unignored=False) is True
+
+
+def test_a_junction_leading_INTO_the_checkout_is_refused(lab) -> None:
+    """The other direction: `--out` looks external, the link puts the bytes inside the checkout.
+
+    This one already passed BEFORE the fix, precisely because the guard resolved the path - which is
+    why the resolved form is kept alongside the lexical one rather than replaced by it. Dropping it
+    would trade one hole for another and this test is what says so.
+    """
+    out = lab.junction_in / "sweepin"
+    assert h.unignored_output_paths(out.absolute()) == [], "fixture proves nothing: the lexical form already refuses"
+    assert h.refuse_unignored_output(out, allow_unignored=False) is True
+
+
+def test_a_checkout_reached_through_a_junction_is_not_falsely_refused(lab) -> None:
+    """The false-refusal control. A guard that refuses everything is not a guard, it is an outage.
+
+    `<tmp>/linkrepo` -> `<repo>`, so the lexical form names a path the checkout's own toplevel does
+    not contain. Asking that repo about it anyway yields "outside repository" (exit 128), which is
+    an unprovable answer and would therefore refuse an `--out` that is plainly ignored.
+    """
+    out = lab.linked_repo / "_sweep-hosted"
+    assert h.refuse_unignored_output(out, allow_unignored=False) is False
+
+
+def test_the_junction_cli_refuses_and_writes_nothing(lab) -> None:
+    """End to end, by exit code: 2, and not one byte through the link."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(REPO_ROOT / "scripts" / "harvest_estate_assets.py"),
+            "--out",
+            str(Path("linkdir") / "sweepout"),
+            "--skip-download",
+        ],
+        cwd=lab.repo,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 2, f"the CLI accepted a junctioned --out:\n{result.stdout}\n{result.stderr}"
+    assert "REFUSING" in (result.stdout + result.stderr)
+    assert not (lab.outside / "sweepout").exists(), "the refusal ran too late - it already wrote through the link"
+
+
+def test_a_literal_tilde_is_judged_where_it_would_actually_land(repo: Path, monkeypatch) -> None:
+    """Acceptance criterion 1, at the guard. `~` reaches argv unexpanded from cmd.exe, from a quoted
+    PowerShell argument, and from any programmatic call; `Path("~/x")` is a plain relative path."""
+    monkeypatch.chdir(repo)
+    home_form = Path("~/harvest-374-sweep").expanduser().resolve()
+
+    old_question = h.unignored_output_paths(home_form)
+    if old_question:
+        pytest.skip("the home directory is itself an unignored path inside a checkout on this machine")
+    assert old_question == [], "the OLD guard judged the home directory, and called it safe"
+    assert h.refuse_unignored_output(Path("~/harvest-374-sweep"), allow_unignored=False) is True
+
+
+def test_the_tilde_directory_is_never_created_inside_the_checkout(repo: Path) -> None:
+    """Acceptance criterion 1, end to end: refuse, and leave no literal `~` behind."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(REPO_ROOT / "scripts" / "harvest_estate_assets.py"),
+            "--out",
+            "~/harvest-374-sweep",
+            "--skip-download",
+        ],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 2, f"the CLI accepted a literal ~ --out:\n{result.stdout}\n{result.stderr}"
+    assert not (repo / "~").exists(), "a literal `~` directory was created inside the checkout"
+
+
+def test_the_run_writes_to_the_form_the_guard_passed(tmp_path: Path, monkeypatch) -> None:
+    """The other half of the asymmetry: checking one form and writing another proves nothing.
+
+    Runs `main` in-process with a fake HOME so no real home directory is touched, from a cwd in no
+    work tree so the guard legitimately allows the run. The output must land on the RESOLVED form.
+    `sqlite3` then fails on the empty estate DB (exit 1) - by design: the write happens first, and
+    stubbing the engine keeps this independent of whether the conversion plugin is installed.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    workdir = tmp_path / "workdir"
+    workdir.mkdir()
+    if _git(["rev-parse", "--is-inside-work-tree"], workdir).stdout.strip() == "true":
+        pytest.skip("pytest tmp_path is itself inside a git work tree on this machine")
+    monkeypatch.setenv("USERPROFILE", str(home))
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.chdir(workdir)
+    monkeypatch.setattr(h, "engine_scripts_dir", lambda: tmp_path)
+    monkeypatch.setattr(h, "resolve_env", lambda _path: {})
+    monkeypatch.setattr(sys, "argv", ["harvest", "--out", "~/sweep", "--skip-download", "--db", str(tmp_path / "e.db")])
+
+    assert h.main() == 1  # the empty estate DB, reached only AFTER --out is created
+    assert (home / "sweep" / "assets").is_dir(), "the run did not write to the resolved form it checked"
+    assert not (workdir / "~").exists(), "the run wrote to the raw argument, not the checked form"
+
+
+def test_an_out_that_cannot_be_resolved_fails_closed(repo: Path, monkeypatch) -> None:
+    """A form we cannot compute is a question we cannot answer, and unanswerable means unsafe."""
+
+    def explode(_path: Path) -> Path:
+        raise OSError("WinError 1921: the name of the file cannot be resolved by the system")
+
+    monkeypatch.setattr(h, "_resolved", explode)
+    with pytest.raises(h.OutputPathNotIgnoredError):
+        h.output_path_forms(repo / "_sweep")
+    assert h.refuse_unignored_output(repo / "_sweep", allow_unignored=False) is True
+
+
+def test_both_path_forms_are_offered_and_neither_is_dropped(repo: Path, monkeypatch) -> None:
+    """The contract `refuse_unignored_output` depends on, asserted where it is cheap to read."""
+    monkeypatch.chdir(repo)
+    forms = h.output_path_forms(Path("~/harvest-374-sweep"))
+    assert forms == [repo / "~" / "harvest-374-sweep", Path("~/harvest-374-sweep").expanduser().resolve()]
+    assert h.output_path_forms(repo / "_sweep") == [repo / "_sweep"], "identical forms must collapse to one probe"
+
+
+def test_the_out_of_checkout_remedy_still_works(lab) -> None:
+    """Acceptance criterion 3. The remedy the refusal recommends must not itself be refused.
+
+    Asserted at the guard AND by exit code. The CLI cannot reach 0 here - there is no estate DB, and
+    on a machine without the conversion plugin it stops earlier still - so the claim is that it is
+    not stopped by the GUARD (exit 2), which is the thing under test.
+    """
+    assert h.refuse_unignored_output(lab.outside / "sweep", allow_unignored=False) is False
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(REPO_ROOT / "scripts" / "harvest_estate_assets.py"),
+            "--out",
+            str(lab.outside / "sweep"),
+            "--skip-download",
+        ],
+        cwd=lab.repo,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode != 2, f"the guard blocked its own recommended remedy:\n{result.stdout}{result.stderr}"
+    assert "REFUSING" not in (result.stdout + result.stderr)

--- a/tests/test_harvest_output_guard.py
+++ b/tests/test_harvest_output_guard.py
@@ -800,3 +800,33 @@ def test_an_ignored_out_named_through_a_resolvable_alias_still_proceeds(lab) -> 
         assert h.refuse_unignored_output(alias / "_sweep-alias", allow_unignored=False) is False, (
             f"an ignored --out spelled {alias} was refused"
         )
+
+
+def test_a_path_longer_than_git_can_access_is_still_judged_correctly(lab) -> None:
+    """git and the filesystem disagree about long paths on Windows; the verdict must not.
+
+    Measured on this machine - `core.longpaths` UNSET while the OS has `LongPathsEnabled=1`, git
+    2.55.0.windows.3 - at 310 characters `git check-ignore` still returns the RIGHT answer, 0 for an
+    ignored prefix and 1 for an unignored one, while printing `warning: unable to access ...` to
+    stderr. The guard reads the exit code, not the warning, so the verdict survives; and a path git
+    cannot answer for at all raises and refuses, which the fail-closed rule already covers.
+
+    Characterisation, not new coverage: it pins a boundary where the two layers are known to
+    disagree, and it is near-vacuous on POSIX where 310 characters is unremarkable. Nothing is
+    created on disk - the guard judges paths that do not exist, by design, so this needs no deep
+    directory tree and leaves nothing to clean up.
+    """
+
+    def long_out(first: str) -> Path:
+        out = lab.repo / first
+        while len(str(out / "assets" / "harvested-workbook.twbx")) < 300:
+            out = out / ("d" * 40)
+        return out
+
+    ignored, unignored = long_out("_sweep-long"), long_out("leaky-long")
+    assert min(len(str(ignored)), len(str(unignored))) > 260, "fixture proves nothing: the paths are not long"
+    assert not ignored.exists() and not unignored.exists(), "the guard must judge these without creating them"
+
+    assert h.refuse_unignored_output(unignored, allow_unignored=False) is True
+    assert h.refuse_unignored_output(ignored, allow_unignored=False) is False
+    assert not ignored.exists() and not unignored.exists(), "the guard created a directory while judging"

--- a/tests/test_harvest_output_guard.py
+++ b/tests/test_harvest_output_guard.py
@@ -18,6 +18,7 @@ No customer data is used or created anywhere below: every fixture is an empty te
 
 from __future__ import annotations
 
+import ctypes
 import os
 import subprocess
 import sys
@@ -577,3 +578,225 @@ def test_the_out_of_checkout_remedy_still_works(lab) -> None:
     )
     assert result.returncode != 2, f"the guard blocked its own recommended remedy:\n{result.stdout}{result.stderr}"
     assert "REFUSING" not in (result.stdout + result.stderr)
+
+
+# ------------------------------------------------------- issue #374, second round (blind review)
+#
+# Junctions were only the first spelling. Three more got past the guard, each writing a stageable
+# file INSIDE the checkout while the plain spelling of the SAME target was correctly refused - so
+# they are bypasses of the comparison, not of the rule. Measured before the fix, CLI exit 0 for all
+# three where the plain form exits 2:
+#
+#   \\?\<repo>\leak-extended                    extended-length prefix
+#   \\localhost\c$\...\<repo>\leak-unc          UNC administrative-share alias
+#   <8.3 repo>\link-out\leak-short              8.3 short name PLUS an outbound junction
+#
+# The third is the one that decides the fix: 8.3 alone is expanded by `resolve()` and caught, but
+# combined with a junction the lexical form stays short and the resolved form lands outside, so BOTH
+# forms pass. Only filesystem identity (`os.path.samefile`) answers it - and resolving the lexical
+# form to "fix" it would re-open the outbound-junction hole the first round closed.
+#
+# Plus two that are not about spelling at all: a repository git cannot read was read as "no work
+# tree here, carry on", and the documented out-of-checkout remedy was refused in its `..` spelling.
+
+WINDOWS_ONLY = pytest.mark.skipif(sys.platform != "win32", reason="Windows-specific path spelling")
+
+
+def _short_name(path: Path) -> str | None:
+    """`path`'s 8.3 alias, or None when the volume has 8.3 generation disabled."""
+    buffer = ctypes.create_unicode_buffer(1024)
+    if not ctypes.windll.kernel32.GetShortPathNameW(str(path), buffer, 1024):  # pragma: no cover
+        return None
+    return buffer.value if buffer.value.lower() != str(path).lower() else None
+
+
+def _assert_alias_reproduces(alias: Path, repo: Path) -> None:
+    """The fixture must be a genuine alias: same directory, spelling git cannot lexically relate.
+
+    Without this a "bypass" test can pass for the wrong reason - because the spelling collapsed back
+    to the plain path that was already refused, proving nothing about the alias.
+    """
+    with pytest.raises(ValueError):
+        alias.relative_to(repo)
+    assert h.refuse_unignored_output(repo / alias.name, allow_unignored=False) is True, (
+        "fixture proves nothing: the plain spelling of this target is not refused either"
+    )
+
+
+@WINDOWS_ONLY
+def test_an_extended_length_prefix_cannot_smuggle_a_path_into_the_checkout(lab) -> None:
+    r"""`\\?\C:\...` names the same directory, and both `absolute()` and `resolve()` preserve it."""
+    alias = Path(f"\\\\?\\{lab.repo}\\leaky-extended")
+    _assert_alias_reproduces(alias, lab.repo)
+    assert h.refuse_unignored_output(alias, allow_unignored=False) is True
+
+
+@WINDOWS_ONLY
+def test_a_unc_admin_share_alias_cannot_smuggle_a_path_into_the_checkout(lab) -> None:
+    r"""`\\localhost\c$\...` is the same directory over a different namespace."""
+    drive = str(lab.repo)[0]
+    share = f"\\\\localhost\\{drive}$"
+    try:
+        reachable = Path(share).is_dir()
+    except OSError:  # pragma: no cover - depends on local policy
+        reachable = False
+    if not reachable:
+        pytest.skip("the administrative share is not reachable on this machine")
+    alias = Path(str(lab.repo).replace(f"{drive}:", share, 1)) / "leaky-unc"
+    _assert_alias_reproduces(alias, lab.repo)
+    assert h.refuse_unignored_output(alias, allow_unignored=False) is True
+
+
+@WINDOWS_ONLY
+def test_an_8_3_short_name_plus_an_outbound_junction_cannot_smuggle_a_path_in(lab) -> None:
+    """The combination that defeats resolving: short lexically, outside once resolved.
+
+    Asserted explicitly, because this is the one case where fixing the alias by resolving the
+    lexical form would silently re-open the junction hole instead of closing anything.
+    """
+    short = _short_name(lab.repo)
+    if short is None:
+        pytest.skip("8.3 name generation is disabled on this volume")
+    alias = Path(short) / "linkdir" / "leaky-short"
+    with pytest.raises(ValueError):
+        alias.relative_to(lab.repo)
+    resolved = h._resolved(alias)  # pylint: disable=protected-access
+    assert not _same_path(resolved, lab.repo) and lab.outside in resolved.parents, (
+        f"fixture proves nothing: the resolved form {resolved} is not outside the checkout"
+    )
+    assert h.refuse_unignored_output(lab.repo / "linkdir" / "leaky-short", allow_unignored=False) is True, (
+        "fixture proves nothing: the plain spelling of this junctioned target is not refused either"
+    )
+    assert h.refuse_unignored_output(alias, allow_unignored=False) is True
+
+
+def _same_path(a: Path, b: Path) -> bool:
+    return str(a).lower() == str(b).lower()
+
+
+def test_a_repository_git_cannot_read_is_treated_as_unsafe(lab) -> None:
+    """A `.git` that yields no work tree means git could not answer, not that nothing is here.
+
+    Reachable without sabotage: a dubious-ownership refusal over UNC produces exactly this shape in
+    the wild. Reproduced deterministically with a stale gitdir pointer, which any moved worktree
+    leaves behind.
+    """
+    (lab.repo / ".git").rename(lab.repo / ".git-disabled")
+    (lab.repo / ".git").write_text("gitdir: does-not-exist\n", encoding="utf-8")
+    assert _git(["rev-parse", "--show-toplevel"], lab.repo).returncode != 0, "fixture: rev-parse must fail"
+    assert (lab.repo / ".git").exists(), "fixture: the checkout marker must still be there"
+
+    with pytest.raises(h.OutputPathNotIgnoredError):
+        h.unignored_output_paths(lab.repo / "leaky-broken")
+    assert h.refuse_unignored_output(lab.repo / "leaky-broken", allow_unignored=False) is True
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(REPO_ROOT / "scripts" / "harvest_estate_assets.py"),
+            "--out",
+            "leaky-broken",
+            "--skip-download",
+        ],
+        cwd=lab.repo,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 2, f"the CLI wrote into a checkout git could not read:\n{result.stdout}{result.stderr}"
+    assert not (lab.repo / "leaky-broken").exists()
+
+
+def test_a_failing_rev_parse_is_unsafe_even_when_check_ignore_would_answer(lab, monkeypatch) -> None:
+    """`test_an_unanswerable_git_is_treated_as_unsafe` forces `check-ignore` to 128 while leaving
+    `rev-parse` healthy - a different call on a different path, so it cannot cover this.
+
+    The `--out` here is `_sweep`, which the real `.gitignore` DOES ignore, so this can only pass
+    because worktree discovery failed closed - never because the path happened to be unignored.
+    """
+    real_run = subprocess.run
+
+    def fake_run(cmd, **kwargs):
+        if "rev-parse" in cmd:
+            return subprocess.CompletedProcess(cmd, 128, "", "fatal: detected dubious ownership in repository")
+        return real_run(cmd, **kwargs)
+
+    assert h.refuse_unignored_output(lab.repo / "_sweep", allow_unignored=False) is False, (
+        "fixture proves nothing: `_sweep` must be ignored here, or the refusal below is trivial"
+    )
+    monkeypatch.setattr(h.subprocess, "run", fake_run)
+    with pytest.raises(h.OutputPathNotIgnoredError):
+        h.unignored_output_paths(lab.repo / "_sweep")
+    assert h.refuse_unignored_output(lab.repo / "_sweep", allow_unignored=False) is True
+
+
+def test_the_relative_dot_dot_spelling_of_the_remedy_still_works(lab, monkeypatch) -> None:
+    """`--out ..\\outside\\out` is the documented remedy in its most natural relative spelling.
+
+    `Path.absolute()` keeps `..` (measured on 3.11.9 and 3.13.2), and a surviving `..` still passes
+    a `relative_to(<repo>)` test, so the guard asked git about a path outside the repository, got
+    "outside repository", and refused the very thing the refusal message recommends.
+    """
+    monkeypatch.chdir(lab.repo)
+    relative = Path("..") / "outside" / "remedy"
+    assert ".." in relative.absolute().parts, "fixture proves nothing: this Python collapses `..` in absolute()"
+    assert h.refuse_unignored_output(relative, allow_unignored=False) is False
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(REPO_ROOT / "scripts" / "harvest_estate_assets.py"),
+            "--out",
+            str(relative),
+            "--skip-download",
+        ],
+        cwd=lab.repo,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode != 2, f"the guard refused its own remedy:\n{result.stdout}{result.stderr}"
+    assert "REFUSING" not in (result.stdout + result.stderr)
+
+
+def test_the_probe_is_rebuilt_from_the_work_tree_root_spelling(lab) -> None:
+    """A CONTRACT test, and labelled as one - it pins a defence, not an observed behaviour.
+
+    Measured on both platforms: `git check-ignore` answers an aliased spelling exactly as it answers
+    the plain one (`\\\\?\\` and 8.3 on Windows with git 2.55.0, a symlinked root on Linux with
+    2.43.0), or refuses to answer it at all (`\\\\localhost\\c$`, where `rev-parse` fails first and
+    the run is already refused). So rebuilding the probe from the ROOT's own spelling changes no
+    verdict this suite can observe, and no end-to-end test can kill it - said plainly rather than
+    dressed up as coverage.
+
+    It is kept because the one failure this guard cannot survive is git answering PERMISSIVELY for a
+    spelling it half-understands, and asking about a path the work tree itself named removes that
+    whole class. Pinned here so it cannot be dropped without a deliberate decision.
+    """
+    alias = lab.linked_repo / "_sweep-contract"
+    assert alias != lab.repo / "_sweep-contract", "fixture proves nothing: the alias is the plain spelling"
+    root, probe = h._canonical_probe_target(alias)  # pylint: disable=protected-access
+    assert _same_path(root, lab.repo), f"the work tree root was not resolved to the checkout: {root}"
+    assert probe == lab.repo / "_sweep-contract", f"the probe kept the caller's spelling: {probe}"
+
+
+@WINDOWS_ONLY
+def test_an_ignored_out_named_through_a_resolvable_alias_still_proceeds(lab) -> None:
+    """The guard refuses aliases it cannot verify, not aliases as a class.
+
+    `\\\\?\\` and 8.3 are spellings git CAN work from (measured: `rev-parse` with either as cwd exits
+    0 and reports the long-form toplevel), so an ignored `--out` named that way must still run. The
+    UNC admin share is deliberately excluded: `rev-parse` there exits 128, which is unanswerable and
+    therefore refused - a noisy outcome the asymmetry accepts, unlike a silent write.
+    """
+    aliases = [Path(f"\\\\?\\{lab.repo}")]
+    short = _short_name(lab.repo)
+    if short is not None:
+        aliases.append(Path(short))
+    assert h.refuse_unignored_output(lab.repo / "_sweep-alias", allow_unignored=False) is False, "control"
+    for alias in aliases:
+        with pytest.raises(ValueError):
+            alias.relative_to(lab.repo)  # a real alias, not the plain spelling in disguise
+        assert h.refuse_unignored_output(alias / "_sweep-alias", allow_unignored=False) is False, (
+            f"an ignored --out spelled {alias} was refused"
+        )

--- a/tests/test_harvest_output_guard.py
+++ b/tests/test_harvest_output_guard.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import ctypes
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -759,25 +760,132 @@ def test_the_relative_dot_dot_spelling_of_the_remedy_still_works(lab, monkeypatc
     assert "REFUSING" not in (result.stdout + result.stderr)
 
 
-def test_the_probe_is_rebuilt_from_the_work_tree_root_spelling(lab) -> None:
-    """A CONTRACT test, and labelled as one - it pins a defence, not an observed behaviour.
+@WINDOWS_ONLY
+def test_the_canonical_probe_is_what_lets_a_substituted_drive_through(lab) -> None:
+    """Rebuilding the probe from the work-tree ROOT's spelling, proved by behaviour not by contract.
 
-    Measured on both platforms: `git check-ignore` answers an aliased spelling exactly as it answers
-    the plain one (`\\\\?\\` and 8.3 on Windows with git 2.55.0, a symlinked root on Linux with
-    2.43.0), or refuses to answer it at all (`\\\\localhost\\c$`, where `rev-parse` fails first and
-    the run is already refused). So rebuilding the probe from the ROOT's own spelling changes no
-    verdict this suite can observe, and no end-to-end test can kill it - said plainly rather than
-    dressed up as coverage.
+    This started life as a contract test, on the measured grounds that git answers every aliased
+    spelling exactly as it answers the plain one - so the rebuild changed no observable verdict and
+    no mutation could kill it. That was wrong, and `subst` is the case that shows it:
 
-    It is kept because the one failure this guard cannot survive is git answering PERMISSIVELY for a
-    spelling it half-understands, and asking about a path the work tree itself named removes that
-    whole class. Pinned here so it cannot be dropped without a deliberate decision.
+        subst Z: <repo>                        exit 0
+        git -C Z:\\ rev-parse --show-toplevel   exit 0, reports the long C:\\...\\repo
+        check-ignore <canonical ignored path>  exit 0   -> ignored
+        check-ignore Z:\\_sweep-p14\\...         exit 128 -> UNANSWERABLE
+
+    Probing what the caller typed would therefore raise and refuse a plainly ignored `--out`;
+    probing the path rebuilt from the root's own spelling answers it correctly. So the assertion
+    below is that an ignored output on a substituted drive PROCEEDS.
+
+    Windows only - `subst` has no POSIX equivalent, and no discriminating case for the rebuild is
+    known there, so on Linux this defence remains unpinned. Said, not hidden.
     """
-    alias = lab.linked_repo / "_sweep-contract"
-    assert alias != lab.repo / "_sweep-contract", "fixture proves nothing: the alias is the plain spelling"
-    root, probe = h._canonical_probe_target(alias)  # pylint: disable=protected-access
-    assert _same_path(root, lab.repo), f"the work tree root was not resolved to the checkout: {root}"
-    assert probe == lab.repo / "_sweep-contract", f"the probe kept the caller's spelling: {probe}"
+    letter = _free_drive_letter()
+    if letter is None:
+        pytest.skip("no free drive letter available for subst")
+    made = subprocess.run(["subst", f"{letter}:", str(lab.repo)], capture_output=True, text=True, check=False)
+    if made.returncode != 0:
+        pytest.skip(f"subst failed: {made.stdout.strip()} {made.stderr.strip()}")
+    try:
+        drive = Path(f"{letter}:\\")
+        canonical = lab.repo / "_sweep-p14" / "assets" / "harvested-workbook.twbx"
+        assert _git(["check-ignore", "-q", "--", str(canonical)], lab.repo).returncode == 0, (
+            "fixture proves nothing: the canonical path is not ignored here"
+        )
+        assert _git(["check-ignore", "-q", "--", str(drive / "_sweep-p14" / "assets")], lab.repo).returncode not in (
+            0,
+            1,
+        ), "fixture proves nothing: git can answer the substituted-drive spelling, so nothing discriminates"
+
+        assert h.refuse_unignored_output(drive / "_sweep-p14", allow_unignored=False) is False
+        assert h.refuse_unignored_output(drive / "leaky-p14", allow_unignored=False) is True
+    finally:
+        subprocess.run(["subst", f"{letter}:", "/D"], capture_output=True, check=False)
+
+
+def _free_drive_letter() -> str | None:
+    """A drive letter nothing is using, for `subst`. None when the machine has none free."""
+    return next((letter for letter in "ZYXWVUT" if not Path(f"{letter}:\\").exists()), None)
+
+
+def test_a_dangling_git_link_is_still_a_checkout(lab) -> None:
+    """`exists()` FOLLOWS a reparse point, so a dangling `.git` link reports absent.
+
+    The checkout marker is then missed, the failed `rev-parse` is treated as "nothing here", and an
+    unignored output is written and staged (measured before the fix: CLI exit 0, wrote). The entry
+    exists; only its target does not. `os.path.lexists` asks the question that matters.
+    """
+    gone = lab.repo.parent / "gone-gitdir"
+    gone.mkdir()
+    shutil.rmtree(lab.repo / ".git")
+    _link_dir(lab.repo / ".git", gone)
+    os.rmdir(gone)
+    try:
+        assert not (lab.repo / ".git").exists(), "fixture proves nothing: the link is not dangling"
+        assert os.path.lexists(lab.repo / ".git"), "fixture proves nothing: the entry is gone entirely"
+        assert _git(["rev-parse", "--show-toplevel"], lab.repo).returncode != 0, "fixture: rev-parse must fail"
+
+        assert h.refuse_unignored_output(lab.repo / "leaky-dangling", allow_unignored=False) is True
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(REPO_ROOT / "scripts" / "harvest_estate_assets.py"),
+                "--out",
+                "leaky-dangling",
+                "--skip-download",
+            ],
+            cwd=lab.repo,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        assert result.returncode == 2, f"the CLI wrote into a dangling-.git checkout:\n{result.stdout}{result.stderr}"
+        assert not (lab.repo / "leaky-dangling").exists()
+    finally:
+        _unlink_dir(lab.repo / ".git")
+
+
+def test_an_identity_comparison_that_cannot_answer_is_treated_as_unsafe(lab, monkeypatch) -> None:
+    """A filesystem that will not say whether two paths are the same has not said "no".
+
+    Collapsing that `OSError` to `False` made containment look DISPROVEN rather than unproven, so
+    `_canonical_probe_target` reported "no work tree holds this" and the run proceeded - measured
+    before the fix: exit 0, a customer workbook name in `parse-sweep.json`, `git status` staging it.
+
+    The `--out` here is plainly unignored, and the control below proves the guard refuses it for the
+    ordinary reason first, so this cannot pass merely because the path was bad.
+    """
+    assert h.refuse_unignored_output(lab.repo / "leaky-samefile", allow_unignored=False) is True, "control"
+
+    def denied(_a, _b):
+        raise PermissionError(13, "Access is denied")
+
+    monkeypatch.setattr(os.path, "samefile", denied)
+    with pytest.raises(h.OutputPathNotIgnoredError):
+        h.unignored_output_paths(lab.repo / "leaky-samefile")
+    assert h.refuse_unignored_output(lab.repo / "leaky-samefile", allow_unignored=False) is True
+    assert h.refuse_unignored_output(lab.repo / "_sweep-samefile", allow_unignored=False) is True, (
+        "an IGNORED path must also refuse while identity is unprovable - unanswerable is unsafe"
+    )
+
+
+@WINDOWS_ONLY
+def test_an_ancestry_with_nothing_to_examine_is_treated_as_unsafe(lab) -> None:
+    """If not one directory above `--out` can be looked at, nothing about it has been established.
+
+    Both of these previously proceeded. POSIX has no equivalent - `/` always exists, so there is
+    always something to examine - hence Windows only rather than a synthetic stub.
+    """
+    letter = _free_drive_letter()
+    if letter is None:
+        pytest.skip("no unused drive letter to point at")
+    assert not Path(f"{letter}:\\").exists(), "fixture proves nothing: the drive exists"
+
+    for target in (Path(f"{letter}:\\nowhere\\out"), Path("\\\\no-such-host-x9\\share\\out")):
+        assert h.refuse_unignored_output(target, allow_unignored=False) is True, f"{target} was allowed"
+    assert h.refuse_unignored_output(lab.outside / "sweep", allow_unignored=False) is False, (
+        "control: a real directory outside the checkout must still proceed"
+    )
 
 
 @WINDOWS_ONLY

--- a/tests/test_harvest_output_guard.py
+++ b/tests/test_harvest_output_guard.py
@@ -108,14 +108,75 @@ def test_a_name_outside_the_convention_is_still_reported_unignored(repo: Path) -
     assert not _is_ignored(repo / "sweep-without-underscore", repo)
 
 
+def _rule_comment_block(text: str, rule: str) -> str:
+    """The contiguous comment block immediately above the LINE that IS `rule` in `.gitignore`.
+
+    Located by matching a whole line, never by splitting on the rule text. `text.split(rule)[0]`
+    lands on the FIRST occurrence anywhere in the file, so a comment quoting a rule verbatim earlier
+    on hijacks it and this test fails on prose that is entirely correct - hit for real on PR #382,
+    whose author reworded their comment rather than edit a file outside their group.
+
+    The hazard is already live: `.gitignore:109-110` quotes both `/_harvest*/` and `/_sweep*/` inside
+    the general-rule commentary, and this test survives only because those lines sit BELOW the rules
+    they quote. Moving that block up, or adding any similar note above line 83, breaks a test that
+    has nothing to do with the change.
+
+    An ambiguous file is refused rather than guessed at: if a rule is listed twice, no single comment
+    block governs it, and picking the first silently answers a question the file does not settle.
+    """
+    lines = text.splitlines()
+    matches = [i for i, line in enumerate(lines) if line.strip() == rule]
+    assert len(matches) == 1, f"`.gitignore` has {len(matches)} lines equal to `{rule}`, expected exactly 1"
+    index = matches[0]
+    start = index
+    while start > 0 and lines[start - 1].strip():
+        start -= 1
+    return "\n".join(lines[start:index])
+
+
 def test_the_two_harvesters_do_not_share_one_documented_folder() -> None:
     """`.gitignore` must say WHICH tool writes where; one folder for two tools is the collision."""
     text = (REPO_ROOT / ".gitignore").read_text(encoding="utf-8")
-    harvest_block = text.split("/_harvest*/")[0].rsplit("\n\n", 1)[-1]
-    sweep_block = text.split("/_sweep*/")[0].rsplit("\n\n", 1)[-1]
+    harvest_block = _rule_comment_block(text, "/_harvest*/")
+    sweep_block = _rule_comment_block(text, "/_sweep*/")
     assert "harvest_tableau_public.py" in harvest_block, "_harvest* rule does not name its owning tool"
     assert "harvest_estate_assets.py" in sweep_block, "_sweep* rule does not name its owning tool"
     assert "harvest_estate_assets.py" not in harvest_block, "both harvesters documented into _harvest*"
+
+
+def test_the_rule_locator_is_not_hijacked_by_a_comment_quoting_the_rule() -> None:
+    """The regression PR #382 hit: correct prose, unrelated file, red test.
+
+    Asserts twice on purpose - first that the OLD split-based locator really is hijacked by this
+    fixture, so a fixture that does not reproduce the defect cannot pass quietly.
+    """
+    text = (
+        "# THE GENERAL RULE, added after the specific ones below.\n"
+        "# `/_harvest*/` and `/_sweep*/` both cite issue #125.\n"
+        "/_*\n"
+        "\n"
+        "# `harvest_tableau_public.py` output (`--out-dir`, default `_harvest`).\n"
+        "/_harvest*/\n"
+        "candidates.json\n"
+        "\n"
+        "# `harvest_estate_assets.py` output (`--out`): downloaded .twbx/.tdsx from a REAL site.\n"
+        "/_sweep*/\n"
+    )
+    for rule, owner in (("/_harvest*/", "harvest_tableau_public.py"), ("/_sweep*/", "harvest_estate_assets.py")):
+        hijacked = text.split(rule)[0].rsplit("\n\n", 1)[-1]
+        assert owner not in hijacked, f"fixture proves nothing: the old locator was not hijacked for {rule}"
+        assert owner in _rule_comment_block(text, rule), f"the locator missed the real {rule} block"
+
+
+def test_the_rule_locator_refuses_a_file_it_cannot_answer_for() -> None:
+    """A missing or duplicated rule must fail loudly, never return an empty block that asserts True.
+
+    An empty string satisfies `"x" not in block`, so a silent miss would turn the collision check
+    above into a rubber stamp - the same fail-open shape the output guard is built to avoid.
+    """
+    for text in ("# nothing here\n/_assessment*/\n", "/_sweep*/\n\n# a second, contradictory home\n/_sweep*/\n"):
+        with pytest.raises(AssertionError):
+            _rule_comment_block(text, "/_sweep*/")
 
 
 # --------------------------------------------------------------------------- the script's guard


### PR DESCRIPTION
## What

`harvest_estate_assets.py` downloads **every workbook and published datasource on a Tableau site**, and this repository is **public**. Its output guard had the check/write asymmetry #322 fixed in `connections_manifest.py`, plus a junction anchor hole. Both were reproduced by construction before the fix, on Windows **and** Linux.

## The two defects, measured

Fake checkout carrying this repo's **real** `.gitignore`; `git 2.55.0.windows.3`.

**1. Check/write asymmetry** — the guard normalised, the writer did not.

```
--out ~/lab-sweep    guard judged  C:\Users\<me>\lab-sweep     (no work tree -> allowed)
                     CLI wrote     <checkout>\~\lab-sweep\assets
                     check-ignore  exit 1 -- NOT ignored, stageable
```

**2. Junction anchor** — `_existing_ancestor` of the *resolved* path lands at the junction target, and git answers from there about somewhere else.

```
mklink /J <repo>\linkdir <outside>
--out linkdir\sweepout   anchor      <outside>
                         rev-parse   exit 128, "not a git repository"
                         guard       allowed
                         CLI         wrote through the junction
git add -A --dry-run at <repo>:
  add 'linkdir/sweepout/assets/harvested-workbook.twbx'      <- customer content, stageable
```

Asked from `<repo>`, the same git answers `check-ignore` **exit 1**, correctly.

## The fix

`output_path_forms` returns the **lexical** form (`absolute()`, nothing expanded or followed — the string git's own working-tree walk sees) and the **resolved** form (where the bytes land). `refuse_unignored_output` requires *every* form to pass; `main` then writes to the resolved one, so the checked path is the written path. `unignored_output_paths` no longer normalises — the caller chooses the form — and anchors at the first **lexical** ancestor whose work-tree root actually contains that form, so a junction below the root cannot move the question. An unresolvable path **raises** instead of degrading: unanswerable means unsafe.

Anchoring at `Path.cwd()` (the issue's remedy, and what #322 did) closes the measured case; the ancestor walk is a superset — it also holds when the script is invoked from *outside* the checkout, which is a normal way to run it.

| `--out` | before | after |
|---|---|---|
| plainly unignored in-repo | refuse | refuse |
| ignored in-repo (`_sweep*`) | proceed | proceed |
| genuinely outside the checkout | proceed | proceed |
| **junction pointing OUT of the checkout** | **proceed, wrote, stageable** | **refuse, exit 2, nothing written** |
| junction pointing INTO the checkout | refuse | refuse |
| **literal `~`** | **proceed, created `<repo>\~\...`** | **refuse, exit 2, no `~` created** |
| checkout itself reached through a junction | proceed | proceed (no false refusal) |

## Contradicting the issue, with evidence

The **second junction direction** — an `--out` that looks external but resolves *into* the checkout — was **already refused before this change**, precisely because the old guard resolved. That is why the resolved form is *kept alongside* the lexical one rather than replaced by it, and `test_a_junction_leading_INTO_the_checkout_is_refused` asserts the lexical form alone would **not** have caught it.

The containment test is load-bearing in the other direction: a checkout *reached through* a junction reports a toplevel that does not contain the lexical form, and asking it anyway yields `"outside repository"` (exit 128) → a refusal for a plainly ignored `--out`. `test_a_checkout_reached_through_a_junction_is_not_falsely_refused` pins that.

## Linux

Measured in WSL (git 2.43.0) with symlinks: **the same hole, and the same refusals after the fix.** The leak *shape* differs and the control test asserts each platform separately — git walks into an NTFS junction and stages the `.twbx` itself, while a POSIX symlink is staged as a link object (`add 'linkdir'`) and not walked into.

## Mutation testing — 11/11 caught

Each mutation was written to disk and **asserted present** before scoring, and scored on pytest's own count (≥1 failed, 0 errors, full 34-test collection) — not on exit code, which an import error also trips.

| # | mutation | pytest |
|---|---|---|
| M1 | guard disabled (always proceeds) | 16 failed, 18 passed |
| M2 | trailing slash on the check-ignore probe | 12 failed, 22 passed |
| M3 | fail-open when git cannot answer check-ignore | 1 failed, 33 passed |
| M4 | fail-open when the git binary is missing | 1 failed, 33 passed |
| M5 | drop the LEXICAL path form | 6 failed, 28 passed |
| M6 | drop the RESOLVED path form | 2 failed, 32 passed |
| M7 | stop the ancestor walk at the first non-work-tree (old anchor) | 3 failed, 31 passed |
| M8 | drop the lexical-containment applicability test | 1 failed, 33 passed |
| M9 | main writes the RAW argument instead of the checked form | 1 failed, 33 passed |
| M10 | fail-open on an unresolvable path | 1 failed, 33 passed |
| M11 | probe `--out` itself instead of a file inside it | 2 failed, 32 passed |

Every new refusal test asserts **twice** — first that the question the *old* guard asked returns "safe" for that fixture, then that the guard refuses anyway — so a fixture that never exercises the defect fails loudly instead of passing for the wrong reason (the shape found in review of #362). Fixtures use this repo's **real** `.gitignore`, byte for byte, and every link is unlinked in fixture teardown with `os.rmdir`/`unlink` so the target is never touched.

## Scope

`provision_tableau_estate.py` imports `refuse_unignored_output` and is **unchanged**: it already normalised once and wrote where it checked, so it had no asymmetry, and it inherits the junction fix for free. Its 105 tests still pass.

The residual the issue says not to chase — naming a junction **target** directly is still exposed via the junction — is now stated in the module docstring rather than left implied.

## Gates (exit codes)

- `ruff format --check scripts tests .github/skills` → **0**
- `ruff check scripts tests .github/skills` → **0**
- `.venv\Scripts\python.exe -m pylint scripts` → **10.00/10, exit 0**
- `pytest tests/test_harvest_output_guard.py tests/test_harvest_project_scope.py tests/test_provision_tableau_estate.py tests/test_connections_manifest.py` → **155 passed, exit 0**
- Full suite: **2514 passed**, 3 failures in `tests/test_upstream_repro_pins.py` — **pre-existing**, confirmed identical on the base tree with these changes stashed.

## Not verified

- The **pytest suite itself was executed on Windows only**. WSL has no pip and no passwordless sudo, so the Linux evidence comes from a standalone script driving the same guard code, not from pytest. CI will be the first Linux pytest run.
- Reparse points other than junctions and symlinks (mount points, appexec links, WSL DrvFs paths) were not tested.
- No live Tableau site was contacted; every fixture is an empty temp directory and no customer data was used or created.

Fixes #374
