### PR TITLE
Suppress a dialog only when benign CONTENT was positively read

### DIFF
--- a/.github/skills/pbip-model-refresh/SKILL.md
+++ b/.github/skills/pbip-model-refresh/SKILL.md
@@ -154,8 +154,9 @@ stay byte-identical.
 > |---|---|---|
 > | `CREDENTIAL_MISSING` | 1 | text matched `credential_modal_signature.regex`. The hard stop. |
 > | `CREDENTIAL_PRESENT` | 0 | a refresh was invoked and ran to the deadline with nothing unclassifiable up. Still not the gate of record for a serverless source — confirm with the one-row data probe. |
-> | `REFRESH_IN_PROGRESS` | 3 | a progress dialog was already up **at t=0**: another refresh owns this instance. Wait for it or cancel the stale one; do not stack a second refresh. |
-> | `DIALOG_UNRECOGNIZED` | 3 | a dialog is up whose text matched neither signature. We read it, and it is **not** a credential prompt — but we cannot say what it is. |
+> | `REFRESH_IN_PROGRESS` | 3 | a dialog whose **whole content** positively reads as refresh progress was already up **at t=0**: another refresh owns this instance. Wait for it or cancel the stale one; do not stack a second refresh. |
+> | `DIALOG_NEEDS_HUMAN` | 3 | a **known** human-blocking prompt that is not a credential prompt — the **native-database-query approval modal** above all. Not exit 1, because the remedy is an approval, not a sign-in. Never suppressed, and it outranks any progress text in the same window. |
+> | `DIALOG_UNRECOGNIZED` | 3 | a dialog is up whose text matched **no** signature, **or** which shows progress text *alongside* prose that is not progress status. We read it, and it is **not** a credential prompt — but we cannot account for all of it. |
 > | `DIALOG_UNREADABLE` | 3 | a dialog is up that could not be **shown to be harmless**: no text at all, or only a reassuring **caption**, or benign-looking content read from an **incomplete** harvest (truncated, timed out, or a pattern that threw). Deliberately distinct from `DIALOG_UNRECOGNIZED`: *absent is not empty*, and "we could not establish it" is a weaker state of knowledge than "we read it and it did not match". |
 > | `UNKNOWN` | 3 | no window for the pid, a minimized owner, or no Refresh control was ever invoked. |
 >
@@ -233,9 +234,46 @@ stay byte-identical.
 > looking at the screen; on the benign path it would be a **silent** false clear.
 >
 > **The net effect is deliberately conservative.** Every uncertainty — unread content, a truncated
-> harvest, a wedged provider, an unknown field type — lands in the exit-3 band, which is loud and
-> recoverable. A mostly-conservative arbiter with a narrow proven-benign path is a better artifact than
-> a clever one with a residual silent clear.
+> harvest, a wedged provider, an unknown field type, prose nobody can explain — lands in the exit-3
+> band, which is loud and recoverable. A mostly-conservative arbiter with a narrow proven-benign path is
+> a better artifact than a clever one with a residual silent clear.
+
+> ⚠️ **One benign element must not account for a whole window — and the native-query modal is why.**
+> Round 3 of review found that the **first** content element matching the progress signature classified
+> the entire window, so `Evaluating` sitting beside
+> *"Permission is required to run this native database query"* was suppressed → **exit 0**. That prompt
+> is documented as a live hazard three sections below, and
+> `tests/test_credential_modal_detection.py` already treated it as blocking — the bundle would have
+> contradicted itself. Three changes, in order of how much they carry:
+>
+> 1. **`scripts/blocking_prompt_signature.regex`** — known human-blocking prompts that are *not*
+>    credential prompts (native-query approval, `Authentication required`). Matched **before** benign
+>    and **before** the enabled-owner exoneration, and reported as **`DIALOG_NEEDS_HUMAN`, exit 3** —
+>    a human must act, but the remedy is an approval, not a sign-in, so it must not enter the band
+>    whose documented meaning is *"sign in once"*.
+> 2. **The whole content is scanned before benign is concluded.** Progress text plus prose that is not
+>    progress status is `mixed-content` → `DIALOG_UNRECOGNIZED`. The backstop for prompts in *neither*
+>    signature is a word count: a content element of **5+ words** that is not itself recognised status
+>    is prose written for a human, and it vetoes suppression. Short data labels (`Orders`,
+>    `1,204 rows loaded`, `Cancel`) do not — otherwise the benign path is unreachable and the probe
+>    could never return `CREDENTIAL_PRESENT` while Desktop shows its own refresh dialog.
+> 3. **The benign expressions are whole-element status patterns**, not substrings. `\bLoading data\b`
+>    matched inside *"Loading data requires authentication"*. Every alternative is now anchored, so a
+>    status word buried in a sentence is not a status.
+>
+> ⚠️ **And validate the harvest child's payload, not just its JSON.** The parent computed
+> `(-not $p.Truncated) -and (-not $p.PatternsIncomplete)`. A missing property is `$null`, and
+> `-not $null` is `$true`, so a well-formed-but-schema-incomplete payload became `HarvestComplete`
+> **`$true`** — a *real Boolean*, which then sailed straight through the strict
+> `Test-HarvestComplete` guard because the coercion had already happened upstream of it. The child must
+> now exit 0, and both flags must **exist** and be actual Booleans. Items are still merged when they
+> parse (unread text only lowers credential recall), but `Complete` stays false.
+>
+> **Notice the shape all three review rounds share: MISSING EVIDENCE READ AS GOOD EVIDENCE.** A caption
+> standing in for content; "we read something" standing in for "we read the thing that matters"; the
+> first benign element standing in for the whole window; a missing JSON property standing in for a
+> completed harvest. If you extend this probe — or write any other detector whose output can stop a
+> pipeline — that is the failure to look for first.
 >
 > The **Python** fast check (`_credential_modal.blocking_dialog_candidates`, used by
 > `refresh_pbip_model.py` and `probe_desktop_query.py`) still promotes any >= 100x100 non-main window
@@ -308,6 +346,13 @@ stay byte-identical.
 > anything about credentials.** `blocking_dialog_candidates()` will report it as
 > `BLOCKED_BY_DIALOG` rather than a false `NO_CREDENTIAL`, which is honest but not yet specific —
 > capture the modal's exact title when you first hit one so it can be classified by name.
+>
+> ✅ **`probe_desktop_credential.ps1` now classifies it by name.**
+> `scripts/blocking_prompt_signature.regex` recognises `native database quer(y|ies)` /
+> `requires your approval`, and the arbiter reports **`VERDICT: DIALOG_NEEDS_HUMAN`, exit 3** — checked
+> *before* the progress signature and *before* the enabled-owner exoneration, so a refresh dialog in the
+> same window cannot suppress it. Round 3 of review found exactly that suppression and it exited 0;
+> see the verdict table above.
 
 Read-only preflight (proves credentials + source reachability without changing anything):
 

--- a/.github/skills/pbip-model-refresh/SKILL.md
+++ b/.github/skills/pbip-model-refresh/SKILL.md
@@ -29,7 +29,10 @@ so `dotnet add` cannot silently no-op on a net10 default:
 - [**`scripts/probe_desktop_credential.ps1`**](scripts/probe_desktop_credential.ps1) - the arbiter a
   refresh TIMEOUT names: a UI-Automation check for a data-source sign-in modal, so "slow" and
   "blocked" are told apart by evidence, not guessed. Ships **inside** the bundle, so the instruction
-  the script prints at runtime resolves to a file that is actually here.
+  the script prints at runtime resolves to a file that is actually here. **Only `CREDENTIAL_MISSING`
+  (exit 1) is a hard stop**; everything it cannot positively identify as a credential prompt lands in
+  the exit-3 "could not probe" band (`REFRESH_IN_PROGRESS` / `DIALOG_UNRECOGNIZED` /
+  `DIALOG_UNREADABLE` / `UNKNOWN`) rather than escalating to a human — see the verdict table below.
 - [**`tests/`**](tests) - the regression suite for both, runnable from this folder
   (`pytest tests`). It is what makes the portability claim below checkable rather than aspirational.
 
@@ -133,6 +136,55 @@ stay byte-identical.
 > `BLOCKED_BY_DIALOG` (visible non-main dialog, text unreadable/non-credential). In both cases a
 > human must look at Desktop before the run proceeds. Check this first before suspecting the bridge or
 > filing an upstream defect.
+
+> ⚠️ **A big window is NOT evidence of a credential wall — the arbiter no longer says it is
+> (issue #367).** `probe_desktop_credential.ps1` used to decide "blocking" from geometry alone: any
+> visible non-main window >= 100x100 was returned as a blocking dialog and reported
+> `VERDICT: BLOCKED_BY_DIALOG`, **exit 1 — the same hard-stop band as a real credential wall**. A Power
+> BI Refresh progress dialog satisfies that trivially. Field report, 2026-08-28: running three
+> concurrent refreshes, the probe returned a blocking verdict for one unit; screenshotting the window
+> showed Power BI's own Refresh progress dialog, stalled behind a Snowflake warehouse cold start. A
+> false credential wall is expensive precisely *because* the toolkit treats a real one as a hard stop
+> that no retry may override.
+>
+> It now classifies each candidate window from **what it says**, and only `CREDENTIAL_MISSING` reaches
+> exit 1:
+>
+> | verdict | exit | what was actually observed |
+> |---|---|---|
+> | `CREDENTIAL_MISSING` | 1 | text matched `credential_modal_signature.regex`. The hard stop. |
+> | `CREDENTIAL_PRESENT` | 0 | a refresh was invoked and ran to the deadline with nothing unclassifiable up. Still not the gate of record for a serverless source — confirm with the one-row data probe. |
+> | `REFRESH_IN_PROGRESS` | 3 | a progress dialog was already up **at t=0**: another refresh owns this instance. Wait for it or cancel the stale one; do not stack a second refresh. |
+> | `DIALOG_UNRECOGNIZED` | 3 | a dialog is up whose text matched neither signature. We read it, and it is **not** a credential prompt — but we cannot say what it is. |
+> | `DIALOG_UNREADABLE` | 3 | a dialog is up that exposes no readable text at all. Deliberately distinct from `DIALOG_UNRECOGNIZED`: *absent is not empty*, and "we could not read it" is a weaker state of knowledge than "we read it and it did not match". |
+> | `UNKNOWN` | 3 | no window for the pid, a minimized owner, or no Refresh control was ever invoked. |
+>
+> **Which way it errs, and why.** A false *positive* here terminates at exit 1 and escalates to a
+> human, so nothing downstream ever runs. A false *negative* lands on `CREDENTIAL_PRESENT`, which the
+> repo already treats as untrustworthy on its own — `docs/data-source-credentials.md` records three
+> false `CREDENTIAL_PRESENT` results against a serverless warehouse, which is why the one-row data
+> probe is the gate of record. One direction has a backstop; the other does not. So this arbiter errs
+> **away from declaring a hard stop** — but never into silence: an unclassifiable dialog is *latched*
+> during the poll loop and reported at the deadline, so it can neither halt a healthy run nor be
+> erased by a quiet timeout.
+>
+> Two supporting mechanisms:
+> - **Modality is used ONE WAY.** `IsWindowEnabled(GetWindow(hwnd, GW_OWNER))` returning true proves a
+>   window blocks nothing, and exonerates it. The converse is not used: Power BI's refresh dialog also
+>   disables its owner, so a disabled owner would convict the innocent. No owner at all reports `null`
+>   — the test did not apply, which is not the same as passing it.
+> - **`scripts/benign_dialog_signature.regex`** is the progress vocabulary ("Evaluating", "N rows
+>   loaded", "Waiting for other queries"). ⚠️ It is **inferred** from Power BI's refresh UI, not
+>   captured from a live dialog, and it is deliberately not load-bearing: a miss only downgrades
+>   `REFRESH_IN_PROGRESS` to `DIALOG_UNRECOGNIZED` — both exit 3, neither a credential wall. Keep its
+>   alternatives narrow and anchored; a broad pattern here is the one way this file could hide a real
+>   modal, and `test_the_benign_signature_can_never_shadow_a_credential_prompt` gates exactly that. If
+>   you ever have a real progress dialog on screen, capture its exact text and tighten this file.
+>
+> The **Python** fast check (`_credential_modal.blocking_dialog_candidates`, used by
+> `refresh_pbip_model.py` and `probe_desktop_query.py`) still promotes any >= 100x100 non-main window
+> to `BLOCKED_BY_DIALOG` on a size-only test. That half was out of scope for #367 and is unchanged —
+> so the note above about `BLOCKED_BY_DIALOG` still describes the Python path exactly.
 
 > ⚠️ **Do not wait blindly for `NO_BRIDGE` / `not_connected` — bound the bridge wait, then prove the
 > executable by PID.** Field report, 2026-08-18, two machines: a box with two Desktop versions

--- a/.github/skills/pbip-model-refresh/SKILL.md
+++ b/.github/skills/pbip-model-refresh/SKILL.md
@@ -156,7 +156,7 @@ stay byte-identical.
 > | `CREDENTIAL_PRESENT` | 0 | a refresh was invoked and ran to the deadline with nothing unclassifiable up. Still not the gate of record for a serverless source — confirm with the one-row data probe. |
 > | `REFRESH_IN_PROGRESS` | 3 | a progress dialog was already up **at t=0**: another refresh owns this instance. Wait for it or cancel the stale one; do not stack a second refresh. |
 > | `DIALOG_UNRECOGNIZED` | 3 | a dialog is up whose text matched neither signature. We read it, and it is **not** a credential prompt — but we cannot say what it is. |
-> | `DIALOG_UNREADABLE` | 3 | a dialog is up that exposes no readable text at all. Deliberately distinct from `DIALOG_UNRECOGNIZED`: *absent is not empty*, and "we could not read it" is a weaker state of knowledge than "we read it and it did not match". |
+> | `DIALOG_UNREADABLE` | 3 | a dialog is up whose **content** could not be read — either it exposes no text at all, or its *caption* matched the progress signature while its content stayed unread. Deliberately distinct from `DIALOG_UNRECOGNIZED`: *absent is not empty*, and "we could not read it" is a weaker state of knowledge than "we read it and it did not match". |
 > | `UNKNOWN` | 3 | no window for the pid, a minimized owner, or no Refresh control was ever invoked. |
 >
 > **Which way it errs, and why.** A false *positive* here terminates at exit 1 and escalates to a
@@ -180,6 +180,40 @@ stay byte-identical.
 >   alternatives narrow and anchored; a broad pattern here is the one way this file could hide a real
 >   modal, and `test_the_benign_signature_can_never_shadow_a_credential_prompt` gates exactly that. If
 >   you ever have a real progress dialog on screen, capture its exact text and tighten this file.
+
+> ⚠️ **Win32 child-HWND text does NOT see inside a WPF dialog — and the first fix for #367 shipped a
+> silent false negative because of it.** WPF renders its entire visual tree into **one** HWND, so
+> `EnumChildWindows` harvests nothing and only the window **caption** survives. Caught in blind review
+> 2026-08-29 against a real owned WPF modal (WinForms owner, `TextBlock` reading `Enter your
+> credentials`, `ShowDialog()` disabling the owner, raised 0.8 s after Refresh is invoked):
+>
+> | build | result |
+> |---|---|
+> | first #367 fix | `refresh invoked: True` → *no credential modal within 12s* → **`CREDENTIAL_PRESENT`, exit 0** |
+> | shipped fix | `credential modal detected: 'Enter your credentials'` → **`CREDENTIAL_MISSING`, exit 1** |
+>
+> The caption was `Refresh`, which matched the benign signature; in-flight suppression then discarded
+> it and the deadline printed a clean bill of health. **A silent false negative on a hard stop is
+> strictly worse than the loud false positive #367 removed** — and note that the old size-only detector
+> caught this case *by accident*, precisely because it never read text at all. Two independent guards
+> now cover it:
+>
+> 1. **UI Automation harvest.** `Get-AutomationText` walks each candidate's UIA descendants
+>    (`Name` + `ValuePattern`) and merges them into the window's text before either signature runs. It
+>    is applied to **candidates only** — walking the main window's visual tree would cost seconds on
+>    every 2 s poll for text no classifier reads. Failure to harvest returns `$null` (distinct from
+>    `@()`, "ran and found nothing"), and both mean *content unread*.
+> 2. **The `ContentRead` gate.** A benign match on the **caption** of a window whose content was never
+>    read is reported as indeterminate (`DIALOG_UNREADABLE`), never suppressed. A **missing**
+>    `ContentRead` field fails safe to "unread". This holds even if the harvest itself breaks.
+>
+> **The joined-text rule is asymmetric, on purpose.** WPF splits one sentence across elements, so the
+> **credential** signature also searches the whitespace-normalised *join* of a window's texts (maximum
+> recall for the detector that convicts). The **benign** signature searches individual elements only.
+> Joining can manufacture a phrase — two adjacent table names reading `Account` `Key` join to the
+> signature `Account Key` — and the direction matters: on the credential path that is a **loud** false
+> stop a human resolves by looking at the screen; on the benign path it would be a **silent** false
+> clear. Never give the benign path the joined text.
 >
 > The **Python** fast check (`_credential_modal.blocking_dialog_candidates`, used by
 > `refresh_pbip_model.py` and `probe_desktop_query.py`) still promotes any >= 100x100 non-main window

--- a/.github/skills/pbip-model-refresh/SKILL.md
+++ b/.github/skills/pbip-model-refresh/SKILL.md
@@ -156,7 +156,7 @@ stay byte-identical.
 > | `CREDENTIAL_PRESENT` | 0 | a refresh was invoked and ran to the deadline with nothing unclassifiable up. Still not the gate of record for a serverless source — confirm with the one-row data probe. |
 > | `REFRESH_IN_PROGRESS` | 3 | a progress dialog was already up **at t=0**: another refresh owns this instance. Wait for it or cancel the stale one; do not stack a second refresh. |
 > | `DIALOG_UNRECOGNIZED` | 3 | a dialog is up whose text matched neither signature. We read it, and it is **not** a credential prompt — but we cannot say what it is. |
-> | `DIALOG_UNREADABLE` | 3 | a dialog is up whose **content** could not be read — either it exposes no text at all, or its *caption* matched the progress signature while its content stayed unread. Deliberately distinct from `DIALOG_UNRECOGNIZED`: *absent is not empty*, and "we could not read it" is a weaker state of knowledge than "we read it and it did not match". |
+> | `DIALOG_UNREADABLE` | 3 | a dialog is up that could not be **shown to be harmless**: no text at all, or only a reassuring **caption**, or benign-looking content read from an **incomplete** harvest (truncated, timed out, or a pattern that threw). Deliberately distinct from `DIALOG_UNRECOGNIZED`: *absent is not empty*, and "we could not establish it" is a weaker state of knowledge than "we read it and it did not match". |
 > | `UNKNOWN` | 3 | no window for the pid, a minimized owner, or no Refresh control was ever invoked. |
 >
 > **Which way it errs, and why.** A false *positive* here terminates at exit 1 and escalates to a
@@ -181,39 +181,61 @@ stay byte-identical.
 >   modal, and `test_the_benign_signature_can_never_shadow_a_credential_prompt` gates exactly that. If
 >   you ever have a real progress dialog on screen, capture its exact text and tighten this file.
 
-> ⚠️ **Win32 child-HWND text does NOT see inside a WPF dialog — and the first fix for #367 shipped a
-> silent false negative because of it.** WPF renders its entire visual tree into **one** HWND, so
-> `EnumChildWindows` harvests nothing and only the window **caption** survives. Caught in blind review
-> 2026-08-29 against a real owned WPF modal (WinForms owner, `TextBlock` reading `Enter your
-> credentials`, `ShowDialog()` disabling the owner, raised 0.8 s after Refresh is invoked):
+> ⚠️ **Win32 child-HWND text does NOT see inside a WPF dialog — and the burden of proof runs ONE WAY.**
+> WPF renders its entire visual tree into **one** HWND, so `EnumChildWindows` harvests nothing and only
+> the window **caption** survives. Two blind-review rounds on 2026-08-29 found two different silent
+> false negatives here, and the second was worse than the first:
+>
+> | attempt | rule | how it broke |
+> |---|---|---|
+> | 1 | benign by **caption** | a WPF modal captioned `Refresh` whose content read `Enter your credentials` → suppressed → **`CREDENTIAL_PRESENT`, exit 0** |
+> | 2 | benign by caption **+ "we harvested some text"** | a `Cancel` button satisfied that. Beaten three ways: `TextPattern`-only content, content past the element cap, and a split defeated by an interposed element |
+>
+> Round 2's root cause is the lesson: `ContentRead` was a **proxy** for *"we read the credential-bearing
+> content"*, and **no proxy can carry that weight**. A silent false negative on a hard stop is strictly
+> worse than the loud false positive #367 removed — and note the old size-only detector caught all of
+> this *by accident*, precisely because it never trusted text it had not read.
+>
+> **The rule now: a dialog is suppressed only when we POSITIVELY READ benign CONTENT** — never because
+> we read *something* and the caption looked reassuring. Measured, same owned WPF modal:
 >
 > | build | result |
 > |---|---|
-> | first #367 fix | `refresh invoked: True` → *no credential modal within 12s* → **`CREDENTIAL_PRESENT`, exit 0** |
-> | shipped fix | `credential modal detected: 'Enter your credentials'` → **`CREDENTIAL_MISSING`, exit 1** |
+> | before | `refresh invoked: True` → *no credential modal within 12s* → **`CREDENTIAL_PRESENT`, exit 0** |
+> | now | `credential modal detected: 'Enter your credentials'` → **`CREDENTIAL_MISSING`, exit 1** |
 >
-> The caption was `Refresh`, which matched the benign signature; in-flight suppression then discarded
-> it and the deadline printed a clean bill of health. **A silent false negative on a hard stop is
-> strictly worse than the loud false positive #367 removed** — and note that the old size-only detector
-> caught this case *by accident*, precisely because it never read text at all. Two independent guards
-> now cover it:
+> Four mechanisms, each doing one job:
 >
-> 1. **UI Automation harvest.** `Get-AutomationText` walks each candidate's UIA descendants
->    (`Name` + `ValuePattern`) and merges them into the window's text before either signature runs. It
->    is applied to **candidates only** — walking the main window's visual tree would cost seconds on
->    every 2 s poll for text no classifier reads. Failure to harvest returns `$null` (distinct from
->    `@()`, "ran and found nothing"), and both mean *content unread*.
-> 2. **The `ContentRead` gate.** A benign match on the **caption** of a window whose content was never
->    read is reported as indeterminate (`DIALOG_UNREADABLE`), never suppressed. A **missing**
->    `ContentRead` field fails safe to "unread". This holds even if the harvest itself breaks.
+> 1. **UIA harvest** — `Get-AutomationHarvest` reads `Name`, `ValuePattern` **and `TextPattern`** for
+>    every candidate's descendants. `TextPattern` is not optional: a read-only `RichTextBox` with an
+>    **empty `Name`** exposes its text only there. ⚠️ `LegacyIAccessiblePattern` is **not available** —
+>    the type does not exist in the managed `System.Windows.Automation` API (verified; it is UIA-COM
+>    only), so MSAA-bridged-only content is unreadable from here. That gap is survivable *only* because
+>    completeness is never assumed.
+> 2. **`HarvestComplete`, and it must be a real Boolean.** Truncated by the element cap, timed out, or
+>    any pattern read that threw → not complete → benign-looking content is reported
+>    `DIALOG_UNREADABLE`, not suppressed. `-eq $true` is **coercive**: integer `1` and the string
+>    `"true"` both passed it and both cleared a window in review. The test is
+>    `($v -is [bool]) -and $v`.
+> 3. **A killable child process per harvest.** `FindAll` is a synchronous cross-process COM call —
+>    `try/catch` cannot interrupt it and neither can a background thread. Measured against a modal
+>    sleeping 120 s on its own UI thread: **6.2 s bounded vs 70.5 s in-process**, same verdict both
+>    times. The defect was purely the budget, so only a *time* assertion can see it.
+> 4. **The prose join skips interactive elements.** WPF splits a sentence across elements, and an
+>    interposed `Cancel` button between `Enter your` and `credentials` defeated a naive whole-window
+>    join.
 >
-> **The joined-text rule is asymmetric, on purpose.** WPF splits one sentence across elements, so the
-> **credential** signature also searches the whitespace-normalised *join* of a window's texts (maximum
-> recall for the detector that convicts). The **benign** signature searches individual elements only.
-> Joining can manufacture a phrase — two adjacent table names reading `Account` `Key` join to the
-> signature `Account Key` — and the direction matters: on the credential path that is a **loud** false
-> stop a human resolves by looking at the screen; on the benign path it would be a **silent** false
-> clear. Never give the benign path the joined text.
+> **The join stays asymmetric, on purpose.** The **credential** signature reads individual elements
+> *and* the prose join (maximum recall for the detector that convicts). The **benign** signature reads
+> individual **content** elements only — never the caption, never a join. Joining can manufacture a
+> phrase — two adjacent table names reading `Account` `Key` join to the signature `Account Key` — and
+> the direction matters: on the credential path that is a **loud** false stop a human resolves by
+> looking at the screen; on the benign path it would be a **silent** false clear.
+>
+> **The net effect is deliberately conservative.** Every uncertainty — unread content, a truncated
+> harvest, a wedged provider, an unknown field type — lands in the exit-3 band, which is loud and
+> recoverable. A mostly-conservative arbiter with a narrow proven-benign path is a better artifact than
+> a clever one with a residual silent clear.
 >
 > The **Python** fast check (`_credential_modal.blocking_dialog_candidates`, used by
 > `refresh_pbip_model.py` and `probe_desktop_query.py`) still promotes any >= 100x100 non-main window

--- a/.github/skills/pbip-model-refresh/scripts/benign_dialog_signature.regex
+++ b/.github/skills/pbip-model-refresh/scripts/benign_dialog_signature.regex
@@ -1,1 +1,1 @@
-^Refresh$|^Refreshing\b|\bEvaluating\b|\bWaiting for other queries\b|\b\d[\d,\. ]*rows?\s+loaded\b|\bLoading data\b|\bPreparing to load\b
+^Refresh$|^Refreshing[\s\.]*$|^Evaluating[\s\.]*$|^Waiting for other queries[\s\.]*$|^\d[\d,\. ]*rows?\s+loaded[\s\.]*$|^Loading data[\s\.]*$|^Preparing to load[\s\.]*$

--- a/.github/skills/pbip-model-refresh/scripts/benign_dialog_signature.regex
+++ b/.github/skills/pbip-model-refresh/scripts/benign_dialog_signature.regex
@@ -1,0 +1,1 @@
+^Refresh$|^Refreshing\b|\bEvaluating\b|\bWaiting for other queries\b|\b\d[\d,\. ]*rows?\s+loaded\b|\bLoading data\b|\bPreparing to load\b

--- a/.github/skills/pbip-model-refresh/scripts/blocking_prompt_signature.regex
+++ b/.github/skills/pbip-model-refresh/scripts/blocking_prompt_signature.regex
@@ -1,0 +1,1 @@
+native database quer(?:y|ies)|requires your approval|Authentication (?:is )?required

--- a/.github/skills/pbip-model-refresh/scripts/probe_desktop_credential.ps1
+++ b/.github/skills/pbip-model-refresh/scripts/probe_desktop_credential.ps1
@@ -55,10 +55,11 @@
     exit 3  DIALOG_UNRECOGNIZED  a dialog is up whose text matched NEITHER signature. We read it and
                                  it is not a credential prompt - so it is not a credential wall - but
                                  we cannot say what it is. A human should look at the screen.
-    exit 3  DIALOG_UNREADABLE    a dialog is up that exposes NO readable text at all. Distinct from
-                                 DIALOG_UNRECOGNIZED on purpose: "we could not read it" is a weaker
-                                 state of knowledge than "we read it and it did not match", and the
-                                 two must not collapse into one verdict.
+    exit 3  DIALOG_UNREADABLE    a dialog is up whose CONTENT could not be read - either it exposes no
+                                 text at all, or its caption matched the progress signature while its
+                                 content stayed unread. Distinct from DIALOG_UNRECOGNIZED on purpose:
+                                 "we could not read it" is a weaker state of knowledge than "we read
+                                 it and it did not match", and the two must not collapse into one.
 
   ⚠️ `BLOCKED_BY_DIALOG` is deliberately NOT emitted here any more (issue #367). It used to be, on a
   size-only test - ANY visible non-main window >=100x100 - which a Power BI Refresh progress dialog
@@ -97,12 +98,37 @@ $sig = (Get-Content -LiteralPath (Join-Path $PSScriptRoot 'credential_modal_sign
 # this file could hide a genuine blocker.
 $benignSig = (Get-Content -LiteralPath (Join-Path $PSScriptRoot 'benign_dialog_signature.regex') -Raw).Trim()
 
+function Get-NormalizedText {
+  <# Whitespace-normalised, de-duplicated window text, optionally plus a JOINED variant.
+
+  The joined variant exists because a WPF dialog splits one sentence across several visual elements,
+  so `Enter your credentials` can arrive as `Enter your` + `credentials` and match neither fragment.
+
+  ⚠️ It is applied ASYMMETRICALLY, and that is the whole point: the credential signature searches the
+  joined text (broadest possible recall for the detector that CONVICTS), while the benign signature
+  searches the individual elements only (narrowest possible reach for the detector that EXONERATES).
+  Joining can in principle manufacture a phrase - two adjacent table names reading `Account` `Key`
+  would join to the signature `Account Key` - and the direction that error takes matters: on the
+  credential path it produces a LOUD false stop a human resolves by looking at the screen, whereas on
+  the benign path it would produce a SILENT false clear. Never give the benign path the joined text.
+  #>
+  param([object[]]$Texts, [switch]$IncludeJoined)
+  $clean = @()
+  foreach ($t in $Texts) {
+    if ($null -eq $t) { continue }
+    $normalized = (([string]$t) -replace '\s+', ' ').Trim()
+    if ($normalized -and ($clean -notcontains $normalized)) { $clean += $normalized }
+  }
+  if ($IncludeJoined -and $clean.Count -gt 1) { $clean += ($clean -join ' ') }
+  return $clean
+}
+
 function Test-CredentialModal {
   <# First matching credential-signature text across EVERY window, any class, any size. #>
   param([object[]]$Windows)
   foreach ($w in $Windows) {
-    foreach ($n in $w.Texts) {
-      if ($n -and $n -match $sig) { return $n }
+    foreach ($n in (Get-NormalizedText -Texts $w.Texts -IncludeJoined)) {
+      if ($n -match $sig) { return $n }
     }
   }
   return $null
@@ -129,42 +155,57 @@ function Get-DialogClassification {
   <# Classify ONE candidate window from what it says, and from whether it disables its owner.
 
   Kinds, in the order they are tested:
-    credential    text matched the credential signature -> the hard stop.
-    benign        text matched the progress signature   -> Power BI is working.
-    non-blocking  the owner window is ENABLED. Modality is a ONE-WAY test: a modal dialog disables its
-                  owner, so an enabled owner PROVES this window is not blocking anything. The converse
-                  does not hold - Power BI's refresh dialog also disables the owner - so a disabled
-                  owner is never used to convict. `$null` (no owner at all) proves nothing either way.
-    unreadable    no readable text at all: we could not classify it.
-    unrecognized  readable text that matched neither signature: we looked, and it is not a credential
-                  prompt. Distinct from `unreadable` on purpose - absent is not empty.
+    credential        text matched the credential signature -> the hard stop. Searched over the JOINED
+                      text too, so a signature split across WPF elements still convicts.
+    benign            a text ELEMENT matched the progress signature AND the window's content was
+                      actually read -> Power BI is working.
+    benign-title-only the progress signature matched, but `ContentRead` is not `$true`: the caption
+                      says "Refresh" and the CONTENT was never read. Reported as indeterminate, not
+                      suppressed. This is the review defect of 2026-08-29: a WPF modal titled
+                      `Refresh` whose visual content read `Enter your credentials` was classified
+                      benign from its caption, suppressed in flight, and the probe exited 0 -
+                      a SILENT false negative on a hard stop, strictly worse than the false positive
+                      #367 set out to remove. `absent != empty`, one level down: content we did not
+                      read cannot be evidence of harmlessness.
+    non-blocking      the owner window is ENABLED. Modality is a ONE-WAY test: a modal dialog disables
+                      its owner, so an enabled owner PROVES this window is not blocking anything. The
+                      converse does not hold - Power BI's refresh dialog also disables the owner - so a
+                      disabled owner is never used to convict. `$null` (no owner) proves nothing.
+    unreadable        no readable text at all: we could not classify it.
+    unrecognized      readable text that matched neither signature: we looked, and it is not a
+                      credential prompt. Distinct from `unreadable` on purpose - absent is not empty.
   #>
   param([Parameter(Mandatory = $true)][object]$Window)
 
-  $texts = @()
-  if ($null -ne $Window.Texts) {
-    $texts = @($Window.Texts | Where-Object { $_ -and $_.Trim() })
-  }
-  foreach ($t in $texts) {
+  $elements = Get-NormalizedText -Texts $Window.Texts
+  $searchable = Get-NormalizedText -Texts $Window.Texts -IncludeJoined
+  foreach ($t in $searchable) {
     if ($t -match $sig) { return [pscustomobject]@{ Kind = 'credential'; Evidence = $t } }
   }
-  foreach ($t in $texts) {
-    if ($t -match $benignSig) { return [pscustomobject]@{ Kind = 'benign'; Evidence = $t } }
+  foreach ($t in $elements) {
+    if ($t -match $benignSig) {
+      # `$null`/missing ContentRead fails SAFE: a window whose collector never said it read the
+      # content is treated as unread, so a synthesised or future window shape cannot silently
+      # re-open the suppression path.
+      if ($Window.ContentRead -eq $true) { return [pscustomobject]@{ Kind = 'benign'; Evidence = $t } }
+      return [pscustomobject]@{ Kind = 'benign-title-only'; Evidence = $t }
+    }
   }
   if ($Window.OwnerEnabled -eq $true) {
     return [pscustomobject]@{ Kind = 'non-blocking'; Evidence = 'owner window is enabled' }
   }
-  if ($texts.Count -eq 0) {
+  if ($elements.Count -eq 0) {
     return [pscustomobject]@{ Kind = 'unreadable'; Evidence = '' }
   }
-  return [pscustomobject]@{ Kind = 'unrecognized'; Evidence = $texts[0] }
+  return [pscustomobject]@{ Kind = 'unrecognized'; Evidence = $elements[0] }
 }
 
 function Format-DialogEvidence {
   <# One-line window description for a verdict line. #>
   param([object]$Window)
   $title = if ($Window.Title) { $Window.Title } else { '(empty title)' }
-  return ("class={0} title='{1}' size={2}x{3}" -f $Window.ClassName, $title, $Window.Width, $Window.Height)
+  $read = if ($Window.ContentRead -eq $true) { 'read' } else { 'UNREAD' }
+  return ("class={0} title='{1}' size={2}x{3} content={4}" -f $Window.ClassName, $title, $Window.Width, $Window.Height, $read)
 }
 
 function Get-DialogVerdict {
@@ -177,6 +218,9 @@ function Get-DialogVerdict {
       outrank a window we could not classify - otherwise one progress dialog masks a real modal.
     * `unreadable` outranks `unrecognized` because it is the weaker state of knowledge, and the weaker
       state is the one that must stay visible.
+    * `benign-title-only` joins the `unreadable` band, NOT the benign one. Its content was never read,
+      so it is an indeterminate wearing a reassuring caption - and it is the one shape that must not be
+      suppressible, because suppression is what turned a real credential modal into exit 0.
 
   `-RefreshInFlight` is set only inside the poll loop, i.e. after THIS script invoked the refresh.
   There, a progress dialog is our own and is ignored. At t=0 it is somebody else's, and stacking a
@@ -197,6 +241,7 @@ function Get-DialogVerdict {
         return $found
       }
       'unreadable' { if ($null -eq $unreadable) { $found.Verdict = 'DIALOG_UNREADABLE'; $unreadable = $found } }
+      'benign-title-only' { if ($null -eq $unreadable) { $found.Verdict = 'DIALOG_UNREADABLE'; $unreadable = $found } }
       'unrecognized' { if ($null -eq $unrecognized) { $found.Verdict = 'DIALOG_UNRECOGNIZED'; $unrecognized = $found } }
       'benign' { if ($null -eq $benign) { $found.Verdict = 'REFRESH_IN_PROGRESS'; $benign = $found } }
       default { }
@@ -298,10 +343,94 @@ public static class Win32CredentialWindows {
 $root = [System.Windows.Automation.AutomationElement]::RootElement
 $cond = New-Object System.Windows.Automation.PropertyCondition([System.Windows.Automation.AutomationElement]::ProcessIdProperty, $DesktopPid)
 
+function Get-AutomationText {
+  <# UI Automation descendant Name/Value text for one HWND, or `$null` if the harvest FAILED.
+
+  Win32 `EnumChildWindows` is not enough and this is not a corner case: WPF renders its visual tree
+  into ONE HWND, so a WPF dialog's entire content is invisible to child-HWND enumeration and only its
+  caption survives. Measured 2026-08-29 in review - an owned WPF modal titled `Refresh` containing
+  `Enter your credentials` read as a progress dialog and the probe exited 0. UI Automation sees that
+  text; a UIA dump of the same window returned `DescendantNames: Enter your credentials`.
+
+  Three distinct outcomes, kept distinct on purpose: `$null` = the harvest could not run, `@()` = it
+  ran and the window genuinely exposes nothing, a populated array = content. The caller turns the
+  first two into "content unread", which is an indeterminate, never a clean bill of health.
+  #>
+  param([long]$Hwnd, [int]$MaxElements = 400)
+  $texts = @()
+  try {
+    $element = [System.Windows.Automation.AutomationElement]::FromHandle([IntPtr]$Hwnd)
+    if ($null -eq $element) { return $null }
+    $descendants = $element.FindAll(
+      [System.Windows.Automation.TreeScope]::Descendants,
+      [System.Windows.Automation.Condition]::TrueCondition)
+    $seen = 0
+    foreach ($d in $descendants) {
+      if ($seen -ge $MaxElements) { break }
+      $seen++
+      try {
+        if ($d.Current.Name) { $texts += $d.Current.Name }
+        $pattern = $null
+        if ($d.TryGetCurrentPattern([System.Windows.Automation.ValuePattern]::Pattern, [ref]$pattern)) {
+          if ($pattern.Current.Value) { $texts += $pattern.Current.Value }
+        }
+      } catch {
+        # One unreachable element must not discard the text already harvested from its siblings.
+        continue
+      }
+    }
+  } catch {
+    return $null
+  }
+  return , $texts
+}
+
+function ConvertTo-ProbeWindow {
+  <# Win32 `WindowInfo` -> the plain window object the pure classifiers consume.
+
+  `ContentRead` is the field the classifiers gate the benign path on: it is true only when text was
+  obtained that is NOT merely the window caption - a Win32 child text (WinForms dialogs expose those)
+  or a UIA descendant. A caption on its own can never establish that a dialog is harmless.
+  #>
+  param([object]$Window, [switch]$Enrich)
+  $title = [string]$Window.Title
+  $texts = @()
+  foreach ($t in $Window.Texts) { if ($t) { $texts += [string]$t } }
+  $contentRead = @($texts | Where-Object { $_ -ne $title }).Count -gt 0
+  if ($Enrich) {
+    $hwnd = if ($Window.Hwnd -is [IntPtr]) { $Window.Hwnd.ToInt64() } else { [long]$Window.Hwnd }
+    $harvested = Get-AutomationText -Hwnd $hwnd
+    if ($null -ne $harvested) {
+      foreach ($t in $harvested) { if ($t -and ($texts -notcontains $t)) { $texts += [string]$t } }
+      if (@($harvested | Where-Object { $_ -and $_ -ne $title }).Count -gt 0) { $contentRead = $true }
+    }
+  }
+  return [pscustomobject]@{
+    Hwnd         = $Window.Hwnd
+    Title        = $title
+    ClassName    = [string]$Window.ClassName
+    Width        = [int]$Window.Width
+    Height       = [int]$Window.Height
+    Minimized    = [bool]$Window.Minimized
+    OwnerEnabled = $Window.OwnerEnabled
+    Texts        = $texts
+    ContentRead  = $contentRead
+  }
+}
+
 function Get-PidWindows {
   # EVERY visible top-level/owned window of the target process, not UIA RootElement children. A
   # Power BI credential modal is an owned window; UIA root-child discovery misses it.
-  return [Win32CredentialWindows]::GetPidWindows($DesktopPid)
+  #
+  # The UIA text harvest is applied to CANDIDATE windows only. Walking the main Power BI window's
+  # visual tree would cost seconds per poll for text the classifiers never read (it is excluded by
+  # class), and this loop runs every 2s.
+  $enriched = @()
+  foreach ($w in [Win32CredentialWindows]::GetPidWindows($DesktopPid)) {
+    $isCandidate = @(Select-DialogCandidate -Windows @($w)).Count -eq 1
+    $enriched += (ConvertTo-ProbeWindow -Window $w -Enrich:$isCandidate)
+  }
+  return $enriched
 }
 
 $windows = Get-PidWindows
@@ -324,9 +453,10 @@ if ($blocker) {
   if ($blocker.Evidence) {
     Write-Output ("  matched text: '{0}'" -f $blocker.Evidence.Substring(0, [Math]::Min(80, $blocker.Evidence.Length)))
   }
-  switch ($blocker.Verdict) {
-    'REFRESH_IN_PROGRESS' { Write-Output "  a refresh is already running on this pid - wait for it, or cancel the stale one; do not stack a second refresh on it" }
-    'DIALOG_UNREADABLE' { Write-Output "  this window exposes no readable text, so it could not be classified at all - look at the Desktop screen" }
+  switch ($blocker.Kind) {
+    'benign' { Write-Output "  a refresh is already running on this pid - wait for it, or cancel the stale one; do not stack a second refresh on it" }
+    'benign-title-only' { Write-Output "  its CAPTION looks like a progress dialog, but its content could not be read - an unread window is not evidence that it is harmless; look at the Desktop screen" }
+    'unreadable' { Write-Output "  this window exposes no readable text, so it could not be classified at all - look at the Desktop screen" }
     default { Write-Output "  its text matches no credential-prompt signature, so this is not a credential wall - look at the Desktop screen" }
   }
   Write-Output ("VERDICT: {0}" -f $blocker.Verdict)

--- a/.github/skills/pbip-model-refresh/scripts/probe_desktop_credential.ps1
+++ b/.github/skills/pbip-model-refresh/scripts/probe_desktop_credential.ps1
@@ -64,12 +64,19 @@
     exit 3  UNKNOWN              no window for the pid, a minimized owner, or no Refresh control was
                                  ever invoked (with nothing invoked, "no modal appeared" proves
                                  nothing - reporting PRESENT would be a fail-open arbiter).
-    exit 3  REFRESH_IN_PROGRESS  a dialog whose CONTENT positively reads as refresh progress was
-                                 already up at t=0. Desktop is busy, so the credential state cannot be
-                                 probed; wait for it, or cancel the stale refresh.
-    exit 3  DIALOG_UNRECOGNIZED  a dialog is up whose text matched NEITHER signature. We read it and
-                                 it is not a credential prompt - so it is not a credential wall - but
-                                 we cannot say what it is. A human should look at the screen.
+    exit 3  REFRESH_IN_PROGRESS  a dialog whose CONTENT positively reads as refresh progress - all of
+                                 it, not just its first element - was already up at t=0. Desktop is
+                                 busy, so the credential state cannot be probed; wait for it, or
+                                 cancel the stale refresh.
+    exit 3  DIALOG_NEEDS_HUMAN   a KNOWN human-blocking prompt that is not a credential prompt - the
+                                 native database query approval modal above all. Not exit 1, because
+                                 the remedy is an approval, not a sign-in. Never suppressed, and it
+                                 outranks any progress text in the same window.
+    exit 3  DIALOG_UNRECOGNIZED  a dialog is up whose text matched NO signature, or which shows
+                                 progress text ALONGSIDE prose that is not progress status. We read it
+                                 and it is not a credential prompt - so it is not a credential wall -
+                                 but we cannot account for all of it. A human should look at the
+                                 screen.
     exit 3  DIALOG_UNREADABLE    a dialog is up that could not be shown to be harmless: no text at
                                  all, or only a reassuring CAPTION, or benign-looking content read
                                  from an INCOMPLETE harvest. "We could not establish it" is a weaker
@@ -135,6 +142,20 @@ $sig = (Get-Content -LiteralPath (Join-Path $PSScriptRoot 'credential_modal_sign
 # see SKILL.md. Keep the alternatives narrow and anchored: this is the only file that can cause a
 # dialog to be ignored, so a broad pattern here is the one way to hide a genuine blocker.
 $benignSig = (Get-Content -LiteralPath (Join-Path $PSScriptRoot 'benign_dialog_signature.regex') -Raw).Trim()
+
+# Prompts that are KNOWN to need a human but are NOT credential prompts - the native-database-query
+# approval modal above all. Migrated custom-SQL sources emit exactly the shape that triggers it, and
+# SKILL.md's standing instruction is to check for it before concluding anything about credentials; a
+# probe that suppressed it would make this bundle contradict its own documentation. Matched BEFORE
+# benign, so one progress element in the same window cannot erase it (review round 3).
+$blockingSig = (Get-Content -LiteralPath (Join-Path $PSScriptRoot 'blocking_prompt_signature.regex') -Raw).Trim()
+
+# A content element with at least this many words is PROSE - something written to be read by a human.
+# If it is not itself a recognised progress status, it is unaccounted for, and a window with
+# unaccounted prose is not provably a progress dialog however much progress text sits beside it.
+# This is the backstop for prompts that are in NEITHER signature; the cost of it firing wrongly is one
+# more exit 3, which is loud and recoverable.
+$MinPromptWords = 5
 
 function Get-NormalizedText {
   <# Whitespace-normalised, de-duplicated, order-preserving text. #>
@@ -221,19 +242,29 @@ function Get-DialogClassification {
 
   Kinds, in the order they are tested:
     credential        the credential signature matched a text element or the prose join -> hard stop.
-    benign            the benign signature matched CONTENT (not the caption) AND the harvest completed
-                      -> Power BI is working. The one suppressible kind.
-    benign-unverified the benign signature matched content, but the harvest was truncated, timed out,
-                      or hit a pattern it could not read. Benign-LOOKING is not benign.
+    needs-human       a KNOWN human-blocking prompt that is not a credential prompt - the native
+                      database query approval modal. Exit 3, not 1: a human must act, but the remedy
+                      is an approval, not a sign-in.
+    mixed-content     progress text AND unaccounted prose in the same window. Round 3's defect: the
+                      FIRST content element matching the benign regex used to classify the whole
+                      window, so `Evaluating` beside
+                      `Permission is required to run this native database query` cleared it at exit 0.
+                      The entire content is now scanned before benign can be concluded.
+    benign            every content element is either recognised progress status or too short to be a
+                      human-directed prompt, at least one IS progress status, AND the harvest
+                      completed -> Power BI is working. The one suppressible kind.
+    benign-unverified as `benign`, but the harvest was truncated, timed out, or hit a pattern it could
+                      not read. Benign-LOOKING is not benign.
     non-blocking      the owner window is ENABLED. Modality is a ONE-WAY test: a modal dialog disables
                       its owner, so an enabled owner PROVES this window blocks nothing. The converse
                       does not hold - Power BI's refresh dialog also disables the owner - so a disabled
-                      owner never convicts. `$null` (no owner) proves nothing either way.
+                      owner never convicts. `$null` (no owner) proves nothing either way. It is tested
+                      AFTER `needs-human` on purpose: a known blocking prompt outranks the exoneration.
     benign-title-only the CAPTION matched the benign signature and no content did. A caption is not
                       content.
     unreadable        no readable text at all.
-    unrecognized      readable text that matched neither signature: we looked, and it is not a
-                      credential prompt. Distinct from `unreadable` on purpose - absent is not empty.
+    unrecognized      readable text that matched no signature: we looked, and it is not a credential
+                      prompt. Distinct from `unreadable` on purpose - absent is not empty.
 
   Everything except `credential` and `benign` lands in the exit-3 band, so the failure mode of every
   uncertainty here is a LOUD stop-and-look, never a silent clear.
@@ -244,13 +275,29 @@ function Get-DialogClassification {
   foreach ($t in $sets.Search) {
     if ($t -match $sig) { return [pscustomobject]@{ Kind = 'credential'; Evidence = $t } }
   }
+  foreach ($t in $sets.Search) {
+    if ($t -match $blockingSig) { return [pscustomobject]@{ Kind = 'needs-human'; Evidence = $t } }
+  }
+
+  # Scan ALL of the content. A first-match-wins loop let one benign element erase everything after it.
+  $benignHit = $null
+  $unaccounted = $null
   foreach ($t in $sets.Content) {
     if ($t -match $benignSig) {
-      if (Test-HarvestComplete -Value $Window.HarvestComplete) {
-        return [pscustomobject]@{ Kind = 'benign'; Evidence = $t }
-      }
-      return [pscustomobject]@{ Kind = 'benign-unverified'; Evidence = $t }
+      if ($null -eq $benignHit) { $benignHit = $t }
+      continue
     }
+    if ($null -eq $unaccounted) {
+      $words = @($t -split '\s+' | Where-Object { $_ })
+      if ($words.Count -ge $MinPromptWords) { $unaccounted = $t }
+    }
+  }
+  if ($benignHit) {
+    if ($unaccounted) { return [pscustomobject]@{ Kind = 'mixed-content'; Evidence = $unaccounted } }
+    if (Test-HarvestComplete -Value $Window.HarvestComplete) {
+      return [pscustomobject]@{ Kind = 'benign'; Evidence = $benignHit }
+    }
+    return [pscustomobject]@{ Kind = 'benign-unverified'; Evidence = $benignHit }
   }
   if ($Window.OwnerEnabled -eq $true) {
     return [pscustomobject]@{ Kind = 'non-blocking'; Evidence = 'owner window is enabled' }
@@ -262,6 +309,36 @@ function Get-DialogClassification {
     return [pscustomobject]@{ Kind = 'unreadable'; Evidence = '' }
   }
   return [pscustomobject]@{ Kind = 'unrecognized'; Evidence = $sets.All[0] }
+}
+
+function ConvertTo-HarvestResult {
+  <# Validate a harvest child's payload before any of it is believed.
+
+  Round 3's MEDIUM, and the third instance on this branch of MISSING EVIDENCE READ AS GOOD EVIDENCE:
+  the parent checked only that the payload was valid JSON, then computed
+  `(-not $p.Truncated) -and (-not $p.PatternsIncomplete)`. A missing property is `$null`, and
+  `-not $null` is `$true`, so a well-formed-but-schema-incomplete payload became
+  `HarvestComplete = $true` - a real Boolean, which then sailed through the strict
+  `Test-HarvestComplete` guard because the coercion had already happened upstream of it.
+
+  Both flags must EXIST and be actual Booleans, and the child must have exited 0. Items are still
+  merged when they are present and the flags are not - unread text lowers credential recall, so
+  keeping it costs nothing and can only help - but `Complete` stays `$false`, so a malformed payload
+  can never authorise suppression.
+  #>
+  param([object]$Payload, [int]$ExitCode)
+
+  if ($ExitCode -ne 0 -or $null -eq $Payload) { return $null }
+  $properties = $Payload.PSObject.Properties
+  $hasTruncated = $null -ne $properties['Truncated']
+  $hasPatterns = $null -ne $properties['PatternsIncomplete']
+  $truncated = if ($hasTruncated) { $Payload.Truncated } else { $null }
+  $patterns = if ($hasPatterns) { $Payload.PatternsIncomplete } else { $null }
+  $schemaOk = $hasTruncated -and $hasPatterns -and ($truncated -is [bool]) -and ($patterns -is [bool])
+  $items = @()
+  if ($null -ne $properties['Items'] -and $null -ne $Payload.Items) { $items = @($Payload.Items) }
+  $complete = $schemaOk -and (-not $truncated) -and (-not $patterns)
+  return [pscustomobject]@{ Items = $items; Complete = [bool]$complete }
 }
 
 function Format-DialogEvidence {
@@ -292,6 +369,7 @@ function Get-DialogVerdict {
   #>
   param([object[]]$Windows, [switch]$RefreshInFlight)
 
+  $needsHuman = $null
   $unreadable = $null
   $unrecognized = $null
   $benign = $null
@@ -304,14 +382,17 @@ function Get-DialogVerdict {
         $found.ExitCode = 1
         return $found
       }
+      'needs-human' { if ($null -eq $needsHuman) { $found.Verdict = 'DIALOG_NEEDS_HUMAN'; $needsHuman = $found } }
       'unreadable' { if ($null -eq $unreadable) { $found.Verdict = 'DIALOG_UNREADABLE'; $unreadable = $found } }
       'benign-unverified' { if ($null -eq $unreadable) { $found.Verdict = 'DIALOG_UNREADABLE'; $unreadable = $found } }
       'benign-title-only' { if ($null -eq $unreadable) { $found.Verdict = 'DIALOG_UNREADABLE'; $unreadable = $found } }
+      'mixed-content' { if ($null -eq $unrecognized) { $found.Verdict = 'DIALOG_UNRECOGNIZED'; $unrecognized = $found } }
       'unrecognized' { if ($null -eq $unrecognized) { $found.Verdict = 'DIALOG_UNRECOGNIZED'; $unrecognized = $found } }
       'benign' { if ($null -eq $benign) { $found.Verdict = 'REFRESH_IN_PROGRESS'; $benign = $found } }
       default { }
     }
   }
+  if ($null -ne $needsHuman) { return $needsHuman }
   if ($null -ne $unreadable) { return $unreadable }
   if ($null -ne $unrecognized) { return $unrecognized }
   if ($null -ne $benign -and -not $RefreshInFlight) { return $benign }
@@ -517,7 +598,10 @@ function Get-BoundedAutomationHarvest {
     if (-not $raw) { return $null }
     $line = @($raw -split "`r?`n" | Where-Object { $_ -like 'HARVEST:*' })
     if ($line.Count -eq 0) { return $null }
-    return ConvertFrom-Json $line[0].Substring(8)
+    $payload = $null
+    try { $payload = ConvertFrom-Json $line[0].Substring(8) } catch { return $null }
+    # Valid JSON is not a valid payload. Schema and exit code are checked before anything is believed.
+    return ConvertTo-HarvestResult -Payload $payload -ExitCode $child.ExitCode
   } catch {
     return $null
   } finally {
@@ -543,7 +627,7 @@ function ConvertTo-ProbeWindow {
         $texts += [string]$item.Text
         if ($item.Interactive) { $interactive += [string]$item.Text }
       }
-      $complete = (-not $harvested.Truncated) -and (-not $harvested.PatternsIncomplete)
+      $complete = [bool]$harvested.Complete
     }
   }
   return [pscustomobject]@{
@@ -597,6 +681,8 @@ if ($blocker) {
   }
   switch ($blocker.Kind) {
     'benign' { Write-Output "  a refresh is already running on this pid - wait for it, or cancel the stale one; do not stack a second refresh on it" }
+    'needs-human' { Write-Output "  this is a known human-blocking prompt (e.g. native database query approval), NOT a credential prompt - approve it at the Desktop screen; no sign-in is implied" }
+    'mixed-content' { Write-Output "  it shows refresh progress AND prose that is not progress status - a progress dialog does not explain the rest of this window; look at the Desktop screen" }
     'benign-unverified' { Write-Output "  its content LOOKS like refresh progress, but the read was truncated or incomplete - benign-looking is not benign; look at the Desktop screen" }
     'benign-title-only' { Write-Output "  its CAPTION looks like a progress dialog, but no content confirmed it - a caption is not content; look at the Desktop screen" }
     'unreadable' { Write-Output "  this window exposes no readable text, so it could not be classified at all - look at the Desktop screen" }

--- a/.github/skills/pbip-model-refresh/scripts/probe_desktop_credential.ps1
+++ b/.github/skills/pbip-model-refresh/scripts/probe_desktop_credential.ps1
@@ -32,19 +32,183 @@
   How long to wait for the credential modal after triggering refresh. Default 75s; use >=60s because a
   serverless warehouse (e.g. Databricks) can cold-start before the prompt appears.
 
+.PARAMETER LoadDetectorsOnly
+  Dot-source seam for the test suite: define the pure window classifiers, then return WITHOUT loading
+  UI Automation, compiling the Win32 shim, or touching any process. The classifiers are the part that
+  decides a hard stop, so they must be exercisable against synthesised windows on a machine with no
+  Power BI Desktop. Not for interactive use.
+
 .OUTPUTS
-  Final line `VERDICT: CREDENTIAL_MISSING` (exit 1) or `VERDICT: CREDENTIAL_PRESENT` (exit 0), or
-  `VERDICT: UNKNOWN` (exit 3) if no window for the pid can be found OR a Refresh control was never
-  invoked (with nothing invoked, "no modal appeared" proves nothing - reporting PRESENT then would be
-  a fail-open arbiter, worse than none).
+  A single final `VERDICT:` line, and an exit code in three bands:
+
+    exit 1  CREDENTIAL_MISSING   a window's text matched the credential signature. THIS IS THE HARD
+                                 STOP - a human must sign in once; no automation can fill it.
+    exit 0  CREDENTIAL_PRESENT   a refresh was invoked and ran to the deadline with no credential
+                                 modal and no unclassifiable dialog. Still not the gate of record for
+                                 a serverless source - confirm with the one-row data probe.
+    exit 3  UNKNOWN              no window for the pid, a minimized owner, or no Refresh control was
+                                 ever invoked (with nothing invoked, "no modal appeared" proves
+                                 nothing - reporting PRESENT would be a fail-open arbiter).
+    exit 3  REFRESH_IN_PROGRESS  a refresh progress dialog was ALREADY up at t=0. Desktop is busy, so
+                                 the credential state cannot be probed; wait for it, or cancel the
+                                 stale refresh. Do not stack a second refresh on top of it.
+    exit 3  DIALOG_UNRECOGNIZED  a dialog is up whose text matched NEITHER signature. We read it and
+                                 it is not a credential prompt - so it is not a credential wall - but
+                                 we cannot say what it is. A human should look at the screen.
+    exit 3  DIALOG_UNREADABLE    a dialog is up that exposes NO readable text at all. Distinct from
+                                 DIALOG_UNRECOGNIZED on purpose: "we could not read it" is a weaker
+                                 state of knowledge than "we read it and it did not match", and the
+                                 two must not collapse into one verdict.
+
+  ⚠️ `BLOCKED_BY_DIALOG` is deliberately NOT emitted here any more (issue #367). It used to be, on a
+  size-only test - ANY visible non-main window >=100x100 - which a Power BI Refresh progress dialog
+  satisfies trivially; a field report on 2026-08-28 caught it reporting exactly that under three
+  concurrent refreshes. This script has no way to establish that a dialog is *blocking*, so every
+  `BLOCKED_BY_DIALOG` it emitted was an inference dressed as a finding, in the one verdict class the
+  toolkit treats as a hard stop. The Python fast check (`_credential_modal.blocking_dialog_candidates`)
+  still emits that token on its own path; this arbiter now names what it actually observed instead.
 
 .EXAMPLE
   powershell -ExecutionPolicy Bypass -File scripts/probe_desktop_credential.ps1 -DesktopPid 42532
 #>
+[CmdletBinding(DefaultParameterSetName = 'Probe')]
 param(
-  [Parameter(Mandatory = $true)][int]$DesktopPid,
-  [int]$TimeoutSec = 75
+  [Parameter(Mandatory = $true, ParameterSetName = 'Probe')][int]$DesktopPid,
+  [Parameter(ParameterSetName = 'Probe')][int]$TimeoutSec = 75,
+  [Parameter(Mandatory = $true, ParameterSetName = 'Detectors')][switch]$LoadDetectorsOnly
 )
+
+# --------------------------------------------------------------------------------------------------
+# Pure detectors. No Win32, no UI Automation, no process access - they take window objects and return
+# a classification, so `-LoadDetectorsOnly` can dot-source this far and the suite can drive them with
+# synthesised windows. Everything below the `if ($LoadDetectorsOnly) { return }` line needs a live
+# Desktop and is therefore only reachable in a real probe run.
+# --------------------------------------------------------------------------------------------------
+
+# Connector credential-dialog signature text (covers Databricks / SQL / Snowflake / generic OAuth).
+# Shared with the Python t=0/poll detector so the fast path and this arbiter cannot drift.
+$sig = (Get-Content -LiteralPath (Join-Path $PSScriptRoot 'credential_modal_signature.regex') -Raw).Trim()
+
+# Progress-dialog text. Matching this means "Power BI is working", NOT "a human is needed".
+# ⚠️ Provenance: INFERRED from Power BI Desktop's refresh UI, not measured against a live capture -
+# see SKILL.md. It is deliberately not load-bearing: a miss downgrades REFRESH_IN_PROGRESS to
+# DIALOG_UNRECOGNIZED (both exit 3, neither a credential stop), so a wrong guess costs specificity,
+# never correctness. Keep the alternatives narrow and anchored - a broad pattern here is the one way
+# this file could hide a genuine blocker.
+$benignSig = (Get-Content -LiteralPath (Join-Path $PSScriptRoot 'benign_dialog_signature.regex') -Raw).Trim()
+
+function Test-CredentialModal {
+  <# First matching credential-signature text across EVERY window, any class, any size. #>
+  param([object[]]$Windows)
+  foreach ($w in $Windows) {
+    foreach ($n in $w.Texts) {
+      if ($n -and $n -match $sig) { return $n }
+    }
+  }
+  return $null
+}
+
+function Select-DialogCandidate {
+  <# Windows big enough, and of the right class, to be worth CLASSIFYING.
+
+  Size selects what to look at; it is not itself evidence of anything (issue #367). The old
+  `Test-BlockingDialog` returned the first window past this filter as a blocking dialog, which is why
+  a Refresh progress dialog read as a credential wall.
+  #>
+  param([object[]]$Windows)
+  $candidates = @()
+  foreach ($w in $Windows) {
+    if ($w.ClassName -and $w.ClassName.StartsWith('WindowsForms10.Window.8')) { continue }
+    if ($w.Width -lt 100 -or $w.Height -lt 100) { continue }
+    $candidates += $w
+  }
+  return $candidates
+}
+
+function Get-DialogClassification {
+  <# Classify ONE candidate window from what it says, and from whether it disables its owner.
+
+  Kinds, in the order they are tested:
+    credential    text matched the credential signature -> the hard stop.
+    benign        text matched the progress signature   -> Power BI is working.
+    non-blocking  the owner window is ENABLED. Modality is a ONE-WAY test: a modal dialog disables its
+                  owner, so an enabled owner PROVES this window is not blocking anything. The converse
+                  does not hold - Power BI's refresh dialog also disables the owner - so a disabled
+                  owner is never used to convict. `$null` (no owner at all) proves nothing either way.
+    unreadable    no readable text at all: we could not classify it.
+    unrecognized  readable text that matched neither signature: we looked, and it is not a credential
+                  prompt. Distinct from `unreadable` on purpose - absent is not empty.
+  #>
+  param([Parameter(Mandatory = $true)][object]$Window)
+
+  $texts = @()
+  if ($null -ne $Window.Texts) {
+    $texts = @($Window.Texts | Where-Object { $_ -and $_.Trim() })
+  }
+  foreach ($t in $texts) {
+    if ($t -match $sig) { return [pscustomobject]@{ Kind = 'credential'; Evidence = $t } }
+  }
+  foreach ($t in $texts) {
+    if ($t -match $benignSig) { return [pscustomobject]@{ Kind = 'benign'; Evidence = $t } }
+  }
+  if ($Window.OwnerEnabled -eq $true) {
+    return [pscustomobject]@{ Kind = 'non-blocking'; Evidence = 'owner window is enabled' }
+  }
+  if ($texts.Count -eq 0) {
+    return [pscustomobject]@{ Kind = 'unreadable'; Evidence = '' }
+  }
+  return [pscustomobject]@{ Kind = 'unrecognized'; Evidence = $texts[0] }
+}
+
+function Format-DialogEvidence {
+  <# One-line window description for a verdict line. #>
+  param([object]$Window)
+  $title = if ($Window.Title) { $Window.Title } else { '(empty title)' }
+  return ("class={0} title='{1}' size={2}x{3}" -f $Window.ClassName, $title, $Window.Width, $Window.Height)
+}
+
+function Get-DialogVerdict {
+  <# Fold per-window classifications into ONE verdict, or `$null` when nothing needs reporting.
+
+  Precedence is credential > unreadable > unrecognized > benign, and it is not arbitrary:
+
+    * credential is the only terminal finding, so it short-circuits.
+    * `benign` is the only classification carrying POSITIVE evidence of harmlessness, so it must never
+      outrank a window we could not classify - otherwise one progress dialog masks a real modal.
+    * `unreadable` outranks `unrecognized` because it is the weaker state of knowledge, and the weaker
+      state is the one that must stay visible.
+
+  `-RefreshInFlight` is set only inside the poll loop, i.e. after THIS script invoked the refresh.
+  There, a progress dialog is our own and is ignored. At t=0 it is somebody else's, and stacking a
+  second refresh on it is exactly what the 2026-08-28 field report had to unpick by hand.
+  #>
+  param([object[]]$Windows, [switch]$RefreshInFlight)
+
+  $unreadable = $null
+  $unrecognized = $null
+  $benign = $null
+  foreach ($w in @(Select-DialogCandidate -Windows $Windows)) {
+    $c = Get-DialogClassification -Window $w
+    $found = [pscustomobject]@{ Kind = $c.Kind; Verdict = ''; ExitCode = 3; Window = $w; Evidence = $c.Evidence }
+    switch ($c.Kind) {
+      'credential' {
+        $found.Verdict = 'CREDENTIAL_MISSING'
+        $found.ExitCode = 1
+        return $found
+      }
+      'unreadable' { if ($null -eq $unreadable) { $found.Verdict = 'DIALOG_UNREADABLE'; $unreadable = $found } }
+      'unrecognized' { if ($null -eq $unrecognized) { $found.Verdict = 'DIALOG_UNRECOGNIZED'; $unrecognized = $found } }
+      'benign' { if ($null -eq $benign) { $found.Verdict = 'REFRESH_IN_PROGRESS'; $benign = $found } }
+      default { }
+    }
+  }
+  if ($null -ne $unreadable) { return $unreadable }
+  if ($null -ne $unrecognized) { return $unrecognized }
+  if ($null -ne $benign -and -not $RefreshInFlight) { return $benign }
+  return $null
+}
+
+if ($LoadDetectorsOnly) { return }
 
 Add-Type -AssemblyName UIAutomationClient, UIAutomationTypes, WindowsBase
 Add-Type @"
@@ -61,6 +225,7 @@ public static class Win32CredentialWindows {
     public int Width;
     public int Height;
     public bool Minimized;
+    public bool? OwnerEnabled;
     public List<string> Texts = new List<string>();
   }
 
@@ -70,6 +235,8 @@ public static class Win32CredentialWindows {
   [DllImport("user32.dll")] private static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint processId);
   [DllImport("user32.dll")] private static extern bool IsWindowVisible(IntPtr hWnd);
   [DllImport("user32.dll")] private static extern bool IsIconic(IntPtr hWnd);
+  [DllImport("user32.dll")] private static extern bool IsWindowEnabled(IntPtr hWnd);
+  [DllImport("user32.dll")] private static extern IntPtr GetWindow(IntPtr hWnd, uint uCmd);
   [DllImport("user32.dll")] private static extern int GetWindowTextLength(IntPtr hWnd);
   [DllImport("user32.dll", CharSet = CharSet.Unicode)] private static extern int GetWindowText(IntPtr hWnd, StringBuilder text, int count);
   [DllImport("user32.dll", CharSet = CharSet.Unicode)] private static extern int GetClassName(IntPtr hWnd, StringBuilder className, int count);
@@ -93,6 +260,7 @@ public static class Win32CredentialWindows {
   }
 
   public static List<WindowInfo> GetPidWindows(int pid) {
+    const uint GW_OWNER = 4;
     var windows = new List<WindowInfo>();
     EnumWindows(delegate (IntPtr hWnd, IntPtr lParam) {
       uint ownerPid;
@@ -100,13 +268,18 @@ public static class Win32CredentialWindows {
       if (ownerPid != (uint)pid || !IsWindowVisible(hWnd)) { return true; }
       RECT rect;
       GetWindowRect(hWnd, out rect);
+      IntPtr owner = GetWindow(hWnd, GW_OWNER);
       var info = new WindowInfo {
         Hwnd = hWnd,
         Title = Text(hWnd),
         ClassName = ClassNameOf(hWnd),
         Width = Math.Max(0, rect.Right - rect.Left),
         Height = Math.Max(0, rect.Bottom - rect.Top),
-        Minimized = IsIconic(hWnd)
+        Minimized = IsIconic(hWnd),
+        // null when the window has NO owner: "we could not apply the test" must stay distinct from
+        // "the test said the owner is disabled". Only `true` is ever acted on (see
+        // Get-DialogClassification) - modality can exonerate a window, never convict one.
+        OwnerEnabled = (owner == IntPtr.Zero) ? (bool?)null : IsWindowEnabled(owner)
       };
       if (!String.IsNullOrEmpty(info.Title)) { info.Texts.Add(info.Title); }
       EnumChildWindows(hWnd, delegate (IntPtr child, IntPtr childParam) {
@@ -125,49 +298,39 @@ public static class Win32CredentialWindows {
 $root = [System.Windows.Automation.AutomationElement]::RootElement
 $cond = New-Object System.Windows.Automation.PropertyCondition([System.Windows.Automation.AutomationElement]::ProcessIdProperty, $DesktopPid)
 
-# Connector credential-dialog signature text (covers Databricks / SQL / Snowflake / generic OAuth).
-# Shared with the Python t=0/poll detector so the fast path and this arbiter cannot drift.
-$sig = Get-Content -LiteralPath (Join-Path $PSScriptRoot 'credential_modal_signature.regex') -Raw
-
 function Get-PidWindows {
   # EVERY visible top-level/owned window of the target process, not UIA RootElement children. A
   # Power BI credential modal is an owned window; UIA root-child discovery misses it.
   return [Win32CredentialWindows]::GetPidWindows($DesktopPid)
 }
 
-function Test-CredentialModal {
-  foreach ($w in Get-PidWindows) {
-    foreach ($n in $w.Texts) {
-      if ($n -and $n -match $sig) { return $n }
-    }
-  }
-  return $null
-}
-
-function Test-BlockingDialog {
-  foreach ($w in Get-PidWindows) {
-    if ($w.ClassName.StartsWith('WindowsForms10.Window.8')) { continue }
-    if ($w.Width -lt 100 -or $w.Height -lt 100) { continue }
-    return $w
-  }
-  return $null
-}
-
 $windows = Get-PidWindows
 if (-not $windows -or $windows.Count -eq 0) { Write-Output "no window for pid $DesktopPid found"; Write-Output "VERDICT: UNKNOWN"; exit 3 }
 
 # 1. If a credential modal is ALREADY open, the credential is missing - report immediately.
-$hit = Test-CredentialModal
+$hit = Test-CredentialModal -Windows $windows
 if ($hit) {
   Write-Output ("credential modal already open: '{0}'" -f $hit.Substring(0, [Math]::Min(80, $hit.Length)))
   Write-Output "VERDICT: CREDENTIAL_MISSING"
   exit 1
 }
-$blocker = Test-BlockingDialog
+
+# 1b. A dialog is up that is not a credential prompt. It is NOT a credential wall - say what it is and
+# exit 3 (cannot probe), never exit 1 (human needed). Invoking a Refresh on top of an unclassified
+# dialog is how the 2026-08-28 field report ended up with a stale duplicate refresh to cancel.
+$blocker = Get-DialogVerdict -Windows $windows
 if ($blocker) {
-  Write-Output ("blocking dialog already open: class={0} size={1}x{2}" -f $blocker.ClassName, $blocker.Width, $blocker.Height)
-  Write-Output "VERDICT: BLOCKED_BY_DIALOG"
-  exit 1
+  Write-Output ("dialog already open: {0}" -f (Format-DialogEvidence -Window $blocker.Window))
+  if ($blocker.Evidence) {
+    Write-Output ("  matched text: '{0}'" -f $blocker.Evidence.Substring(0, [Math]::Min(80, $blocker.Evidence.Length)))
+  }
+  switch ($blocker.Verdict) {
+    'REFRESH_IN_PROGRESS' { Write-Output "  a refresh is already running on this pid - wait for it, or cancel the stale one; do not stack a second refresh on it" }
+    'DIALOG_UNREADABLE' { Write-Output "  this window exposes no readable text, so it could not be classified at all - look at the Desktop screen" }
+    default { Write-Output "  its text matches no credential-prompt signature, so this is not a credential wall - look at the Desktop screen" }
+  }
+  Write-Output ("VERDICT: {0}" -f $blocker.Verdict)
+  exit $blocker.ExitCode
 }
 foreach ($w in $windows) {
   if ($w.Minimized -and $w.ClassName.StartsWith('WindowsForms10.Window.8')) {
@@ -200,20 +363,30 @@ if (-not $invoked) {
 }
 
 $deadline = (Get-Date).AddSeconds($TimeoutSec)
+# From here on a progress dialog is OUR refresh, so it is ignored (-RefreshInFlight). An
+# unreadable/unrecognized dialog is LATCHED rather than acted on: it is not a credential prompt, so it
+# must not abort a healthy refresh, but it also means "no modal appeared" is no longer established, so
+# it must not be erased by a quiet deadline either. Latching is the same shape the Python detector uses
+# for its indeterminate states, and it is what keeps the two failure directions both closed.
+$latched = $null
 while ((Get-Date) -lt $deadline) {
   Start-Sleep -Milliseconds 2000
-  $hit = Test-CredentialModal
+  $windows = Get-PidWindows
+  $hit = Test-CredentialModal -Windows $windows
   if ($hit) {
     Write-Output ("credential modal detected: '{0}'" -f $hit.Substring(0, [Math]::Min(80, $hit.Length)))
     Write-Output "VERDICT: CREDENTIAL_MISSING"
     exit 1
   }
-  $blocker = Test-BlockingDialog
-  if ($blocker) {
-    Write-Output ("blocking dialog detected: class={0} size={1}x{2}" -f $blocker.ClassName, $blocker.Width, $blocker.Height)
-    Write-Output "VERDICT: BLOCKED_BY_DIALOG"
-    exit 1
-  }
+  $observed = Get-DialogVerdict -Windows $windows -RefreshInFlight
+  if ($observed -and $null -eq $latched) { $latched = $observed }
+}
+if ($latched) {
+  Write-Output ("a dialog was up during the refresh: {0}" -f (Format-DialogEvidence -Window $latched.Window))
+  Write-Output "  it matched no credential-prompt signature, so this is NOT a credential wall and no sign-in is implied"
+  Write-Output "  but a window we could not classify was open the whole time, so 'no modal appeared' is not established"
+  Write-Output ("VERDICT: {0}" -f $latched.Verdict)
+  exit $latched.ExitCode
 }
 Write-Output "no credential modal within ${TimeoutSec}s (refresh proceeded)"
 Write-Output "VERDICT: CREDENTIAL_PRESENT"

--- a/.github/skills/pbip-model-refresh/scripts/probe_desktop_credential.ps1
+++ b/.github/skills/pbip-model-refresh/scripts/probe_desktop_credential.ps1
@@ -32,11 +32,26 @@
   How long to wait for the credential modal after triggering refresh. Default 75s; use >=60s because a
   serverless warehouse (e.g. Databricks) can cold-start before the prompt appears.
 
+.PARAMETER HarvestTimeoutSec
+  Wall-clock cap on ONE window-text harvest. 0 (default) derives it from -TimeoutSec, clamped to 2..8s.
+
+.PARAMETER HarvestMaxElements
+  Cap on UI Automation elements inspected per window. Hitting it marks the harvest TRUNCATED, which is
+  a distinct outcome from "read it all and found nothing" - see -LoadDetectorsOnly's note on proof.
+
 .PARAMETER LoadDetectorsOnly
   Dot-source seam for the test suite: define the pure window classifiers, then return WITHOUT loading
   UI Automation, compiling the Win32 shim, or touching any process. The classifiers are the part that
   decides a hard stop, so they must be exercisable against synthesised windows on a machine with no
   Power BI Desktop. Not for interactive use.
+
+.PARAMETER HarvestHwnd
+  Internal. Re-invokes THIS script as a short-lived child process that harvests one window's UI
+  Automation text and prints it as JSON. `AutomationElement.FindAll` is a synchronous cross-process
+  call: a hung provider cannot be cancelled in-process, and neither `try/catch` nor a background
+  thread helps. A child process can be killed, which is the only way this probe can promise a verdict
+  within a bounded time (measured in review 2026-08-29: a blocked provider held a `-TimeoutSec 1` run
+  for 15.1s and produced NO verdict at all).
 
 .OUTPUTS
   A single final `VERDICT:` line, and an exit code in three bands:
@@ -44,22 +59,22 @@
     exit 1  CREDENTIAL_MISSING   a window's text matched the credential signature. THIS IS THE HARD
                                  STOP - a human must sign in once; no automation can fill it.
     exit 0  CREDENTIAL_PRESENT   a refresh was invoked and ran to the deadline with no credential
-                                 modal and no unclassifiable dialog. Still not the gate of record for
+                                 modal and nothing unclassifiable up. Still not the gate of record for
                                  a serverless source - confirm with the one-row data probe.
     exit 3  UNKNOWN              no window for the pid, a minimized owner, or no Refresh control was
                                  ever invoked (with nothing invoked, "no modal appeared" proves
                                  nothing - reporting PRESENT would be a fail-open arbiter).
-    exit 3  REFRESH_IN_PROGRESS  a refresh progress dialog was ALREADY up at t=0. Desktop is busy, so
-                                 the credential state cannot be probed; wait for it, or cancel the
-                                 stale refresh. Do not stack a second refresh on top of it.
+    exit 3  REFRESH_IN_PROGRESS  a dialog whose CONTENT positively reads as refresh progress was
+                                 already up at t=0. Desktop is busy, so the credential state cannot be
+                                 probed; wait for it, or cancel the stale refresh.
     exit 3  DIALOG_UNRECOGNIZED  a dialog is up whose text matched NEITHER signature. We read it and
                                  it is not a credential prompt - so it is not a credential wall - but
                                  we cannot say what it is. A human should look at the screen.
-    exit 3  DIALOG_UNREADABLE    a dialog is up whose CONTENT could not be read - either it exposes no
-                                 text at all, or its caption matched the progress signature while its
-                                 content stayed unread. Distinct from DIALOG_UNRECOGNIZED on purpose:
-                                 "we could not read it" is a weaker state of knowledge than "we read
-                                 it and it did not match", and the two must not collapse into one.
+    exit 3  DIALOG_UNREADABLE    a dialog is up that could not be shown to be harmless: no text at
+                                 all, or only a reassuring CAPTION, or benign-looking content read
+                                 from an INCOMPLETE harvest. "We could not establish it" is a weaker
+                                 state of knowledge than "we read it and it did not match", and the
+                                 two must not collapse into one verdict.
 
   ⚠️ `BLOCKED_BY_DIALOG` is deliberately NOT emitted here any more (issue #367). It used to be, on a
   size-only test - ANY visible non-main window >=100x100 - which a Power BI Refresh progress dialog
@@ -69,6 +84,26 @@
   toolkit treats as a hard stop. The Python fast check (`_credential_modal.blocking_dialog_candidates`)
   still emits that token on its own path; this arbiter now names what it actually observed instead.
 
+  ⚠️ THE BURDEN OF PROOF RUNS ONE WAY: a dialog is suppressed only when we POSITIVELY READ benign
+  CONTENT. It is never suppressed because we read *something* and the caption looked reassuring. The
+  first two attempts at #367 both got this wrong, and the second was worse than the first:
+
+    attempt 1  benign by CAPTION. A WPF modal captioned `Refresh` whose content read
+               `Enter your credentials` was suppressed -> CREDENTIAL_PRESENT, exit 0.
+    attempt 2  benign by caption + "we harvested SOME text" (`ContentRead`). A `Cancel` button was
+               enough to satisfy that, so the same modal cleared again whenever the credential text
+               itself was missed - via `TextPattern`-only content, past the element cap, or split by an
+               interposed element. Three separate exploits, one root cause: `ContentRead` was a PROXY
+               for "we read the credential-bearing content", and no proxy can carry that weight.
+
+  There is no reliable way to prove a UIA harvest saw everything - `LegacyIAccessiblePattern` is not
+  even exposed by the managed `System.Windows.Automation` API (verified 2026-08-29: the type is
+  missing, it is UIA-COM only), so some MSAA-bridged content is structurally unreadable from here.
+  That is exactly why completeness is no longer claimed. Under this rule a coverage gap costs RECALL on
+  the credential path (exit 3 instead of exit 1 - loud, and a human looks at the screen) and can never
+  produce a silent clear. Master's size-only behaviour was accidentally right for the same reason: it
+  never trusted text it had not read.
+
 .EXAMPLE
   powershell -ExecutionPolicy Bypass -File scripts/probe_desktop_credential.ps1 -DesktopPid 42532
 #>
@@ -76,7 +111,11 @@
 param(
   [Parameter(Mandatory = $true, ParameterSetName = 'Probe')][int]$DesktopPid,
   [Parameter(ParameterSetName = 'Probe')][int]$TimeoutSec = 75,
-  [Parameter(Mandatory = $true, ParameterSetName = 'Detectors')][switch]$LoadDetectorsOnly
+  [Parameter(ParameterSetName = 'Probe')][int]$HarvestTimeoutSec = 0,
+  [Parameter(ParameterSetName = 'Probe')]
+  [Parameter(ParameterSetName = 'Harvest')][int]$HarvestMaxElements = 2000,
+  [Parameter(Mandatory = $true, ParameterSetName = 'Detectors')][switch]$LoadDetectorsOnly,
+  [Parameter(Mandatory = $true, ParameterSetName = 'Harvest')][long]$HarvestHwnd
 )
 
 # --------------------------------------------------------------------------------------------------
@@ -90,44 +129,70 @@ param(
 # Shared with the Python t=0/poll detector so the fast path and this arbiter cannot drift.
 $sig = (Get-Content -LiteralPath (Join-Path $PSScriptRoot 'credential_modal_signature.regex') -Raw).Trim()
 
-# Progress-dialog text. Matching this means "Power BI is working", NOT "a human is needed".
+# Progress-dialog text. Matching this means "Power BI is working", NOT "a human is needed" - but only
+# when it matches CONTENT, never the caption alone.
 # ⚠️ Provenance: INFERRED from Power BI Desktop's refresh UI, not measured against a live capture -
-# see SKILL.md. It is deliberately not load-bearing: a miss downgrades REFRESH_IN_PROGRESS to
-# DIALOG_UNRECOGNIZED (both exit 3, neither a credential stop), so a wrong guess costs specificity,
-# never correctness. Keep the alternatives narrow and anchored - a broad pattern here is the one way
-# this file could hide a genuine blocker.
+# see SKILL.md. Keep the alternatives narrow and anchored: this is the only file that can cause a
+# dialog to be ignored, so a broad pattern here is the one way to hide a genuine blocker.
 $benignSig = (Get-Content -LiteralPath (Join-Path $PSScriptRoot 'benign_dialog_signature.regex') -Raw).Trim()
 
 function Get-NormalizedText {
-  <# Whitespace-normalised, de-duplicated window text, optionally plus a JOINED variant.
-
-  The joined variant exists because a WPF dialog splits one sentence across several visual elements,
-  so `Enter your credentials` can arrive as `Enter your` + `credentials` and match neither fragment.
-
-  ⚠️ It is applied ASYMMETRICALLY, and that is the whole point: the credential signature searches the
-  joined text (broadest possible recall for the detector that CONVICTS), while the benign signature
-  searches the individual elements only (narrowest possible reach for the detector that EXONERATES).
-  Joining can in principle manufacture a phrase - two adjacent table names reading `Account` `Key`
-  would join to the signature `Account Key` - and the direction that error takes matters: on the
-  credential path it produces a LOUD false stop a human resolves by looking at the screen, whereas on
-  the benign path it would produce a SILENT false clear. Never give the benign path the joined text.
-  #>
-  param([object[]]$Texts, [switch]$IncludeJoined)
+  <# Whitespace-normalised, de-duplicated, order-preserving text. #>
+  param([object[]]$Texts)
   $clean = @()
   foreach ($t in $Texts) {
     if ($null -eq $t) { continue }
     $normalized = (([string]$t) -replace '\s+', ' ').Trim()
     if ($normalized -and ($clean -notcontains $normalized)) { $clean += $normalized }
   }
-  if ($IncludeJoined -and $clean.Count -gt 1) { $clean += ($clean -join ' ') }
   return $clean
+}
+
+function Get-DialogTextSet {
+  <# The three views of a window's text that a classification needs.
+
+  `All`      every text, caption included. Evidence, and the per-element credential scan.
+  `Content`  everything that is NOT the caption. The ONLY view the benign signature may read - a
+             caption cannot establish that a dialog is harmless (review 2026-08-29).
+  `Search`   `All` plus the PROSE JOIN: non-interactive texts joined in tree order. WPF splits one
+             sentence across visual elements, so `Enter your` + `credentials` matches nothing on its
+             own; and interactive elements are excluded because an interposed `Cancel` button between
+             those two fragments defeated a naive whole-window join.
+
+  The join is applied to `Search` ONLY, and `Search` is read ONLY by the credential signature. That
+  asymmetry is a safety property, not an accident: joining can manufacture a phrase (two adjacent
+  table names `Account` `Key` join to the signature `Account Key`), and on the credential path that
+  error is a LOUD false stop a human resolves by looking at the screen, whereas on the benign path it
+  would be a SILENT false clear. Never let the benign signature read a join.
+  #>
+  param([Parameter(Mandatory = $true)][object]$Window)
+
+  $title = (([string]$Window.Title) -replace '\s+', ' ').Trim()
+  $all = Get-NormalizedText -Texts $Window.Texts
+  $interactive = Get-NormalizedText -Texts $Window.InteractiveTexts
+  $content = @($all | Where-Object { $_ -ne $title })
+  $prose = @($all | Where-Object { $interactive -notcontains $_ })
+  $search = @($all)
+  if ($prose.Count -gt 1) { $search += ($prose -join ' ') }
+  return [pscustomobject]@{ Title = $title; All = $all; Content = $content; Prose = $prose; Search = $search }
+}
+
+function Test-HarvestComplete {
+  <# A REAL Boolean `$true`, nothing coercible to one.
+
+  `-eq $true` is coercive: integer `1` and the string `"true"` both pass it, and both produced a clear
+  in review. Anything that is not a Boolean is an unknown window shape, and an unknown shape must not
+  be able to authorise suppression.
+  #>
+  param([object]$Value)
+  return (($Value -is [bool]) -and $Value)
 }
 
 function Test-CredentialModal {
   <# First matching credential-signature text across EVERY window, any class, any size. #>
   param([object[]]$Windows)
   foreach ($w in $Windows) {
-    foreach ($n in (Get-NormalizedText -Texts $w.Texts -IncludeJoined)) {
+    foreach ($n in (Get-DialogTextSet -Window $w).Search) {
       if ($n -match $sig) { return $n }
     }
   }
@@ -152,79 +217,78 @@ function Select-DialogCandidate {
 }
 
 function Get-DialogClassification {
-  <# Classify ONE candidate window from what it says, and from whether it disables its owner.
+  <# Classify ONE candidate window. Only `benign` is suppressible, and only it needs positive proof.
 
   Kinds, in the order they are tested:
-    credential        text matched the credential signature -> the hard stop. Searched over the JOINED
-                      text too, so a signature split across WPF elements still convicts.
-    benign            a text ELEMENT matched the progress signature AND the window's content was
-                      actually read -> Power BI is working.
-    benign-title-only the progress signature matched, but `ContentRead` is not `$true`: the caption
-                      says "Refresh" and the CONTENT was never read. Reported as indeterminate, not
-                      suppressed. This is the review defect of 2026-08-29: a WPF modal titled
-                      `Refresh` whose visual content read `Enter your credentials` was classified
-                      benign from its caption, suppressed in flight, and the probe exited 0 -
-                      a SILENT false negative on a hard stop, strictly worse than the false positive
-                      #367 set out to remove. `absent != empty`, one level down: content we did not
-                      read cannot be evidence of harmlessness.
+    credential        the credential signature matched a text element or the prose join -> hard stop.
+    benign            the benign signature matched CONTENT (not the caption) AND the harvest completed
+                      -> Power BI is working. The one suppressible kind.
+    benign-unverified the benign signature matched content, but the harvest was truncated, timed out,
+                      or hit a pattern it could not read. Benign-LOOKING is not benign.
     non-blocking      the owner window is ENABLED. Modality is a ONE-WAY test: a modal dialog disables
-                      its owner, so an enabled owner PROVES this window is not blocking anything. The
-                      converse does not hold - Power BI's refresh dialog also disables the owner - so a
-                      disabled owner is never used to convict. `$null` (no owner) proves nothing.
-    unreadable        no readable text at all: we could not classify it.
+                      its owner, so an enabled owner PROVES this window blocks nothing. The converse
+                      does not hold - Power BI's refresh dialog also disables the owner - so a disabled
+                      owner never convicts. `$null` (no owner) proves nothing either way.
+    benign-title-only the CAPTION matched the benign signature and no content did. A caption is not
+                      content.
+    unreadable        no readable text at all.
     unrecognized      readable text that matched neither signature: we looked, and it is not a
                       credential prompt. Distinct from `unreadable` on purpose - absent is not empty.
+
+  Everything except `credential` and `benign` lands in the exit-3 band, so the failure mode of every
+  uncertainty here is a LOUD stop-and-look, never a silent clear.
   #>
   param([Parameter(Mandatory = $true)][object]$Window)
 
-  $elements = Get-NormalizedText -Texts $Window.Texts
-  $searchable = Get-NormalizedText -Texts $Window.Texts -IncludeJoined
-  foreach ($t in $searchable) {
+  $sets = Get-DialogTextSet -Window $Window
+  foreach ($t in $sets.Search) {
     if ($t -match $sig) { return [pscustomobject]@{ Kind = 'credential'; Evidence = $t } }
   }
-  foreach ($t in $elements) {
+  foreach ($t in $sets.Content) {
     if ($t -match $benignSig) {
-      # `$null`/missing ContentRead fails SAFE: a window whose collector never said it read the
-      # content is treated as unread, so a synthesised or future window shape cannot silently
-      # re-open the suppression path.
-      if ($Window.ContentRead -eq $true) { return [pscustomobject]@{ Kind = 'benign'; Evidence = $t } }
-      return [pscustomobject]@{ Kind = 'benign-title-only'; Evidence = $t }
+      if (Test-HarvestComplete -Value $Window.HarvestComplete) {
+        return [pscustomobject]@{ Kind = 'benign'; Evidence = $t }
+      }
+      return [pscustomobject]@{ Kind = 'benign-unverified'; Evidence = $t }
     }
   }
   if ($Window.OwnerEnabled -eq $true) {
     return [pscustomobject]@{ Kind = 'non-blocking'; Evidence = 'owner window is enabled' }
   }
-  if ($elements.Count -eq 0) {
+  if ($sets.Title -and $sets.Title -match $benignSig) {
+    return [pscustomobject]@{ Kind = 'benign-title-only'; Evidence = $sets.Title }
+  }
+  if ($sets.All.Count -eq 0) {
     return [pscustomobject]@{ Kind = 'unreadable'; Evidence = '' }
   }
-  return [pscustomobject]@{ Kind = 'unrecognized'; Evidence = $elements[0] }
+  return [pscustomobject]@{ Kind = 'unrecognized'; Evidence = $sets.All[0] }
 }
 
 function Format-DialogEvidence {
   <# One-line window description for a verdict line. #>
   param([object]$Window)
   $title = if ($Window.Title) { $Window.Title } else { '(empty title)' }
-  $read = if ($Window.ContentRead -eq $true) { 'read' } else { 'UNREAD' }
-  return ("class={0} title='{1}' size={2}x{3} content={4}" -f $Window.ClassName, $title, $Window.Width, $Window.Height, $read)
+  $harvest = if (Test-HarvestComplete -Value $Window.HarvestComplete) { 'complete' } else { 'INCOMPLETE' }
+  return ("class={0} title='{1}' size={2}x{3} harvest={4}" -f
+    $Window.ClassName, $title, $Window.Width, $Window.Height, $harvest)
 }
 
 function Get-DialogVerdict {
   <# Fold per-window classifications into ONE verdict, or `$null` when nothing needs reporting.
 
-  Precedence is credential > unreadable > unrecognized > benign, and it is not arbitrary:
+  Precedence: credential > (unreadable band) > unrecognized > benign. It is not arbitrary:
 
     * credential is the only terminal finding, so it short-circuits.
-    * `benign` is the only classification carrying POSITIVE evidence of harmlessness, so it must never
-      outrank a window we could not classify - otherwise one progress dialog masks a real modal.
-    * `unreadable` outranks `unrecognized` because it is the weaker state of knowledge, and the weaker
-      state is the one that must stay visible.
-    * `benign-title-only` joins the `unreadable` band, NOT the benign one. Its content was never read,
-      so it is an indeterminate wearing a reassuring caption - and it is the one shape that must not be
-      suppressible, because suppression is what turned a real credential modal into exit 0.
+    * `benign` is the only kind carrying POSITIVE evidence of harmlessness, so it must never outrank a
+      window we could not account for - otherwise one progress dialog masks a real modal.
+    * the unreadable band (`unreadable`, `benign-unverified`, `benign-title-only`) outranks
+      `unrecognized` because it is the weaker state of knowledge, and the weaker state is what must
+      stay visible.
 
   `-RefreshInFlight` is set only inside the poll loop, i.e. after THIS script invoked the refresh.
-  There, a progress dialog is our own and is ignored. At t=0 it is somebody else's, and stacking a
-  second refresh on it is exactly what the 2026-08-28 field report had to unpick by hand.
+  There, a proven-benign progress dialog is our own and is ignored - and nothing else is. At t=0 it is
+  somebody else's, and stacking a second refresh on it is exactly what the 2026-08-28 field report had
+  to unpick by hand.
   #>
   param([object[]]$Windows, [switch]$RefreshInFlight)
 
@@ -241,6 +305,7 @@ function Get-DialogVerdict {
         return $found
       }
       'unreadable' { if ($null -eq $unreadable) { $found.Verdict = 'DIALOG_UNREADABLE'; $unreadable = $found } }
+      'benign-unverified' { if ($null -eq $unreadable) { $found.Verdict = 'DIALOG_UNREADABLE'; $unreadable = $found } }
       'benign-title-only' { if ($null -eq $unreadable) { $found.Verdict = 'DIALOG_UNREADABLE'; $unreadable = $found } }
       'unrecognized' { if ($null -eq $unrecognized) { $found.Verdict = 'DIALOG_UNRECOGNIZED'; $unrecognized = $found } }
       'benign' { if ($null -eq $benign) { $found.Verdict = 'REFRESH_IN_PROGRESS'; $benign = $found } }
@@ -256,6 +321,84 @@ function Get-DialogVerdict {
 if ($LoadDetectorsOnly) { return }
 
 Add-Type -AssemblyName UIAutomationClient, UIAutomationTypes, WindowsBase
+
+# Control types whose text labels an ACTION rather than forming prose. Excluded from the prose join
+# only - their text is still searched element-by-element and still counts as content.
+$InteractiveControlTypes = @(
+  'Button', 'CheckBox', 'RadioButton', 'ComboBox', 'MenuItem', 'TabItem',
+  'ListItem', 'Hyperlink', 'SplitButton', 'TreeItem', 'ScrollBar', 'Thumb'
+)
+
+function Get-AutomationHarvest {
+  <# Every text-bearing UI Automation property under one window, plus HOW COMPLETE the read was.
+
+  Win32 `EnumChildWindows` is not enough and this is not a corner case: WPF renders its visual tree
+  into ONE HWND, so a WPF dialog's entire content is invisible to child-HWND enumeration and only its
+  caption survives.
+
+  Three text-bearing sources are read: `Name`, `ValuePattern`, and `TextPattern`. `TextPattern` is not
+  optional - review 2026-08-29 built a modal whose credential text lived in a read-only `RichTextBox`
+  with an EMPTY `Name`, reachable only through `TextPattern`.
+  `LegacyIAccessiblePattern` is deliberately absent: the type does not exist in the managed
+  `System.Windows.Automation` API (verified - it is UIA-COM only), so MSAA-bridged-only content cannot
+  be read from here at all. That gap is survivable ONLY because completeness is never assumed:
+  `Truncated`/`PatternsIncomplete` withhold the right to suppress, they do not grant it.
+  #>
+  param([long]$Hwnd, [int]$MaxElements = 2000)
+
+  $items = @()
+  $truncated = $false
+  $incomplete = $false
+  try {
+    $element = [System.Windows.Automation.AutomationElement]::FromHandle([IntPtr]$Hwnd)
+    if ($null -eq $element) { return $null }
+    $descendants = $element.FindAll(
+      [System.Windows.Automation.TreeScope]::Descendants,
+      [System.Windows.Automation.Condition]::TrueCondition)
+  } catch {
+    return $null
+  }
+  $seen = 0
+  foreach ($d in $descendants) {
+    if ($seen -ge $MaxElements) { $truncated = $true; break }
+    $seen++
+    $typeName = ''
+    try { $typeName = [string]$d.Current.ControlType.ProgrammaticName } catch { $incomplete = $true }
+    $isInteractive = $false
+    foreach ($known in $InteractiveControlTypes) {
+      if ($typeName -like "*.$known") { $isInteractive = $true; break }
+    }
+    $texts = @()
+    try { if ($d.Current.Name) { $texts += [string]$d.Current.Name } } catch { $incomplete = $true }
+    try {
+      $valuePattern = $null
+      if ($d.TryGetCurrentPattern([System.Windows.Automation.ValuePattern]::Pattern, [ref]$valuePattern)) {
+        if ($valuePattern.Current.Value) { $texts += [string]$valuePattern.Current.Value }
+      }
+    } catch { $incomplete = $true }
+    try {
+      $textPattern = $null
+      if ($d.TryGetCurrentPattern([System.Windows.Automation.TextPattern]::Pattern, [ref]$textPattern)) {
+        $document = $textPattern.DocumentRange.GetText(8000)
+        if ($document) { $texts += [string]$document }
+      }
+    } catch { $incomplete = $true }
+    foreach ($t in $texts) {
+      $items += [pscustomobject]@{ Text = $t; Interactive = $isInteractive }
+    }
+  }
+  return [pscustomobject]@{ Items = $items; Truncated = $truncated; PatternsIncomplete = $incomplete }
+}
+
+if ($PSCmdlet.ParameterSetName -eq 'Harvest') {
+  # Child-process mode. Kept above the Win32 `Add-Type` so the child compiles nothing it does not need
+  # - this runs once per candidate per poll.
+  $harvested = Get-AutomationHarvest -Hwnd $HarvestHwnd -MaxElements $HarvestMaxElements
+  if ($null -eq $harvested) { exit 4 }
+  Write-Output ('HARVEST:' + (ConvertTo-Json $harvested -Compress -Depth 5))
+  exit 0
+}
+
 Add-Type @"
 using System;
 using System.Collections.Generic;
@@ -343,78 +486,77 @@ public static class Win32CredentialWindows {
 $root = [System.Windows.Automation.AutomationElement]::RootElement
 $cond = New-Object System.Windows.Automation.PropertyCondition([System.Windows.Automation.AutomationElement]::ProcessIdProperty, $DesktopPid)
 
-function Get-AutomationText {
-  <# UI Automation descendant Name/Value text for one HWND, or `$null` if the harvest FAILED.
+# One harvest's wall-clock cap. Derived from the caller's own budget rather than fixed, so a
+# deliberately short probe cannot be held open by a wedged provider for an order of magnitude longer
+# than it asked for. The probe's total is therefore always finite: (cap x polls) + TimeoutSec.
+$harvestBudget = if ($HarvestTimeoutSec -gt 0) { $HarvestTimeoutSec } else { [Math]::Max(2, [Math]::Min(8, $TimeoutSec)) }
 
-  Win32 `EnumChildWindows` is not enough and this is not a corner case: WPF renders its visual tree
-  into ONE HWND, so a WPF dialog's entire content is invisible to child-HWND enumeration and only its
-  caption survives. Measured 2026-08-29 in review - an owned WPF modal titled `Refresh` containing
-  `Enter your credentials` read as a progress dialog and the probe exited 0. UI Automation sees that
-  text; a UIA dump of the same window returned `DescendantNames: Enter your credentials`.
+function Get-BoundedAutomationHarvest {
+  <# `Get-AutomationHarvest` in a KILLABLE child process, or `$null` if it did not finish in time.
 
-  Three distinct outcomes, kept distinct on purpose: `$null` = the harvest could not run, `@()` = it
-  ran and the window genuinely exposes nothing, a populated array = content. The caller turns the
-  first two into "content unread", which is an indeterminate, never a clean bill of health.
+  A hung UIA provider blocks `FindAll` inside a cross-process COM call. `try/catch` cannot interrupt
+  that, and neither can a background thread - the call is not cancellable. Killing a child process is.
   #>
-  param([long]$Hwnd, [int]$MaxElements = 400)
-  $texts = @()
+  param([long]$Hwnd, [int]$TimeoutSec, [int]$MaxElements)
+
+  $outFile = [System.IO.Path]::GetTempFileName()
   try {
-    $element = [System.Windows.Automation.AutomationElement]::FromHandle([IntPtr]$Hwnd)
-    if ($null -eq $element) { return $null }
-    $descendants = $element.FindAll(
-      [System.Windows.Automation.TreeScope]::Descendants,
-      [System.Windows.Automation.Condition]::TrueCondition)
-    $seen = 0
-    foreach ($d in $descendants) {
-      if ($seen -ge $MaxElements) { break }
-      $seen++
-      try {
-        if ($d.Current.Name) { $texts += $d.Current.Name }
-        $pattern = $null
-        if ($d.TryGetCurrentPattern([System.Windows.Automation.ValuePattern]::Pattern, [ref]$pattern)) {
-          if ($pattern.Current.Value) { $texts += $pattern.Current.Value }
-        }
-      } catch {
-        # One unreachable element must not discard the text already harvested from its siblings.
-        continue
-      }
+    $exe = [System.Diagnostics.Process]::GetCurrentProcess().MainModule.FileName
+    $argv = @(
+      '-NoProfile', '-ExecutionPolicy', 'Bypass',
+      '-File', ('"{0}"' -f $PSCommandPath),
+      '-HarvestHwnd', $Hwnd,
+      '-HarvestMaxElements', $MaxElements
+    )
+    $child = Start-Process -FilePath $exe -ArgumentList $argv -NoNewWindow -PassThru -RedirectStandardOutput $outFile
+    if (-not $child.WaitForExit($TimeoutSec * 1000)) {
+      try { $child.Kill() } catch { }
+      return $null
     }
+    $raw = Get-Content -LiteralPath $outFile -Raw -ErrorAction SilentlyContinue
+    if (-not $raw) { return $null }
+    $line = @($raw -split "`r?`n" | Where-Object { $_ -like 'HARVEST:*' })
+    if ($line.Count -eq 0) { return $null }
+    return ConvertFrom-Json $line[0].Substring(8)
   } catch {
     return $null
+  } finally {
+    Remove-Item -LiteralPath $outFile -Force -ErrorAction SilentlyContinue
   }
-  return , $texts
 }
 
 function ConvertTo-ProbeWindow {
-  <# Win32 `WindowInfo` -> the plain window object the pure classifiers consume.
+  <# Win32 `WindowInfo` (+ optional UIA harvest) -> the plain object the pure classifiers consume. #>
+  param([object]$Window, [switch]$Enrich, [int]$TimeoutSec = 8, [int]$MaxElements = 2000)
 
-  `ContentRead` is the field the classifiers gate the benign path on: it is true only when text was
-  obtained that is NOT merely the window caption - a Win32 child text (WinForms dialogs expose those)
-  or a UIA descendant. A caption on its own can never establish that a dialog is harmless.
-  #>
-  param([object]$Window, [switch]$Enrich)
   $title = [string]$Window.Title
   $texts = @()
   foreach ($t in $Window.Texts) { if ($t) { $texts += [string]$t } }
-  $contentRead = @($texts | Where-Object { $_ -ne $title }).Count -gt 0
+  $interactive = @()
+  $complete = $false
   if ($Enrich) {
     $hwnd = if ($Window.Hwnd -is [IntPtr]) { $Window.Hwnd.ToInt64() } else { [long]$Window.Hwnd }
-    $harvested = Get-AutomationText -Hwnd $hwnd
+    $harvested = Get-BoundedAutomationHarvest -Hwnd $hwnd -TimeoutSec $TimeoutSec -MaxElements $MaxElements
     if ($null -ne $harvested) {
-      foreach ($t in $harvested) { if ($t -and ($texts -notcontains $t)) { $texts += [string]$t } }
-      if (@($harvested | Where-Object { $_ -and $_ -ne $title }).Count -gt 0) { $contentRead = $true }
+      foreach ($item in @($harvested.Items)) {
+        if (-not $item.Text) { continue }
+        $texts += [string]$item.Text
+        if ($item.Interactive) { $interactive += [string]$item.Text }
+      }
+      $complete = (-not $harvested.Truncated) -and (-not $harvested.PatternsIncomplete)
     }
   }
   return [pscustomobject]@{
-    Hwnd         = $Window.Hwnd
-    Title        = $title
-    ClassName    = [string]$Window.ClassName
-    Width        = [int]$Window.Width
-    Height       = [int]$Window.Height
-    Minimized    = [bool]$Window.Minimized
-    OwnerEnabled = $Window.OwnerEnabled
-    Texts        = $texts
-    ContentRead  = $contentRead
+    Hwnd             = $Window.Hwnd
+    Title            = $title
+    ClassName        = [string]$Window.ClassName
+    Width            = [int]$Window.Width
+    Height           = [int]$Window.Height
+    Minimized        = [bool]$Window.Minimized
+    OwnerEnabled     = $Window.OwnerEnabled
+    Texts            = $texts
+    InteractiveTexts = $interactive
+    HarvestComplete  = [bool]$complete
   }
 }
 
@@ -422,13 +564,13 @@ function Get-PidWindows {
   # EVERY visible top-level/owned window of the target process, not UIA RootElement children. A
   # Power BI credential modal is an owned window; UIA root-child discovery misses it.
   #
-  # The UIA text harvest is applied to CANDIDATE windows only. Walking the main Power BI window's
-  # visual tree would cost seconds per poll for text the classifiers never read (it is excluded by
-  # class), and this loop runs every 2s.
+  # The UIA harvest is applied to CANDIDATE windows only. Walking the main Power BI window's visual
+  # tree would cost seconds per poll for text the classifiers never read (it is excluded by class).
   $enriched = @()
   foreach ($w in [Win32CredentialWindows]::GetPidWindows($DesktopPid)) {
     $isCandidate = @(Select-DialogCandidate -Windows @($w)).Count -eq 1
-    $enriched += (ConvertTo-ProbeWindow -Window $w -Enrich:$isCandidate)
+    $enriched += (ConvertTo-ProbeWindow -Window $w -Enrich:$isCandidate `
+        -TimeoutSec $harvestBudget -MaxElements $HarvestMaxElements)
   }
   return $enriched
 }
@@ -455,7 +597,8 @@ if ($blocker) {
   }
   switch ($blocker.Kind) {
     'benign' { Write-Output "  a refresh is already running on this pid - wait for it, or cancel the stale one; do not stack a second refresh on it" }
-    'benign-title-only' { Write-Output "  its CAPTION looks like a progress dialog, but its content could not be read - an unread window is not evidence that it is harmless; look at the Desktop screen" }
+    'benign-unverified' { Write-Output "  its content LOOKS like refresh progress, but the read was truncated or incomplete - benign-looking is not benign; look at the Desktop screen" }
+    'benign-title-only' { Write-Output "  its CAPTION looks like a progress dialog, but no content confirmed it - a caption is not content; look at the Desktop screen" }
     'unreadable' { Write-Output "  this window exposes no readable text, so it could not be classified at all - look at the Desktop screen" }
     default { Write-Output "  its text matches no credential-prompt signature, so this is not a credential wall - look at the Desktop screen" }
   }
@@ -493,11 +636,12 @@ if (-not $invoked) {
 }
 
 $deadline = (Get-Date).AddSeconds($TimeoutSec)
-# From here on a progress dialog is OUR refresh, so it is ignored (-RefreshInFlight). An
-# unreadable/unrecognized dialog is LATCHED rather than acted on: it is not a credential prompt, so it
-# must not abort a healthy refresh, but it also means "no modal appeared" is no longer established, so
-# it must not be erased by a quiet deadline either. Latching is the same shape the Python detector uses
-# for its indeterminate states, and it is what keeps the two failure directions both closed.
+# From here on a PROVEN-benign progress dialog is our own refresh, so it is ignored (-RefreshInFlight).
+# Nothing else is: an unreadable, unverified, caption-only or unrecognized dialog is LATCHED rather
+# than acted on. It is not a credential prompt, so it must not abort a healthy refresh - but it also
+# means "no modal appeared" is no longer established, so it must not be erased by a quiet deadline
+# either. Latching is the same shape the Python detector uses for its indeterminate states, and it is
+# what keeps both failure directions closed.
 $latched = $null
 while ((Get-Date) -lt $deadline) {
   Start-Sleep -Milliseconds 2000
@@ -514,7 +658,7 @@ while ((Get-Date) -lt $deadline) {
 if ($latched) {
   Write-Output ("a dialog was up during the refresh: {0}" -f (Format-DialogEvidence -Window $latched.Window))
   Write-Output "  it matched no credential-prompt signature, so this is NOT a credential wall and no sign-in is implied"
-  Write-Output "  but a window we could not classify was open the whole time, so 'no modal appeared' is not established"
+  Write-Output "  but a window we could not account for was open, so 'no modal appeared' is not established"
   Write-Output ("VERDICT: {0}" -f $latched.Verdict)
   exit $latched.ExitCode
 }

--- a/.github/skills/pbip-model-refresh/tests/test_credential_modal_detection.py
+++ b/.github/skills/pbip-model-refresh/tests/test_credential_modal_detection.py
@@ -1066,10 +1066,13 @@ def _window(**overrides) -> dict:
         # `None` = the window has no owner, so the modality test could not be applied at all. That is
         # NOT the same as `False` (owner disabled), and the classifier must not treat it as such.
         "OwnerEnabled": None,
-        # Whether text beyond the CAPTION was obtained. Defaults true here because most fixtures model
-        # a window whose content was read; the fail-safe default for a MISSING field is pinned
-        # separately by `test_a_window_with_no_content_read_field_at_all_fails_safe`.
-        "ContentRead": True,
+        # Texts belonging to interactive controls. Excluded from the PROSE JOIN only - an interposed
+        # `Cancel` button between `Enter your` and `credentials` defeated a naive whole-window join.
+        "InteractiveTexts": [],
+        # Whether the UIA harvest ran to completion: not truncated by the element cap, not timed out,
+        # no pattern read that threw. Defaults true here because most fixtures model a complete read;
+        # the fail-safe treatment of every non-Boolean value is pinned by its own test.
+        "HarvestComplete": True,
     }
     window.update(overrides)
     return window
@@ -1103,6 +1106,7 @@ REFRESH_PROGRESS = _window(
     Title="Refresh",
     ClassName="HwndWrapper[PBIDesktop.exe;;refresh]",
     Texts=["Refresh", "Orders", "1,204 rows loaded", "Cancel"],
+    InteractiveTexts=["Cancel"],
     # A Power BI refresh dialog DOES disable its owner, so modality alone cannot tell it from a
     # credential modal. Pinned false on purpose: the fix must not lean on the owner test.
     OwnerEnabled=False,
@@ -1114,22 +1118,32 @@ CREDENTIAL_MODAL = _window(
 )
 # The review defect of 2026-08-29, as the collector actually produced it. A WPF modal renders its
 # whole visual tree into ONE HWND, so `EnumChildWindows` harvested nothing and only the caption
-# survived - a caption that matches the progress signature. `ContentRead` false is the collector
-# saying so.
+# survived - a caption that matches the progress signature.
 WPF_CREDENTIAL_MODAL_SEEN_AS_CAPTION_ONLY = _window(
     Title="Refresh",
     ClassName="HwndWrapper[PBIDesktop.exe;;dialog]",
     Texts=["Refresh"],
     OwnerEnabled=False,
-    ContentRead=False,
+    HarvestComplete=False,
+)
+# The second round's defect: a `Cancel` button was enough to satisfy the old "we read SOME text"
+# proxy, so a benign CAPTION cleared the window while the credential text stayed unread.
+WPF_CREDENTIAL_MODAL_WITH_ONLY_A_BUTTON_READ = _window(
+    Title="Refresh",
+    ClassName="HwndWrapper[PBIDesktop.exe;;dialog]",
+    Texts=["Refresh", "Cancel"],
+    InteractiveTexts=["Cancel"],
+    OwnerEnabled=False,
+    HarvestComplete=True,
 )
 # The same window once UI Automation supplies the visual text the Win32 collector could not see.
 WPF_CREDENTIAL_MODAL_WITH_UIA_TEXT = _window(
     Title="Refresh",
     ClassName="HwndWrapper[PBIDesktop.exe;;dialog]",
     Texts=["Refresh", "Enter your credentials", "OK", "Cancel"],
+    InteractiveTexts=["OK", "Cancel"],
     OwnerEnabled=False,
-    ContentRead=True,
+    HarvestComplete=True,
 )
 
 
@@ -1503,16 +1517,91 @@ def test_uia_harvested_text_turns_the_same_window_into_a_credential_stop(tmp_pat
     assert result["credential"] == "Enter your credentials"
 
 
-def test_a_window_with_no_content_read_field_at_all_fails_safe(tmp_path: Path) -> None:
-    """A MISSING ContentRead field must read as "not read", never as "read".
+@pytest.mark.parametrize(
+    "value",
+    [
+        pytest.param("__absent__", id="field-missing"),
+        pytest.param(None, id="null"),
+        pytest.param(False, id="false"),
+        pytest.param(0, id="int-0"),
+        pytest.param(1, id="int-1"),
+        pytest.param("true", id="str-true"),
+        pytest.param("false", id="str-false"),
+        pytest.param("", id="empty-string"),
+        pytest.param([], id="empty-list"),
+    ],
+)
+def test_only_a_real_boolean_true_can_authorise_suppression(tmp_path: Path, value) -> None:
+    """`-eq $true` is COERCIVE, and review proved it: integer `1` and the string `"true"` both cleared.
 
-    This is the shape a future collector change, or a caller that predates the field, would produce.
-    Defaulting it to true would silently restore the suppression path with nothing to notice it.
+    Anything that is not a Boolean is an unknown window shape - a future collector change, a caller
+    that predates the field, a JSON round-trip that widened a type - and an unknown shape must never be
+    able to authorise suppression. Only `$true` itself counts.
     """
-    window = _window(Title="Refresh", Texts=["Refresh"], OwnerEnabled=False)
-    del window["ContentRead"]
+    window = _window(Title="Refresh", Texts=["Refresh", "1,204 rows loaded"], OwnerEnabled=False)
+    if value == "__absent__":
+        del window["HarvestComplete"]
+    else:
+        window["HarvestComplete"] = value
 
-    assert classify(tmp_path, [window])["kind"] == "benign-title-only"
+    result = classify(tmp_path, [window], refresh_in_flight=True)
+
+    assert result["kind"] == "benign-unverified", f"HarvestComplete={value!r} must not count as complete"
+    assert result["verdict"] == "DIALOG_UNREADABLE"
+    assert result["exit_code"] == 3
+
+
+def test_a_real_boolean_true_does_authorise_suppression(tmp_path: Path) -> None:
+    """The positive control for the test above - otherwise it could pass by refusing everything."""
+    window = _window(Title="Refresh", Texts=["Refresh", "1,204 rows loaded"], OwnerEnabled=False)
+    window["HarvestComplete"] = True
+
+    assert classify(tmp_path, [window], refresh_in_flight=True)["verdict"] is None
+
+
+def test_reading_only_a_button_does_not_authorise_a_benign_caption(tmp_path: Path) -> None:
+    """Round 2's defect: "we harvested SOME text" was a proxy for "we read the credential content".
+
+    A `Cancel` button satisfied it. Under the inverted rule the harvest being complete is necessary but
+    not sufficient - the BENIGN SIGNATURE ITSELF must match content, and `Cancel` does not. So the
+    three separate exploits that beat the old proxy (TextPattern-only content, content past the element
+    cap, a split defeated by an interposed element) all stop being silent clears at once: none of them
+    ever produced benign content to read.
+    """
+    result = classify(tmp_path, [WPF_CREDENTIAL_MODAL_WITH_ONLY_A_BUTTON_READ], refresh_in_flight=True)
+
+    assert result["kind"] != "benign", "a button label is not evidence that a dialog is harmless"
+    assert result["verdict"] == "DIALOG_UNREADABLE"
+    assert result["exit_code"] == 3
+
+
+def test_a_benign_caption_over_unreadable_content_is_never_suppressed(tmp_path: Path) -> None:
+    """Whatever the collector missed, a caption alone cannot clear a window - in flight or at t=0."""
+    for in_flight in (False, True):
+        result = classify(tmp_path, [WPF_CREDENTIAL_MODAL_SEEN_AS_CAPTION_ONLY], refresh_in_flight=in_flight)
+        assert result["kind"] == "benign-title-only", f"in_flight={in_flight}"
+        assert result["verdict"] == "DIALOG_UNREADABLE"
+        assert result["exit_code"] == 3
+
+
+def test_benign_content_from_a_truncated_harvest_is_not_benign(tmp_path: Path) -> None:
+    """Truncated must never read as "complete and clean" - the element cap was independently exploitable.
+
+    450 ordinary elements followed by the credential `TextBlock` cleared the window because the cap
+    silently stopped short. The cap still exists (it bounds the work), but hitting it now withholds the
+    right to suppress instead of quietly granting it.
+    """
+    window = _window(
+        Title="Refresh",
+        Texts=["Refresh", "Evaluating"],
+        OwnerEnabled=False,
+        HarvestComplete=False,
+    )
+
+    result = classify(tmp_path, [window], refresh_in_flight=True)
+
+    assert result["kind"] == "benign-unverified"
+    assert result["exit_code"] == 3
 
 
 def test_a_credential_signature_split_across_wpf_elements_still_convicts(tmp_path: Path) -> None:
@@ -1578,16 +1667,273 @@ def test_the_pinned_alternative_list_still_covers_the_shipped_signature() -> Non
 
 
 def test_the_probe_harvests_window_text_through_ui_automation() -> None:
-    """Regression pin on the collector: the UIA harvest must stay wired into `Get-PidWindows`.
+    """Regression pin on the collector: the harvest, its patterns, and its BOUNDS stay wired in.
 
-    The behavioural tests above take `ContentRead` as an input. Only the live WPF test proves it is
-    produced, and that one skips where there is no interactive desktop - so this keeps the wiring
-    itself gated everywhere.
+    The behavioural tests above take `Texts`/`HarvestComplete` as inputs. Only the live tests prove
+    they are produced, and those skip where there is no interactive desktop - so this keeps the wiring
+    gated everywhere, including on Linux CI.
     """
     body = PROBE_PS1.read_text(encoding="utf-8")
 
-    assert "function Get-AutomationText" in body
+    assert "function Get-AutomationHarvest" in body
     assert "AutomationElement]::FromHandle" in body, "the harvest must start from the window handle"
+    assert "TextPattern]::Pattern" in body, (
+        "TextPattern is not optional: a read-only RichTextBox with an empty Name exposes its text only there"
+    )
+    assert "ValuePattern]::Pattern" in body
+    assert "$truncated = $true" in body, "hitting the element cap must be recorded, not silently absorbed"
+    assert "PatternsIncomplete" in body, "a pattern read that threw must withhold the right to suppress"
     assert "ConvertTo-ProbeWindow" in body and "-Enrich:$isCandidate" in body, (
         "Get-PidWindows must enrich candidate windows, or the classifiers only ever see the caption"
+    )
+    assert "function Get-BoundedAutomationHarvest" in body and "WaitForExit" in body and "Kill()" in body, (
+        "the harvest must run in a killable child process: a hung UIA provider cannot be cancelled in-process"
+    )
+
+
+def test_the_harvest_child_process_is_this_same_script() -> None:
+    """The bounded harvest re-invokes THIS file, so the bundle stays copyable as one folder.
+
+    A second script would have to be copied too, and `SKILL.md` promises that copying this one folder
+    takes the whole procedure with it.
+    """
+    body = PROBE_PS1.read_text(encoding="utf-8")
+
+    assert "$PSCommandPath" in body, "the child must be this script, not a sibling file"
+    assert "ParameterSetName -eq 'Harvest'" in body
+    assert "'HARVEST:'" in body, "the child's payload needs a marker the parent can find in its output"
+
+
+# --------------------------------------------------------------------------------------------------
+# Live regressions for the round-2 exploits (blind review, 2026-08-29)
+# --------------------------------------------------------------------------------------------------
+#
+# Each of these beat the previous `ContentRead` proxy and ended at CREDENTIAL_PRESENT, exit 0. They are
+# kept as LIVE tests, not synthesised ones, because every one of them lived in the COLLECTOR - the part
+# a synthesised window object cannot exercise by construction.
+
+_WPF_APP_PREAMBLE = r"""
+param([Parameter(Mandatory = $true)][string]$ReadyFile)
+Add-Type -AssemblyName System.Windows.Forms
+Add-Type -AssemblyName PresentationFramework
+Add-Type -AssemblyName PresentationCore
+Add-Type -AssemblyName WindowsBase
+Add-Type -AssemblyName WindowsFormsIntegration
+[System.Windows.Forms.Application]::EnableVisualStyles()
+$script:form = New-Object System.Windows.Forms.Form
+$script:form.Text = 'Fake Desktop'
+$script:form.Width = 640
+$script:form.Height = 480
+$button = New-Object System.Windows.Controls.Button
+$button.Content = 'Refresh'
+$hostControl = New-Object System.Windows.Forms.Integration.ElementHost
+$hostControl.Width = 140
+$hostControl.Height = 48
+$hostControl.Child = $button
+$script:form.Controls.Add($hostControl)
+$script:timer = New-Object System.Windows.Forms.Timer
+$script:timer.Interval = 800
+"""
+
+_WPF_APP_EPILOGUE = r"""
+$button.Add_Click({ $script:timer.Start() })
+$script:form.Add_Shown({ Set-Content -LiteralPath $ReadyFile -Value 'ready' -Encoding ascii })
+[System.Windows.Forms.Application]::Run($script:form)
+"""
+
+# Credential text in a read-only RichTextBox: reachable ONLY through TextPattern, with an empty Name,
+# and a Cancel button alongside it so the old "we harvested some text" proxy would have been satisfied.
+_MODAL_TEXTPATTERN_ONLY = r"""
+$script:timer.Add_Tick({
+    $script:timer.Stop()
+    $modal = New-Object System.Windows.Window
+    $modal.Title = 'Refresh'
+    $modal.Width = 520
+    $modal.Height = 320
+    $panel = New-Object System.Windows.Controls.StackPanel
+    $rich = New-Object System.Windows.Controls.RichTextBox
+    $rich.IsReadOnly = $true
+    $paragraph = New-Object System.Windows.Documents.Paragraph
+    $paragraph.Inlines.Add((New-Object System.Windows.Documents.Run('Enter your credentials')))
+    $rich.Document = New-Object System.Windows.Documents.FlowDocument($paragraph)
+    $null = $panel.Children.Add($rich)
+    $cancel = New-Object System.Windows.Controls.Button
+    $cancel.Content = 'Cancel'
+    $null = $panel.Children.Add($cancel)
+    $modal.Content = $panel
+    $helper = New-Object System.Windows.Interop.WindowInteropHelper($modal)
+    $helper.Owner = $script:form.Handle
+    $null = $modal.ShowDialog()
+  })
+"""
+
+# 450 ordinary elements ahead of the credential text: the old 400-element cap truncated silently and
+# the result was indistinguishable from "read it all, found nothing".
+_MODAL_PAST_THE_ELEMENT_CAP = r"""
+$script:timer.Add_Tick({
+    $script:timer.Stop()
+    $modal = New-Object System.Windows.Window
+    $modal.Title = 'Refresh'
+    $modal.Width = 520
+    $modal.Height = 320
+    $panel = New-Object System.Windows.Controls.StackPanel
+    for ($i = 0; $i -lt 450; $i++) {
+      $filler = New-Object System.Windows.Controls.TextBlock
+      $filler.Text = "row $i"
+      $null = $panel.Children.Add($filler)
+    }
+    $block = New-Object System.Windows.Controls.TextBlock
+    $block.Text = 'Enter your credentials'
+    $null = $panel.Children.Add($block)
+    $scroller = New-Object System.Windows.Controls.ScrollViewer
+    $scroller.Content = $panel
+    $modal.Content = $scroller
+    $helper = New-Object System.Windows.Interop.WindowInteropHelper($modal)
+    $helper.Owner = $script:form.Handle
+    $null = $modal.ShowDialog()
+  })
+"""
+
+# `Enter your` / `Cancel` / `credentials`: an interactive element interposed between the two halves of
+# the signature, which defeated a naive whole-window join.
+_MODAL_INTERPOSED_SPLIT = r"""
+$script:timer.Add_Tick({
+    $script:timer.Stop()
+    $modal = New-Object System.Windows.Window
+    $modal.Title = 'Refresh'
+    $modal.Width = 520
+    $modal.Height = 320
+    $panel = New-Object System.Windows.Controls.StackPanel
+    $first = New-Object System.Windows.Controls.TextBlock
+    $first.Text = 'Enter your'
+    $null = $panel.Children.Add($first)
+    $cancel = New-Object System.Windows.Controls.Button
+    $cancel.Content = 'Cancel'
+    $null = $panel.Children.Add($cancel)
+    $second = New-Object System.Windows.Controls.TextBlock
+    $second.Text = 'credentials'
+    $null = $panel.Children.Add($second)
+    $modal.Content = $panel
+    $helper = New-Object System.Windows.Interop.WindowInteropHelper($modal)
+    $helper.Owner = $script:form.Handle
+    $null = $modal.ShowDialog()
+  })
+"""
+
+# A modal that WEDGES its own UI thread. UI Automation's FindAll then blocks cross-process, which is
+# what held a `-TimeoutSec 1` probe for 15.1s and produced no verdict at all.
+_MODAL_WEDGED_UI_THREAD = r"""
+$script:timer.Add_Tick({
+    $script:timer.Stop()
+    $modal = New-Object System.Windows.Window
+    $modal.Title = 'Refresh'
+    $modal.Width = 520
+    $modal.Height = 320
+    $block = New-Object System.Windows.Controls.TextBlock
+    $block.Text = 'Enter your credentials'
+    $modal.Content = $block
+    $helper = New-Object System.Windows.Interop.WindowInteropHelper($modal)
+    $helper.Owner = $script:form.Handle
+    $modal.Add_ContentRendered({ Start-Sleep -Seconds 120 })
+    $null = $modal.ShowDialog()
+  })
+"""
+
+
+def _run_probe_against_wpf_modal(tmp_path: Path, modal_body: str, extra_args: list[str] | None = None):
+    """Launch the fake-Desktop app with ``modal_body``, run the probe, return the completed process."""
+    exe = _powershell()
+    app_script = tmp_path / "fake_desktop.ps1"
+    app_script.write_text(_WPF_APP_PREAMBLE + modal_body + _WPF_APP_EPILOGUE, encoding="utf-8")
+    ready = tmp_path / "ready.txt"
+    app = subprocess.Popen(  # pylint: disable=consider-using-with
+        [exe, "-Sta", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", str(app_script), "-ReadyFile", str(ready)],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        for _ in range(60):
+            if ready.exists():
+                break
+            time.sleep(0.5)
+        if not ready.exists():
+            pytest.skip("the WPF fixture app never showed a window (no interactive desktop?)")
+        argv = [exe, "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", str(PROBE_PS1)]
+        argv += ["-DesktopPid", str(app.pid)]
+        extra = extra_args or []
+        if "-TimeoutSec" not in extra:
+            argv += ["-TimeoutSec", "12"]
+        argv += extra
+        started = time.monotonic()
+        done = subprocess.run(argv, capture_output=True, text=True, timeout=300, check=False)
+        done.elapsed = time.monotonic() - started  # type: ignore[attr-defined]
+        if "refresh invoked: True" not in done.stdout:
+            pytest.skip(f"the fixture app exposed no invokable Refresh to UI Automation:\n{done.stdout}")
+        return done
+    finally:
+        app.kill()
+        app.wait(timeout=30)
+
+
+def test_credential_text_reachable_only_through_textpattern_is_a_hard_stop(tmp_path: Path) -> None:
+    """Exploit 1. `Name` + `ValuePattern` alone miss a read-only RichTextBox's content entirely."""
+    done = _run_probe_against_wpf_modal(tmp_path, _MODAL_TEXTPATTERN_ONLY)
+
+    assert "VERDICT: CREDENTIAL_MISSING" in done.stdout, done.stdout
+    assert done.returncode == 1
+
+
+def test_credential_text_beyond_the_element_cap_never_reads_as_clean(tmp_path: Path) -> None:
+    """Exploit 2. Truncation must not be indistinguishable from a complete, clean read.
+
+    Two acceptable outcomes and one forbidden one: read it all and convict (exit 1), or report the
+    harvest incomplete (exit 3). Never exit 0.
+    """
+    done = _run_probe_against_wpf_modal(tmp_path, _MODAL_PAST_THE_ELEMENT_CAP, ["-HarvestMaxElements", "400"])
+
+    assert done.returncode != 0, f"a truncated harvest must never clear a window:\n{done.stdout}"
+    assert "CREDENTIAL_PRESENT" not in done.stdout
+
+
+def test_credential_text_beyond_the_element_cap_convicts_when_the_cap_allows_it(tmp_path: Path) -> None:
+    """The same window with the shipped cap: read in full, and convicted."""
+    done = _run_probe_against_wpf_modal(tmp_path, _MODAL_PAST_THE_ELEMENT_CAP)
+
+    assert "VERDICT: CREDENTIAL_MISSING" in done.stdout, done.stdout
+    assert done.returncode == 1
+
+
+def test_a_signature_split_by_an_interposed_button_is_a_hard_stop(tmp_path: Path) -> None:
+    """Exploit 3. The prose join must skip interactive elements, or `Cancel` breaks the sentence."""
+    done = _run_probe_against_wpf_modal(tmp_path, _MODAL_INTERPOSED_SPLIT)
+
+    assert "VERDICT: CREDENTIAL_MISSING" in done.stdout, done.stdout
+    assert done.returncode == 1
+
+
+def test_a_wedged_uia_provider_still_produces_a_verdict(tmp_path: Path) -> None:
+    """The MEDIUM finding: an uncapped UIA walk let a 1s probe run 15s+ and emit nothing at all.
+
+    `FindAll` is a synchronous cross-process call, so neither `try/catch` nor a background thread can
+    interrupt it - only killing a child process can.
+
+    The bound is what this test is FOR, and it has to be tight enough to fail. Measured here against a
+    modal that sleeps 120s on its own UI thread, with `-TimeoutSec 1 -HarvestTimeoutSec 2`:
+
+        bounded child process : 6.2s   exit 3  VERDICT: DIALOG_UNREADABLE
+        in-process harvest    : 70.5s  exit 3  VERDICT: DIALOG_UNREADABLE
+
+    Note both eventually print the SAME verdict - the defect is purely the time budget, so an assertion
+    on the verdict alone cannot see it. A first draft used `elapsed < 120` and the mutation walked
+    straight through at 70.5s. 25s sits ~4x above the bounded case and ~3x below the unbounded one.
+    """
+    done = _run_probe_against_wpf_modal(
+        tmp_path, _MODAL_WEDGED_UI_THREAD, ["-TimeoutSec", "1", "-HarvestTimeoutSec", "2"]
+    )
+
+    assert "VERDICT:" in done.stdout, f"a wedged provider must not swallow the verdict:\n{done.stdout}"
+    assert "CREDENTIAL_PRESENT" not in done.stdout, "an unreadable window is not a clean bill of health"
+    assert done.returncode == 3
+    assert done.elapsed < 25, (
+        f"the probe inherited the provider's wedge instead of bounding it (took {done.elapsed:.1f}s)"
     )

--- a/.github/skills/pbip-model-refresh/tests/test_credential_modal_detection.py
+++ b/.github/skills/pbip-model-refresh/tests/test_credential_modal_detection.py
@@ -8,7 +8,11 @@ from __future__ import annotations
 
 import threading
 import time
+import json
 import os
+import re
+import shutil
+import subprocess
 import sys
 from pathlib import Path
 
@@ -994,3 +998,319 @@ def test_probe_query_worker_cannot_print_after_credential_verdict(monkeypatch, c
     assert first_out.startswith("PREFLIGHT: CREDENTIAL_MISSING")
     assert "DATA_OK_FROM_WORKER_AFTER_RELEASE" not in first_out
     assert later_out == ""
+
+
+# ==================================================================================================
+# probe_desktop_credential.ps1 - the PowerShell arbiter's own dialog classifiers (issue #367)
+# ==================================================================================================
+#
+# The arbiter used to decide "blocking" from GEOMETRY alone: `Test-BlockingDialog` returned the first
+# visible non-main window >= 100x100 as a blocking dialog, and the caller printed
+# `VERDICT: BLOCKED_BY_DIALOG`, exit 1 - the same hard-stop band as a real credential wall. A Power BI
+# Refresh progress dialog satisfies that trivially, and on 2026-08-28 a field report caught it doing
+# exactly that under three concurrent refreshes: the "credential wall" was an ordinary progress dialog
+# stalled behind a Snowflake cold start.
+#
+# These tests drive the SHIPPED classifiers directly, through the `-LoadDetectorsOnly` dot-source seam,
+# with synthesised window objects. That seam exists so the part that decides a hard stop is testable on
+# a machine with no Power BI Desktop; everything past it (UI Automation, the Win32 shim, the refresh
+# invoke) still needs a live Desktop and is NOT covered here.
+
+PROBE_PS1 = Path(__file__).resolve().parents[1] / "scripts" / "probe_desktop_credential.ps1"
+CREDENTIAL_SIGNATURE = PROBE_PS1.parent / "credential_modal_signature.regex"
+BENIGN_SIGNATURE = PROBE_PS1.parent / "benign_dialog_signature.regex"
+
+_HARNESS = r"""
+param(
+  [Parameter(Mandatory = $true)][string]$Probe,
+  [Parameter(Mandatory = $true)][string]$WindowsJson,
+  [switch]$RefreshInFlight
+)
+$ErrorActionPreference = 'Stop'
+. $Probe -LoadDetectorsOnly
+$parsed = ConvertFrom-Json (Get-Content -LiteralPath $WindowsJson -Raw)
+$windows = @($parsed)
+$verdict = Get-DialogVerdict -Windows $windows -RefreshInFlight:$RefreshInFlight
+$credential = Test-CredentialModal -Windows $windows
+$payload = [ordered]@{
+  credential = $credential
+  verdict    = $(if ($null -eq $verdict) { $null } else { [string]$verdict.Verdict })
+  kind       = $(if ($null -eq $verdict) { $null } else { [string]$verdict.Kind })
+  exit_code  = $(if ($null -eq $verdict) { 0 } else { [int]$verdict.ExitCode })
+  evidence   = $(if ($null -eq $verdict) { $null } else { [string]$verdict.Evidence })
+  candidates = @(Select-DialogCandidate -Windows $windows).Count
+}
+Write-Output ('<<<PROBE-JSON>>>' + (ConvertTo-Json $payload -Compress -Depth 4))
+"""
+
+
+def _powershell() -> str:
+    """Path to Windows PowerShell, or skip - this arbiter is Windows-only by construction."""
+    if os.name != "nt":
+        pytest.skip("probe_desktop_credential.ps1 is a Windows-only UI Automation arbiter")
+    exe = shutil.which("powershell") or shutil.which("pwsh")
+    if not exe:
+        pytest.skip("no PowerShell interpreter on PATH")
+    return exe
+
+
+def _window(**overrides) -> dict:
+    """A synthesised Desktop window, shaped exactly like `Win32CredentialWindows.WindowInfo`."""
+    window = {
+        "Title": "",
+        "ClassName": "#32770",
+        "Width": 600,
+        "Height": 400,
+        "Texts": [],
+        "Minimized": False,
+        # `None` = the window has no owner, so the modality test could not be applied at all. That is
+        # NOT the same as `False` (owner disabled), and the classifier must not treat it as such.
+        "OwnerEnabled": None,
+    }
+    window.update(overrides)
+    return window
+
+
+def classify(tmp_path: Path, windows: list[dict], *, refresh_in_flight: bool = False) -> dict:
+    """Run the SHIPPED classifiers over ``windows`` and return their verdict as a dict.
+
+    Deliberately routed through files and `-File` rather than `-Command`: a quoting slip in an inline
+    command is how a mutation run in this repo scored a false pass. A non-zero exit (a renamed or
+    deleted function, a parse error) raises here rather than degrading to an empty result, so a
+    mutation cannot pass by breaking the harness.
+    """
+    exe = _powershell()
+    harness = tmp_path / "classify.ps1"
+    harness.write_text(_HARNESS, encoding="utf-8")
+    payload = tmp_path / "windows.json"
+    payload.write_text(json.dumps(windows), encoding="utf-8")
+    argv = [exe, "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", str(harness), "-Probe", str(PROBE_PS1)]
+    argv += ["-WindowsJson", str(payload)]
+    if refresh_in_flight:
+        argv.append("-RefreshInFlight")
+    done = subprocess.run(argv, capture_output=True, text=True, timeout=120, check=False)
+    assert done.returncode == 0, f"harness failed ({done.returncode}):\n{done.stdout}\n{done.stderr}"
+    marker = "<<<PROBE-JSON>>>"
+    assert marker in done.stdout, f"harness produced no result payload:\n{done.stdout}\n{done.stderr}"
+    return json.loads(done.stdout.split(marker, 1)[1].strip().splitlines()[0])
+
+
+REFRESH_PROGRESS = _window(
+    Title="Refresh",
+    ClassName="HwndWrapper[PBIDesktop.exe;;refresh]",
+    Texts=["Refresh", "Orders", "1,204 rows loaded", "Cancel"],
+    # A Power BI refresh dialog DOES disable its owner, so modality alone cannot tell it from a
+    # credential modal. Pinned false on purpose: the fix must not lean on the owner test.
+    OwnerEnabled=False,
+)
+CREDENTIAL_MODAL = _window(
+    Title="",
+    Texts=["Please specify how to connect", "Edit Credentials"],
+    OwnerEnabled=False,
+)
+
+
+def test_a_refresh_progress_dialog_is_not_reported_as_a_credential_block(tmp_path: Path) -> None:
+    """AC1. The field-reported false positive: an ordinary progress dialog is not a hard stop.
+
+    Two separate claims, and both matter. It must not be classified as a credential prompt, AND its
+    verdict must not land in the exit-1 hard-stop band - `BLOCKED_BY_DIALOG` was exit 1, the same code
+    a genuine credential wall uses, which is what made the false positive halt an unattended run.
+    """
+    result = classify(tmp_path, [REFRESH_PROGRESS])
+
+    assert result["candidates"] == 1, "the size pre-filter must still SELECT it; only the verdict changed"
+    assert result["credential"] is None
+    assert result["kind"] == "benign"
+    assert result["verdict"] != "BLOCKED_BY_DIALOG"
+    assert result["exit_code"] != 1, "a progress dialog must never reach the credential hard-stop band"
+
+
+def test_a_refresh_progress_dialog_during_our_own_refresh_is_ignored_entirely(tmp_path: Path) -> None:
+    """AC1/AC3. Once THIS script invoked the refresh, the progress dialog it caused is not a finding.
+
+    The distinction is the whole point of `-RefreshInFlight`: the same window means "somebody else is
+    refreshing, do not stack a second one" at t=0, and "your own refresh is running" in the poll loop.
+    """
+    assert classify(tmp_path, [REFRESH_PROGRESS], refresh_in_flight=True)["verdict"] is None
+
+
+def test_a_progress_dialog_already_up_at_t0_reports_refresh_in_progress(tmp_path: Path) -> None:
+    """AC3. Concurrent multi-instance refresh, as a first-class condition rather than setup noise.
+
+    The 2026-08-28 report ran three refreshes at once and had to cancel a stale duplicate by hand. A
+    progress dialog already open before this probe triggers anything is exactly that state, and the
+    verdict has to say so: not a credential wall (exit 1), not "all clear" (exit 0), but "Desktop is
+    busy, I could not probe" (exit 3).
+    """
+    result = classify(tmp_path, [REFRESH_PROGRESS])
+
+    assert result["verdict"] == "REFRESH_IN_PROGRESS"
+    assert result["exit_code"] == 3
+
+
+def test_a_genuine_credential_modal_is_still_detected(tmp_path: Path) -> None:
+    """AC2. The true positive must survive the fix for the false positive.
+
+    This is the "moved the boundary" guard: silencing the progress dialog by loosening the credential
+    path would pass every other test in this section and destroy the arbiter's only reason to exist.
+    """
+    result = classify(tmp_path, [CREDENTIAL_MODAL])
+
+    assert result["credential"] == "Please specify how to connect"
+    assert result["verdict"] == "CREDENTIAL_MISSING"
+    assert result["exit_code"] == 1
+
+
+def test_a_credential_modal_is_still_detected_behind_a_concurrent_refresh_dialog(tmp_path: Path) -> None:
+    """AC2/AC3. A benign classification must never mask a real modal on another window.
+
+    Ordering matters here and is easy to get wrong: iterate windows and return the first classification,
+    and a progress dialog enumerated first swallows the credential modal enumerated second. Run with
+    `refresh_in_flight` so the progress dialog is in its most-ignorable state.
+    """
+    result = classify(tmp_path, [REFRESH_PROGRESS, CREDENTIAL_MODAL], refresh_in_flight=True)
+
+    assert result["verdict"] == "CREDENTIAL_MISSING"
+    assert result["exit_code"] == 1
+
+
+def test_an_unreadable_dialog_is_a_third_verdict_not_one_of_the_other_two(tmp_path: Path) -> None:
+    """A window exposing no text at all: "we could not read it" is its own answer.
+
+    Absent is not empty. It must not collapse into `CREDENTIAL_MISSING` (we have no evidence of a
+    credential prompt) nor into "nothing here" (we have no evidence of health either).
+    """
+    result = classify(tmp_path, [_window(Texts=[], OwnerEnabled=False)])
+
+    assert result["kind"] == "unreadable"
+    assert result["verdict"] == "DIALOG_UNREADABLE"
+    assert result["exit_code"] == 3
+    assert result["credential"] is None
+
+
+def test_a_readable_but_unrecognized_dialog_is_distinct_from_an_unreadable_one(tmp_path: Path) -> None:
+    """The two ambiguous states are NOT the same state, and the verdict has to distinguish them.
+
+    "We read this window and it is not a credential prompt" is strictly more knowledge than "we could
+    not read this window at all". Collapsing them loses the only fact that tells an operator whether
+    looking at the screen will help.
+    """
+    unrecognized = classify(tmp_path, [_window(Title="Whoops", Texts=["Whoops", "Something went wrong"])])
+    unreadable = classify(tmp_path, [_window(Texts=[])])
+
+    assert unrecognized["kind"] == "unrecognized"
+    assert unrecognized["verdict"] == "DIALOG_UNRECOGNIZED"
+    assert unrecognized["exit_code"] == 3
+    assert unrecognized["verdict"] != unreadable["verdict"], "the two ambiguous states must not collapse"
+    assert unrecognized["evidence"], "the readable case must carry the text it read, or it proves nothing"
+
+
+def test_an_unclassifiable_window_outranks_a_benign_one(tmp_path: Path) -> None:
+    """Precedence. `benign` is the only classification carrying positive evidence of harmlessness.
+
+    So it must never outrank a window nobody could classify - otherwise one progress dialog is enough
+    to hide every other window Desktop has open.
+
+    Asserted at t=0 FIRST, and that ordering is load-bearing: in flight the benign branch is skipped
+    anyway, so an in-flight-only assertion passes even when the precedence is reversed. Caught by
+    mutation - moving the benign return above the unreadable one went undetected until t=0 was covered.
+    """
+    windows = [REFRESH_PROGRESS, _window(Texts=[])]
+
+    assert classify(tmp_path, windows)["verdict"] == "DIALOG_UNREADABLE"
+    assert classify(tmp_path, windows, refresh_in_flight=True)["verdict"] == "DIALOG_UNREADABLE"
+
+
+def test_a_readable_unrecognized_window_outranks_a_benign_one(tmp_path: Path) -> None:
+    """Same precedence rule for the other ambiguous state, at t=0 where both are live."""
+    windows = [REFRESH_PROGRESS, _window(Title="Whoops", Texts=["Whoops", "Something went wrong"])]
+
+    assert classify(tmp_path, windows)["verdict"] == "DIALOG_UNRECOGNIZED"
+
+
+def test_an_enabled_owner_window_exonerates_a_dialog(tmp_path: Path) -> None:
+    """Modality is used ONE WAY: it can exonerate a window, never convict one.
+
+    A modal dialog disables its owner, so an enabled owner proves this window blocks nothing. The
+    converse does not hold - `REFRESH_PROGRESS` above pins `OwnerEnabled=False` precisely because Power
+    BI's own progress dialog also disables the owner - so a disabled owner is never treated as evidence.
+    """
+    exonerated = classify(tmp_path, [_window(Texts=["Something else"], OwnerEnabled=True)])
+    not_exonerated = classify(tmp_path, [_window(Texts=["Something else"], OwnerEnabled=False)])
+    no_owner = classify(tmp_path, [_window(Texts=["Something else"], OwnerEnabled=None)])
+
+    assert exonerated["verdict"] is None
+    assert not_exonerated["verdict"] == "DIALOG_UNRECOGNIZED"
+    assert no_owner["verdict"] == "DIALOG_UNRECOGNIZED", "no owner means the test did not apply, not that it passed"
+
+
+def test_the_main_window_and_tiny_helper_windows_are_still_not_candidates(tmp_path: Path) -> None:
+    """The class and size pre-filters survive; they were never the defect, only their promotion to a verdict."""
+    main_window = _window(
+        Title="MyReport - Power BI Desktop",
+        ClassName="WindowsForms10.Window.8.app.0.141b42a_r6_ad1",
+        Width=1920,
+        Height=1080,
+        Texts=["MyReport - Power BI Desktop", "Refresh"],
+    )
+    tiny = _window(Width=10, Height=10)
+
+    result = classify(tmp_path, [main_window, tiny])
+
+    assert result["candidates"] == 0
+    assert result["verdict"] is None
+
+
+def test_the_arbiter_no_longer_derives_a_blocking_verdict_from_size_alone() -> None:
+    """Regression pin on the shipped file: the size-only detector and its exit-1 verdict are gone.
+
+    The behavioural tests above prove the classifiers are right; this proves the CALLERS were rewired to
+    them. A revert that restored `Test-BlockingDialog` while leaving the new functions in place would
+    pass every behavioural test in this section and still ship the defect.
+    """
+    body = PROBE_PS1.read_text(encoding="utf-8")
+
+    assert "function Test-BlockingDialog" not in body, "the size-only detector must not come back"
+    emitted = re.findall(r'VERDICT:\s*\{?0?\}?\s*"|VERDICT: ([A-Z_]+)', body)
+    assert "BLOCKED_BY_DIALOG" not in [name for name in emitted if name], (
+        "this arbiter must not emit BLOCKED_BY_DIALOG: it cannot establish that a dialog is blocking"
+    )
+    assert "exit $blocker.ExitCode" in body, "the t=0 branch must exit with the classifier's code, not a literal 1"
+
+
+def test_the_benign_signature_can_never_shadow_a_credential_prompt() -> None:
+    """The one way this fix could fail OPEN: a benign pattern broad enough to match a real modal.
+
+    In the poll loop a `benign` classification is IGNORED, so a credential prompt that matched the
+    benign signature would end the probe at `CREDENTIAL_PRESENT` - the fail-open the script's own header
+    calls worse than no arbiter. Platform-independent by design: it reads the two shipped resources, so
+    it gates on Linux CI too, where the PowerShell tests above skip.
+    """
+    benign = re.compile(BENIGN_SIGNATURE.read_text(encoding="utf-8").strip(), re.IGNORECASE)
+    credential_phrases = [
+        "You aren't signed in",
+        "Personal Access Token",
+        "Databricks Client Credentials",
+        "Please specify how to connect",
+        "Account Key",
+        "Enter your credentials",
+        "Permission is required to run this native database query",
+    ]
+
+    for phrase in credential_phrases:
+        assert not benign.search(phrase), f"benign signature must not match a credential prompt: {phrase!r}"
+
+
+def test_the_benign_signature_matches_real_refresh_progress_text() -> None:
+    """The progress vocabulary the arbiter is meant to recognise, pinned as data.
+
+    ⚠️ INFERRED from Power BI Desktop's refresh UI, not captured from a live dialog - so treat a miss as
+    a specificity gap, not a correctness one: an unmatched progress dialog degrades to
+    `DIALOG_UNRECOGNIZED`, which is still exit 3 and still not a credential wall.
+    """
+    benign = re.compile(BENIGN_SIGNATURE.read_text(encoding="utf-8").strip(), re.IGNORECASE)
+
+    for phrase in ["Refresh", "Evaluating", "1,204 rows loaded", "Waiting for other queries", "Loading data"]:
+        assert benign.search(phrase), f"benign signature should match progress text: {phrase!r}"
+    assert not benign.search("Refresh failed"), "'Refresh' is anchored so it cannot swallow arbitrary sentences"

--- a/.github/skills/pbip-model-refresh/tests/test_credential_modal_detection.py
+++ b/.github/skills/pbip-model-refresh/tests/test_credential_modal_detection.py
@@ -1019,15 +1019,31 @@ def test_probe_query_worker_cannot_print_after_credential_verdict(monkeypatch, c
 PROBE_PS1 = Path(__file__).resolve().parents[1] / "scripts" / "probe_desktop_credential.ps1"
 CREDENTIAL_SIGNATURE = PROBE_PS1.parent / "credential_modal_signature.regex"
 BENIGN_SIGNATURE = PROBE_PS1.parent / "benign_dialog_signature.regex"
+BLOCKING_SIGNATURE = PROBE_PS1.parent / "blocking_prompt_signature.regex"
 
 _HARNESS = r"""
 param(
   [Parameter(Mandatory = $true)][string]$Probe,
-  [Parameter(Mandatory = $true)][string]$WindowsJson,
+  [string]$WindowsJson,
+  [string]$PayloadJson,
+  [int]$PayloadExit = 0,
   [switch]$RefreshInFlight
 )
 $ErrorActionPreference = 'Stop'
 . $Probe -LoadDetectorsOnly
+if ($PayloadJson) {
+  $payload = $null
+  try { $payload = ConvertFrom-Json (Get-Content -LiteralPath $PayloadJson -Raw) } catch { $payload = $null }
+  $result = ConvertTo-HarvestResult -Payload $payload -ExitCode $PayloadExit
+  $accepted = ($null -ne $result)
+  $shaped = [ordered]@{
+    accepted = $accepted
+    complete = $(if ($accepted) { [bool]$result.Complete } else { $false })
+    items    = $(if ($accepted) { @($result.Items).Count } else { 0 })
+  }
+  Write-Output ('<<<PROBE-JSON>>>' + (ConvertTo-Json $shaped -Compress -Depth 4))
+  return
+}
 $parsed = ConvertFrom-Json (Get-Content -LiteralPath $WindowsJson -Raw)
 $windows = @($parsed)
 $verdict = Get-DialogVerdict -Windows $windows -RefreshInFlight:$RefreshInFlight
@@ -1095,6 +1111,22 @@ def classify(tmp_path: Path, windows: list[dict], *, refresh_in_flight: bool = F
     argv += ["-WindowsJson", str(payload)]
     if refresh_in_flight:
         argv.append("-RefreshInFlight")
+    done = subprocess.run(argv, capture_output=True, text=True, timeout=120, check=False)
+    assert done.returncode == 0, f"harness failed ({done.returncode}):\n{done.stdout}\n{done.stderr}"
+    marker = "<<<PROBE-JSON>>>"
+    assert marker in done.stdout, f"harness produced no result payload:\n{done.stdout}\n{done.stderr}"
+    return json.loads(done.stdout.split(marker, 1)[1].strip().splitlines()[0])
+
+
+def harvest_result(tmp_path: Path, payload, *, exit_code: int = 0) -> dict:
+    """Run the SHIPPED payload validator over a raw child payload and return what it accepted."""
+    exe = _powershell()
+    harness = tmp_path / "classify.ps1"
+    harness.write_text(_HARNESS, encoding="utf-8")
+    blob = tmp_path / "payload.json"
+    blob.write_text(payload if isinstance(payload, str) else json.dumps(payload), encoding="utf-8")
+    argv = [exe, "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", str(harness), "-Probe", str(PROBE_PS1)]
+    argv += ["-PayloadJson", str(blob), "-PayloadExit", str(exit_code)]
     done = subprocess.run(argv, capture_output=True, text=True, timeout=120, check=False)
     assert done.returncode == 0, f"harness failed ({done.returncode}):\n{done.stdout}\n{done.stderr}"
     marker = "<<<PROBE-JSON>>>"
@@ -1689,6 +1721,10 @@ def test_the_probe_harvests_window_text_through_ui_automation() -> None:
     assert "function Get-BoundedAutomationHarvest" in body and "WaitForExit" in body and "Kill()" in body, (
         "the harvest must run in a killable child process: a hung UIA provider cannot be cancelled in-process"
     )
+    assert "ConvertTo-HarvestResult -Payload" in body and "-ExitCode $child.ExitCode" in body, (
+        "the collector must route the child payload through the validator, carrying the child's exit code - "
+        "the validator is behaviourally tested on its own, but nothing else pins that it is actually WIRED IN"
+    )
 
 
 def test_the_harvest_child_process_is_this_same_script() -> None:
@@ -1841,7 +1877,17 @@ $script:timer.Add_Tick({
 
 
 def _run_probe_against_wpf_modal(tmp_path: Path, modal_body: str, extra_args: list[str] | None = None):
-    """Launch the fake-Desktop app with ``modal_body``, run the probe, return the completed process."""
+    """Launch the fake-Desktop app with ``modal_body``, run the probe, return the completed process.
+
+    ⚠️ **These live tests are CONTENTION-SENSITIVE, and that is not flakiness.** They drive a real GUI
+    process and a real cross-process UI Automation harvest, so running them alongside the whole skills
+    suite can slow the fixture enough that it never exposes an invokable `Refresh` (skip below), or slow
+    the harvest enough that it hits its own timeout and the verdict degrades to `DIALOG_UNREADABLE`.
+    Both are the fail-safe working: every degraded path lands in the exit-3 band, never a clear.
+    Measured 2026-08-29: a clean run is 100 passed; the same suite under a concurrent full-suite run
+    skipped one live test. Prefer asserting on the BAND (never exit 0, never suppressed) and reserve
+    exact-verdict assertions for the cases that are stable.
+    """
     exe = _powershell()
     app_script = tmp_path / "fake_desktop.ps1"
     app_script.write_text(_WPF_APP_PREAMBLE + modal_body + _WPF_APP_EPILOGUE, encoding="utf-8")
@@ -1937,3 +1983,244 @@ def test_a_wedged_uia_provider_still_produces_a_verdict(tmp_path: Path) -> None:
     assert done.elapsed < 25, (
         f"the probe inherited the provider's wedge instead of bounding it (took {done.elapsed:.1f}s)"
     )
+
+
+# --------------------------------------------------------------------------------------------------
+# Round 3: one benign element must not erase the rest of the window, and a payload must be validated
+# --------------------------------------------------------------------------------------------------
+#
+# Both findings are the SAME root cause, for the third time on this branch: missing evidence read as
+# good evidence. Round 1 let a caption stand in for content; round 2 let "we read something" stand in
+# for "we read the thing that matters"; round 3 let the FIRST benign element stand in for the whole
+# window, and a MISSING JSON property stand in for a completed harvest.
+
+NATIVE_QUERY_PROMPT = "Permission is required to run this native database query"
+
+
+def test_a_native_query_approval_beside_progress_text_is_not_suppressed(tmp_path: Path) -> None:
+    """The finding this branch must not ship without: one `Evaluating` erased a known blocking prompt.
+
+    `Permission is required to run this native database query` is Power BI Desktop's native-database-
+    query approval modal. It is not hypothetical - `SKILL.md` documents it at length, notes that
+    migrated custom-SQL sources emit exactly the shape that triggers it, and instructs the reader to
+    check for it *before* concluding anything about credentials. A probe that suppressed it would make
+    this bundle contradict its own documentation.
+
+    Exit 3, not 1: a human must act, but the remedy is an approval, not a sign-in - so it must not be
+    reported in the band whose documented meaning is "sign in once".
+    """
+    window = _window(
+        Title="Refresh",
+        Texts=["Refresh", "Evaluating", NATIVE_QUERY_PROMPT],
+        OwnerEnabled=False,
+    )
+
+    result = classify(tmp_path, [window], refresh_in_flight=True)
+
+    assert result["kind"] == "needs-human"
+    assert result["verdict"] == "DIALOG_NEEDS_HUMAN"
+    assert result["exit_code"] == 3
+    assert NATIVE_QUERY_PROMPT in (result["evidence"] or ""), "the verdict must carry the prompt it found"
+
+
+def test_a_native_query_approval_outranks_an_enabled_owner(tmp_path: Path) -> None:
+    """Modality exonerates a window we know nothing about, not one we have identified as blocking."""
+    window = _window(Title="Refresh", Texts=["Refresh", NATIVE_QUERY_PROMPT], OwnerEnabled=True)
+
+    assert classify(tmp_path, [window], refresh_in_flight=True)["kind"] == "needs-human"
+
+
+def test_authentication_required_alongside_loading_data_is_not_suppressed(tmp_path: Path) -> None:
+    """The second round-3 case: `\\bLoading data\\b` matched as a substring of a real prompt.
+
+    Two independent guards now stop it: the benign expressions are WHOLE-ELEMENT status patterns, so
+    `Loading data requires authentication` is not progress text at all; and `Authentication required`
+    is itself a known human-blocking prompt.
+    """
+    window = _window(
+        Title="Authentication required",
+        Texts=["Authentication required", "Loading data requires authentication"],
+        OwnerEnabled=False,
+    )
+
+    result = classify(tmp_path, [window], refresh_in_flight=True)
+
+    assert result["exit_code"] == 3
+    assert result["verdict"] != "REFRESH_IN_PROGRESS"
+
+
+def test_unaccounted_prose_beside_progress_text_is_not_suppressed(tmp_path: Path) -> None:
+    """The backstop for a blocking prompt in NEITHER signature.
+
+    A window is a progress dialog only when its content is ACCOUNTED FOR: recognised status text, or
+    short enough that it cannot be a human-directed prompt. A sentence nobody can explain sitting
+    beside `Evaluating` means the progress dialog does not explain this window.
+    """
+    window = _window(
+        Title="Refresh",
+        Texts=["Refresh", "Evaluating", "Something entirely unknown is blocking this refresh now"],
+        OwnerEnabled=False,
+    )
+
+    result = classify(tmp_path, [window], refresh_in_flight=True)
+
+    assert result["kind"] == "mixed-content"
+    assert result["verdict"] == "DIALOG_UNRECOGNIZED"
+    assert result["exit_code"] == 3
+
+
+def test_short_data_labels_beside_progress_text_do_not_block_suppression(tmp_path: Path) -> None:
+    """Positive control. Without this, "scan everything" could degenerate into "never suppress".
+
+    A real refresh dialog lists table names and row counts next to its status text. Those are short
+    data labels, not prose, and they must not veto - otherwise the benign path is unreachable and the
+    probe can never return CREDENTIAL_PRESENT while Desktop shows its own refresh dialog.
+    """
+    window = _window(
+        Title="Refresh",
+        Texts=["Refresh", "Orders", "Customers", "1,204 rows loaded", "Evaluating", "Cancel"],
+        InteractiveTexts=["Cancel"],
+        OwnerEnabled=False,
+    )
+
+    assert classify(tmp_path, [window], refresh_in_flight=True)["verdict"] is None
+    assert classify(tmp_path, [window])["verdict"] == "REFRESH_IN_PROGRESS"
+
+
+def test_the_benign_signature_matches_whole_elements_not_substrings() -> None:
+    """Platform-independent gate on the resource itself: no broad substring alternatives.
+
+    `\\bLoading data\\b` matched inside `Loading data requires authentication`. Every alternative is now
+    anchored, so a status word buried in a sentence is not a status.
+    """
+    benign = re.compile(BENIGN_SIGNATURE.read_text(encoding="utf-8").strip(), re.IGNORECASE)
+
+    for status in ["Refresh", "Evaluating", "Evaluating...", "Loading data", "1,204 rows loaded"]:
+        assert benign.search(status), f"a whole-element status must still match: {status!r}"
+    for sentence in [
+        "Loading data requires authentication",
+        "Refresh failed",
+        "Evaluating whether you have permission to sign in",
+        "Waiting for other queries and then a sign-in prompt",
+    ]:
+        assert not benign.search(sentence), f"a status word inside a sentence is not a status: {sentence!r}"
+
+
+def test_the_blocking_prompt_signature_covers_the_documented_native_query_modal() -> None:
+    """The prompt `SKILL.md` documents must actually be in the resource that recognises it."""
+    blocking = re.compile(BLOCKING_SIGNATURE.read_text(encoding="utf-8").strip(), re.IGNORECASE)
+
+    for phrase in [
+        NATIVE_QUERY_PROMPT,
+        "This native database query requires your approval",
+        "Authentication required",
+        "Authentication is required",
+    ]:
+        assert blocking.search(phrase), f"blocking signature must recognise: {phrase!r}"
+    for benign_status in ["Refresh", "Evaluating", "1,204 rows loaded", "Orders"]:
+        assert not blocking.search(benign_status), f"progress text must not be a blocking prompt: {benign_status!r}"
+
+
+@pytest.mark.parametrize(
+    "payload,exit_code,why",
+    [
+        pytest.param({"Items": []}, 0, "both flags missing", id="no-flags"),
+        pytest.param({"Items": [], "Truncated": False}, 0, "PatternsIncomplete missing", id="one-flag"),
+        pytest.param({"Items": [], "PatternsIncomplete": False}, 0, "Truncated missing", id="other-flag"),
+        pytest.param({"Items": [], "Truncated": None, "PatternsIncomplete": None}, 0, "null flags", id="null-flags"),
+        pytest.param({"Items": [], "Truncated": 0, "PatternsIncomplete": 0}, 0, "integer flags", id="int-flags"),
+        pytest.param(
+            {"Items": [], "Truncated": "false", "PatternsIncomplete": "false"}, 0, "string flags", id="str-flags"
+        ),
+        pytest.param(
+            {"Items": [], "Truncated": False, "PatternsIncomplete": False}, 4, "child failed", id="nonzero-exit"
+        ),
+    ],
+)
+def test_a_structurally_incomplete_child_payload_is_never_complete(tmp_path: Path, payload, exit_code, why) -> None:
+    """A missing property is `$null`, and `-not $null` is `$true` - so absence computed to "complete".
+
+    That coercion happened UPSTREAM of the strict `Test-HarvestComplete` guard, which is why the guard
+    did not save it: by the time it ran, the malformed value was already a real Boolean `$true`.
+    """
+    result = harvest_result(tmp_path, payload, exit_code=exit_code)
+
+    assert result["complete"] is False, f"payload must not be complete ({why})"
+
+
+def test_a_well_formed_child_payload_is_accepted_as_complete(tmp_path: Path) -> None:
+    """Positive control for the validator - otherwise it could pass by rejecting everything."""
+    payload = {
+        "Items": [{"Text": "Evaluating", "Interactive": False}],
+        "Truncated": False,
+        "PatternsIncomplete": False,
+    }
+
+    result = harvest_result(tmp_path, payload)
+
+    assert result["accepted"] is True
+    assert result["complete"] is True
+    assert result["items"] == 1
+
+
+def test_a_malformed_payloads_items_are_still_read_but_never_authorise_suppression(tmp_path: Path) -> None:
+    """Keeping the text costs nothing and can only raise credential recall; `Complete` still stays false."""
+    payload = {"Items": [{"Text": "Enter your credentials", "Interactive": False}], "Truncated": False}
+
+    result = harvest_result(tmp_path, payload)
+
+    assert result["items"] == 1, "unread text lowers credential recall, so salvage what parsed"
+    assert result["complete"] is False, "but a schema-incomplete payload can never authorise benign"
+
+
+def test_invalid_json_and_flagged_incompleteness_are_rejected(tmp_path: Path) -> None:
+    """The two shapes that were already safe, pinned so they stay that way."""
+    assert harvest_result(tmp_path, "{not json", exit_code=0)["accepted"] is False
+    truncated = {"Items": [], "Truncated": True, "PatternsIncomplete": False}
+    assert harvest_result(tmp_path, truncated)["complete"] is False
+    patterns = {"Items": [], "Truncated": False, "PatternsIncomplete": True}
+    assert harvest_result(tmp_path, patterns)["complete"] is False
+
+
+# `Evaluating` and the native-query approval prompt in ONE fully-harvested modal - the round-3 High,
+# reproduced end to end rather than only at the classifier.
+_MODAL_PROGRESS_PLUS_NATIVE_QUERY = r"""
+$script:timer.Add_Tick({
+    $script:timer.Stop()
+    $modal = New-Object System.Windows.Window
+    $modal.Title = 'Refresh'
+    $modal.Width = 560
+    $modal.Height = 320
+    $panel = New-Object System.Windows.Controls.StackPanel
+    $status = New-Object System.Windows.Controls.TextBlock
+    $status.Text = 'Evaluating'
+    $null = $panel.Children.Add($status)
+    $prompt = New-Object System.Windows.Controls.TextBlock
+    $prompt.Text = 'Permission is required to run this native database query'
+    $null = $panel.Children.Add($prompt)
+    $ok = New-Object System.Windows.Controls.Button
+    $ok.Content = 'Cancel'
+    $null = $panel.Children.Add($ok)
+    $modal.Content = $panel
+    $helper = New-Object System.Windows.Interop.WindowInteropHelper($modal)
+    $helper.Owner = $script:form.Handle
+    $null = $modal.ShowDialog()
+  })
+"""
+
+
+def test_a_native_query_prompt_beside_progress_text_is_live_reported(tmp_path: Path) -> None:
+    """Round 3's High, end to end: a fully-harvested mixed window must not clear.
+
+    ⚠️ The live tests in this module drive a real GUI process and a real UI Automation harvest, so they
+    are CONTENTION-SENSITIVE: running them alongside the whole skills suite can slow the harvest enough
+    that it times out and the verdict degrades to `DIALOG_UNREADABLE`. That is the fail-safe working as
+    designed, not flakiness - every degraded path still lands in the exit-3 band. Assertions here are
+    therefore written against the BAND (never exit 0, never suppressed), with the exact verdict checked
+    only where it is stable.
+    """
+    done = _run_probe_against_wpf_modal(tmp_path, _MODAL_PROGRESS_PLUS_NATIVE_QUERY)
+
+    assert done.returncode == 3, f"a native-query approval must never clear or be a credential stop:\n{done.stdout}"
+    assert "CREDENTIAL_PRESENT" not in done.stdout
+    assert "REFRESH_IN_PROGRESS" not in done.stdout, "one progress element must not suppress the whole window"

--- a/.github/skills/pbip-model-refresh/tests/test_credential_modal_detection.py
+++ b/.github/skills/pbip-model-refresh/tests/test_credential_modal_detection.py
@@ -1055,7 +1055,7 @@ def _powershell() -> str:
 
 
 def _window(**overrides) -> dict:
-    """A synthesised Desktop window, shaped exactly like `Win32CredentialWindows.WindowInfo`."""
+    """A synthesised Desktop window, shaped exactly like `ConvertTo-ProbeWindow`'s output."""
     window = {
         "Title": "",
         "ClassName": "#32770",
@@ -1066,6 +1066,10 @@ def _window(**overrides) -> dict:
         # `None` = the window has no owner, so the modality test could not be applied at all. That is
         # NOT the same as `False` (owner disabled), and the classifier must not treat it as such.
         "OwnerEnabled": None,
+        # Whether text beyond the CAPTION was obtained. Defaults true here because most fixtures model
+        # a window whose content was read; the fail-safe default for a MISSING field is pinned
+        # separately by `test_a_window_with_no_content_read_field_at_all_fails_safe`.
+        "ContentRead": True,
     }
     window.update(overrides)
     return window
@@ -1107,6 +1111,25 @@ CREDENTIAL_MODAL = _window(
     Title="",
     Texts=["Please specify how to connect", "Edit Credentials"],
     OwnerEnabled=False,
+)
+# The review defect of 2026-08-29, as the collector actually produced it. A WPF modal renders its
+# whole visual tree into ONE HWND, so `EnumChildWindows` harvested nothing and only the caption
+# survived - a caption that matches the progress signature. `ContentRead` false is the collector
+# saying so.
+WPF_CREDENTIAL_MODAL_SEEN_AS_CAPTION_ONLY = _window(
+    Title="Refresh",
+    ClassName="HwndWrapper[PBIDesktop.exe;;dialog]",
+    Texts=["Refresh"],
+    OwnerEnabled=False,
+    ContentRead=False,
+)
+# The same window once UI Automation supplies the visual text the Win32 collector could not see.
+WPF_CREDENTIAL_MODAL_WITH_UIA_TEXT = _window(
+    Title="Refresh",
+    ClassName="HwndWrapper[PBIDesktop.exe;;dialog]",
+    Texts=["Refresh", "Enter your credentials", "OK", "Cancel"],
+    OwnerEnabled=False,
+    ContentRead=True,
 )
 
 
@@ -1314,3 +1337,257 @@ def test_the_benign_signature_matches_real_refresh_progress_text() -> None:
     for phrase in ["Refresh", "Evaluating", "1,204 rows loaded", "Waiting for other queries", "Loading data"]:
         assert benign.search(phrase), f"benign signature should match progress text: {phrase!r}"
     assert not benign.search("Refresh failed"), "'Refresh' is anchored so it cannot swallow arbitrary sentences"
+
+
+# --------------------------------------------------------------------------------------------------
+# WPF content harvest (blind review, 2026-08-29)
+# --------------------------------------------------------------------------------------------------
+#
+# The Win32 collector reads a window's caption plus its CHILD HWND text. WPF renders its whole visual
+# tree into ONE HWND, so a WPF dialog contributes nothing but its caption. A modal titled `Refresh`
+# whose content read `Enter your credentials` was therefore classified benign from the caption alone,
+# suppressed in-flight, and the probe exited 0 with `CREDENTIAL_PRESENT`.
+#
+# Measured here on an owned WPF modal (WinForms owner so it is excluded by class, WPF `TextBlock`
+# child, `ShowDialog()` disabling the owner, raised 0.8s after Refresh is invoked):
+#
+#   commit 0aa3767 : refresh invoked: True / no credential modal within 12s / CREDENTIAL_PRESENT  exit 0
+#   fixed          : refresh invoked: True / credential modal detected: 'Enter your credentials'  exit 1
+#
+# That is a SILENT false negative on a hard stop - strictly worse than the loud false positive #367
+# set out to remove. Two independent guards now cover it: the UIA harvest (below), and the
+# `ContentRead` gate that keeps a caption-only benign match indeterminate even if the harvest fails.
+
+CREDENTIAL_ALTERNATIVES = [
+    "You aren't signed in",
+    "Personal Access Token",
+    "Databricks Client Credentials",
+    "specify how to connect",
+    "Account Key",
+    "Enter your credentials",
+    "Please specify how to connect",
+]
+
+_FAKE_DESKTOP_APP = r"""
+param([Parameter(Mandatory = $true)][string]$ReadyFile)
+Add-Type -AssemblyName System.Windows.Forms
+Add-Type -AssemblyName PresentationFramework
+Add-Type -AssemblyName PresentationCore
+Add-Type -AssemblyName WindowsBase
+Add-Type -AssemblyName WindowsFormsIntegration
+[System.Windows.Forms.Application]::EnableVisualStyles()
+
+# WinForms owner: its class starts with WindowsForms10.Window.8, so the probe excludes it exactly as
+# it excludes the real Power BI Desktop main window.
+$script:form = New-Object System.Windows.Forms.Form
+$script:form.Text = 'Fake Desktop'
+$script:form.Width = 640
+$script:form.Height = 480
+
+# A WPF button hosted in the form. A plain WinForms Button surfaces to UI Automation as
+# ControlType.Pane with NO patterns (measured), so the probe's `Name -eq 'Refresh'` + Invoke scan
+# would never fire and the run would end at the not-invoked guard instead of testing anything.
+$button = New-Object System.Windows.Controls.Button
+$button.Content = 'Refresh'
+$hostControl = New-Object System.Windows.Forms.Integration.ElementHost
+$hostControl.Width = 140
+$hostControl.Height = 48
+$hostControl.Child = $button
+$script:form.Controls.Add($hostControl)
+
+# Raised on a timer so the click handler returns immediately - InvokePattern.Invoke() must not be
+# left waiting on a modal message loop.
+$script:timer = New-Object System.Windows.Forms.Timer
+$script:timer.Interval = 800
+$script:timer.Add_Tick({
+    $script:timer.Stop()
+    $modal = New-Object System.Windows.Window
+    $modal.Title = 'Refresh'
+    $modal.Width = 520
+    $modal.Height = 320
+    $panel = New-Object System.Windows.Controls.StackPanel
+    $block = New-Object System.Windows.Controls.TextBlock
+    $block.Text = 'Enter your credentials'
+    $null = $panel.Children.Add($block)
+    $modal.Content = $panel
+    $helper = New-Object System.Windows.Interop.WindowInteropHelper($modal)
+    $helper.Owner = $script:form.Handle
+    $null = $modal.ShowDialog()
+  })
+$button.Add_Click({ $script:timer.Start() })
+$script:form.Add_Shown({ Set-Content -LiteralPath $ReadyFile -Value 'ready' -Encoding ascii })
+[System.Windows.Forms.Application]::Run($script:form)
+"""
+
+
+def test_an_owned_wpf_credential_modal_titled_refresh_is_a_hard_stop(tmp_path: Path) -> None:
+    """Live regression for the review defect: the whole script, against a real owned WPF modal.
+
+    The offline tests below pin the classifier's half of this. This one pins the COLLECTOR's half -
+    that the probe actually harvests text a WPF window only exposes through UI Automation - and it is
+    the only test here that exercises the real Win32 + UIA + refresh-invoke path end to end.
+    """
+    exe = _powershell()
+    app_script = tmp_path / "fake_desktop.ps1"
+    app_script.write_text(_FAKE_DESKTOP_APP, encoding="utf-8")
+    ready = tmp_path / "ready.txt"
+    app = subprocess.Popen(  # pylint: disable=consider-using-with
+        [exe, "-Sta", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", str(app_script), "-ReadyFile", str(ready)],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        for _ in range(60):
+            if ready.exists():
+                break
+            time.sleep(0.5)
+        if not ready.exists():
+            pytest.skip("the WPF fixture app never showed a window (no interactive desktop?)")
+        done = subprocess.run(
+            [exe, "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", str(PROBE_PS1), "-DesktopPid", str(app.pid)]
+            + ["-TimeoutSec", "12"],
+            capture_output=True,
+            text=True,
+            timeout=180,
+            check=False,
+        )
+        if "refresh invoked: True" not in done.stdout:
+            pytest.skip(f"the fixture app exposed no invokable Refresh to UI Automation:\n{done.stdout}")
+
+        assert "Enter your credentials" in done.stdout, (
+            "the probe must harvest WPF visual text; child-HWND enumeration alone sees only the caption"
+        )
+        assert "VERDICT: CREDENTIAL_MISSING" in done.stdout
+        assert done.returncode == 1, (
+            f"a real credential modal must be a hard stop, not exit {done.returncode}:\n{done.stdout}"
+        )
+    finally:
+        app.kill()
+        app.wait(timeout=30)
+
+
+def test_a_caption_only_benign_match_stays_indeterminate(tmp_path: Path) -> None:
+    """The collector's half can fail; this is the guard that holds when it does.
+
+    A window whose CONTENT was never read cannot be evidence of harmlessness, however reassuring its
+    caption. `absent != empty`, applied one level down - so a `Refresh` caption over unread content is
+    reported as indeterminate rather than suppressed.
+    """
+    result = classify(tmp_path, [WPF_CREDENTIAL_MODAL_SEEN_AS_CAPTION_ONLY])
+
+    assert result["kind"] == "benign-title-only"
+    assert result["verdict"] == "DIALOG_UNREADABLE"
+    assert result["exit_code"] == 3
+
+
+def test_a_caption_only_benign_match_is_not_suppressed_in_flight(tmp_path: Path) -> None:
+    """The exact step that produced exit 0: in-flight suppression of a caption-only benign match.
+
+    In the poll loop a genuine `benign` window is ignored, because it is our own refresh. A
+    caption-only match must NOT get that treatment - nothing was read, so nothing was established, and
+    a suppressed observation leaves the deadline free to print CREDENTIAL_PRESENT.
+    """
+    result = classify(tmp_path, [WPF_CREDENTIAL_MODAL_SEEN_AS_CAPTION_ONLY], refresh_in_flight=True)
+
+    assert result["verdict"] == "DIALOG_UNREADABLE", "an unread window must stay latchable in flight"
+    assert result["exit_code"] == 3
+
+
+def test_uia_harvested_text_turns_the_same_window_into_a_credential_stop(tmp_path: Path) -> None:
+    """With the visual text merged in, the caption stops mattering: credential beats benign."""
+    result = classify(tmp_path, [WPF_CREDENTIAL_MODAL_WITH_UIA_TEXT], refresh_in_flight=True)
+
+    assert result["kind"] == "credential"
+    assert result["verdict"] == "CREDENTIAL_MISSING"
+    assert result["exit_code"] == 1
+    assert result["credential"] == "Enter your credentials"
+
+
+def test_a_window_with_no_content_read_field_at_all_fails_safe(tmp_path: Path) -> None:
+    """A MISSING ContentRead field must read as "not read", never as "read".
+
+    This is the shape a future collector change, or a caller that predates the field, would produce.
+    Defaulting it to true would silently restore the suppression path with nothing to notice it.
+    """
+    window = _window(Title="Refresh", Texts=["Refresh"], OwnerEnabled=False)
+    del window["ContentRead"]
+
+    assert classify(tmp_path, [window])["kind"] == "benign-title-only"
+
+
+def test_a_credential_signature_split_across_wpf_elements_still_convicts(tmp_path: Path) -> None:
+    """WPF splits one sentence across visual elements, so the signature must see the joined text.
+
+    Both readers are asserted: `Get-DialogVerdict` (the classifier) and `Test-CredentialModal` (the
+    all-windows scan the main body runs first). They are separate call sites and either one losing the
+    joined text re-opens the gap on its own.
+    """
+    window = _window(Title="Refresh", Texts=["Refresh", "Enter your", "credentials"], OwnerEnabled=False)
+
+    result = classify(tmp_path, [window], refresh_in_flight=True)
+
+    assert result["verdict"] == "CREDENTIAL_MISSING"
+    assert result["exit_code"] == 1
+    assert result["credential"] == "Refresh Enter your credentials", (
+        "Test-CredentialModal must search the joined text too, not just the classifier"
+    )
+
+
+def test_the_benign_signature_is_never_matched_against_joined_text(tmp_path: Path) -> None:
+    """The join is asymmetric on purpose, and the asymmetry is the safety property.
+
+    Joining can manufacture a phrase from adjacent fragments. On the credential path that yields a LOUD
+    false stop a human resolves by looking at the screen; on the benign path it would yield a SILENT
+    false clear. `Loading` + `data` must therefore not join into the benign signature `Loading data`.
+    """
+    window = _window(Title="Loading", Texts=["Loading", "data"], OwnerEnabled=False)
+
+    result = classify(tmp_path, [window])
+
+    assert result["kind"] == "unrecognized", "benign must read individual elements only, never the join"
+
+
+@pytest.mark.parametrize("phrase", CREDENTIAL_ALTERNATIVES)
+def test_every_credential_signature_alternative_is_still_a_hard_stop(tmp_path: Path, phrase: str) -> None:
+    """The full true-positive set, re-proved after the text pipeline was rewritten.
+
+    Fixing a false positive by eroding the true positives is the failure mode this whole change is
+    most exposed to, so the signature's alternatives are asserted one by one rather than sampled.
+    """
+    window = _window(Title="Refresh", Texts=["Refresh", phrase], OwnerEnabled=False)
+
+    result = classify(tmp_path, [window], refresh_in_flight=True)
+
+    assert result["verdict"] == "CREDENTIAL_MISSING", f"{phrase!r} must convict even under a benign caption"
+    assert result["exit_code"] == 1
+
+
+def test_the_pinned_alternative_list_still_covers_the_shipped_signature() -> None:
+    """If someone adds an alternative to the signature file, the parametrised set above must grow too.
+
+    Without this, the "all alternatives" claim quietly becomes "the alternatives that existed in 2026".
+    """
+    alternatives = [alt for alt in CREDENTIAL_SIGNATURE.read_text(encoding="utf-8").strip().split("|") if alt]
+    signature = re.compile(CREDENTIAL_SIGNATURE.read_text(encoding="utf-8").strip(), re.IGNORECASE)
+
+    assert len(alternatives) == len(CREDENTIAL_ALTERNATIVES), (
+        f"signature has {len(alternatives)} alternatives but {len(CREDENTIAL_ALTERNATIVES)} are exercised"
+    )
+    for phrase in CREDENTIAL_ALTERNATIVES:
+        assert signature.search(phrase), f"pinned phrase no longer matches the shipped signature: {phrase!r}"
+
+
+def test_the_probe_harvests_window_text_through_ui_automation() -> None:
+    """Regression pin on the collector: the UIA harvest must stay wired into `Get-PidWindows`.
+
+    The behavioural tests above take `ContentRead` as an input. Only the live WPF test proves it is
+    produced, and that one skips where there is no interactive desktop - so this keeps the wiring
+    itself gated everywhere.
+    """
+    body = PROBE_PS1.read_text(encoding="utf-8")
+
+    assert "function Get-AutomationText" in body
+    assert "AutomationElement]::FromHandle" in body, "the harvest must start from the window handle"
+    assert "ConvertTo-ProbeWindow" in body and "-Enrich:$isCandidate" in body, (
+        "Get-PidWindows must enrich candidate windows, or the classifiers only ever see the caption"
+    )

--- a/docs/data-source-credentials.md
+++ b/docs/data-source-credentials.md
@@ -98,10 +98,12 @@ watches for the connector modal:
 - No modal within the timeout -> `VERDICT: CREDENTIAL_PRESENT` (exit 0), **but** re-confirm with the
   data probe before trusting it (see the serverless false-positive above).
 - A dialog is up that is *not* a credential prompt -> one of `REFRESH_IN_PROGRESS` (another refresh
-  already owns this instance — wait for it or cancel the stale one), `DIALOG_UNRECOGNIZED` (we read its
-  text and it matched no credential signature) or `DIALOG_UNREADABLE` (its **content** could not be
-  read — no text at all, or only a caption), each **exit 3**. All three mean *"could not probe"*, never
-  *"a human must sign in"*.
+  already owns this instance — wait for it or cancel the stale one), `DIALOG_NEEDS_HUMAN` (a **known**
+  human-blocking prompt that is not a credential prompt — the native-database-query approval modal;
+  approve it, no sign-in implied), `DIALOG_UNRECOGNIZED` (no signature matched, or progress text
+  alongside prose that is not progress status) or `DIALOG_UNREADABLE` (its **content** could not be
+  shown to be harmless), each **exit 3**. All four mean *"could not probe"*, never *"a human must sign
+  in"*.
 
 ⚠️ **Do not read a non-`CREDENTIAL_MISSING` verdict as a credential wall.** Until issue #367 the probe
 returned `BLOCKED_BY_DIALOG` at **exit 1** for *any* visible non-main window >= 100x100 — a Power BI
@@ -127,6 +129,12 @@ harvest in a **killable child process** (a hung provider held a 1 s probe for 15
 at all), and — the load-bearing part — **suppresses a dialog only when it positively reads benign
 CONTENT**, never because a caption looked reassuring. If you extend this probe, or write another dialog
 detector: **a caption is not content, and "we read something" is not "we read the thing that matters".**
+A third round found the same shape twice more: the **first** benign element used to classify the whole
+window (so `Evaluating` beside *"Permission is required to run this native database query"* cleared it),
+and a **missing JSON property** in the harvest child's payload computed to "complete" because
+`-not $null` is `$true`. The probe now scans all content, recognises known human-blocking prompts by
+name (`DIALOG_NEEDS_HUMAN`, exit 3), and validates the child's schema and exit code. The one-line
+lesson across all three rounds: **missing evidence must never read as good evidence.**
 
 **The robust positive check: query one row from the Desktop model (verified 2026-07).** Modal-absence is
 a *negative* signal; the *positive* proof that data actually flows is to query the loaded model. Power BI

--- a/docs/data-source-credentials.md
+++ b/docs/data-source-credentials.md
@@ -99,8 +99,9 @@ watches for the connector modal:
   data probe before trusting it (see the serverless false-positive above).
 - A dialog is up that is *not* a credential prompt -> one of `REFRESH_IN_PROGRESS` (another refresh
   already owns this instance — wait for it or cancel the stale one), `DIALOG_UNRECOGNIZED` (we read its
-  text and it matched no credential signature) or `DIALOG_UNREADABLE` (it exposes no readable text at
-  all), each **exit 3**. All three mean *"could not probe"*, never *"a human must sign in"*.
+  text and it matched no credential signature) or `DIALOG_UNREADABLE` (its **content** could not be
+  read — no text at all, or only a caption), each **exit 3**. All three mean *"could not probe"*, never
+  *"a human must sign in"*.
 
 ⚠️ **Do not read a non-`CREDENTIAL_MISSING` verdict as a credential wall.** Until issue #367 the probe
 returned `BLOCKED_BY_DIALOG` at **exit 1** for *any* visible non-main window >= 100x100 — a Power BI
@@ -114,6 +115,14 @@ text and reports what it actually saw; the size test only decides which windows 
 Two gotchas learned building it: (a) use a **generous timeout (>=60s)** because a serverless warehouse
 (Databricks) can **cold-start** before the modal appears, so a short wait yields a false PRESENT; and
 (b) also treat an **already-open** modal as MISSING (check before triggering refresh).
+
+⚠️ **A third, found in blind review 2026-08-29: Win32 child-HWND text cannot see inside a WPF dialog.**
+WPF renders its whole visual tree into one HWND, so only the window *caption* survives child
+enumeration. A real owned WPF modal captioned `Refresh`, whose content read `Enter your credentials`,
+was classified as a progress dialog and the probe exited **0 with `CREDENTIAL_PRESENT`** — a silent
+false negative on a hard stop. The probe now merges **UI Automation** descendant text before matching
+any signature, and treats a caption-only match on unread content as indeterminate rather than benign.
+If you extend this probe, or write another dialog detector: **a caption is not content**.
 
 **The robust positive check: query one row from the Desktop model (verified 2026-07).** Modal-absence is
 a *negative* signal; the *positive* proof that data actually flows is to query the loaded model. Power BI

--- a/docs/data-source-credentials.md
+++ b/docs/data-source-credentials.md
@@ -116,13 +116,17 @@ Two gotchas learned building it: (a) use a **generous timeout (>=60s)** because 
 (Databricks) can **cold-start** before the modal appears, so a short wait yields a false PRESENT; and
 (b) also treat an **already-open** modal as MISSING (check before triggering refresh).
 
-⚠️ **A third, found in blind review 2026-08-29: Win32 child-HWND text cannot see inside a WPF dialog.**
-WPF renders its whole visual tree into one HWND, so only the window *caption* survives child
-enumeration. A real owned WPF modal captioned `Refresh`, whose content read `Enter your credentials`,
-was classified as a progress dialog and the probe exited **0 with `CREDENTIAL_PRESENT`** — a silent
-false negative on a hard stop. The probe now merges **UI Automation** descendant text before matching
-any signature, and treats a caption-only match on unread content as indeterminate rather than benign.
-If you extend this probe, or write another dialog detector: **a caption is not content**.
+⚠️ **A third, found in blind review 2026-08-29: Win32 child-HWND text cannot see inside a WPF dialog,
+and no proxy for "we read the content" survives contact.** WPF renders its whole visual tree into one
+HWND, so only the window *caption* survives child enumeration. A real owned WPF modal captioned
+`Refresh`, whose content read `Enter your credentials`, was classified as a progress dialog and the
+probe exited **0 with `CREDENTIAL_PRESENT`** — a silent false negative on a hard stop. A second attempt
+that also required "we harvested some text" fell to a `Cancel` button. The probe now merges **UI
+Automation** text (`Name`, `ValuePattern`, `TextPattern`) before matching any signature, runs that
+harvest in a **killable child process** (a hung provider held a 1 s probe for 15 s+ producing no verdict
+at all), and — the load-bearing part — **suppresses a dialog only when it positively reads benign
+CONTENT**, never because a caption looked reassuring. If you extend this probe, or write another dialog
+detector: **a caption is not content, and "we read something" is not "we read the thing that matters".**
 
 **The robust positive check: query one row from the Desktop model (verified 2026-07).** Modal-absence is
 a *negative* signal; the *positive* proof that data actually flows is to query the loaded model. Power BI

--- a/docs/data-source-credentials.md
+++ b/docs/data-source-credentials.md
@@ -93,9 +93,23 @@ NOT be trusted on its own for a serverless source — always confirm with `DATA_
 
 `scripts/probe_desktop_credential.ps1 -DesktopPid <pid>` triggers a refresh via UI Automation and
 watches for the connector modal:
-- Modal appears (or is already open) -> `VERDICT: CREDENTIAL_MISSING` -> prompt the user to sign in once.
-- No modal within the timeout -> `VERDICT: CREDENTIAL_PRESENT`, **but** re-confirm with the data probe
-  before trusting it (see the serverless false-positive above).
+- Modal appears (or is already open) -> `VERDICT: CREDENTIAL_MISSING` (exit 1) -> prompt the user to
+  sign in once. **This is the only verdict that is a hard stop.**
+- No modal within the timeout -> `VERDICT: CREDENTIAL_PRESENT` (exit 0), **but** re-confirm with the
+  data probe before trusting it (see the serverless false-positive above).
+- A dialog is up that is *not* a credential prompt -> one of `REFRESH_IN_PROGRESS` (another refresh
+  already owns this instance — wait for it or cancel the stale one), `DIALOG_UNRECOGNIZED` (we read its
+  text and it matched no credential signature) or `DIALOG_UNREADABLE` (it exposes no readable text at
+  all), each **exit 3**. All three mean *"could not probe"*, never *"a human must sign in"*.
+
+⚠️ **Do not read a non-`CREDENTIAL_MISSING` verdict as a credential wall.** Until issue #367 the probe
+returned `BLOCKED_BY_DIALOG` at **exit 1** for *any* visible non-main window >= 100x100 — a Power BI
+Refresh progress dialog trips that trivially, and a field report on 2026-08-28 caught it doing so under
+three concurrent refreshes against a cold Snowflake warehouse. The probe now classifies a dialog by its
+text and reports what it actually saw; the size test only decides which windows are worth reading. The
+**Python** fast check (`probe_desktop_query.py` / `refresh_pbip_model.py`) still emits
+`BLOCKED_BY_DIALOG` from a size-only rule, so treat that token — wherever it comes from — as
+"something is on screen", not as "sign-in required".
 
 Two gotchas learned building it: (a) use a **generous timeout (>=60s)** because a serverless warehouse
 (Databricks) can **cold-start** before the modal appears, so a short wait yields a false PRESENT; and


### PR DESCRIPTION
Fixes #367 — `Test-BlockingDialog` reported ANY window >=100x100 as a credential block, so a `Refresh` progress dialog tripped it. A false credential wall is a hard stop, so this needed to be exact rather than merely narrower.

## Four rounds of blind review found one root cause wearing four faces

| round | what stood in for what |
|---|---|
| 1 | a **caption** stood in for content |
| 2 | *"we read something"* stood in for *"we read the thing that matters"* |
| 3a | the **first benign element** stood in for the whole window |
| 3b | a **missing JSON property** stood in for a completed harvest |

Each round the reviewer built a real owned WPF modal and defeated the previous fix. The generalisation is now written into `SKILL.md` and `docs/data-source-credentials.md` — reviewer's verdict on it: *"sound; all four failures were instances of partial or missing evidence being promoted into positive evidence."*

## The governing rule this landed on

> **A dialog is suppressed only when we POSITIVELY READ BENIGN CONTENT.** Never because we read *something* and the caption looked reassuring.

Master was right *by accident* — its size-only rule never read text at all, so it could not be fooled by text it had misread.

## Mechanisms

- **`blocking_prompt_signature.regex`** matched before benign and before the enabled-owner exoneration -> `DIALOG_NEEDS_HUMAN`, **exit 3**. Deliberately not exit 1: Power BI's native-database-query approval needs an *approval*, not a sign-in, so it must not enter the band documented as "sign in once".
- **Whole-content scan** — the first benign element no longer classifies the window. A content element of 5+ words that is not recognised status vetoes suppression, **with a positive control** so short data labels (`Orders`, `1,204 rows loaded`, `Cancel`) do not veto and `CREDENTIAL_PRESENT` stays reachable.
- **Whole-element benign patterns** — `\bLoading data\b` was matching inside `Loading data requires authentication`.
- **`TextPattern` harvested**, element cap raised 400 -> 2000, truncation recorded and non-suppressible.
- **Killable child process per harvest** with a wall-clock bound. Measured: a wedged UI thread took 70.5s in-process vs 6.2s bounded.
- **`ConvertTo-HarvestResult`** requires child exit 0 and both completeness flags to exist as real Booleans (`-not $null` is `$true`, which silently meant "complete").

## Why this mattered more than it looked

`Permission is required to run this native database query` is Power BI Desktop's native-query approval modal, documented at length in this repo's own `pbip-model-refresh` skill as a live hazard for migrated custom-SQL sources — and `tests/test_credential_modal_detection.py:1335` already treated it as blocking. An intermediate version of this fix would have suppressed it, making the probe conclude the opposite of our own guidance.

## Verification (independent, by the reviewer)

- All three round-2 exploits -> `CREDENTIAL_MISSING`, exit 1
- Native-query prompt beside `Evaluating` -> `DIALOG_NEEDS_HUMAN`, exit 3
- 2000-element truncation -> `DIALOG_UNREADABLE`, exit 3, never a clear
- Every credential alternative beside benign content -> exit 1 (precedence intact)
- **A live healthy progress dialog remains clearable -> `CREDENTIAL_PRESENT`, exit 0**
- Spawn failure, invalid HWND, timeout, empty output, malformed JSON -> all fail closed

**Mutations 30/30.** Two escaped first and both were the author's own tests: a redundant regex alternative made one mutation a no-op, and the payload validator was behaviourally tested but never pinned as *wired in*. Scoring was hardened to require a named `N failed` rather than a non-zero exit — which immediately surfaced a bug in the harness itself.

Gates: `pytest .github/skills` 0 (252 passed; credential suite 100, +18) · `pytest tests/` 0 (2157) · both pylint 10.00/10 exit 0 · ruff 0 · six repo gates 0.

## Known limits, stated rather than hidden

- **No Power BI Desktop was available.** The 5-word threshold cannot be validated against the real refresh dialog; if its progress text contains a long non-status sentence, that dialog becomes exit 3. Conservative direction, but a real behaviour change.
- `LegacyIAccessiblePattern` **does not exist** in the managed `System.Windows.Automation` API (verified by type check; `AutomationPattern.LookupById(10018)` has no registered managed pattern). MSAA-bridged-only content is unreadable from here — bounded to a recall loss, never a clear.
- `Authentication required` routes to exit 3 rather than exit 1, because promoting it means editing `credential_modal_signature.regex`, shared with the Python path. Reviewer: acceptable, since it cannot produce a silent clear. Follow-up alongside #376.
- Live tests are contention-sensitive — recorded in the helper docstring with guidance to assert on the verdict *band*, not an exact verdict.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
