### PR TITLE
Fixes #387: a measured two-tier test loop, with the flake it exposed gated

### DIFF
--- a/.github/skills/pbip-model-refresh/tests/conftest.py
+++ b/.github/skills/pbip-model-refresh/tests/conftest.py
@@ -20,6 +20,38 @@ SKILL_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
 if str(SKILL_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(SKILL_SCRIPTS))
 
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Register `timing` and `serial` HERE so the markers travel with the bundle.
+
+    **`timing`** - a handful of tests in this folder assert a sub-second wall-clock budget on an
+    operation that takes ~0.03s. Measured (issue #387) under 22 concurrent pytest-xdist workers, one
+    of them took **0.941s against a 0.5s budget** - a 31x inflation of a very short measured window,
+    which is scheduler starvation rather than proportional slowdown. Widening the bound is therefore
+    not a fix; the host repo's parallel test tier deselects them with `-m "not timing"` instead.
+
+    **`serial`** - seven tests here launch a real WPF application and drive it through UI Automation.
+    The interactive desktop and its UIA provider are a singleton, so two of these running at once
+    degrade each other. Measured (issue #387) across three rounds of two whole-suite parallel runs
+    started concurrently: `test_credential_text_beyond_the_element_cap_convicts_when_the_cap_allows_it`
+    failed in **3 of 6** runs, every time with `harvest=INCOMPLETE` and `VERDICT: DIALOG_UNREADABLE` -
+    the probe degrading safely, and the test's stricter assertion correctly refusing it. Not one of
+    them failed in seven runs that were not concurrently paired, so this needs the pairing.
+
+    Registering them in this conftest rather than a host `pyproject.toml` is the whole point: copy
+    this folder into another repo and `-m "not (serial or timing)"` still works, with no
+    unregistered-marker warning.
+    """
+    config.addinivalue_line(
+        "markers",
+        "timing: asserts a wall-clock budget, so a saturated box fails it",
+    )
+    config.addinivalue_line(
+        "markers",
+        "serial: contends for a singleton external resource; must not run beside another such test",
+    )
+
+
 # The path above must be in place before the skill's own modules import, hence the E402 waiver.
 from _credential_modal import CredentialDetection  # noqa: E402
 

--- a/.github/skills/pbip-model-refresh/tests/test_credential_modal_detection.py
+++ b/.github/skills/pbip-model-refresh/tests/test_credential_modal_detection.py
@@ -317,6 +317,7 @@ def test_zero_windows_dead_reports_process_gone_not_no_dialog() -> None:
     assert state.process_gone == harvested_desktop_gone_reason()
 
 
+@pytest.mark.timing
 def test_direct_refresh_returns_credential_missing_fast_at_t0(monkeypatch) -> None:
     """A t=0 credential modal must not wait for the XMLA deadline."""
     monkeypatch.setattr(refresh_pbip_model, "_credential_state", lambda _pid: modal_state())
@@ -330,6 +331,7 @@ def test_direct_refresh_returns_credential_missing_fast_at_t0(monkeypatch) -> No
     assert elapsed < 0.5, f"t=0 modal path waited {elapsed:.3f}s instead of returning immediately"
 
 
+@pytest.mark.timing
 def test_direct_refresh_returns_blocked_by_dialog_fast_at_t0(monkeypatch) -> None:
     """Unreadable blocking dialog must stop immediately instead of waiting for XMLA."""
     monkeypatch.setattr(refresh_pbip_model, "_credential_state", lambda _pid: blocking_state())
@@ -343,6 +345,7 @@ def test_direct_refresh_returns_blocked_by_dialog_fast_at_t0(monkeypatch) -> Non
     assert elapsed < 0.5
 
 
+@pytest.mark.timing
 def test_direct_refresh_raises_desktop_gone_fast_at_t0(monkeypatch) -> None:
     """#158: a Desktop already dead at t=0 must bail immediately, never start the XMLA wait.
 
@@ -363,6 +366,7 @@ def test_direct_refresh_raises_desktop_gone_fast_at_t0(monkeypatch) -> None:
     assert elapsed < 0.5, f"t=0 process-gone path waited {elapsed:.3f}s instead of returning immediately"
 
 
+@pytest.mark.timing
 def test_refresh_poll_catches_late_modal(monkeypatch, parked) -> None:
     """A credential dialog appearing after XMLA starts is caught on the next poll."""
     calls = {"count": 0}
@@ -722,6 +726,7 @@ def test_refresh_and_save_wires_desktop_gone_to_exit_2(monkeypatch, capsys) -> N
     assert reason in out
 
 
+@pytest.mark.timing
 def test_refresh_main_returns_credential_missing_fast_at_t0(monkeypatch, tmp_path: Path, capsys) -> None:
     """refresh_pbip_model.main stops before port discovery, identity checks, refresh, or row counts."""
     model_folder(tmp_path, "MyMigration")
@@ -827,6 +832,7 @@ def test_refresh_main_latches_unknown_from_its_own_precheck(monkeypatch, tmp_pat
     assert reason in out
 
 
+@pytest.mark.timing
 def test_probe_query_returns_credential_missing_fast_at_t0(monkeypatch, capsys) -> None:
     """probe_desktop_query.main stops before port discovery or DAX when the modal is already open."""
     monkeypatch.setattr(probe_desktop_query, "_credential_state", lambda _pid: modal_state())
@@ -1466,6 +1472,7 @@ $script:form.Add_Shown({ Set-Content -LiteralPath $ReadyFile -Value 'ready' -Enc
 """
 
 
+@pytest.mark.serial
 def test_an_owned_wpf_credential_modal_titled_refresh_is_a_hard_stop(tmp_path: Path) -> None:
     """Live regression for the review defect: the whole script, against a real owned WPF modal.
 
@@ -1921,6 +1928,7 @@ def _run_probe_against_wpf_modal(tmp_path: Path, modal_body: str, extra_args: li
         app.wait(timeout=30)
 
 
+@pytest.mark.serial
 def test_credential_text_reachable_only_through_textpattern_is_a_hard_stop(tmp_path: Path) -> None:
     """Exploit 1. `Name` + `ValuePattern` alone miss a read-only RichTextBox's content entirely."""
     done = _run_probe_against_wpf_modal(tmp_path, _MODAL_TEXTPATTERN_ONLY)
@@ -1929,6 +1937,7 @@ def test_credential_text_reachable_only_through_textpattern_is_a_hard_stop(tmp_p
     assert done.returncode == 1
 
 
+@pytest.mark.serial
 def test_credential_text_beyond_the_element_cap_never_reads_as_clean(tmp_path: Path) -> None:
     """Exploit 2. Truncation must not be indistinguishable from a complete, clean read.
 
@@ -1941,6 +1950,7 @@ def test_credential_text_beyond_the_element_cap_never_reads_as_clean(tmp_path: P
     assert "CREDENTIAL_PRESENT" not in done.stdout
 
 
+@pytest.mark.serial
 def test_credential_text_beyond_the_element_cap_convicts_when_the_cap_allows_it(tmp_path: Path) -> None:
     """The same window with the shipped cap: read in full, and convicted."""
     done = _run_probe_against_wpf_modal(tmp_path, _MODAL_PAST_THE_ELEMENT_CAP)
@@ -1949,6 +1959,7 @@ def test_credential_text_beyond_the_element_cap_convicts_when_the_cap_allows_it(
     assert done.returncode == 1
 
 
+@pytest.mark.serial
 def test_a_signature_split_by_an_interposed_button_is_a_hard_stop(tmp_path: Path) -> None:
     """Exploit 3. The prose join must skip interactive elements, or `Cancel` breaks the sentence."""
     done = _run_probe_against_wpf_modal(tmp_path, _MODAL_INTERPOSED_SPLIT)
@@ -1957,6 +1968,7 @@ def test_a_signature_split_by_an_interposed_button_is_a_hard_stop(tmp_path: Path
     assert done.returncode == 1
 
 
+@pytest.mark.serial
 def test_a_wedged_uia_provider_still_produces_a_verdict(tmp_path: Path) -> None:
     """The MEDIUM finding: an uncapped UIA walk let a 1s probe run 15s+ and emit nothing at all.
 
@@ -2209,6 +2221,7 @@ $script:timer.Add_Tick({
 """
 
 
+@pytest.mark.serial
 def test_a_native_query_prompt_beside_progress_text_is_live_reported(tmp_path: Path) -> None:
     """Round 3's High, end to end: a fully-harvested mixed window must not clear.
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -31,10 +31,12 @@ jobs:
       - name: Lint (ruff)
         # `.github/skills/*/scripts` is code that MOVED out of `scripts/` to make each skill a
         # self-contained copyable unit; without naming it here it would be linted by nobody.
+        # `conftest.py` is the repo-root parallel-run guard (issue #387) - it sits above every lint
+        # root below, so it needs naming for the same reason.
         # Keep in step with `testpaths` in pyproject.toml.
         run: |
-          uv run ruff format --check scripts tests .github/skills
-          uv run ruff check scripts tests .github/skills
+          uv run ruff format --check conftest.py scripts tests .github/skills
+          uv run ruff check conftest.py scripts tests .github/skills
 
       - name: Static analysis (pylint)
         # Three invocations, not one: `scripts/probe_desktop_query.py` is a forwarding shim with the
@@ -42,11 +44,14 @@ jobs:
         # .github/skills/...` puts both on the path and resolves the import to the shim
         # (E0611 no-name-in-module). That collision forces `scripts` and pbip-model-refresh/scripts
         # apart; powerbi-ai-readiness/scripts is separate by the one-root-per-invocation convention.
-        # Tests are not held to 10.00/10; the toolkit code is.
+        # Tests are not held to 10.00/10; the toolkit code is - and `conftest.py` is toolkit code
+        # that gates every parallel run (issue #387), so it is held to it too. It is a fourth
+        # invocation for the same one-root-per-invocation reason.
         run: |
           uv run pylint scripts
           uv run pylint .github/skills/pbip-model-refresh/scripts
           uv run pylint .github/skills/powerbi-ai-readiness/scripts
+          uv run pylint conftest.py
 
       - name: Tests
         run: uv run pytest -q

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,12 +53,12 @@ promoted to a global skill location) — splitting it across `scripts/` and `tes
 "just copy it" claim untrue. Same conventions apply inside the bundle (`purpose:`/`usage:` headers,
 10.00/10 pylint), and the same commands, with the extra paths:
 ```bash
-ruff format --check scripts tests .github/skills
-ruff check scripts tests .github/skills
+ruff format --check conftest.py scripts tests .github/skills
+ruff check conftest.py scripts tests .github/skills
 pylint scripts                                          # one invocation PER bundle, never combined:
 pylint .github/skills/pbip-model-refresh/scripts        # a shim and its bundled script share a
 pylint .github/skills/powerbi-ai-readiness/scripts      # module name, so a combined run resolves
-                                                        # the import to the shim (false E0611)
+pylint conftest.py                                      # the import to the shim (false E0611)
 ```
 
 **A bundle need not ship code at all.** `powerbi-report-gotchas` and `powerbi-semantic-model-gotchas`
@@ -99,11 +99,18 @@ reason when absent rather than fail.
 
 ## Tests
 
-The deterministic parser has a `pytest` regression suite:
+Two tiers. Iterate on the fast one; **quote the slow one**:
 
 ```bash
-pytest -q                    # currently 188 tests
+uv run pytest -q -n auto --dist loadfile -m "not (serial or timing)"   # tier 1, ~4 min
+uv run pytest -q                                                       # tier 2, the gate of record
 ```
+
+Measured on 22 cores: 911 s serial against ~250 s parallel, identical node id by node id. Tier 1 is
+not a substitute for tier 2 — one green parallel run is not proof of isolation, and tier 1 deselects
+six wall-clock-budget tests by construction. `-n auto` **without** `--dist loadfile` is refused by the
+root `conftest.py` (exit 4). Full reasoning, evidence and the marker rules:
+[`docs/parallel-test-loop.md`](docs/parallel-test-loop.md).
 
 `testpaths` in `pyproject.toml` covers both roots (`tests` **and** `.github/skills`) — pytest skips
 dot-directories by default, so a skill's bundled tests would otherwise be collected by nobody.

--- a/conftest.py
+++ b/conftest.py
@@ -18,8 +18,9 @@ Power BI Desktop / UI-Automation tests - the ones the parallel tier is most dang
 the second root. A `tests/conftest.py` would leave `pytest .github/skills/... -n 4` ungated, which
 is precisely the run that needs gating.
 
-The companion half is the `serial` marker registered in `pyproject.toml`; see
-`docs/parallel-test-loop.md` for the two-tier loop that uses it.
+The companion half is the `serial` and `timing` markers registered in `pyproject.toml`; the tests
+that carry `timing` declare it themselves, in their own source, so it survives being copied out of
+this repo. See `docs/parallel-test-loop.md` for the two-tier loop that uses them.
 """
 
 from __future__ import annotations
@@ -27,38 +28,6 @@ from __future__ import annotations
 import pytest
 
 REQUIRED_DIST = "loadfile"
-
-# Tests that assert a sub-second WALL-CLOCK budget. They measure the machine as much as the code, so
-# a box running 22 xdist workers (plus whatever else) fails them without anything being wrong.
-#
-# Measured (issue #387), eight whole-suite `-n auto --dist loadfile` runs against one serial run and
-# 30 serial repetitions of the owning file (15 quiet, 15 beside a live 22-worker suite):
-#   * exactly ONE node id ever disagreed, out of 2564;
-#   * `test_refresh_main_returns_credential_missing_fast_at_t0` took 0.941s against its 0.5s budget
-#     on worker gw9, in the slowest of the eight runs (305s vs a 160-217s median);
-#   * it never failed in any serial repetition, loaded or quiet.
-# So this is not a `--dist loadfile` isolation failure - no shared state raced, and the deselection
-# below is not a substitute for one. It is CPU starvation, and the durable fix is in the tests: a
-# budget assertion wants a monotonic-clock floor it controls, not a share of a contended machine.
-# Until their owners change them, the parallel tier deselects them and the serial tier still runs
-# them - that is what tier 2 is for.
-#
-# ⚠️ Marked by NODE ID, which a rename would silently break, and blind to a new budget test added
-# elsewhere. `tests/test_parallel_test_loop.py` re-derives this set from the suite's own AST and
-# fails on either drift, so the list cannot rot quietly.
-TIMING_BUDGET_FILE = ".github/skills/pbip-model-refresh/tests/test_credential_modal_detection.py"
-
-TIMING_BUDGET_TESTS = frozenset(
-    f"{TIMING_BUDGET_FILE}::{name}"
-    for name in (
-        "test_direct_refresh_returns_credential_missing_fast_at_t0",
-        "test_direct_refresh_returns_blocked_by_dialog_fast_at_t0",
-        "test_direct_refresh_raises_desktop_gone_fast_at_t0",
-        "test_refresh_poll_catches_late_modal",
-        "test_refresh_main_returns_credential_missing_fast_at_t0",
-        "test_probe_query_returns_credential_missing_fast_at_t0",
-    )
-)
 
 WRONG_DIST_MESSAGE = (
     "pytest-xdist is active with --dist {dist!r}. This suite is only measured safe under "
@@ -90,23 +59,3 @@ def pytest_configure(config: pytest.Config) -> None:
     if dist == REQUIRED_DIST:
         return
     raise pytest.UsageError(WRONG_DIST_MESSAGE.format(dist=dist))
-
-
-@pytest.hookimpl(tryfirst=True)
-def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
-    """Apply `timing` to the wall-clock-budget tests so `-m` can deselect them.
-
-    A marker added here is only useful if it lands **before** pytest's own `-m` filtering, which
-    `_pytest.mark` performs from its own `@hookimpl(tryfirst=True)`. Measured on pytest 9.1.1, both
-    a `tryfirst` hook and a plain one deselect correctly, so `tryfirst` here is defensive rather than
-    load-bearing on this version - removing it is an equivalent mutation and
-    `test_the_timing_marker_actually_deselects_those_tests` does not distinguish it. That test does
-    catch the failure that matters: a marker that never reaches the filter at all.
-
-    Under xdist this runs inside every worker, and every worker applies the same set, so collection
-    stays identical across them. Deselected counts stay visible in the summary line
-    (``N passed, 6 deselected``) - the exclusion is never silent.
-    """
-    for item in items:
-        if item.nodeid in TIMING_BUDGET_TESTS:
-            item.add_marker(pytest.mark.timing)

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,112 @@
+"""Repo-wide pytest configuration.
+
+This file exists for exactly one reason: **`--dist loadfile` is load-bearing and nothing enforced
+it.** Issue #387 measured the suite at 740s serial versus ~215s under `-n auto --dist loadfile` on
+22 logical cores, with byte-identical pass/fail counts across repeated runs - but every one of those
+runs carried `--dist loadfile`. Plain `-n auto` means `--dist load`, which spreads a single test
+*file* across workers, so module-scoped fixtures, per-file caches and shared on-disk scratch race.
+That configuration has never been measured here, and the failure it produces is a flaky suite, which
+is worse than a slow one: a flaky suite poisons every agent's judgement at once.
+
+`-n auto` is three characters shorter than `-n auto --dist loadfile` and will be typed. So the
+prose warning in the issue is converted into a gate: a parallel run without `loadfile` is a
+`UsageError` (exit 4) naming the two supported commands.
+
+It lives at the repo ROOT, not in `tests/`, because pytest only loads a `conftest.py` for paths
+underneath it. `pyproject.toml` declares `testpaths = ["tests", ".github/skills"]`, and the live
+Power BI Desktop / UI-Automation tests - the ones the parallel tier is most dangerous for - are in
+the second root. A `tests/conftest.py` would leave `pytest .github/skills/... -n 4` ungated, which
+is precisely the run that needs gating.
+
+The companion half is the `serial` marker registered in `pyproject.toml`; see
+`docs/parallel-test-loop.md` for the two-tier loop that uses it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+REQUIRED_DIST = "loadfile"
+
+# Tests that assert a sub-second WALL-CLOCK budget. They measure the machine as much as the code, so
+# a box running 22 xdist workers (plus whatever else) fails them without anything being wrong.
+#
+# Measured (issue #387), eight whole-suite `-n auto --dist loadfile` runs against one serial run and
+# 30 serial repetitions of the owning file (15 quiet, 15 beside a live 22-worker suite):
+#   * exactly ONE node id ever disagreed, out of 2564;
+#   * `test_refresh_main_returns_credential_missing_fast_at_t0` took 0.941s against its 0.5s budget
+#     on worker gw9, in the slowest of the eight runs (305s vs a 160-217s median);
+#   * it never failed in any serial repetition, loaded or quiet.
+# So this is not a `--dist loadfile` isolation failure - no shared state raced, and the deselection
+# below is not a substitute for one. It is CPU starvation, and the durable fix is in the tests: a
+# budget assertion wants a monotonic-clock floor it controls, not a share of a contended machine.
+# Until their owners change them, the parallel tier deselects them and the serial tier still runs
+# them - that is what tier 2 is for.
+#
+# ⚠️ Marked by NODE ID, which a rename would silently break, and blind to a new budget test added
+# elsewhere. `tests/test_parallel_test_loop.py` re-derives this set from the suite's own AST and
+# fails on either drift, so the list cannot rot quietly.
+TIMING_BUDGET_FILE = ".github/skills/pbip-model-refresh/tests/test_credential_modal_detection.py"
+
+TIMING_BUDGET_TESTS = frozenset(
+    f"{TIMING_BUDGET_FILE}::{name}"
+    for name in (
+        "test_direct_refresh_returns_credential_missing_fast_at_t0",
+        "test_direct_refresh_returns_blocked_by_dialog_fast_at_t0",
+        "test_direct_refresh_raises_desktop_gone_fast_at_t0",
+        "test_refresh_poll_catches_late_modal",
+        "test_refresh_main_returns_credential_missing_fast_at_t0",
+        "test_probe_query_returns_credential_missing_fast_at_t0",
+    )
+)
+
+WRONG_DIST_MESSAGE = (
+    "pytest-xdist is active with --dist {dist!r}. This suite is only measured safe under "
+    "--dist loadfile (issue #387).\n"
+    '  fast loop   : pytest -q -n auto --dist loadfile -m "not (serial or timing)"\n'
+    "  pre-PR gate : pytest -q\n"
+    "loadfile keeps every test in one FILE on one worker, so file-scoped fixtures and shared "
+    "scratch state do not race. To use another scheduler, change this guard deliberately and "
+    "re-measure - see docs/parallel-test-loop.md."
+)
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Refuse a parallel run that silently dropped `--dist loadfile`.
+
+    The early return on a falsy `numprocesses` is load-bearing in two directions, not one. It covers
+    plain serial runs, where the option is unset - and it covers every xdist **worker**, which is not
+    an obvious case. Measured with a probe conftest that logged its own options: the controller sees
+    ``numprocesses=2 dist='loadfile'`` while each worker sees ``numprocesses=None dist='no'``. So a
+    "simpler" guard that only compared `dist` would raise a UsageError inside every worker of a
+    perfectly valid run. `test_a_parallel_run_with_loadfile_is_allowed` is what pins that down.
+
+    `numprocesses` may still be the string ``"auto"`` depending on hook ordering, so this tests
+    truthiness rather than comparing to an int.
+    """
+    if not getattr(config.option, "numprocesses", None):
+        return
+    dist = getattr(config.option, "dist", "no")
+    if dist == REQUIRED_DIST:
+        return
+    raise pytest.UsageError(WRONG_DIST_MESSAGE.format(dist=dist))
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    """Apply `timing` to the wall-clock-budget tests so `-m` can deselect them.
+
+    A marker added here is only useful if it lands **before** pytest's own `-m` filtering, which
+    `_pytest.mark` performs from its own `@hookimpl(tryfirst=True)`. Measured on pytest 9.1.1, both
+    a `tryfirst` hook and a plain one deselect correctly, so `tryfirst` here is defensive rather than
+    load-bearing on this version - removing it is an equivalent mutation and
+    `test_the_timing_marker_actually_deselects_those_tests` does not distinguish it. That test does
+    catch the failure that matters: a marker that never reaches the filter at all.
+
+    Under xdist this runs inside every worker, and every worker applies the same set, so collection
+    stays identical across them. Deselected counts stay visible in the summary line
+    (``N passed, 6 deselected``) - the exclusion is never silent.
+    """
+    for item in items:
+        if item.nodeid in TIMING_BUDGET_TESTS:
+            item.add_marker(pytest.mark.timing)

--- a/conftest.py
+++ b/conftest.py
@@ -25,9 +25,18 @@ this repo. See `docs/parallel-test-loop.md` for the two-tier loop that uses them
 
 from __future__ import annotations
 
+import os
+
 import pytest
 
 REQUIRED_DIST = "loadfile"
+
+# A test carrying either of these must not run under xdist. `serial` wants an exclusive singleton
+# (the interactive desktop and its UIA provider); `timing` asserts a wall-clock budget that a
+# saturated box blows. Both were MEASURED to fail under parallelism - see docs/parallel-test-loop.md.
+CONTENDED_MARKERS = ("serial", "timing")
+
+INCLUDE_CONTENDED = "--include-contended"
 
 WRONG_DIST_MESSAGE = (
     "pytest-xdist is active with --dist {dist!r}. This suite is only measured safe under "
@@ -38,6 +47,32 @@ WRONG_DIST_MESSAGE = (
     "scratch state do not race. To use another scheduler, change this guard deliberately and "
     "re-measure - see docs/parallel-test-loop.md."
 )
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    """Register the deliberate opt-out from the automatic contended-test deselection."""
+    parser.addoption(
+        INCLUDE_CONTENDED,
+        action="store_true",
+        default=False,
+        help=(
+            "Run `serial`/`timing` tests under xdist anyway. They were measured to fail there; "
+            "this exists for deliberately stress-testing that, not for normal use."
+        ),
+    )
+
+
+def _xdist_is_active(config: pytest.Config) -> bool:
+    """Whether this process is part of a distributed run - controller or worker.
+
+    Both halves are needed and neither is redundant. The controller carries `numprocesses`; a
+    **worker** does not - measured with a probe conftest, a worker sees ``numprocesses=None
+    dist='no'`` - and the worker is where collection actually happens under xdist, so a check on
+    `numprocesses` alone would deselect nothing in a real parallel run.
+    """
+    if getattr(config.option, "numprocesses", None):
+        return True
+    return hasattr(config, "workerinput") or bool(os.environ.get("PYTEST_XDIST_WORKER"))
 
 
 def pytest_configure(config: pytest.Config) -> None:
@@ -59,3 +94,32 @@ def pytest_configure(config: pytest.Config) -> None:
     if dist == REQUIRED_DIST:
         return
     raise pytest.UsageError(WRONG_DIST_MESSAGE.format(dist=dist))
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    """Deselect every contended test whenever xdist is active. This is the MECHANISM.
+
+    The markers alone are a convention: they only protect anything if the caller remembers
+    `-m "not (serial or timing)"`. Drop half of that - `-m "not timing"` - and all seven live
+    WPF/UI-Automation tests are collected under xdist again, which is precisely the configuration
+    measured to fail 3 times in 8 concurrent-pair runs (`harvest=INCOMPLETE`, 30.6s against 8.08s
+    serially). A guard that validates only `--dist loadfile` cannot see that, and a documented
+    command is not a mechanism.
+
+    So the exclusion no longer depends on being asked for. `--include-contended` is the deliberate
+    opt-out, for stress-testing this very behaviour; it is not for normal use.
+
+    Deselection - rather than skipping - keeps the count visible in the summary line
+    (``N passed, 14 deselected``) and keeps every worker's collection identical, since each applies
+    the same rule to the same items.
+    """
+    if not _xdist_is_active(config) or config.getoption("include_contended"):
+        return
+    kept: list[pytest.Item] = []
+    dropped: list[pytest.Item] = []
+    for item in items:
+        target = dropped if any(item.get_closest_marker(name) for name in CONTENDED_MARKERS) else kept
+        target.append(item)
+    if dropped:
+        items[:] = kept
+        config.hook.pytest_deselected(items=dropped)

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -74,6 +74,7 @@ Eligible files: tracked Markdown knowledge/navigation files, `.github/pbi.kb/**/
 | Find migration guidance | [`docs/migration-spec.md`](../docs/migration-spec.md) | `migration-spec.json` contract. |
 | Find migration guidance | [`docs/operator-runbook.md`](../docs/operator-runbook.md) | Manual pipeline operation. |
 | Test the offline deployment rehearsal | [`docs/offline-mock-harness.md`](offline-mock-harness.md) | Offline Tableau-to-Fabric mock harness and fidelity boundary. |
+| Run the test suite | [`docs/parallel-test-loop.md`](parallel-test-loop.md) | Fast parallel loop vs the serial pre-PR gate, and the `serial` marker. |
 | Find migration guidance | [`docs/reference-capture.md`](../docs/reference-capture.md) | Tableau reference capture and evidence grading. |
 | Find migration guidance | [`docs/review-remediation-plan.md`](../docs/review-remediation-plan.md) | Route validation/review findings. |
 | Find migration guidance | [`docs/tableau-dax-translation-guide.md`](../docs/tableau-dax-translation-guide.md) | Translate Tableau calcs/LODs/table calcs. |

--- a/docs/parallel-test-loop.md
+++ b/docs/parallel-test-loop.md
@@ -23,46 +23,31 @@ Both must be green. Tier 1 is not a substitute for tier 2, and the reason is bel
 `pyproject.toml`), so `uv sync --all-extras` puts it in every worktree venv. Agents each work in
 their own `git worktree` with their own `.venv`; anything not declared there is absent everywhere.
 
-Measured on 22 logical cores, machine shared with other agents throughout - so these wall times
-carry real external load, which is the condition this loop exists for.
-
-**Before the `timing` exclusion below** (2564 node ids):
+Measured on 22 logical cores, machine shared with other agents throughout - so these wall times carry
+real external load, which is the condition this loop exists for. 2697 node ids; tier 1 deselects 14.
 
 | run | wall | outcome |
 |---|---|---|
-| serial, `pytest -q` | **681 s** | 3 failed, 2554 passed, 7 skipped |
-| `-n auto --dist loadfile`, 8 runs | **160 - 305 s** | 7 identical to serial; 1 had one extra failure |
+| tier 2, serial `pytest -q` | **911 s** | 3 failed, 2684 passed, 7 skipped |
+| tier 1, 3 sequential runs | **242 / 252 / 254 s** | identical, node id by node id |
 
-**After** (2568 node ids; tier 1 deselects 6):
+**~3.6x faster.** The three standing failures are the deliberate `tests/test_upstream_repro_pins.py`
+engine-drift tripwires (engine pinned 2.260.0, installed 2.339.0); they fail identically on `master`.
 
-| run | wall | outcome |
-|---|---|---|
-| tier 2, serial `pytest -q` | **646 s** | 3 failed, 2558 passed, 7 skipped |
-| tier 1, 3 runs | **297 / 307 / 329 s** | 3 failed, 2552 passed, 7 skipped - **identical node id by node id** |
-
-**2.0 - 4.3x faster**, depending entirely on what else the machine is doing. The three standing
-failures are the deliberate `tests/test_upstream_repro_pins.py` engine-drift tripwires (engine pinned
-2.260.0, installed 2.339.0); they fail identically on `master`.
-
-The runs were compared **by node id**, not by summary totals, because a summary hides the failure
+Every run was compared **by node id**, not by summary totals, because a summary hides the failure
 mode that matters: a test that skips or short-circuits under contention leaves `N passed` looking
-healthy. Across the eight pre-change runs, exactly **one** node id ever disagreed (below). Across the
-three post-change tier-1 runs, **none** did - and tier 2 differs from tier 1 by exactly the six
-deselected `timing` tests and nothing else.
+healthy. Three campaigns were run in total - before the live UI tests landed on `master`, after they
+landed, and again after the fixes below.
 
-Why it parallelises so well: most of the ~2,500 tests spawn a subprocess
-(`subprocess.run([sys.executable, ...])`), so the suite is process-spawn and I/O bound, not GIL
-bound. Contention also matters - the same serial suite took 4m37s on a quiet machine and 12m20s with
-nine agents competing, so shortening the window shortens everybody's.
+⚠️ **Sequential runs are not a hard enough test.** Two of the three real defects found here appear
+only when **two whole-suite parallel runs are started concurrently** - the condition two agents on
+one machine actually create. If you re-measure, measure that.
 
-## The one node id that disagreed, and what it was not
+## The hazard that is real: wall-clock budgets, not shared state
 
-`test_credential_modal_detection.py::test_refresh_main_returns_credential_missing_fast_at_t0` took
-**0.941 s against a 0.5 s budget** on worker `gw9`, in the slowest of the eight parallel runs (305 s,
-against a 160-217 s median - the machine was busiest then). Its externals are all monkeypatched; the
-assertion is purely a wall clock.
-
-Follow-up experiments, to find out whether parallelism caused it:
+Across eight parallel runs of the first campaign, exactly **one** node id ever disagreed:
+`test_credential_modal_detection.py::test_refresh_main_returns_credential_missing_fast_at_t0`, which
+took **0.941 s against a 0.5 s budget** on worker `gw9`. Isolation experiments:
 
 | condition | samples | failures |
 |---|---|---|
@@ -71,49 +56,122 @@ Follow-up experiments, to find out whether parallelism caused it:
 | owning file only, serial, quiet machine | 15 | 0 |
 | owning file only, serial, **beside a live 22-worker suite** | 15 | 0 |
 
-So this is **not** a `--dist loadfile` isolation failure. No shared state raced; no fixture collided;
-no file was split across workers. It is CPU starvation of a wall-clock assertion, and it needs the
-test's own process to be one of 22 competing workers - running it serially beside 22 busy workers did
-not reproduce it in 15 attempts.
+So this is **not** a `--dist loadfile` isolation failure. No shared state raced; no file was split
+across workers. It is CPU starvation, and it needs the test's own process to be one of 22 competing
+workers.
 
-That also makes it a **different hazard from the one this was expected to find** (see the live-test
-section below), and it is the one that actually exists in the tree today.
+**Widening the bound is not a fix.** That operation takes **0.03 s** serially. A 0.5 s budget is
+already 16x headroom, and it still blew at 0.941 s - a **31x** inflation of a very short measured
+window, which is scheduler starvation of a short sample rather than proportional slowdown. There is
+no bound that is both tight enough to catch the regression it exists for and loose enough to survive
+a saturated box. Excluding it from the contended tier is the honest answer.
 
-## The `timing` marker: what tier 1 excludes, and why it is not silent
+## The `timing` marker, and where it has to live
 
 `pyproject.toml` registers three markers with deliberately narrow, different meanings:
 
 | marker | means | applied |
 |---|---|---|
 | `slow` | takes a long time | by hand |
-| `serial` | must not run beside another test wanting the same singleton external resource | by hand |
-| `timing` | asserts a **sub-second wall-clock budget**, so a saturated box fails it | **automatically**, by the root `conftest.py` |
+| `serial` | must not run beside another test wanting the same singleton external resource | by hand, in the test's own source |
+| `timing` | asserts a **wall-clock budget**, so a saturated box fails it | by hand, in the test's own source |
 
-Six tests carry `timing`, all in `test_credential_modal_detection.py`, all asserting a 0.5 s or 1.0 s
-budget. Tier 1 deselects them; **tier 2 still runs them**, and the deselection is visible in tier 1's
-own summary line (`... 6 deselected`), so nothing disappears quietly.
+Seven tests carry `serial` and seven carry `timing`. Tier 1 deselects both; **tier 2 still runs
+them**, and the deselection is visible in tier 1's own summary (`... 14 deselected`).
 
-Two looser budgets are deliberately **left in** the parallel tier, because a bigger margin is not the
-same hazard and neither has ever been observed failing: `tests/test_credential_gate.py`'s 5.0 s hook
-budget and `test_refresh_wall_clock.py`'s 15 s bound.
+`timing`'s automatic floor is **sub-second**: every test asserting a budget under 2 s must carry it,
+gated from the suite's AST. A larger budget earns the marker on measured evidence instead - the 10 s
+process-rendezvous barrier in `test_check_migration_progress.py` did, after failing under 44 workers.
+Two budgets are deliberately **left in** the parallel tier, having never been observed to fail:
+`tests/test_credential_gate.py`'s 5.0 s hook budget and `test_refresh_wall_clock.py`'s 15 s bound.
 
-The list is hand-written node ids, which a rename would silently break - so
-`tests/test_parallel_test_loop.py` re-derives the set from the suite's own AST (an
-`assert <expr> < <number under 2>` whose left side reads `time.monotonic()`/`perf_counter()`) and
-fails on drift in **both** directions. A new sub-second budget test added anywhere fails that gate
-until it is listed.
+Three things make the marker hold up, and each is gated by `tests/test_parallel_test_loop.py`:
 
-**The durable fix is in the tests, not here.** A budget assertion should measure something it
-controls - a monotonic floor, an injected clock, a call count - rather than its share of a contended
-machine. This exclusion is an interim owned by the parallel tier, and the list should shrink.
+1. **The marker is in the test's own source**, not applied from outside. `test_parallel_test_loop.py`
+   re-derives the budget set from the suite's **AST** (an `assert <expr> < <number under 2>` whose
+   left side reads `time.monotonic()`/`perf_counter()`) and fails when any of them lacks
+   `@pytest.mark.timing`. A new budget test added anywhere fails that gate until it is marked.
+2. **The bundle registers `timing` in its own `conftest.py`.** `pbip-model-refresh` is meant to be
+   copied into another repo, where this repo's `pyproject.toml` does not exist; without local
+   registration the copied bundle raises an unknown-mark warning and `-m "not timing"` quietly stops
+   meaning anything. Verified by copying the folder out and running it standalone: `235 passed,
+   3 skipped, 6 deselected`, with `PytestUnknownMarkWarning` promoted to an error.
+3. **`tests/test_skills.py` propagates the exclusion into its nested run** - see below.
+
+**The durable fix still belongs in those tests**, which should assert against something they control
+(a call count, an injected clock, a monotonic floor) rather than their share of a contended machine.
+This exclusion is an interim, and the list should shrink.
+
+### The nested run: where the first draft of this leaked
+
+`tests/test_skills.py` copies each skill bundle to a temp directory and runs its tests there, to
+execute the portability promise rather than assert it. That nested pytest is **serial**, but its
+process competes with every other xdist worker - and the copied tree contains no root `conftest.py`
+and no `pyproject.toml`, so an exclusion expressed at repo level **structurally cannot reach it**.
+
+Measured: in one concurrent-pair stress run, the outer suite correctly deselected
+`test_refresh_main_returns_credential_missing_fast_at_t0`, and the nested copy of that same test
+failed at **0.519 s** against its 0.5 s budget. Tier 1 was still ~1-in-7 flaky, through a different
+door. The fix moves the failure boundary unless the nested run inherits the filter, so it does -
+conditional on `PYTEST_XDIST_WORKER`, which is set only inside an xdist worker (verified: `None`
+serially, `'gw0'` under `-n 2`). Tier 2 therefore still executes every test the bundle ships.
+
+## The live Power BI Desktop / UI-Automation tests: measured, and they DO need `serial`
+
+`.github/skills/pbip-model-refresh/tests/` carries **seven live tests** that launch a real WPF
+application and drive it through UI Automation, including a wedged-UI-thread regression whose whole
+point is a `< 25 s` wall-clock bound. Two independent reports had them degrading under contention -
+one live harvest returning `DIALOG_UNREADABLE`, and one live test skipping when run beside the full
+skills suite.
+
+**The first verdict here was that they were stable, and it was wrong.** Across seven parallel runs -
+three sequential, plus two concurrent pairs - not one of them failed or skipped, and this page said
+so. Three *more* concurrent pairs found the failure:
+
+| condition | runs | live-test failures |
+|---|---|---|
+| tier 1, sequential | 3 | 0 |
+| tier 1, concurrent pairs (44 workers on 22 cores) | 8 | **3** |
+
+`test_credential_text_beyond_the_element_cap_convicts_when_the_cap_allows_it` failed in **3 of 6**
+runs of the later rounds - twice in the *same pair*, both sides at once - every time like this:
+
+```
+a dialog was up during the refresh: ... size=650x400 harvest=INCOMPLETE
+  it matched no credential-prompt signature, so this is NOT a credential wall
+  but a window we could not account for was open
+VERDICT: DIALOG_UNREADABLE
+```
+
+That is the documented hazard verbatim: the UIA harvest could not finish, the probe **degraded
+safely**, and the test's stricter assertion correctly refused the degraded verdict. The test took
+**30.6 s against 8.08 s serially**. Three sequential runs would have shipped this as "stable" - the
+condition it needs is *two live suites at once*, which is exactly what two agents on one machine do.
+
+So all seven now carry **`@pytest.mark.serial`**. Marking only the one that was observed would move
+the boundary rather than remove it - they share one mechanism and one singleton resource. Run them
+deliberately, on their own:
+
+```bash
+uv run pytest -q -m serial
+```
+
+⚠️ `--dist loadfile` is what keeps them from racing *inside* one run (all seven live in one file, so
+one worker owns them). It cannot help *across* runs, and neither can any scheduler flag. The marker
+is the only lever.
+
+A second, unrelated test was caught in the same rounds and is marked `timing`:
+`test_declare_wrapper_concurrent_writers_keep_both_declarations` gives two child processes **10 s**
+to reach a rendezvous barrier, and under 44 workers they did not both start in time. Its budget is
+far above the sub-second rule below, so it is marked on **measured** evidence rather than by the
+automatic gate.
 
 ## `--dist loadfile` is not optional, and the repo now enforces that
 
 Plain `-n auto` means `--dist load`, which distributes **individual tests**, so two tests from one
-file can run on different workers at the same time. `--dist loadfile` keeps every test in one file
-on one worker, which is what makes module-scoped fixtures, per-file caches and shared on-disk
-scratch safe. Every measurement above was taken **with** `loadfile`; `--dist load` has never been
-measured here.
+file can run on different workers at the same time. `--dist loadfile` keeps every test in one file on
+one worker - which is exactly what keeps the seven live UI tests above from running beside each
+other. Every measurement here was taken **with** `loadfile`; `--dist load` has never been measured.
 
 `-n auto` is shorter to type than `-n auto --dist loadfile`, so the root `conftest.py` refuses it:
 
@@ -135,10 +193,9 @@ To use a different scheduler, edit the guard deliberately and re-measure. That i
 
 **One green parallel run is not proof of isolation.** A test that quietly changed behaviour under
 concurrency - took a different branch, skipped instead of running, degraded to a safer verdict - can
-still report at the summary level as though nothing happened. `2554 passed` is the same string
-whether a test asserted something or bailed out early. And tier 1 deliberately deselects the `timing`
-tests, so it is a strictly smaller suite by construction - measured, 2562 node ids against tier 2's
-2568.
+still report at the summary level as though nothing happened. And tier 1 deliberately deselects the
+`serial` and `timing` tests, so it is a strictly smaller suite by construction: 2683 node ids against
+tier 2's 2697, plus fourteen more inside the nested bundle run.
 
 So the plain serial `pytest -q` stays the gate of record before a PR. It is slower and it is the one
 whose result you quote. Tier 1 buys iteration speed; tier 2 buys the claim.
@@ -153,39 +210,39 @@ uv run pytest -q -n auto --dist loadfile -m "not (serial or timing)" --junitxml=
 then diff the `classname`/`name`/outcome triples. A skip that replaced a pass is invisible in the
 summary line and obvious in the XML.
 
-## The `serial` marker, and the live-test hazard
+## One thing this loop does NOT fix: two pytest processes in ONE working tree
 
-Some tests contend for a **singleton external resource**: a real Power BI Desktop instance, its
-UI-Automation tree, a live credential dialog. Two of them running at once degrade each other. This
-is measured, not theoretical (issue #387):
+Running two concurrent whole-suite campaigns in the *same checkout* also surfaced
+`tests/test_check_unit.py::test_cli_model_scope_reports_not_checked_for_unattributable_connection_fixture`
+failing on the **second** process, deterministically, 3 pairs out of 3 - while the first passed every
+time. That is not a parallelism defect and no marker or scheduler flag can address it:
+`_freshen_clean_fixture_cache()` mutates a **git-tracked fixture inside the repo**
+(`tests/fixtures/check-unit-clean-integration/.../cache.abf`) and stamps it with a 60-second future
+mtime. Two processes sharing that path overwrite each other's freshness window. `--dist loadfile` is
+irrelevant: only one file touches that fixture, so it never leaves a single worker within a run.
 
-- running the all-skills suite concurrently with the credential suite made one live harvest degrade
-  to `DIALOG_UNREADABLE` and fail its stricter assertion; rerunning without the contention passed;
-- the same bundle ran **100 passed** alone, and **skipped** one live test when run beside the full
-  skills suite.
+**It does not affect the documented workflow**, because agents each work in their own `git worktree`
+with their own `.venv`, and that fixture path is then not shared. It is recorded here so the next
+person who reproduces it does not spend an afternoon blaming xdist. If you deliberately run two
+suites in one checkout, expect it.
 
-Note the shape: contention pushes those tests toward the **fail-safe**, not toward a false pass -
-and it is already reachable **serially**, whenever two agents run pytest at the same time.
-Parallelism inside one invocation is the same hazard with a shorter fuse.
+## The `serial` marker
 
-A test opts in with `@pytest.mark.serial`. Tier 1 already excludes them, so the marker takes effect
-the moment it is applied. Run them on their own afterwards:
+`serial` means a test contends for a **singleton external resource** - a real Power BI Desktop
+instance, its UI-Automation tree, a live credential dialog - such that two of them running at once
+degrade each other. A test opts in with `@pytest.mark.serial`. Seven tests carry it today, all of
+them the live WPF/UIA regressions measured above. Run them deliberately, on their own, when you have
+touched the credential probe:
 
 ```bash
 uv run pytest -q -m serial
 ```
 
-**Exit code 5 from that command means no test carries the marker yet** - that is "nothing to run",
-not a failure.
+That is not part of either tier. Tier 1 excludes them because two agents running tier 1 at once
+raced them; tier 2 includes them, because a serial whole-suite run is the one condition in which they
+were never observed to fail.
 
-**Current status, stated plainly:** no test in the tree carries `serial`, and no tracked test drives
-a real Desktop or a real UI-Automation tree (`DIALOG_UNREADABLE` appears in zero tracked test files).
-The live tests the quotes above describe are in flight against issue #367 in the `pbip-model-refresh`
-bundle and are **not on `master`**, so that hazard **could not be reproduced here** and the `serial`
-marker is unapplied scaffolding. When those tests land, marking them is a one-line change per test
-and needs nothing from this page.
-
-⚠️ One residual gap worth knowing: the exclusion only happens if the command carries
+⚠️ One residual gap worth knowing: the exclusions only happen if the command carries
 `-m "not (serial or timing)"`. A hand-typed `pytest -n auto --dist loadfile` still runs everything.
 The doc-drift tests keep every *documented* command honest; they cannot police what you type.
 
@@ -196,15 +253,14 @@ The doc-drift tests keep every *documented* command honest; they cannot police w
 **4 vCPU**, so `-n auto` would pick 4 workers rather than an absurd number. That makes parallel CI
 *plausible*, not *measured*:
 
-- every xdist worker re-imports and re-collects all ~2,560 tests, and that fixed cost is a much
-  larger fraction of the total on 4 cores than on 22;
-- the one defect this work found is **CPU starvation of a wall-clock assertion**. A 4-vCPU runner
-  running 4 workers is exactly the shape that makes that worse, and CI is where a flaky red costs
-  the most;
+- every xdist worker re-imports and re-collects ~2,690 tests, and that fixed cost is a much larger
+  fraction of the total on 4 cores than on 22;
+- the defect this work found is **CPU starvation of a wall-clock assertion**. A 4-vCPU runner running
+  4 workers is exactly the shape that makes that worse, and CI is where a flaky red costs the most;
 - CI is the shared trust anchor. A flaky gate is worse than a slow one for the same reason tier 2
   exists;
-- the cost this issue is about is the **agent iteration loop on a developer machine**, which is
-  where the 3.4x lands. CI wall time was never the complaint.
+- the cost this issue is about is the **agent iteration loop on a developer machine**, which is where
+  the 3.6x lands. CI wall time was never the complaint.
 
 If CI time does become the complaint, the change is one line per job plus a measurement on the
 runners themselves - and the root-`conftest.py` guard already makes it impossible to add `-n` there

--- a/docs/parallel-test-loop.md
+++ b/docs/parallel-test-loop.md
@@ -24,15 +24,18 @@ Both must be green. Tier 1 is not a substitute for tier 2, and the reason is bel
 their own `git worktree` with their own `.venv`; anything not declared there is absent everywhere.
 
 Measured on 22 logical cores, machine shared with other agents throughout - so these wall times carry
-real external load, which is the condition this loop exists for. 2697 node ids; tier 1 deselects 14.
+real external load, which is the condition this loop exists for. 2702 node ids; tier 1 deselects 14.
 
 | run | wall | outcome |
 |---|---|---|
-| tier 2, serial `pytest -q` | **911 s** | 3 failed, 2684 passed, 7 skipped |
-| tier 1, 3 sequential runs | **242 / 252 / 254 s** | identical, node id by node id |
+| tier 2, serial `pytest -q` | **789 s** | 3 failed, 2692 passed, 7 skipped |
+| tier 1, documented command | **239 s** | 3 failed, 2678 passed, 7 skipped |
+| tier 1, **bare `-n auto --dist loadfile`, no `-m` at all** | **235 s** | identical to the row above, **node id by node id** |
 
-**~3.6x faster.** The three standing failures are the deliberate `tests/test_upstream_repro_pins.py`
-engine-drift tripwires (engine pinned 2.260.0, installed 2.339.0); they fail identically on `master`.
+**~3.3x faster**, and the last row is the point of the mechanism below: forgetting the filter no
+longer changes what runs. The three standing failures are the deliberate
+`tests/test_upstream_repro_pins.py` engine-drift tripwires (engine pinned 2.260.0, installed
+2.339.0); they fail identically on `master`.
 
 Every run was compared **by node id**, not by summary totals, because a summary hides the failure
 mode that matters: a test that skips or short-circuits under contention leaves `N passed` looking
@@ -189,13 +192,46 @@ needs gating.
 
 To use a different scheduler, edit the guard deliberately and re-measure. That is the point of it.
 
+## The markers are enforced by a MECHANISM, not by remembering to type them
+
+A marker on its own is a convention. It only protects anything if the caller supplies
+`-m "not (serial or timing)"` - and the guard above validates `--dist loadfile`, not the filter. Drop
+half of it, and every live UI test is collected again:
+
+```
+$ pytest --collect-only -n 2 --dist loadfile -m "not timing" <the bundle's credential tests>
+94/100 tests collected (6 deselected)     # <- all seven live WPF/UIA tests SELECTED
+```
+
+So the root `conftest.py` now **deselects every `serial` and `timing` test whenever xdist is active**,
+whatever `-m` says. The same command today reports `87/100 tests collected (13 deselected)`, and the
+documented tier-1 filter is belt-and-braces rather than the only line of defence.
+
+Deliberately stress-testing those tests under parallelism is still possible, explicitly:
+
+```bash
+uv run pytest -q -n auto --dist loadfile --include-contended
+```
+
+That flag exists for measuring this behaviour, not for normal use - it re-enables exactly the
+configuration measured to fail.
+
+Two details make the mechanism hold up, and both are gated:
+
+- **It must fire inside the workers.** A worker sees `numprocesses=None dist='no'` (measured), so a
+  check on `numprocesses` alone would deselect nothing in a real run while still looking correct
+  under `--collect-only`, which the controller can answer.
+- **The documentation gate parses the marker expression** with pytest's own compiler and asks whether
+  it excludes each marker. A substring check could not tell `not (serial or timing)` from
+  `not timing`: the earlier draft of that gate returned `3 passed` for the mutated command.
+
 ## Why tier 2 exists
 
 **One green parallel run is not proof of isolation.** A test that quietly changed behaviour under
 concurrency - took a different branch, skipped instead of running, degraded to a safer verdict - can
 still report at the summary level as though nothing happened. And tier 1 deliberately deselects the
-`serial` and `timing` tests, so it is a strictly smaller suite by construction: 2683 node ids against
-tier 2's 2697, plus fourteen more inside the nested bundle run.
+`serial` and `timing` tests, so it is a strictly smaller suite by construction: 2688 node ids against
+tier 2's 2702, plus fourteen more inside the nested bundle run.
 
 So the plain serial `pytest -q` stays the gate of record before a PR. It is slower and it is the one
 whose result you quote. Tier 1 buys iteration speed; tier 2 buys the claim.
@@ -242,9 +278,15 @@ That is not part of either tier. Tier 1 excludes them because two agents running
 raced them; tier 2 includes them, because a serial whole-suite run is the one condition in which they
 were never observed to fail.
 
-⚠️ One residual gap worth knowing: the exclusions only happen if the command carries
-`-m "not (serial or timing)"`. A hand-typed `pytest -n auto --dist loadfile` still runs everything.
-The doc-drift tests keep every *documented* command honest; they cannot police what you type.
+⚠️ **Absence of failure in a short campaign proves nothing here.** Seven runs - including two
+concurrent pairs - found none of it. It took eight concurrent pairs to see three failures. The
+instability is **real but rare**, so "I ran it three times and it was fine" is not evidence that the
+markers can come off. If you want to challenge them, use `--include-contended` and run *many*
+concurrent pairs.
+
+The exclusion no longer depends on anyone typing the right filter - the root `conftest.py` deselects
+`serial` and `timing` whenever xdist is active (see above). A hand-typed
+`pytest -n auto --dist loadfile` is therefore safe too.
 
 ## CI stays serial, deliberately
 

--- a/docs/parallel-test-loop.md
+++ b/docs/parallel-test-loop.md
@@ -1,0 +1,211 @@
+# The two-tier test loop
+
+The full suite is the dominant cost in every agent iteration, and agents run it repeatedly. This page
+is the measured answer to "how do I run it fast without making it lie to me?".
+
+**Short version:**
+
+```bash
+# Tier 1 - fast loop, run this while you iterate
+uv run pytest -q -n auto --dist loadfile -m "not (serial or timing)"
+
+# Tier 2 - pre-PR gate, run this once before you open the PR
+uv run pytest -q
+```
+
+Both must be green. Tier 1 is not a substitute for tier 2, and the reason is below.
+
+---
+
+## The measurement
+
+`pytest-xdist` is a declared **dev dependency** (`[project.optional-dependencies].dev` in
+`pyproject.toml`), so `uv sync --all-extras` puts it in every worktree venv. Agents each work in
+their own `git worktree` with their own `.venv`; anything not declared there is absent everywhere.
+
+Measured on 22 logical cores, machine shared with other agents throughout - so these wall times
+carry real external load, which is the condition this loop exists for.
+
+**Before the `timing` exclusion below** (2564 node ids):
+
+| run | wall | outcome |
+|---|---|---|
+| serial, `pytest -q` | **681 s** | 3 failed, 2554 passed, 7 skipped |
+| `-n auto --dist loadfile`, 8 runs | **160 - 305 s** | 7 identical to serial; 1 had one extra failure |
+
+**After** (2568 node ids; tier 1 deselects 6):
+
+| run | wall | outcome |
+|---|---|---|
+| tier 2, serial `pytest -q` | **646 s** | 3 failed, 2558 passed, 7 skipped |
+| tier 1, 3 runs | **297 / 307 / 329 s** | 3 failed, 2552 passed, 7 skipped - **identical node id by node id** |
+
+**2.0 - 4.3x faster**, depending entirely on what else the machine is doing. The three standing
+failures are the deliberate `tests/test_upstream_repro_pins.py` engine-drift tripwires (engine pinned
+2.260.0, installed 2.339.0); they fail identically on `master`.
+
+The runs were compared **by node id**, not by summary totals, because a summary hides the failure
+mode that matters: a test that skips or short-circuits under contention leaves `N passed` looking
+healthy. Across the eight pre-change runs, exactly **one** node id ever disagreed (below). Across the
+three post-change tier-1 runs, **none** did - and tier 2 differs from tier 1 by exactly the six
+deselected `timing` tests and nothing else.
+
+Why it parallelises so well: most of the ~2,500 tests spawn a subprocess
+(`subprocess.run([sys.executable, ...])`), so the suite is process-spawn and I/O bound, not GIL
+bound. Contention also matters - the same serial suite took 4m37s on a quiet machine and 12m20s with
+nine agents competing, so shortening the window shortens everybody's.
+
+## The one node id that disagreed, and what it was not
+
+`test_credential_modal_detection.py::test_refresh_main_returns_credential_missing_fast_at_t0` took
+**0.941 s against a 0.5 s budget** on worker `gw9`, in the slowest of the eight parallel runs (305 s,
+against a 160-217 s median - the machine was busiest then). Its externals are all monkeypatched; the
+assertion is purely a wall clock.
+
+Follow-up experiments, to find out whether parallelism caused it:
+
+| condition | samples | failures |
+|---|---|---|
+| whole suite, serial | 1 | 0 |
+| whole suite, `-n auto --dist loadfile` | 8 | 1 |
+| owning file only, serial, quiet machine | 15 | 0 |
+| owning file only, serial, **beside a live 22-worker suite** | 15 | 0 |
+
+So this is **not** a `--dist loadfile` isolation failure. No shared state raced; no fixture collided;
+no file was split across workers. It is CPU starvation of a wall-clock assertion, and it needs the
+test's own process to be one of 22 competing workers - running it serially beside 22 busy workers did
+not reproduce it in 15 attempts.
+
+That also makes it a **different hazard from the one this was expected to find** (see the live-test
+section below), and it is the one that actually exists in the tree today.
+
+## The `timing` marker: what tier 1 excludes, and why it is not silent
+
+`pyproject.toml` registers three markers with deliberately narrow, different meanings:
+
+| marker | means | applied |
+|---|---|---|
+| `slow` | takes a long time | by hand |
+| `serial` | must not run beside another test wanting the same singleton external resource | by hand |
+| `timing` | asserts a **sub-second wall-clock budget**, so a saturated box fails it | **automatically**, by the root `conftest.py` |
+
+Six tests carry `timing`, all in `test_credential_modal_detection.py`, all asserting a 0.5 s or 1.0 s
+budget. Tier 1 deselects them; **tier 2 still runs them**, and the deselection is visible in tier 1's
+own summary line (`... 6 deselected`), so nothing disappears quietly.
+
+Two looser budgets are deliberately **left in** the parallel tier, because a bigger margin is not the
+same hazard and neither has ever been observed failing: `tests/test_credential_gate.py`'s 5.0 s hook
+budget and `test_refresh_wall_clock.py`'s 15 s bound.
+
+The list is hand-written node ids, which a rename would silently break - so
+`tests/test_parallel_test_loop.py` re-derives the set from the suite's own AST (an
+`assert <expr> < <number under 2>` whose left side reads `time.monotonic()`/`perf_counter()`) and
+fails on drift in **both** directions. A new sub-second budget test added anywhere fails that gate
+until it is listed.
+
+**The durable fix is in the tests, not here.** A budget assertion should measure something it
+controls - a monotonic floor, an injected clock, a call count - rather than its share of a contended
+machine. This exclusion is an interim owned by the parallel tier, and the list should shrink.
+
+## `--dist loadfile` is not optional, and the repo now enforces that
+
+Plain `-n auto` means `--dist load`, which distributes **individual tests**, so two tests from one
+file can run on different workers at the same time. `--dist loadfile` keeps every test in one file
+on one worker, which is what makes module-scoped fixtures, per-file caches and shared on-disk
+scratch safe. Every measurement above was taken **with** `loadfile`; `--dist load` has never been
+measured here.
+
+`-n auto` is shorter to type than `-n auto --dist loadfile`, so the root `conftest.py` refuses it:
+
+```
+$ uv run pytest -q -n auto
+ERROR: pytest-xdist is active with --dist 'load'. This suite is only measured safe under
+--dist loadfile (issue #387).
+```
+
+That is a `pytest.UsageError`, **exit code 4**. The guard is at the repo root, not in
+`tests/conftest.py`, because `pyproject.toml` sets `testpaths = ["tests", ".github/skills"]` and a
+conftest only covers paths beneath it - a `tests/`-only guard would leave
+`pytest .github/skills/pbip-model-refresh/tests -n 4` ungated, which is the single run that most
+needs gating.
+
+To use a different scheduler, edit the guard deliberately and re-measure. That is the point of it.
+
+## Why tier 2 exists
+
+**One green parallel run is not proof of isolation.** A test that quietly changed behaviour under
+concurrency - took a different branch, skipped instead of running, degraded to a safer verdict - can
+still report at the summary level as though nothing happened. `2554 passed` is the same string
+whether a test asserted something or bailed out early. And tier 1 deliberately deselects the `timing`
+tests, so it is a strictly smaller suite by construction - measured, 2562 node ids against tier 2's
+2568.
+
+So the plain serial `pytest -q` stays the gate of record before a PR. It is slower and it is the one
+whose result you quote. Tier 1 buys iteration speed; tier 2 buys the claim.
+
+When comparing two runs yourself, compare **per test**, not per total:
+
+```bash
+uv run pytest -q -m "not (serial or timing)" --junitxml=serial.xml
+uv run pytest -q -n auto --dist loadfile -m "not (serial or timing)" --junitxml=parallel.xml
+```
+
+then diff the `classname`/`name`/outcome triples. A skip that replaced a pass is invisible in the
+summary line and obvious in the XML.
+
+## The `serial` marker, and the live-test hazard
+
+Some tests contend for a **singleton external resource**: a real Power BI Desktop instance, its
+UI-Automation tree, a live credential dialog. Two of them running at once degrade each other. This
+is measured, not theoretical (issue #387):
+
+- running the all-skills suite concurrently with the credential suite made one live harvest degrade
+  to `DIALOG_UNREADABLE` and fail its stricter assertion; rerunning without the contention passed;
+- the same bundle ran **100 passed** alone, and **skipped** one live test when run beside the full
+  skills suite.
+
+Note the shape: contention pushes those tests toward the **fail-safe**, not toward a false pass -
+and it is already reachable **serially**, whenever two agents run pytest at the same time.
+Parallelism inside one invocation is the same hazard with a shorter fuse.
+
+A test opts in with `@pytest.mark.serial`. Tier 1 already excludes them, so the marker takes effect
+the moment it is applied. Run them on their own afterwards:
+
+```bash
+uv run pytest -q -m serial
+```
+
+**Exit code 5 from that command means no test carries the marker yet** - that is "nothing to run",
+not a failure.
+
+**Current status, stated plainly:** no test in the tree carries `serial`, and no tracked test drives
+a real Desktop or a real UI-Automation tree (`DIALOG_UNREADABLE` appears in zero tracked test files).
+The live tests the quotes above describe are in flight against issue #367 in the `pbip-model-refresh`
+bundle and are **not on `master`**, so that hazard **could not be reproduced here** and the `serial`
+marker is unapplied scaffolding. When those tests land, marking them is a one-line change per test
+and needs nothing from this page.
+
+⚠️ One residual gap worth knowing: the exclusion only happens if the command carries
+`-m "not (serial or timing)"`. A hand-typed `pytest -n auto --dist loadfile` still runs everything.
+The doc-drift tests keep every *documented* command honest; they cannot police what you type.
+
+## CI stays serial, deliberately
+
+`.github/workflows/checks.yml` keeps `uv run pytest -q`. Both jobs - `ubuntu-latest` and the
+`windows-latest` bundle job - are GitHub-hosted standard runners, which for a public repository are
+**4 vCPU**, so `-n auto` would pick 4 workers rather than an absurd number. That makes parallel CI
+*plausible*, not *measured*:
+
+- every xdist worker re-imports and re-collects all ~2,560 tests, and that fixed cost is a much
+  larger fraction of the total on 4 cores than on 22;
+- the one defect this work found is **CPU starvation of a wall-clock assertion**. A 4-vCPU runner
+  running 4 workers is exactly the shape that makes that worse, and CI is where a flaky red costs
+  the most;
+- CI is the shared trust anchor. A flaky gate is worse than a slow one for the same reason tier 2
+  exists;
+- the cost this issue is about is the **agent iteration loop on a developer machine**, which is
+  where the 3.4x lands. CI wall time was never the complaint.
+
+If CI time does become the complaint, the change is one line per job plus a measurement on the
+runners themselves - and the root-`conftest.py` guard already makes it impossible to add `-n` there
+without `--dist loadfile`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,12 +56,15 @@ markers = [
     # concurrent live suites turned one harvest into `DIALOG_UNREADABLE` and made another test SKIP.
     # See docs/parallel-test-loop.md for the tier that runs these on their own.
     "serial: contends for a singleton external resource; must not run beside another such test",
-    # Different hazard, same tier. A `timing` test asserts a sub-second WALL-CLOCK budget, so it
-    # measures the machine as much as the code. Measured (issue #387): 1 failure in 8 whole-suite
-    # `-n auto` runs - `test_refresh_main_returns_credential_missing_fast_at_t0` took 0.941s against
-    # a 0.5s budget on worker gw9. The root `conftest.py` applies this marker automatically; you do
-    # not write it by hand.
-    "timing: asserts a sub-second wall-clock budget, so a saturated box fails it",
+    # Different hazard, same tier. A `timing` test asserts a WALL-CLOCK budget, so it measures the
+    # machine as much as the code. Measured (issue #387): under 22 xdist workers,
+    # `test_refresh_main_returns_credential_missing_fast_at_t0` took 0.941s against a 0.5s budget on
+    # an operation that takes 0.03s serially - a 31x inflation of a very short measured window, so
+    # widening the bound is not a fix. Every SUB-SECOND budget test must carry this (gated from the
+    # suite's AST); a larger budget earns it once measured to fail, as the 10s process-rendezvous
+    # barrier in test_check_migration_progress.py did. Tests carry the marker in their own source
+    # (and the pbip-model-refresh bundle registers it in its own conftest) so it survives a copy.
+    "timing: asserts a wall-clock budget, so a saturated box fails it",
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,10 @@ server = [
 ]
 dev = [
     "pytest>=8.2",
+    # Parallel test loop (issue #387): measured 740s serial -> ~215s with `-n auto --dist loadfile`
+    # on 22 logical cores. A dev dependency, not an optional nicety, because every agent works in its
+    # own `git worktree` + `uv sync` venv - anything not declared here is absent from all of them.
+    "pytest-xdist>=3.6",
     "ruff>=0.6",
     "pylint>=3.2",
 ]
@@ -46,6 +50,18 @@ py-modules = []
 testpaths = ["tests", ".github/skills"]
 markers = [
     "slow: joined offline Tableau-to-Fabric mock integration tests",
+    # `slow` is about DURATION; this is about EXCLUSIVITY. A test earns `serial` when it contends for a
+    # singleton external resource - a real Power BI Desktop instance, its UI-Automation tree, a live
+    # credential dialog - so two of them running at once degrade each other. Measured (issue #387):
+    # concurrent live suites turned one harvest into `DIALOG_UNREADABLE` and made another test SKIP.
+    # See docs/parallel-test-loop.md for the tier that runs these on their own.
+    "serial: contends for a singleton external resource; must not run beside another such test",
+    # Different hazard, same tier. A `timing` test asserts a sub-second WALL-CLOCK budget, so it
+    # measures the machine as much as the code. Measured (issue #387): 1 failure in 8 whole-suite
+    # `-n auto` runs - `test_refresh_main_returns_credential_missing_fast_at_t0` took 0.941s against
+    # a 0.5s budget on worker gw9. The root `conftest.py` applies this marker automatically; you do
+    # not write it by hand.
+    "timing: asserts a sub-second wall-clock budget, so a saturated box fails it",
 ]
 
 [tool.ruff]

--- a/tests/test_check_migration_progress.py
+++ b/tests/test_check_migration_progress.py
@@ -421,6 +421,7 @@ def test_declare_wrapper_records_a_composed_path_fix_script(tmp_path):
     assert any("fix_post_engine.py" in note for note in notes)
 
 
+@pytest.mark.timing
 def test_declare_wrapper_concurrent_writers_keep_both_declarations(tmp_path):
     """Two wrapper processes released by one barrier must not erase each other's declaration."""
     first = Path("M.SemanticModel") / "definition" / "tables" / "Orders.tmdl"

--- a/tests/test_parallel_test_loop.py
+++ b/tests/test_parallel_test_loop.py
@@ -17,14 +17,19 @@ tree rather than importing it, so they exercise the file an operator actually ge
 from __future__ import annotations
 
 import ast
+import functools
 import importlib.util
+import operator
 import os
 import re
 import shutil
 import subprocess
 import sys
 import tomllib
+import xml.etree.ElementTree as ET
 from pathlib import Path
+
+from _pytest.mark.expression import Expression
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 ROOT_CONFTEST = REPO_ROOT / "conftest.py"
@@ -38,6 +43,15 @@ TRIVIAL_TEST = "def test_ok():\n    assert True\n"
 # purpose, and stay in the parallel tier.
 SUB_SECOND_CEILING = 2.0
 CLOCK_FUNCTIONS = {"monotonic", "perf_counter"}
+
+# A budget above SUB_SECOND_CEILING earns `timing` only on measured evidence, never by inference.
+# This one gives two child processes 10s to reach a rendezvous barrier; under two concurrent
+# whole-suite parallel runs (44 workers on 22 cores) they did not both start in time (issue #387).
+MEASURED_LARGER_BUDGETS = frozenset(
+    {"tests/test_check_migration_progress.py::test_declare_wrapper_concurrent_writers_keep_both_declarations"}
+)
+
+BUNDLE_TESTS = ".github/skills/pbip-model-refresh/tests/test_credential_modal_detection.py"
 
 
 def _pyproject() -> dict:
@@ -156,6 +170,44 @@ def _live_desktop_tests_with_marks() -> dict[str, bool]:
             if _launches_the_live_desktop(func):
                 found[f"{rel}::{func.name}"] = _marked(func, "serial")
     return found
+
+
+def _marked_tests(marker: str) -> set[str]:
+    """Every test in the suite carrying `@pytest.mark.<marker>`, by node id."""
+    found: set[str] = set()
+    for path, tree in _parsed_test_files():
+        rel = path.relative_to(REPO_ROOT).as_posix()
+        for func in ast.walk(tree):
+            if isinstance(func, ast.FunctionDef) and func.name.startswith("test_") and _marked(func, marker):
+                found.add(f"{rel}::{func.name}")
+    return found
+
+
+def test_no_timing_marker_outlives_the_budget_it_was_added_for() -> None:
+    """The other direction: a marker left behind after its assertion was removed or loosened.
+
+    The forward gate cannot see this. Delete the clock assertion and keep the marker, and the test
+    simply drops out of the derived set - the remaining entries still satisfy the non-vacuity check
+    and everything passes, while that test and all its OTHER assertions vanish from tier 1 and from
+    the nested bundle run. Coverage disappearing quietly is the exact failure this PR exists to avoid
+    creating, so it is gated from both sides.
+    """
+    stale = sorted(_marked_tests("timing") - _sub_second_budget_tests() - MEASURED_LARGER_BUDGETS)
+    assert not stale, (
+        "these tests carry @pytest.mark.timing but assert no sub-second wall-clock budget, so they "
+        "are excluded from the parallel tier for no reason - remove the marker, or add it to "
+        f"MEASURED_LARGER_BUDGETS with the measurement that earned it: {stale}"
+    )
+
+
+def test_no_serial_marker_outlives_the_live_fixture_it_was_added_for() -> None:
+    """Same both-ways rule for `serial`: it must still drive the live desktop it was marked for."""
+    live = set(_live_desktop_tests_with_marks())
+    stale = sorted(_marked_tests("serial") - live)
+    assert not stale, (
+        "these tests carry @pytest.mark.serial but no longer launch the live WPF fixture, so they "
+        f"are excluded from the parallel tier for no reason: {stale}"
+    )
 
 
 def test_every_live_ui_test_declares_itself_serial() -> None:
@@ -360,26 +412,123 @@ def _documented_pytest_commands() -> list[str]:
     return commands
 
 
-def _is_parallel(command: str) -> bool:
-    """Whether a documented command asks xdist for workers."""
+def _uses_xdist(command: str) -> bool:
+    """Whether a documented command asks xdist for workers, with no exemptions."""
     return " -n " in command or "--numprocesses" in command
+
+
+def _is_filter_judged_parallel(command: str) -> bool:
+    """A parallel command whose marker filter is subject to the exclusion rules.
+
+    `--include-contended` is the documented opt-out from the automatic deselection, so a command
+    carrying it is deliberately running the contended tests. It is exempt from the FILTER rules only
+    - it is still a parallel command for every other purpose, which is what the two predicates keep
+    apart. Conflating them let a mutation of the tier-2 command slip through: the opt-out example was
+    counted as a whole-suite serial run because the single predicate said it was not parallel.
+    """
+    return _uses_xdist(command) and "--include-contended" not in command
 
 
 def test_the_loop_doc_never_documents_parallel_without_loadfile() -> None:
     """A documented command the guard rejects reads as "the guard is broken", not "the doc is wrong"."""
     commands = _documented_pytest_commands()
     assert commands, f"no pytest commands found in {LOOP_DOC.name} - the doc cannot be checked"
-    offenders = [cmd for cmd in commands if _is_parallel(cmd) and "--dist loadfile" not in cmd]
+    offenders = [cmd for cmd in commands if _uses_xdist(cmd) and "--dist loadfile" not in cmd]
     assert not offenders, f"documented parallel commands that the root conftest guard would reject: {offenders}"
 
 
-def test_the_loop_doc_never_documents_a_parallel_run_that_keeps_the_timing_tests() -> None:
-    """The measured flake only reaches an operator through a documented command that forgot the filter."""
-    offenders = [cmd for cmd in _documented_pytest_commands() if _is_parallel(cmd) and "timing" not in cmd]
-    assert not offenders, (
-        "documented parallel commands that would still run the wall-clock-budget tests "
-        f"(measured to fail ~1 run in 8 at 22 workers): {offenders}"
+def _marker_expression(command: str) -> str | None:
+    """The `-m "<expr>"` filter of a documented command, if it has one."""
+    match = re.search(r'-m\s+"([^"]*)"', command)
+    return match.group(1) if match else None
+
+
+def test_the_loop_doc_never_documents_a_parallel_run_that_keeps_contended_tests() -> None:
+    """Judged by pytest's own expression semantics, not by substring.
+
+    A first draft asserted that the documented command *contained* "timing". Mutating
+    `not (serial or timing)` to `not timing` kept the substring, so all three documentation gates
+    returned `3 passed`, exit 0 - while the mutated command collects every live UI test under xdist.
+    Compiling the expression and asking whether it excludes each marker is the only check that can
+    tell those two commands apart.
+    """
+    offenders: list[str] = []
+    for command in _documented_pytest_commands():
+        if not _is_filter_judged_parallel(command):
+            continue
+        expression = _marker_expression(command)
+        if expression is None:
+            offenders.append(f"{command!r}: no -m filter at all")
+            continue
+        compiled = Expression.compile(expression)
+        for marker in ("serial", "timing"):
+            if compiled.evaluate(functools.partial(operator.eq, marker)):
+                offenders.append(f"{command!r}: -m {expression!r} does not exclude `{marker}`")
+    assert not offenders, "documented parallel commands that would still run contended tests: " + "; ".join(offenders)
+
+
+def test_xdist_deselects_contended_tests_without_being_asked() -> None:
+    """The mechanism, not the convention: the exclusion must not depend on the caller's `-m`.
+
+    Reproduces the reviewer's case exactly - a parallel run whose filter drops the `serial` half.
+    Before the root conftest deselected them, this collected all seven live WPF/UI-Automation tests,
+    which is the configuration measured to fail 3 times in 8 concurrent-pair runs.
+    """
+    contended = {node for node in _contended_nodes() if node.startswith(BUNDLE_TESTS + "::")}
+    assert len(contended) >= 13, f"expected the bundle's contended tests to be found, got {sorted(contended)}"
+    result = _run_pytest(
+        REPO_ROOT, ["-q", "--collect-only", "-n", "2", "--dist", "loadfile", "-m", "not timing", BUNDLE_TESTS]
     )
+    output = result.stdout + result.stderr
+    assert result.returncode == 0, output
+    assert f"{len(contended)} deselected" in output, f"expected {len(contended)} deselected:\n{output[-1500:]}"
+    for node in sorted(contended):
+        assert node not in output, f"{node} was collected under xdist despite carrying a contended marker"
+
+
+def test_a_real_parallel_run_deselects_them_inside_the_workers(tmp_path: Path) -> None:
+    """`--collect-only` can be answered by the controller; a real run collects in the WORKERS.
+
+    A worker sees `numprocesses=None dist='no'` (measured), so a mechanism that only checked
+    `numprocesses` would deselect nothing in the run that actually matters while looking correct
+    under `--collect-only`. This drives a genuine `-n 2` run to close that blind spot.
+
+    Judged from the JUnit report, not the summary line: xdist does not aggregate the workers'
+    deselections into `N deselected`, so a real run that correctly skipped all thirteen still prints
+    only `87 passed`. Asserting on the executed node ids is both stronger and unambiguous.
+    """
+    contended = {node for node in _contended_nodes() if node.startswith(BUNDLE_TESTS + "::")}
+    report = tmp_path / "report.xml"
+    result = _run_pytest(
+        REPO_ROOT, ["-q", "--tb=no", "-n", "2", "--dist", "loadfile", f"--junitxml={report}", BUNDLE_TESTS]
+    )
+    output = result.stdout + result.stderr
+    assert result.returncode == 0, output[-2000:]
+    executed = {
+        f"{case.get('classname').replace('.', '/')}.py::{case.get('name')}".replace("/github/skills", ".github/skills")
+        for case in ET.parse(report).getroot().iter("testcase")
+    }
+    still_running = sorted(node for node in contended if node in executed)
+    assert not still_running, f"a real parallel run executed contended tests inside its workers: {still_running}"
+    assert executed, f"the run executed nothing at all:\n{output[-1500:]}"
+
+
+def test_the_opt_out_flag_puts_the_contended_tests_back() -> None:
+    """Deliberate stress-testing must remain possible, or the mechanism is a wall rather than a gate."""
+    result = _run_pytest(
+        REPO_ROOT,
+        ["-q", "--collect-only", "-n", "2", "--dist", "loadfile", "--include-contended", BUNDLE_TESTS],
+    )
+    output = result.stdout + result.stderr
+    assert result.returncode == 0, output
+    assert "deselected" not in output, f"--include-contended did not restore them:\n{output[-1500:]}"
+    for node in sorted(node for node in _contended_nodes() if node.startswith(BUNDLE_TESTS + "::")):
+        assert node in output, f"{node} missing even with --include-contended"
+
+
+def _contended_nodes() -> set[str]:
+    """Every node id that carries a marker the parallel tier excludes."""
+    return _marked_tests("serial") | _marked_tests("timing")
 
 
 def test_the_loop_doc_documents_both_tiers() -> None:
@@ -388,7 +537,7 @@ def test_the_loop_doc_documents_both_tiers() -> None:
     assert any("-n auto" in cmd and "--dist loadfile" in cmd for cmd in commands), (
         f"{LOOP_DOC.name} documents no fast tier: {commands}"
     )
-    whole_suite_serial = [cmd for cmd in commands if not _is_parallel(cmd) and " -m " not in cmd]
+    whole_suite_serial = [cmd for cmd in commands if not _uses_xdist(cmd) and " -m " not in cmd]
     assert whole_suite_serial, (
         f"{LOOP_DOC.name} documents no plain whole-suite serial tier - a filtered or parallel run "
         f"cannot be the gate of record: {commands}"

--- a/tests/test_parallel_test_loop.py
+++ b/tests/test_parallel_test_loop.py
@@ -1,0 +1,294 @@
+"""Gates for the two-tier test loop (issue #387).
+
+The loop is only worth having if it cannot silently decay into something faster and wrong. Three
+things can decay independently, so each gets its own gate:
+
+1. `pytest-xdist` can drop out of `pyproject.toml`, and every worktree venv then loses it silently -
+   agents run `uv sync` per worktree, so an undeclared tool is absent everywhere at once.
+2. The root `conftest.py` guard can be neutered, and `-n auto` (which means `--dist load`) starts
+   spreading a single file across workers - the configuration nobody measured.
+3. `docs/parallel-test-loop.md` can drift from the guard, which is worse than having no doc: an
+   agent copies a documented command that the guard then rejects, and concludes the guard is broken.
+
+The nested-pytest tests below deliberately copy the REAL root `conftest.py` bytes into a scratch
+tree rather than importing it, so they exercise the file an operator actually gets.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ROOT_CONFTEST = REPO_ROOT / "conftest.py"
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+LOOP_DOC = REPO_ROOT / "docs" / "parallel-test-loop.md"
+
+TRIVIAL_TEST = "def test_ok():\n    assert True\n"
+
+# A budget above this is not the hazard: `assert elapsed < 15` has room for a loaded box, and was
+# never observed failing. The two loosest budgets in the suite (5.0s and 15s) sit above it on
+# purpose, and stay in the parallel tier.
+SUB_SECOND_CEILING = 2.0
+CLOCK_FUNCTIONS = {"monotonic", "perf_counter"}
+
+
+def _pyproject() -> dict:
+    """Parsed `pyproject.toml`."""
+    return tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+
+
+def _scratch_suite(root: Path, *, nested: bool) -> Path:
+    """Lay out a miniature suite under `root` carrying the real root-conftest bytes.
+
+    `nested` puts the test file two directories down, mimicking `.github/skills/<skill>/tests/` -
+    the second entry in `testpaths`, and the one a `tests/conftest.py` would not reach.
+    """
+    shutil.copy2(ROOT_CONFTEST, root / "conftest.py")
+    target = root / "skills" / "bundle" / "tests" if nested else root
+    target.mkdir(parents=True, exist_ok=True)
+    (target / "test_scratch.py").write_text(TRIVIAL_TEST, encoding="utf-8")
+    return target
+
+
+def _run_pytest(cwd: Path, args: list[str]) -> subprocess.CompletedProcess:
+    """Run a nested pytest, insulated from this run's own options."""
+    env = dict(os.environ)
+    env.pop("PYTEST_ADDOPTS", None)
+    env.pop("PYTEST_CURRENT_TEST", None)
+    return subprocess.run(
+        [sys.executable, "-m", "pytest", "-p", "no:cacheprovider", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+
+
+def test_pytest_xdist_is_a_declared_dev_dependency() -> None:
+    """Every agent gets its own worktree venv, so an undeclared tool is missing from all of them."""
+    dev = _pyproject()["project"]["optional-dependencies"]["dev"]
+    assert any(req.replace("_", "-").startswith("pytest-xdist") for req in dev), (
+        f"pytest-xdist is not in the dev extra ({dev}) - `uv sync --all-extras` would not install it, "
+        "and the documented fast loop would fail with 'unrecognized arguments: -n'"
+    )
+
+
+def test_the_serial_marker_is_registered() -> None:
+    """`serial` is the hook the live Desktop/UIA tests hang off; an unregistered marker is a warning."""
+    markers = _pyproject()["tool"]["pytest"]["ini_options"]["markers"]
+    assert any(marker.startswith("serial:") for marker in markers), (
+        f"no `serial` marker registered in [tool.pytest.ini_options].markers ({markers}); "
+        'the documented fast loop filters on -m "not (serial or timing)"'
+    )
+
+
+def test_the_timing_marker_is_registered() -> None:
+    """`timing` is applied automatically, which makes registering it more important, not less."""
+    markers = _pyproject()["tool"]["pytest"]["ini_options"]["markers"]
+    assert any(marker.startswith("timing:") for marker in markers), (
+        f"no `timing` marker registered in [tool.pytest.ini_options].markers ({markers}); "
+        "the root conftest applies it to every wall-clock-budget test"
+    )
+
+
+def _mentions_clock(node: ast.AST) -> bool:
+    """Whether an expression reads a monotonic clock anywhere inside it."""
+    return any(isinstance(child, ast.Attribute) and child.attr in CLOCK_FUNCTIONS for child in ast.walk(node))
+
+
+def _collected_test_files() -> list[Path]:
+    """Every `test_*.py` under the roots `testpaths` names."""
+    roots = _pyproject()["tool"]["pytest"]["ini_options"]["testpaths"]
+    files: list[Path] = []
+    for root in roots:
+        files.extend(sorted((REPO_ROOT / root).rglob("test_*.py")))
+    return files
+
+
+def _sub_second_budget_tests() -> set[str]:
+    """Re-derive, from the suite's own AST, every test that asserts a sub-second wall-clock budget.
+
+    The shape being looked for is `elapsed = time.monotonic() - started; assert elapsed < 0.5`, in
+    either spelling - the comparison may read the clock inline, or through a local assigned from it.
+    Deriving it beats trusting a hand-written list: a rename or a brand-new budget test both show up
+    as drift instead of quietly leaving a flaky test in the parallel tier.
+    """
+    found: set[str] = set()
+    for path in _collected_test_files():
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except SyntaxError:  # deliberately malformed fixture files exist in this repo
+            continue
+        rel = path.relative_to(REPO_ROOT).as_posix()
+        for func in ast.walk(tree):
+            if not isinstance(func, ast.FunctionDef) or not func.name.startswith("test_"):
+                continue
+            clock_locals = {
+                target.id
+                for node in ast.walk(func)
+                if isinstance(node, ast.Assign) and _mentions_clock(node.value)
+                for target in node.targets
+                if isinstance(target, ast.Name)
+            }
+            for node in ast.walk(func):
+                if not isinstance(node, ast.Assert) or not isinstance(node.test, ast.Compare):
+                    continue
+                compare = node.test
+                if len(compare.ops) != 1 or not isinstance(compare.ops[0], ast.Lt):
+                    continue
+                right = compare.comparators[0]
+                if not isinstance(right, ast.Constant) or not isinstance(right.value, (int, float)):
+                    continue
+                if right.value >= SUB_SECOND_CEILING:
+                    continue
+                reads_clock = _mentions_clock(compare.left) or any(
+                    isinstance(name, ast.Name) and name.id in clock_locals for name in ast.walk(compare.left)
+                )
+                if reads_clock:
+                    found.add(f"{rel}::{func.name}")
+    return found
+
+
+def _declared_timing_tests() -> set[str]:
+    """The node ids the root conftest excludes from the parallel tier.
+
+    Loaded from the file by path under a distinct module name rather than `import conftest`, so this
+    reads the same bytes whether or not pytest itself loaded the root conftest for this run - the
+    mutation harness deliberately runs with `--confcutdir=tests`, where it has not.
+    """
+    spec = importlib.util.spec_from_file_location("t2p_root_conftest", ROOT_CONFTEST)
+    assert spec is not None and spec.loader is not None, f"cannot load {ROOT_CONFTEST}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return set(module.TIMING_BUDGET_TESTS)
+
+
+def test_the_conftest_timing_list_matches_the_suite_it_claims_to_describe() -> None:
+    """A hand-written node-id list rots on the first rename; re-deriving it is what stops that.
+
+    Fails in both directions on purpose: an entry that no longer exists (renamed, deleted) and a new
+    sub-second budget test that nobody added. The second direction is the one that matters - it is
+    how a fresh flaky test gets caught before it starts costing everyone re-runs.
+    """
+    derived = _sub_second_budget_tests()
+    declared = _declared_timing_tests()
+    assert declared == derived, (
+        "conftest.TIMING_BUDGET_TESTS is out of step with the suite.\n"
+        f"  declared but not found in the suite: {sorted(declared - derived)}\n"
+        f"  found in the suite but not declared: {sorted(derived - declared)}"
+    )
+
+
+def test_the_timing_marker_actually_deselects_those_tests() -> None:
+    """The list is inert unless the marker lands before pytest's own `-m` filtering runs."""
+    declared = sorted(_declared_timing_tests())
+    assert declared, "nothing declared - this test would pass vacuously"
+    target = declared[0].split("::")[0]
+    result = _run_pytest(REPO_ROOT, ["-q", "--collect-only", "-m", "not (serial or timing)", target])
+    output = result.stdout + result.stderr
+    assert result.returncode == 0, output
+    assert f"{len(declared)} deselected" in output, (
+        f"expected {len(declared)} deselected from {target}, got:\n{output[-2000:]}"
+    )
+    for node in declared:
+        assert node not in output, f"{node} survived the -m filter:\n{output[-2000:]}"
+
+
+def test_a_parallel_run_without_loadfile_is_refused(tmp_path: Path) -> None:
+    """`-n auto` alone means `--dist load`, which was never measured here. It must not run."""
+    _scratch_suite(tmp_path, nested=False)
+    result = _run_pytest(tmp_path, ["-q", "-n", "2"])
+    output = result.stdout + result.stderr
+    assert result.returncode != 0, f"a parallel run without --dist loadfile was accepted:\n{output}"
+    assert "--dist loadfile" in output and "issue #387" in output, (
+        f"exited non-zero, but not because of the guard - the message does not name it:\n{output}"
+    )
+
+
+def test_the_guard_also_covers_the_skills_testpath_root(tmp_path: Path) -> None:
+    """The reason the guard is at the repo ROOT and not in `tests/conftest.py`.
+
+    `testpaths` names two roots, and the live Power BI Desktop / UI-Automation tests live under the
+    second one. A guard scoped to `tests/` would leave the single most dangerous parallel run -
+    `pytest .github/skills/<bundle>/tests -n 4` - completely ungated.
+    """
+    target = _scratch_suite(tmp_path, nested=True)
+    result = _run_pytest(tmp_path, ["-q", "-n", "2", str(target.relative_to(tmp_path))])
+    output = result.stdout + result.stderr
+    assert result.returncode != 0, f"a nested-root parallel run escaped the guard:\n{output}"
+    assert "--dist loadfile" in output, f"exited non-zero for some other reason:\n{output}"
+
+
+def test_a_parallel_run_with_loadfile_is_allowed(tmp_path: Path) -> None:
+    """The guard must permit the documented fast loop, or it has simply banned parallelism."""
+    _scratch_suite(tmp_path, nested=False)
+    result = _run_pytest(tmp_path, ["-q", "-n", "2", "--dist", "loadfile"])
+    output = result.stdout + result.stderr
+    assert result.returncode == 0, f"the documented fast loop was rejected:\n{output}"
+    assert "1 passed" in output, f"the scratch test did not run:\n{output}"
+
+
+def test_a_serial_run_is_untouched_by_the_guard(tmp_path: Path) -> None:
+    """Tier 2 is the gate of record; the guard must be invisible to it."""
+    _scratch_suite(tmp_path, nested=False)
+    result = _run_pytest(tmp_path, ["-q"])
+    output = result.stdout + result.stderr
+    assert result.returncode == 0, f"a plain serial run was disturbed by the guard:\n{output}"
+    assert "1 passed" in output, output
+
+
+def _documented_pytest_commands() -> list[str]:
+    """Every pytest invocation inside a ```bash fence in the loop doc.
+
+    Deliberately restricted to `bash`-tagged fences: the doc also shows the guard's own rejection of
+    `-n auto` inside an untagged fence, and that illustration must not be read as a recommendation.
+    """
+    text = LOOP_DOC.read_text(encoding="utf-8")
+    commands: list[str] = []
+    for block in re.findall(r"```bash\n(.*?)```", text, flags=re.DOTALL):
+        commands.extend(line.strip() for line in block.splitlines() if "pytest" in line)
+    return commands
+
+
+def _is_parallel(command: str) -> bool:
+    """Whether a documented command asks xdist for workers."""
+    return " -n " in command or "--numprocesses" in command
+
+
+def test_the_loop_doc_never_documents_parallel_without_loadfile() -> None:
+    """A documented command the guard rejects reads as "the guard is broken", not "the doc is wrong"."""
+    commands = _documented_pytest_commands()
+    assert commands, f"no pytest commands found in {LOOP_DOC.name} - the doc cannot be checked"
+    offenders = [cmd for cmd in commands if _is_parallel(cmd) and "--dist loadfile" not in cmd]
+    assert not offenders, f"documented parallel commands that the root conftest guard would reject: {offenders}"
+
+
+def test_the_loop_doc_never_documents_a_parallel_run_that_keeps_the_timing_tests() -> None:
+    """The measured flake only reaches an operator through a documented command that forgot the filter."""
+    offenders = [cmd for cmd in _documented_pytest_commands() if _is_parallel(cmd) and "timing" not in cmd]
+    assert not offenders, (
+        "documented parallel commands that would still run the wall-clock-budget tests "
+        f"(measured to fail ~1 run in 8 at 22 workers): {offenders}"
+    )
+
+
+def test_the_loop_doc_documents_both_tiers() -> None:
+    """One green parallel run is not proof of isolation, so the serial gate must stay written down."""
+    commands = _documented_pytest_commands()
+    assert any("-n auto" in cmd and "--dist loadfile" in cmd for cmd in commands), (
+        f"{LOOP_DOC.name} documents no fast tier: {commands}"
+    )
+    whole_suite_serial = [cmd for cmd in commands if not _is_parallel(cmd) and " -m " not in cmd]
+    assert whole_suite_serial, (
+        f"{LOOP_DOC.name} documents no plain whole-suite serial tier - a filtered or parallel run "
+        f"cannot be the gate of record: {commands}"
+    )

--- a/tests/test_parallel_test_loop.py
+++ b/tests/test_parallel_test_loop.py
@@ -114,20 +114,88 @@ def _collected_test_files() -> list[Path]:
     return files
 
 
-def _sub_second_budget_tests() -> set[str]:
-    """Re-derive, from the suite's own AST, every test that asserts a sub-second wall-clock budget.
+def _marked(func: ast.FunctionDef, marker: str) -> bool:
+    """Whether a test function carries `@pytest.mark.<marker>` in its own source."""
+    for decorator in func.decorator_list:
+        for node in ast.walk(decorator):
+            if isinstance(node, ast.Attribute) and node.attr == marker:
+                return True
+    return False
 
-    The shape being looked for is `elapsed = time.monotonic() - started; assert elapsed < 0.5`, in
-    either spelling - the comparison may read the clock inline, or through a local assigned from it.
-    Deriving it beats trusting a hand-written list: a rename or a brand-new budget test both show up
-    as drift instead of quietly leaving a flaky test in the parallel tier.
+
+def _marked_timing(func: ast.FunctionDef) -> bool:
+    """Whether a test function carries `@pytest.mark.timing` in its own source."""
+    return _marked(func, "timing")
+
+
+def _launches_the_live_desktop(func: ast.FunctionDef) -> bool:
+    """Whether a test drives a real WPF window through UI Automation.
+
+    Two spellings exist and both are stable: calling the module's `_run_probe_against_wpf_modal`
+    helper, or launching the fixture app directly, which is identifiable by the `-ReadyFile` argument
+    the app uses to announce that its window is up. Deriving it beats a name list - a new live
+    regression added next to these gets caught rather than silently joining the parallel tier.
     """
-    found: set[str] = set()
+    for node in ast.walk(func):
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+            if node.func.id == "_run_probe_against_wpf_modal":
+                return True
+        if isinstance(node, ast.Constant) and node.value == "-ReadyFile":
+            return True
+    return False
+
+
+def _live_desktop_tests_with_marks() -> dict[str, bool]:
+    """Every live WPF/UI-Automation test, mapped to whether it is marked `serial`."""
+    found: dict[str, bool] = {}
+    for path, tree in _parsed_test_files():
+        rel = path.relative_to(REPO_ROOT).as_posix()
+        for func in ast.walk(tree):
+            if not isinstance(func, ast.FunctionDef) or not func.name.startswith("test_"):
+                continue
+            if _launches_the_live_desktop(func):
+                found[f"{rel}::{func.name}"] = _marked(func, "serial")
+    return found
+
+
+def test_every_live_ui_test_declares_itself_serial() -> None:
+    """The interactive desktop and its UIA provider are a singleton; two live tests degrade each other.
+
+    Measured (issue #387) across three rounds of two whole-suite parallel runs started concurrently:
+    `test_credential_text_beyond_the_element_cap_convicts_when_the_cap_allows_it` failed in 3 of 6,
+    every time with `harvest=INCOMPLETE` / `VERDICT: DIALOG_UNREADABLE` - the probe degrading safely
+    and the test's stricter assertion correctly refusing it. Marking only the one that was observed
+    would move the boundary rather than remove it: all of them share the mechanism.
+    """
+    live = _live_desktop_tests_with_marks()
+    assert len(live) >= 7, f"expected the bundle's live WPF regressions to be found, got {sorted(live)}"
+    unmarked = sorted(node for node, marked in live.items() if not marked)
+    assert not unmarked, (
+        "these tests drive a real WPF window through UI Automation but do not carry "
+        f"@pytest.mark.serial, so two concurrent parallel runs would race them: {unmarked}"
+    )
+
+
+def _sub_second_budget_tests() -> set[str]:
+    """Every test that asserts a sub-second wall-clock budget, by node id."""
+    return set(_budget_tests_with_marks())
+
+
+def _parsed_test_files() -> list[tuple[Path, ast.Module]]:
+    """Every `test_*.py` under the `testpaths` roots, parsed once."""
+    parsed: list[tuple[Path, ast.Module]] = []
     for path in _collected_test_files():
         try:
-            tree = ast.parse(path.read_text(encoding="utf-8"))
+            parsed.append((path, ast.parse(path.read_text(encoding="utf-8"))))
         except SyntaxError:  # deliberately malformed fixture files exist in this repo
             continue
+    return parsed
+
+
+def _budget_tests_with_marks() -> dict[str, bool]:
+    """Every sub-second wall-clock budget test, mapped to whether it is marked `timing`."""
+    found: dict[str, bool] = {}
+    for path, tree in _parsed_test_files():
         rel = path.relative_to(REPO_ROOT).as_posix()
         for func in ast.walk(tree):
             if not isinstance(func, ast.FunctionDef) or not func.name.startswith("test_"):
@@ -154,53 +222,86 @@ def _sub_second_budget_tests() -> set[str]:
                     isinstance(name, ast.Name) and name.id in clock_locals for name in ast.walk(compare.left)
                 )
                 if reads_clock:
-                    found.add(f"{rel}::{func.name}")
+                    found[f"{rel}::{func.name}"] = _marked_timing(func)
     return found
 
 
-def _declared_timing_tests() -> set[str]:
-    """The node ids the root conftest excludes from the parallel tier.
+def test_every_sub_second_wall_clock_test_declares_itself_timing() -> None:
+    """A budget test that is not marked runs in the parallel tier, and eventually flakes there.
 
-    Loaded from the file by path under a distinct module name rather than `import conftest`, so this
-    reads the same bytes whether or not pytest itself loaded the root conftest for this run - the
-    mutation harness deliberately runs with `--confcutdir=tests`, where it has not.
+    Derived from the suite's own AST rather than a list, so it fails in both directions that matter:
+    a new sub-second budget test nobody marked, and a marked test whose budget was removed. The
+    first is the one that costs everyone re-runs.
     """
-    spec = importlib.util.spec_from_file_location("t2p_root_conftest", ROOT_CONFTEST)
-    assert spec is not None and spec.loader is not None, f"cannot load {ROOT_CONFTEST}"
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return set(module.TIMING_BUDGET_TESTS)
-
-
-def test_the_conftest_timing_list_matches_the_suite_it_claims_to_describe() -> None:
-    """A hand-written node-id list rots on the first rename; re-deriving it is what stops that.
-
-    Fails in both directions on purpose: an entry that no longer exists (renamed, deleted) and a new
-    sub-second budget test that nobody added. The second direction is the one that matters - it is
-    how a fresh flaky test gets caught before it starts costing everyone re-runs.
-    """
-    derived = _sub_second_budget_tests()
-    declared = _declared_timing_tests()
-    assert declared == derived, (
-        "conftest.TIMING_BUDGET_TESTS is out of step with the suite.\n"
-        f"  declared but not found in the suite: {sorted(declared - derived)}\n"
-        f"  found in the suite but not declared: {sorted(derived - declared)}"
+    budget_tests = _budget_tests_with_marks()
+    assert budget_tests, "no sub-second wall-clock budget tests found at all - the gate is vacuous"
+    unmarked = sorted(node for node, marked in budget_tests.items() if not marked)
+    assert not unmarked, (
+        "these tests assert a sub-second wall-clock budget but do not carry @pytest.mark.timing, "
+        f"so the parallel tier would still run them: {unmarked}"
     )
 
 
-def test_the_timing_marker_actually_deselects_those_tests() -> None:
-    """The list is inert unless the marker lands before pytest's own `-m` filtering runs."""
-    declared = sorted(_declared_timing_tests())
-    assert declared, "nothing declared - this test would pass vacuously"
-    target = declared[0].split("::")[0]
+def test_the_markers_actually_deselect_those_tests() -> None:
+    """The markers are inert unless `-m` really removes those node ids from a collected run."""
+    excluded = _sub_second_budget_tests() | set(_live_desktop_tests_with_marks())
+    assert excluded, "nothing derived - this test would pass vacuously"
+    target = sorted(excluded)[0].split("::")[0]
+    in_target = sorted(node for node in excluded if node.startswith(target + "::"))
     result = _run_pytest(REPO_ROOT, ["-q", "--collect-only", "-m", "not (serial or timing)", target])
     output = result.stdout + result.stderr
     assert result.returncode == 0, output
-    assert f"{len(declared)} deselected" in output, (
-        f"expected {len(declared)} deselected from {target}, got:\n{output[-2000:]}"
+    assert f"{len(in_target)} deselected" in output, (
+        f"expected {len(in_target)} deselected from {target}, got:\n{output[-2000:]}"
     )
-    for node in declared:
+    for node in in_target:
         assert node not in output, f"{node} survived the -m filter:\n{output[-2000:]}"
+
+
+def test_the_timing_marker_travels_with_the_bundle_that_uses_it() -> None:
+    """`-m "not (serial or timing)"` has to work in the COPIED bundle, where this repo's pyproject is absent."""
+    bundle_conftest = REPO_ROOT / ".github/skills/pbip-model-refresh/tests/conftest.py"
+    body = bundle_conftest.read_text(encoding="utf-8")
+    for marker in ("timing:", "serial:"):
+        assert "addinivalue_line" in body and f'"{marker}' in body, (
+            f"{bundle_conftest.relative_to(REPO_ROOT).as_posix()} does not register `{marker[:-1]}`; "
+            "copied out of this repo the marker is unregistered and the filter silently stops meaning anything"
+        )
+
+
+def test_the_nested_bundle_run_inherits_the_parallel_tier_exclusion(monkeypatch: object) -> None:
+    """`test_skills.py` re-runs the bundle in a temp dir, where the root conftest cannot reach.
+
+    Measured (issue #387): during a parallel campaign the outer suite deselected
+    `test_refresh_main_returns_credential_missing_fast_at_t0`, and the nested copy of that same test
+    failed at 0.519s against its 0.5s budget - the flake walked straight through the exclusion.
+
+    Driven behaviourally rather than by grepping the file. A first draft asserted on the presence of
+    the two strings anywhere in the source; deleting the propagation entirely still passed it,
+    because both strings also appear in the prose that explains them.
+    """
+    skills = REPO_ROOT / "tests" / "test_skills.py"
+    spec = importlib.util.spec_from_file_location("t2p_test_skills", skills)
+    assert spec is not None and spec.loader is not None, f"cannot load {skills}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    monkeypatch.delenv("PYTEST_XDIST_WORKER", raising=False)
+    assert module._nested_marker_filter() == [], "a serial outer run must still execute every bundled test"
+    monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw0")
+    assert module._nested_marker_filter() == ["-m", "not (serial or timing)"], (
+        "the nested bundle run does not inherit the parallel-tier exclusion, so a wall-clock-budget "
+        "or live UI test still runs under 22 workers"
+    )
+
+    tree = ast.parse(skills.read_text(encoding="utf-8"))
+    spliced = any(
+        isinstance(node, ast.Starred)
+        and isinstance(node.value, ast.Call)
+        and getattr(node.value.func, "id", "") == "_nested_marker_filter"
+        for node in ast.walk(tree)
+    )
+    assert spliced, "_nested_marker_filter() is never spliced into the nested pytest argv"
 
 
 def test_a_parallel_run_without_loadfile_is_refused(tmp_path: Path) -> None:

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -102,6 +102,23 @@ def _repo_free_env() -> dict[str, str]:
     return env
 
 
+def _nested_marker_filter() -> list[str]:
+    """Deselect wall-clock-budget tests from the nested run, but only under a parallel outer run.
+
+    This nested pytest is serial, but its PROCESS competes with every other xdist worker, and the
+    bundle contains assertions on a ~0.03s operation finishing inside 0.5s. Measured (issue #387):
+    that test failed at 0.519s inside this nested run during a parallel campaign, while the outer
+    suite's own copy of it - deselected by `-m "not (serial or timing)"` - never ran. The outer
+    exclusion structurally cannot reach here: the bundle is copied to a temp directory, so the repo
+    root `conftest.py` and `pyproject.toml` are both absent by construction.
+
+    Conditional on `PYTEST_XDIST_WORKER` rather than unconditional, so the serial pre-PR gate still
+    executes every test the bundle ships. Tier 1 trades those six for a loop that does not flake;
+    tier 2 gives them back.
+    """
+    return ["-m", "not (serial or timing)"] if os.environ.get("PYTEST_XDIST_WORKER") else []
+
+
 @pytest.mark.parametrize("skill_dir", BUNDLED_SKILLS, ids=lambda p: p.name)
 def test_a_bundled_skill_passes_its_own_tests_after_being_copied_out_of_this_repo(
     skill_dir: Path, tmp_path: Path
@@ -122,7 +139,7 @@ def test_a_bundled_skill_passes_its_own_tests_after_being_copied_out_of_this_rep
         ignore=shutil.ignore_patterns("__pycache__", ".pytest_cache"),
     )
     result = subprocess.run(
-        [sys.executable, "-m", "pytest", "-q", str(copied / "tests")],
+        [sys.executable, "-m", "pytest", "-q", str(copied / "tests"), *_nested_marker_filter()],
         cwd=tmp_path,
         env=_repo_free_env(),
         capture_output=True,


### PR DESCRIPTION
Closes #387.

`-n auto --dist loadfile` is 2.0–4.3x faster than serial. This PR is the proof that it
is safe, plus a gate for the one place where it was not — and a correction to the
issue's framing about *which* tests are contention-sensitive.

## Measurement, compared by node id (not by summary totals)

22 logical cores, machine shared with other agents throughout.

**Before the `timing` exclusion** (2564 node ids):

| run | wall | outcome |
|---|---|---|
| serial `pytest -q` | 681 s | 3 failed, 2554 passed, 7 skipped |
| `-n auto --dist loadfile` × **8** | 160–305 s | 7 identical to serial; **1 with one extra failure** |

**After** (2568 node ids; tier 1 deselects 6):

| run | wall | outcome |
|---|---|---|
| tier 2, serial `pytest -q` | 646 s | 3 failed, 2558 passed, 7 skipped |
| tier 1 × 3 | 297 / 307 / 329 s | 3 failed, 2552 passed, 7 skipped |

The three tier-1 runs are **identical to each other across all 2562 node ids**, and tier 2
differs from tier 1 by **exactly the six deselected `timing` tests** (all passing) and nothing
else. The only failures anywhere are the three deliberate `test_upstream_repro_pins.py`
engine-drift tripwires (pinned 2.260.0 vs installed 2.339.0), which fail identically on `master`.

Totals alone would have hidden this: a test that skips under contention still leaves
`N passed` looking healthy.

## The one disagreement — and it is not what the issue predicted

`test_credential_modal_detection.py::test_refresh_main_returns_credential_missing_fast_at_t0`
took **0.941 s against a 0.5 s budget** on worker `gw9`, in the slowest of the eight parallel
runs. Every external is monkeypatched; the assertion is purely a wall clock.

| condition | samples | failures |
|---|---|---|
| whole suite, serial | 1 | 0 |
| whole suite, `-n auto --dist loadfile` | 8 | 1 |
| owning file only, serial, quiet machine | 15 | 0 |
| owning file only, serial, **beside a live 22-worker suite** | 15 | 0 |

So **`--dist loadfile` did not fail to isolate anything** — no shared state raced, no file was
split across workers. It is CPU starvation of a wall-clock assertion, and it needs the test's own
process to be one of 22 competing workers.

That is a **different hazard from the live Desktop/UIA contention the issue anticipated**, and it
is the one that actually exists in the tree today.

## What lands

- **`pytest-xdist>=3.6`** as a dev dependency, so every worktree `uv sync --all-extras` gets it.
- **Root `conftest.py`** — deliberately *not* `tests/conftest.py`, because `testpaths` names two
  roots and a `tests/`-scoped conftest would leave `pytest .github/skills/… -n 4` — the single
  most dangerous parallel run — completely ungated. It does two things:
  - **refuses `-n` without `--dist loadfile`** (`UsageError`, exit 4). The issue says loadfile is
    load-bearing; nothing enforced it, and `-n auto` is shorter to type.
  - **auto-applies a new `timing` marker** to the six sub-second wall-clock-budget tests so tier 1
    deselects them. Visible as `… 6 deselected` — never silent. Tier 2 still runs them.
- **`serial` and `timing` markers** registered, with narrow, different meanings (`slow` = takes
  long; `serial` = wants a singleton external resource; `timing` = asserts a sub-second wall clock).
- **`docs/parallel-test-loop.md`** + `docs/INDEX.md` entry.
- **`checks.yml`: two lines, lint coverage only** — the new root `conftest.py` sits above every
  existing ruff/pylint root, so it would otherwise be linted by nobody. CI's pytest stays serial.

The `timing` list is hand-written node ids, which a rename would silently break — so
`tests/test_parallel_test_loop.py` **re-derives the set from the suite's own AST** (an
`assert <expr> < <number under 2>` whose left side reads `time.monotonic()`/`perf_counter()`) and
fails on drift in **both** directions: a stale entry, *and* a new sub-second budget test nobody
listed. The durable fix belongs in those tests (assert against a clock they control); this
exclusion is an interim and should shrink.

## `serial` is unapplied scaffolding, and I could not measure the hazard it is for

Stated plainly rather than implied: **no test in the tree carries `serial`**, and no tracked test
drives a real Power BI Desktop or UI-Automation tree — `DIALOG_UNREADABLE` appears in **zero**
tracked test files. The live tests behind the issue's `DIALOG_UNREADABLE` / skipped-live-test
reports are in flight against #367 and are **not on `master`**, so that hazard **could not be
reproduced here**. When they land, marking them is one line per test and needs no change to this
PR. That is the follow-up half.

## CI stays serial, deliberately

Runners are **4 vCPU** for a public repo on both `ubuntu-latest` and `windows-latest`, so `-n auto`
would pick a sane worker count — parallel CI is *plausible*, not *measured*. Against it: worker
re-collection is a much larger fraction of the total on 4 cores; the one defect found is CPU
starvation, which 4 workers on 4 vCPU makes worse; and CI is the shared trust anchor, where a
flaky red costs the most. The guard already makes it impossible to add `-n` there without
`--dist loadfile`.

## Mutation table

Harness asserts the mutation is on disk and is not a no-op, then scores **only** a genuine
`N failed` naming every expected test. A non-zero exit alone (collection error, `UsageError`) is
**not** scored as caught. It runs with `--confcutdir=tests` so the root conftest under mutation is
not loaded by the harness's own run.

| # | file | mutation | expected failing test | result |
|---|---|---|---|---|
| M1 | `pyproject.toml` | drop `pytest-xdist` from the dev extra | `test_pytest_xdist_is_a_declared_dev_dependency` | ✅ 1 failed, 11 passed |
| M2 | `pyproject.toml` | unregister the `serial` marker | `test_the_serial_marker_is_registered` | ✅ 1 failed, 11 passed |
| M3 | `conftest.py` | neuter the guard (accept any `--dist`) | `test_a_parallel_run_without_loadfile_is_refused` + `test_the_guard_also_covers_the_skills_testpath_root` | ✅ 2 failed, 10 passed |
| M4 | `conftest.py` | require the wrong scheduler | `test_a_parallel_run_with_loadfile_is_allowed` | ✅ 1 failed, 11 passed |
| M5 | `conftest.py` | let the guard fire on serial runs too | `test_a_serial_run_is_untouched_by_the_guard` | ✅ 3 failed, 9 passed |
| M6 | `docs/parallel-test-loop.md` | document parallel without `--dist loadfile` | `test_the_loop_doc_never_documents_parallel_without_loadfile` | ✅ 1 failed, 11 passed |
| M7 | `docs/parallel-test-loop.md` | turn the serial tier into a filtered run | `test_the_loop_doc_documents_both_tiers` | ✅ 1 failed, 11 passed |
| M8 | `conftest.py` | drop a node id from the timing list | `test_the_conftest_timing_list_matches_the_suite_it_claims_to_describe` | ✅ 1 failed, 11 passed |
| M9 | `conftest.py` | add a node id the suite does not contain | same + `test_the_timing_marker_actually_deselects_those_tests` | ✅ 2 failed, 10 passed |
| M10 | `conftest.py` | drop `tryfirst` from the marking hook | `test_the_timing_marker_actually_deselects_those_tests` | ❌ **NOT CAUGHT** — equivalent mutant, see below |
| M11 | `pyproject.toml` | unregister the `timing` marker | `test_the_timing_marker_is_registered` | ✅ 1 failed, 11 passed |
| M12 | `docs/parallel-test-loop.md` | document a parallel command keeping the timing tests | `test_the_loop_doc_never_documents_a_parallel_run_that_keeps_the_timing_tests` | ✅ 1 failed, 11 passed |
| M13 | `conftest.py` | stop the hook marking anything at all | `test_the_timing_marker_actually_deselects_those_tests` | ✅ 1 failed, 11 passed |

**12/13 caught. M10 is an equivalent mutant, established rather than assumed:** a scratch conftest
marking one of two tests deselects identically with and without
`@pytest.hookimpl(tryfirst=True)` on pytest 9.1.1 (`1 passed, 1 deselected` both ways). My first
draft of that docstring claimed `tryfirst` was *required*; that claim was wrong and is corrected in
the file. The decorator is kept as defence. **M13 covers the failure that does matter** — a hook
that marks nothing.

## Gates run, by exit code

`ruff format --check` / `ruff check` on `conftest.py scripts tests .github/skills` → **0**;
`pylint` on all four roots (`scripts`, both skill script roots, `conftest.py`) → **0**, 10.00/10;
`validate_spec --all --check`, `set_data_folder --check`, `check_datamodel --all`,
`check_navigation_index`, `check_agent_capabilities`, `sync_agent_conventions --check`,
`set_ai_instructions --check` → all **0**.

## What I could not verify

1. **The live Desktop/UIA hazard.** Not on `master`; not reproducible here. `serial` is untested
   scaffolding — its only proof is that `-m "not (serial or timing)"` deselects correctly for the
   `timing` half.
2. **Whether parallel CI would be faster or flakier** on 4-vCPU runners. Not measured; that is why
   CI is unchanged.
3. **The residual gap in the exclusion.** It only applies if the command carries
   `-m "not (serial or timing)"`. A hand-typed `pytest -n auto --dist loadfile` still runs
   everything. The doc-drift tests keep every *documented* command honest; they cannot police what
   you type.
4. **The AST heuristic's recall.** It finds the shape `assert <clock-derived expr> < <n < 2>`. A
   budget expressed some other way (a helper, a fixture, a `pytest.approx`) would not be found — a
   false negative leaves things exactly as they are today, but it is not proof of completeness.
5. **Discoverability outside `docs/`.** `AGENTS.md`, `README.md` and `CONTRIBUTING.md` were out of
   my file group, so the loop is reachable via `docs/INDEX.md` only. Linking it from
   `CONTRIBUTING.md` is a one-line follow-up.


---

## Update after rebasing onto #390 — the live-test question, answered

`#390` merged while this was in flight, putting **seven live Power BI Desktop / UI-Automation
regressions** on `master`. Re-measured, and **my earlier "the live tests are stable" verdict was
wrong** — corrected below, with the run counts.

### Sequential runs were not a hard enough test

| condition | runs | live-test failures |
|---|---|---|
| tier 1, sequential | 3 | 0 |
| tier 1, **concurrent pairs** (two whole-suite runs started at once, 44 workers on 22 cores) | 8 | **3** |

`test_credential_text_beyond_the_element_cap_convicts_when_the_cap_allows_it` failed in **3 of 6**
runs of the later rounds — twice in the *same pair*, both sides at once — every time like this:

```
a dialog was up during the refresh: ... size=650x400 harvest=INCOMPLETE
  but a window we could not account for was open
VERDICT: DIALOG_UNREADABLE
```

That is the reviewer's report verbatim: the UIA harvest could not finish, the probe **degraded
safely**, and the stricter assertion correctly refused the degraded verdict. **30.6 s against 8.08 s
serially.** Seven earlier runs — including two concurrent pairs — found nothing; it took three more
pairs. Sequential measurement would have shipped this as stable.

**All seven live tests now carry `@pytest.mark.serial`.** Marking only the observed one would move
the boundary rather than remove it: they share one mechanism and one singleton resource. The `< 25 s`
budget itself held throughout (9.36–11.44 s under load, 2.2x headroom at worst) — the failure was the
harvest degrading, not the bound.

### My own exclusion leaked through the nested bundle run

Found in the same campaign, and it is the classic "the fix moved the boundary" shape:
`tests/test_skills.py` copies each bundle to a temp dir and re-runs it, so the copied tree has **no
root `conftest.py` and no `pyproject.toml`** — a repo-level exclusion *structurally cannot reach it*.
Measured: the outer suite correctly deselected
`test_refresh_main_returns_credential_missing_fast_at_t0` while **the nested copy of that same test
failed at 0.519 s** against its 0.5 s budget. Tier 1 was still ~1-in-7 flaky, through a different
door.

Fixed by moving both markers **into the tests' own source**, registering them in the **bundle's own
`conftest.py`** (verified by copying the folder out and running it standalone: `235 passed,
3 skipped, 6 deselected`, with `PytestUnknownMarkWarning` promoted to an error), and propagating
`-m "not (serial or timing)"` into the nested run when `PYTEST_XDIST_WORKER` is set (verified: `None`
serially, `'gw0'` under `-n 2`). Tier 2 still runs every test the bundle ships.

The root `conftest.py` consequently **drops its node-id list and marking hook** — it is now
single-purpose, just the `--dist loadfile` guard.

### A third defect, and one deliberate non-fix

- `test_declare_wrapper_concurrent_writers_keep_both_declarations` gives two child processes **10 s**
  to reach a rendezvous barrier; under 44 workers they did not both start in time. Above the
  sub-second automatic rule, so it is marked `timing` on **measured** evidence, and the marker's
  definition widens from "sub-second" to "a wall-clock budget".
- `test_check_unit.py::test_cli_model_scope_reports_not_checked_for_unattributable_connection_fixture`
  failed on the **second** process of a concurrent pair, deterministically, 3 pairs of 3, while the
  first passed every time — and passes solo. It is **not a parallelism defect**:
  `_freshen_clean_fixture_cache()` mutates a **git-tracked fixture inside the repo** and stamps a
  60-second future mtime, so two pytest processes sharing that path overwrite each other's window.
  `--dist loadfile` is irrelevant — one file owns that fixture, so it never leaves a single worker.
  It needs two suites in **one working tree**, which the documented workflow does not do. Recorded in
  the doc; **not marked**, because marking it would hide a real property and cost a good test.

### Post-fix validation

| run | wall | outcome |
|---|---|---|
| tier 2, serial `pytest -q` | 880 s | 3 failed, 2687 passed, 7 skipped |
| tier 1, solo | 260 s | 3 failed, 2673 passed, 7 skipped |

Tier 2 differs from tier 1 by **exactly the 14 marked tests** (7 `serial` + 7 `timing`), all passing,
and nothing else.

### Mutation table — 13/13 caught

| # | file | mutation | expected failing test | result |
|---|---|---|---|---|
| M1 | `pyproject.toml` | drop `pytest-xdist` from the dev extra | `test_pytest_xdist_is_a_declared_dev_dependency` | ✅ |
| M2 | `pyproject.toml` | unregister the `serial` marker | `test_the_serial_marker_is_registered` | ✅ |
| M3 | `conftest.py` | neuter the guard (accept any `--dist`) | `test_a_parallel_run_without_loadfile_is_refused` + `test_the_guard_also_covers_the_skills_testpath_root` | ✅ 2 failed |
| M4 | `conftest.py` | require the wrong scheduler | `test_a_parallel_run_with_loadfile_is_allowed` | ✅ |
| M5 | `conftest.py` | let the guard fire on serial runs too | `test_a_serial_run_is_untouched_by_the_guard` | ✅ 3 failed |
| M6 | `docs/parallel-test-loop.md` | document parallel without `--dist loadfile` | `test_the_loop_doc_never_documents_parallel_without_loadfile` | ✅ |
| M7 | `docs/parallel-test-loop.md` | turn the serial tier into a filtered run | `test_the_loop_doc_documents_both_tiers` | ✅ |
| M8 | bundle test file | unmark a wall-clock-budget test | `test_every_sub_second_wall_clock_test_declares_itself_timing` + `test_the_markers_actually_deselect_those_tests` | ✅ 2 failed |
| M9 | bundle `conftest.py` | stop registering the `serial` marker it carries | `test_the_timing_marker_travels_with_the_bundle_that_uses_it` | ✅ |
| M10 | `tests/test_skills.py` | stop the nested run inheriting the exclusion | `test_the_nested_bundle_run_inherits_the_parallel_tier_exclusion` | ✅ |
| M11 | `pyproject.toml` | unregister the `timing` marker | `test_the_timing_marker_is_registered` | ✅ |
| M12 | `docs/parallel-test-loop.md` | document a parallel command keeping the timing tests | `test_the_loop_doc_never_documents_a_parallel_run_that_keeps_the_timing_tests` | ✅ |
| M13 | bundle test file | unmark a live WPF/UIA test | `test_every_live_ui_test_declares_itself_serial` + `test_the_markers_actually_deselect_those_tests` | ✅ 2 failed |

**M10 initially escaped**, and the reason is worth keeping: that gate grepped the whole file for two
strings, and deleting the propagation entirely still passed — both strings survive in the prose that
explains them. Rewritten to drive `_nested_marker_filter()` behaviourally under both environments and
to assert via AST that it is spliced into the nested argv. The previous round's unkillable mutation
(dropping `tryfirst`) is gone along with the hook it decorated.

Both marker sets are gated **from the suite's own AST, in both directions**: an unmarked sub-second
budget test fails, and an unmarked test that drives a real WPF window fails (identified by a
`_run_probe_against_wpf_modal` call or the `-ReadyFile` fixture argument, not by a name list).

### Discoverability

Landed in `CONTRIBUTING.md` rather than `AGENTS.md`, deliberately: `sync_agent_conventions.py --check`
reports `pbi-migration-validator.agent.md` at **97 % of the 30,000-char cap with 704 chars left**, and
any `AGENTS.md` edit regenerates the shared block into all four personas. The `CONTRIBUTING.md`
lint-command block also gains `conftest.py`, keeping it in step with `checks.yml`.

### Still could not verify

1. **Whether the `< 25 s` bound survives a harder machine.** It held at 2.2x headroom, but its
   CPU-bound siblings inflate 2.0–2.6x while it inflates only 1.16–1.38x, because its runtime is
   dominated by fixed child timeouts. If those tests gain in-process work, re-measure.
2. **How many concurrent pairs are "enough".** Eight pairs found three failures; three pairs found
   none in the first campaign. There is no evidence for a saturation point.
3. **Parallel CI on 4-vCPU runners.** Unmeasured; CI stays serial.
4. **The AST heuristics' recall.** They find `assert <clock expr> < <n < 2>` and two spellings of the
   live-fixture launch. A budget or a live launcher expressed some other way would be missed — a false
   negative leaves things as they are today, but it is not proof of completeness.



---

## Review round 2 — both findings closed

### HIGH: `serial` is now a mechanism, not a convention

Your repro reproduced exactly. The root `conftest.py` now **deselects every `serial` and `timing`
test whenever xdist is active**, whatever `-m` says:

| command | before | after |
|---|---|---|
| `--collect-only -n 2 --dist loadfile -m "not timing"` | `94/100 (6 deselected)` — **all 7 live tests selected** | `87/100 (13 deselected)` |
| `--collect-only -n 2 --dist loadfile` (no `-m` at all) | 100 collected | `87/100 (13 deselected)` |
| `--collect-only -n 2 --dist loadfile --include-contended` | — | 100 collected (deliberate opt-out) |
| serial `--collect-only` | 100 collected | 100 collected (untouched) |

**Whole-suite proof, node id by node id:** the documented tier-1 command and a *bare*
`pytest -n auto --dist loadfile` with no `-m` at all are now **identical across all 2688 node ids**
(239 s vs 235 s). Forgetting the filter no longer changes what runs.

Two details the mechanism needed, each with its own mutation:

- **It must fire inside the workers.** A worker sees `numprocesses=None dist='no'` (measured), so a
  `numprocesses`-only check would deselect nothing in a real run while looking correct under
  `--collect-only`, which the controller can answer. `test_a_real_parallel_run_deselects_them_inside_the_workers`
  drives a genuine `-n 2` run and judges it from the **JUnit report** — because xdist does not
  aggregate worker deselections into the summary, a run that correctly skipped all thirteen still
  prints only `87 passed`. Asserting on that string would have been a false gate.
- **The documentation gate is now semantic**, compiling the expression with pytest's own
  `_pytest.mark.expression.Expression` and asking whether it excludes each marker. Exactly as you
  measured, the substring check returned `3 passed` for `not timing`.

### MEDIUM: both drift gates now fail both ways

Independently derive the marked set, compare against the derived set:

- `test_no_timing_marker_outlives_the_budget_it_was_added_for` — with `MEASURED_LARGER_BUDGETS` as
  the explicit allowlist holding exactly the 10 s rendezvous test that earned its marker by
  measurement.
- `test_no_serial_marker_outlives_the_live_fixture_it_was_added_for` — no allowlist; a `serial`
  marker must still drive the live WPF fixture.

Both are mutation-covered in the stale direction (M18, M19) as well as the missing direction (M8, M13).

### Mutation table — 19/19 caught

| # | mutation | expected failing test | result |
|---|---|---|---|
| M1–M11, M13 | (unchanged from round 1) | — | ✅ all caught |
| M12 | document a parallel command keeping only **half** the exclusion | `test_the_loop_doc_never_documents_a_parallel_run_that_keeps_contended_tests` | ✅ |
| M14 | stop xdist auto-deselecting contended tests | `test_xdist_deselects_contended_tests_without_being_asked` + `test_a_real_parallel_run_deselects_them_inside_the_workers` | ✅ 2 failed |
| M15 | drop `serial` from the auto-deselected marker set | same two | ✅ 2 failed |
| M16 | detect xdist on the controller only, never in a worker | `test_a_real_parallel_run_deselects_them_inside_the_workers` | ✅ |
| M17 | make `--include-contended` do nothing | `test_the_opt_out_flag_puts_the_contended_tests_back` | ✅ |
| M18 | leave a `timing` marker on a test whose budget was removed | `test_no_timing_marker_outlives_the_budget_it_was_added_for` | ✅ |
| M19 | put a `serial` marker on a test that drives no live window | `test_no_serial_marker_outlives_the_live_fixture_it_was_added_for` | ✅ |

**M7 escaped on the first pass of this round, caused by this very change** — exempting
`--include-contended` from the parallel predicate also removed it from the "is this a whole-suite
serial run?" test, so mutating the tier-2 command still left a candidate. Split into `_uses_xdist`
(no exemptions; used for the loadfile and both-tiers rules) and `_is_filter_judged_parallel` (exempt;
used only for the marker-filter rules). Re-run: 19/19.

### Your framing note, adopted

You are right that the reviewer's three clean pairs prove nothing, and that this is the same trap I
fell into. The doc now says so explicitly, next to the flag that lets anyone challenge it properly:

> ⚠️ **Absence of failure in a short campaign proves nothing here.** Seven runs — including two
> concurrent pairs — found none of it. It took eight concurrent pairs to see three failures. The
> instability is **real but rare**, so "I ran it three times and it was fine" is not evidence that
> the markers can come off. If you want to challenge them, use `--include-contended` and run *many*
> concurrent pairs.

### Gates

`ruff format --check` / `ruff check` on `conftest.py scripts tests .github/skills` → **0** ·
`pylint` × 4 roots → **0** (10.00/10) · all 7 repo gates → **0** · `tests/test_parallel_test_loop.py`
**20 passed**, exit 0 · tier 2 `pytest -q` → 3 failed (the engine-drift tripwires), 2692 passed.

### Still could not verify

1. **How many concurrent pairs are "enough".** Eight found three failures; three found none, twice.
   No saturation point established — which is precisely why the markers stay on.
2. **Parallel CI on 4-vCPU runners.** Unmeasured; CI stays serial.
3. **The AST heuristics' recall.** They find `assert <clock expr> < <n < 2>` and two spellings of the
   live-fixture launch. A budget or live launcher expressed some other way would be missed.
4. **`_pytest.mark.expression` is private API.** Chosen deliberately over a hand-rolled evaluator so
   the semantics match pytest exactly; if it moves, the gate fails loudly with an ImportError rather
   than degrading to a weaker check.

