### PR TITLE
Fix red master: size the multibyte test fixture in bytes, not glyphs

### DIFF
--- a/tests/test_read_handover_evidence.py
+++ b/tests/test_read_handover_evidence.py
@@ -1165,8 +1165,16 @@ def test_the_terse_citation_is_bounded_in_BYTES_not_characters(tmp_path, glyph, 
     character count and byte count coincide.
 
     Mutation killed: clip the citation with a character-counting helper.
+
+    The glyph count is derived from the byte width rather than fixed, because this test writes a
+    REAL file and Linux caps a filename component at 255 BYTES: 90 emoji is 360 and raised
+    `OSError [Errno 36]` on CI while passing on Windows, where the cap counts UTF-16 units. The
+    original 90 was itself a character count applied to a byte limit - the exact confusion this
+    test exists to catch. 240 bytes still overruns `TERSE_DRIFT_LINE_MAX_BYTES` (72) by 3.3x and
+    is far past the ~24-character clip window, so the property is unchanged.
     """
-    name = (glyph * 90) + ".json"
+    glyphs = 240 // width
+    name = (glyph * glyphs) + ".json"
     root = bundle(tmp_path, real_workbook(), ORACLE_DRIFTED, oracle_name=name)
     proc = run_cli(str(root), "--max-bytes", str(rh.MIN_MAX_BYTES))
     assert proc.returncode == rh.EXIT_OK
@@ -1183,7 +1191,7 @@ def test_the_terse_citation_is_bounded_in_BYTES_not_characters(tmp_path, glyph, 
     # provenance. A bound honoured by deleting the signal is the failure this file is about.
     assert terse[0].endswith("]"), "the citation must SURVIVE the clip, not be dropped to satisfy it"
     assert ".json]" in terse[0], "and it must still identify the report"
-    assert glyph * 90 not in terse[0]
+    assert glyph * glyphs not in terse[0]
     # ...and the clip must not have produced mojibake by splitting a code point.
     assert terse[0] == terse[0].encode("utf-8").decode("utf-8")
     assert "\ufffd" not in terse[0]


### PR DESCRIPTION
**Master is red at `d6a1bde` and this is the whole of that failure.** Linux-only; `windows-bundle` was green throughout.

```
OSError: [Errno 36] File name too long:
  '/tmp/.../bundle/📈📈📈…(90)….json'
FAILED tests/test_read_handover_evidence.py::test_the_terse_citation_is_bounded_in_BYTES_not_characters[\u732b-3]
FAILED tests/test_read_handover_evidence.py::test_the_terse_citation_is_bounded_in_BYTES_not_characters[\U0001f4c8-4]
2 failed, 2700 passed, 80 skipped
```

## The cause is the defect the test exists to catch

`test_the_terse_citation_is_bounded_in_BYTES_not_characters` writes a **real file** whose name it sized by **glyph count** — `glyph * 90`. That is 270 bytes for a CJK ideograph and **360 for an emoji**, against Linux's **255-byte** per-component limit.

It passed on Windows because NTFS caps at 255 UTF-16 *units*, where 90 emoji is 180.

So a test asserting *"count bytes, not characters"* chose its own fixture by counting characters. Worth stating plainly rather than quietly correcting.

## The fix

The glyph count is derived from the byte width instead of fixed:

```python
glyphs = 240 // width
name = (glyph * glyphs) + ".json"
```

| glyph | width | glyphs | chars | bytes |
|---|---:|---:|---:|---:|
| `猫` | 3 | 80 | 85 | **245** |
| `📈` | 4 | 60 | 65 | **245** |

Both under 255. The unit-level half of the test (lines 1176-1190) never touched the filesystem and is unchanged.

## The property is unchanged — verified, not assumed

240 bytes still overruns `TERSE_DRIFT_LINE_MAX_BYTES` (**72**) by **3.3x**, and 60-80 glyphs is far past the ~24-character clip window.

**Mutation test**, asserted on disk before scoring and restored after — `_clip_tail` reverted to character-counting:

```
mutation on disk: True
FAILED ...[\u732b-3]
FAILED ...[\U0001f4c8-4]
2 failed, 97 deselected
MUTANT EXIT=1
```

Both parametrisations die. The test is alive.

## How this reached master

I merged #384 while its state was `UNSTABLE` rather than waiting for `CLEAN`. That is the process error; the fixture bug is only what it let through.

Gates: `ruff format` / `ruff check` exit 0 · targeted test **2 passed**, exit 0. `tests/` is not in any pylint root.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
