### PR TITLE
Classify the dialog instead of measuring it, in the Python detector too

### DIFF
--- a/.github/skills/pbip-model-refresh/SKILL.md
+++ b/.github/skills/pbip-model-refresh/SKILL.md
@@ -365,9 +365,27 @@ stay byte-identical.
 >
 > | exclusion | the claim it makes |
 > |---|---|
-> | `main_frame(...)` | it is the application, and the thing dialogs block. Identified by **direct ownership** first (an owned window names its owner), falling back to the `MainWindowHandle` convention — first visible unowned window — only when nothing is owned, i.e. when there are no dialogs to hide. |
+> | `main_frame(...)` | it is the application, and the thing dialogs block. Identified by **transitive ownership** — every owned window is walked to its **unowned root** — falling back to the `MainWindowHandle` convention only when *nothing* is owned. **Ambiguity fails closed**: two or more roots, an unresolvable chain, or several candidate unowned windows all return `None`, which excludes nothing. |
 > | `is_proven_non_blocking(...)` | an **enabled owner** proves this window blocks nothing. One-way: a *disabled* owner never convicts (Power BI's own refresh dialog disables it too) and `None` — no owner — means the test **did not apply**, which is not the same as passing it. |
 > | `renders_nothing(...)` | **unowned AND zero-area**: no owner to disable *and* no pixels to display. Both conjuncts are required; either alone is one of the dead proxies. |
+>
+> ⚠️ **Round 4: "first owner" was itself a proxy for "the root", and it hid a credential modal.** The
+> traversal originally stopped at the first ownership edge. An owned window can own another popup, so a
+> Z-order of **`tooltip → credential dialog → frame`** made the *credential dialog* the frame — and the
+> frame is excluded from the prepass **and** from classification, so the modal vanished. Three native
+> reproductions, all missing it:
+>
+> | construction | before |
+> |---|---|
+> | nested chain `tooltip → credential dialog → frame` | frame = the `#32770` credential dialog; **no modal** |
+> | unowned `Internet Explorer_Hidden` ahead of the real frame, reading `Enter your credentials` | selected as the frame; prepass skipped it; **no modal** |
+> | that misidentified dialog owning an *enabled* tooltip, frame busy with benign refresh content, `operation_in_flight=True` | **no modal, no dialog finding, no unknown state** |
+>
+> **Two rules came out of it, and both are load-bearing.** Follow ownership *transitively*; and where
+> identity is **ambiguous, fail closed** — return `None` and exclude nothing. The cost of failing
+> closed is a loud exit 3; the cost of guessing is a real modal disappearing. That is why the unowned
+> fallback requires **exactly one** rendering unowned window, and why it is not reached at all once any
+> window is owned (its premise is that there are no dialogs).
 >
 > The arbiter's one-way enabled-owner exoneration is therefore **ported**, not skipped — that
 > divergence note in the module docstring is gone.

--- a/.github/skills/pbip-model-refresh/SKILL.md
+++ b/.github/skills/pbip-model-refresh/SKILL.md
@@ -318,10 +318,52 @@ stay byte-identical.
 > in `probe_desktop_query`'s poll it is **acted on**, because that loop has no deadline of its own and
 > a latched dialog behind a wedged query would wait for ever.
 >
-> **Downstream, honestly:** `scripts/_verdict_lines.py` does not recognise the new tokens, so
-> `probe_live_source` classifies them **`ERROR`** ("the probe itself could not run") — `rc != 0`, the
-> gate stays armed, and nothing claims a credential wall we never observed. That is the intended
-> outcome and it was verified end-to-end, not assumed.
+> **Downstream, honestly:** `probe_live_source` now recognises the dialog tokens **structurally**
+> (`scripts/_verdict_lines.py`'s `DIALOG_VERDICT_RE` → `classify_child_verdict`) and maps them to
+> **`ERROR`** — *"the probe itself could not run"*. `rc != 0`, the gate stays armed, and nothing claims
+> a credential wall we never observed.
+>
+> ⚠️ **That structural step is load-bearing, not tidiness.** Blind review of PR #400 measured what
+> happened without it: the parent fell through to `CREDENTIAL_MARKERS`, an **unanchored scan of the
+> whole transcript**, so `DIALOG_NEEDS_HUMAN` quoting its own evidence excerpt `Authentication
+> required` — an alternative that genuinely lives in `blocking_prompt_signature.regex` — was relabelled
+> `NO_CREDENTIAL`. The parent contradicted the child on a single word and fired *"a human must sign in;
+> terminate the run"*. Adding the tokens to the **credential-stop** family instead would have been the
+> other wrong answer: it asserts the very wall the child says it did not see.
+
+> ⚠️ **Blind review of PR #400 found the same defect class INSIDE the fix, four more times. Read this
+> before touching the classifier — three of the four were "we could not establish it" quietly becoming
+> "clean" again.**
+>
+> | # | what collapsed into the clean bucket | fix |
+> |---|---|---|
+> | 5 | **A length heuristic stood in for evidence.** `MIN_PROMPT_WORDS = 5` excused every unmatched element under five words, so `Refresh` + `Evaluating...` + **`Please enter your password`** classified `benign` and was **suppressed entirely** in flight. `Password:` (two words) too. Neither matches `credential_modal_signature.regex`, so the prepass did not rescue them. **In that shape the fix was worse than the bug** — the repo's rule is that a credential modal is never worked around. | The amnesty is **gone**. Any content element that is not recognised progress status vetoes dismissal, unless it is in the **enumerated** `benign_chrome_signature.regex` (`Cancel`/`OK`/`Close`) — a positive claim about specific strings that carry no prompt, not a claim about their size. |
+> | 3 | **A geometry threshold stood in for harmlessness — the original defect, surviving inside its own fix.** `dialog_candidates` still rejected everything under 100x100, and the all-window credential prepass only rescued *known-signature* text. Measured: a visible **80x60** unreadable owned window beside a normal main window returned `modal=None, dialog=None, unknown_reason=None` — byte-identical to a healthy Desktop. | **No size test at all.** Every visible non-main window is classified. Two exclusions remain and both are positive claims: **zero-area** windows (they rasterise nothing, so they show a human nothing) and the named `HELPER_WINDOW_CLASSES`. |
+> | 4 | **A report title fabricated a hard stop.** The all-window prepass read the Desktop **main** window, caption and children, so a report legitimately named `Account Key` / `Personal Access Token` / `Databricks Client Credentials` produced `CREDENTIAL_MISSING` at exit 1. | The **identified main window** is excluded from the prepass — and only it. Every real dialog is still scanned at every size and in every class, so an unusual modal class stays detectable. ⚠️ Helper windows are excluded from *classification* but **not** from the prepass: Power BI's AAD sign-in renders in the `Internet Explorer_Hidden` web view, so credential text really can appear there. |
+> | 1 | **Production bypassed the semantics the tests were checking.** `_join_refresh_worker` overrode `join_with_credential_poll`'s in-flight default with the t=0 `_credential_state`, the progress-monitor branch called the t=0 **raise** helper, and the final timeout check repeated it — so a proven-benign progress dialog **stopped the refresh it belonged to**. Measured in both branches: `DialogFoundError(REFRESH_IN_PROGRESS)` on the first poll, with the detector receiving **no `in_flight` argument at all**. The existing test asserted the *helper's* default identity, which production overrode: a test passing for the wrong reason. | Both wait branches and the final check use `_in_flight_credential_state`, and the progress branch latches through the shared `raise_latched_verdict` instead of raising at t=0 semantics. Its latches used to be computed and **discarded**, so it always degraded to a bare `TimeoutError`. The test now asserts on **production's call site** — the argument the detector actually receives. |
+>
+> **The through-line, and the rule that comes out of it:** a fix that adds a *suppression* path has to
+> make its positive claim actually positive. "Short", "big enough", "we read something", "the caption
+> looked fine" are all the same mistake wearing different clothes.
+
+> ⚠️ **The PowerShell arbiter still has finding 5's hole — measured, filed as #406, deliberately NOT
+> fixed here.** `probe_desktop_credential.ps1` keeps `$MinPromptWords = 5`, and driving its shipped
+> classifiers through the test harness shows the identical result: `Refresh` + `Evaluating` +
+> `Please enter your password` → `benign` → `REFRESH_IN_PROGRESS`, and **suppressed to `$null`** under
+> `-RefreshInFlight`; `Password:` likewise. It was left alone on purpose, following the precedent that
+> created issue #376 itself: #367's author found this defect in the Python half, declared it out of
+> scope, and filed it rather than silently widening the diff. Removing the amnesty there also reverses
+> a reviewed decision — `test_short_data_labels_beside_progress_text_do_not_block_suppression` exists
+> to keep `CREDENTIAL_PRESENT` reachable while Desktop shows its own refresh dialog — so it needs its
+> own issue and its own review, not a drive-by.
+>
+> **Reachability, stated rather than hidden.** Removing the amnesty costs the Python detector its
+> `benign` path whenever a dialog exposes a table name as child text (`Orders` is not progress status
+> and not chrome, so it vetoes). That is the sanctioned trade: `benign` is used only to avoid aborting
+> **our own** in-flight operation, so losing it costs extra **exit 3**s, never a silent clear.
+> ⚠️ Unobserved in this corpus whether Power BI's real refresh dialog exposes table names as child
+> HWNDs — no Desktop was available. If it does, expect `DIALOG_UNRECOGNIZED` where you hoped for
+> `REFRESH_IN_PROGRESS`; that is loud and recoverable, and it is the direction this bundle errs in.
 
 > ⚠️ **Do not wait blindly for `NO_BRIDGE` / `not_connected` — bound the bridge wait, then prove the
 > executable by PID.** Field report, 2026-08-18, two machines: a box with two Desktop versions

--- a/.github/skills/pbip-model-refresh/SKILL.md
+++ b/.github/skills/pbip-model-refresh/SKILL.md
@@ -346,8 +346,43 @@ stay byte-identical.
 > make its positive claim actually positive. "Short", "big enough", "we read something", "the caption
 > looked fine" are all the same mistake wearing different clothes.
 
-> ⚠️ **The PowerShell arbiter still has finding 5's hole — measured, filed as #406, deliberately NOT
-> fixed here.** `probe_desktop_credential.ps1` keeps `$MinPromptWords = 5`, and driving its shipped
+> ⚠️ **Round 3 killed three PROXIES at once — blocking is now decided from MODALITY. Read this before
+> adding any exclusion.** The round-2 fix replaced one unsound proxy (size) with three more — a class
+> prefix, zero area, and a helper-class name allowlist — and the reviewer defeated **all three** with
+> native Win32 experiments. They are the same mistake: answering *"is this window blocking a human?"*
+> by looking at something else.
+>
+> | proxy | native repro that defeated it | now |
+> |---|---|---|
+> | `Internet Explorer_Hidden` **name** allowlist | a visible **900×700** host reading `Password:` / `Sign in` / `Continue?` — or nothing at all — returned `modal=None, dialog=None, unknown=None`. Keeping it in the *prepass* only ever rescued **exact signature matches**. | no name is consulted anywhere |
+> | `WindowsForms10.Window.8` **class prefix** | that prefix names a WinForms **family**, not one HWND: an owner **and its owned `FixedDialog`** both reported the exact class `WindowsForms10.Window.8.app.0.2b2196a_r3_ad1`. A real credential dialog was removed from the prepass *and* from classification. | the frame is identified by **ownership** |
+> | **zero area** | a real `WS_VISIBLE` **owned 0×0** window built with `CreateWindowEx`, owner disabled: `owned-visible=True owner-win32-enabled=False rect=0x0`. Genuinely blocking, and on the unbounded query-poll path suppressing it is a false clear **that is also a hang**. | zero area suppresses only **conjoined with unowned** |
+>
+> **Win32 answers the question directly, so it is asked directly: a modal disables its owner.**
+> `DesktopWindow` now carries `owner_hwnd` (`GetWindow(GW_OWNER)`) and a **three-valued**
+> `owner_enabled` (`IsWindowEnabled(owner)`), and exactly three things are excluded from
+> classification, each a positive claim:
+>
+> | exclusion | the claim it makes |
+> |---|---|
+> | `main_frame(...)` | it is the application, and the thing dialogs block. Identified by **direct ownership** first (an owned window names its owner), falling back to the `MainWindowHandle` convention — first visible unowned window — only when nothing is owned, i.e. when there are no dialogs to hide. |
+> | `is_proven_non_blocking(...)` | an **enabled owner** proves this window blocks nothing. One-way: a *disabled* owner never convicts (Power BI's own refresh dialog disables it too) and `None` — no owner — means the test **did not apply**, which is not the same as passing it. |
+> | `renders_nothing(...)` | **unowned AND zero-area**: no owner to disable *and* no pixels to display. Both conjuncts are required; either alone is one of the dead proxies. |
+>
+> The arbiter's one-way enabled-owner exoneration is therefore **ported**, not skipped — that
+> divergence note in the module docstring is gone.
+>
+> ✅ **Proven against real windows, not just dataclasses.**
+> `test_the_win32_harvest_reads_real_ownership_and_owner_enabled_state` builds the reviewer's own
+> reproduction with `CreateWindowEx` in the test process and asserts the production harvest reads
+> `owner_hwnd`/`owner_enabled` from Win32 — every synthesised-window test passes a mutation that
+> hard-codes those fields, so only a native one can see it. ⚠️ Set ctypes **argtypes/restype**
+> explicitly if you extend it: an untyped `GetModuleHandleW` truncates the 64-bit `HINSTANCE` and
+> `RegisterClassW` then faults — a `faulthandler` access-violation dump on a test that still reported
+> a pass. That is the same rule `_configure_user32` states in production.
+
+> ⚠️ **The PowerShell arbiter still has the length-amnesty hole — measured, filed as #406, deliberately
+> NOT fixed here.** `probe_desktop_credential.ps1` keeps `$MinPromptWords = 5`, and driving its shipped
 > classifiers through the test harness shows the identical result: `Refresh` + `Evaluating` +
 > `Please enter your password` → `benign` → `REFRESH_IN_PROGRESS`, and **suppressed to `$null`** under
 > `-RefreshInFlight`; `Password:` likewise. It was left alone on purpose, following the precedent that

--- a/.github/skills/pbip-model-refresh/SKILL.md
+++ b/.github/skills/pbip-model-refresh/SKILL.md
@@ -132,10 +132,10 @@ stay byte-identical.
 > `powerbi-desktop status` -> **"Host is not ready to accept operations"** and
 > `powerbi-desktop screenshot` -> **"Print metadata is not available"** was measured on an otherwise
 > healthy Desktop/bridge when a data-source dialog was already open. Some connector dialogs expose no
-> readable text, so the fast check reports either `CREDENTIAL_MISSING` (signature text matched) or
-> `BLOCKED_BY_DIALOG` (visible non-main dialog, text unreadable/non-credential). In both cases a
-> human must look at Desktop before the run proceeds. Check this first before suspecting the bridge or
-> filing an upstream defect.
+> readable text, so the fast check reports either `CREDENTIAL_MISSING` (signature text matched) or one
+> of the `DIALOG_*` / `REFRESH_IN_PROGRESS` verdicts (a dialog is up whose content did not positively
+> read as harmless). In both cases a human must look at Desktop before the run proceeds. Check this
+> first before suspecting the bridge or filing an upstream defect.
 
 > ⚠️ **A big window is NOT evidence of a credential wall — the arbiter no longer says it is
 > (issue #367).** `probe_desktop_credential.ps1` used to decide "blocking" from geometry alone: any
@@ -275,10 +275,53 @@ stay byte-identical.
 > completed harvest. If you extend this probe — or write any other detector whose output can stop a
 > pipeline — that is the failure to look for first.
 >
-> The **Python** fast check (`_credential_modal.blocking_dialog_candidates`, used by
-> `refresh_pbip_model.py` and `probe_desktop_query.py`) still promotes any >= 100x100 non-main window
-> to `BLOCKED_BY_DIALOG` on a size-only test. That half was out of scope for #367 and is unchanged —
-> so the note above about `BLOCKED_BY_DIALOG` still describes the Python path exactly.
+> ✅ **The Python fast check now classifies too (issue #376).** `_credential_modal` had the same
+> size-only defect on a **more dangerous** path: `inspect_credential_modal` returned the first visible
+> non-main window >= 100x100 as a `blocking_dialog`, and `refresh_pbip_model.py` /
+> `probe_desktop_query.py` — **the gate of record** — printed `BLOCKED_BY_DIALOG` at **exit 1**, which
+> `probe_live_source` maps to `NO_CREDENTIAL` ("you may NOT build; a human must sign in; terminate the
+> run"). It now reads the window and speaks the **same vocabulary as the arbiter** — `CREDENTIAL_MISSING`
+> (exit 1, the only hard stop), `REFRESH_IN_PROGRESS` / `DIALOG_NEEDS_HUMAN` / `DIALOG_UNRECOGNIZED` /
+> `DIALOG_UNREADABLE` (all **exit 3**). `BLOCKED_BY_DIALOG` is **retired** from the Python path.
+>
+> Measured before/after on the same synthesised windows, all 702x355 and non-main so size cannot
+> separate them:
+>
+> | window | before | after |
+> |---|---|---|
+> | `Refresh` + `Evaluating...` | `BLOCKED_BY_DIALOG`, **exit 1** | `REFRESH_IN_PROGRESS`, exit 3 (and **ignored** while our own refresh is in flight) |
+> | `Please specify how to connect` | `CREDENTIAL_MISSING`, exit 1 | unchanged |
+> | native-query approval | `BLOCKED_BY_DIALOG`, **exit 1** | `DIALOG_NEEDS_HUMAN`, exit 3 |
+> | no text at all | `BLOCKED_BY_DIALOG`, exit 1 | `DIALOG_UNREADABLE`, exit 3 |
+> | `Save changes?` | `BLOCKED_BY_DIALOG`, exit 1 | `DIALOG_UNRECOGNIZED`, exit 3 |
+> | credential text in an **80x60** window | **no finding at all** | `CREDENTIAL_MISSING`, exit 1 |
+>
+> That last row is the half nobody had noticed: the 100x100 filter gated the **hard stop** as well as
+> the classification, because `match_credential_modal` was fed only the size-filtered candidates. A
+> credential prompt in a smaller window produced **no finding at all** — a silent false negative on the
+> one verdict that matters most. It now scans **every window, any class, any size**, exactly as
+> `Test-CredentialModal` always has.
+>
+> **Three deliberate divergences from the arbiter**, each because Win32 child-HWND text is strictly less
+> evidence than a UIA harvest. Do not "fix" them by copying the arbiter:
+>
+> | arbiter mechanism | Python | why |
+> |---|---|---|
+> | prose **join** before the credential match | **not ported** | the join needs a control-type signal to skip an interposed `Cancel`; Win32 has none, so the only join available is the naive whole-window one the arbiter discarded — and a join can *manufacture* a phrase (`Account` + `Key` → `Account Key`). That error lands on the one verdict #376 says to err away from. Recall lost this way routes to `unrecognized`/`unreadable` (exit 3, loud), and the arbiter is the escalation path. |
+> | enabled-owner **exoneration** | **not ported** | it is a *suppression* path needing owner/enabled state this module does not harvest, and unverifiable here without a live Desktop. Omitting it costs one more exit 3. |
+> | `benign-unverified` (truncated harvest) | **not needed** | a text read that throws fails the whole enumeration (`Win32EnumerationError` → `unknown_reason`), so a partial read never reaches the classifier. |
+>
+> **One asymmetry, and it is deliberate:** a proven-benign progress dialog is reported at **t=0**
+> (`REFRESH_IN_PROGRESS` — it is somebody else's refresh; do not stack a second on it) and **ignored**
+> once our own operation is in flight. Nothing else is ever ignored. In the bounded refresh wait a
+> dialog finding is **latched** rather than raised, so it cannot abort a refresh that may still finish;
+> in `probe_desktop_query`'s poll it is **acted on**, because that loop has no deadline of its own and
+> a latched dialog behind a wedged query would wait for ever.
+>
+> **Downstream, honestly:** `scripts/_verdict_lines.py` does not recognise the new tokens, so
+> `probe_live_source` classifies them **`ERROR`** ("the probe itself could not run") — `rc != 0`, the
+> gate stays armed, and nothing claims a credential wall we never observed. That is the intended
+> outcome and it was verified end-to-end, not assumed.
 
 > ⚠️ **Do not wait blindly for `NO_BRIDGE` / `not_connected` — bound the bridge wait, then prove the
 > executable by PID.** Field report, 2026-08-18, two machines: a box with two Desktop versions
@@ -343,16 +386,14 @@ stay byte-identical.
 > Options UI, export again, diff. On MSIX, set it through the UI once per agent profile.
 >
 > **If the probe or a refresh stalls on a custom-SQL source, check for this modal before concluding
-> anything about credentials.** `blocking_dialog_candidates()` will report it as
-> `BLOCKED_BY_DIALOG` rather than a false `NO_CREDENTIAL`, which is honest but not yet specific —
-> capture the modal's exact title when you first hit one so it can be classified by name.
->
-> ✅ **`probe_desktop_credential.ps1` now classifies it by name.**
+> anything about credentials.** ✅ **Both detectors now classify it by name.**
 > `scripts/blocking_prompt_signature.regex` recognises `native database quer(y|ies)` /
-> `requires your approval`, and the arbiter reports **`VERDICT: DIALOG_NEEDS_HUMAN`, exit 3** — checked
-> *before* the progress signature and *before* the enabled-owner exoneration, so a refresh dialog in the
-> same window cannot suppress it. Round 3 of review found exactly that suppression and it exited 0;
-> see the verdict table above.
+> `requires your approval`, and both `probe_desktop_credential.ps1` (issue #367) and the Python
+> `_credential_modal.classify_dialog` (issue #376) report **`DIALOG_NEEDS_HUMAN`, exit 3** — checked
+> *before* the progress signature, so a refresh dialog in the same window cannot suppress it. Round 3
+> of #367's review found exactly that suppression and it exited 0; see the verdict table above.
+> Until #376 the Python path reported this as `BLOCKED_BY_DIALOG` at exit 1, i.e. as a sign-in wall,
+> which is the wrong remedy: this needs an **approval**, not an account.
 
 Read-only preflight (proves credentials + source reachability without changing anything):
 

--- a/.github/skills/pbip-model-refresh/SKILL.md
+++ b/.github/skills/pbip-model-refresh/SKILL.md
@@ -365,7 +365,7 @@ stay byte-identical.
 >
 > | exclusion | the claim it makes |
 > |---|---|
-> | `main_frame(...)` | it is the application, and the thing dialogs block. Identified by **transitive ownership** — every owned window is walked to its **unowned root** — falling back to the `MainWindowHandle` convention only when *nothing* is owned. **Ambiguity fails closed**: two or more roots, an unresolvable chain, or several candidate unowned windows all return `None`, which excludes nothing. |
+> | `main_frame(...)` | it is the application, and the thing dialogs block. Identity is **enumerated, not inferred**: every rendering unowned window is a possible root, as is the **unowned root of any ownership chain** (walked transitively). **Ambiguity fails closed**: two or more possible roots, or a chain that cannot be resolved, returns `None`, which excludes nothing. |
 > | `is_proven_non_blocking(...)` | an **enabled owner** proves this window blocks nothing. One-way: a *disabled* owner never convicts (Power BI's own refresh dialog disables it too) and `None` — no owner — means the test **did not apply**, which is not the same as passing it. |
 > | `renders_nothing(...)` | **unowned AND zero-area**: no owner to disable *and* no pixels to display. Both conjuncts are required; either alone is one of the dead proxies. |
 >
@@ -383,9 +383,47 @@ stay byte-identical.
 >
 > **Two rules came out of it, and both are load-bearing.** Follow ownership *transitively*; and where
 > identity is **ambiguous, fail closed** — return `None` and exclude nothing. The cost of failing
-> closed is a loud exit 3; the cost of guessing is a real modal disappearing. That is why the unowned
-> fallback requires **exactly one** rendering unowned window, and why it is not reached at all once any
-> window is owned (its premise is that there are no dialogs).
+> closed is a loud exit 3; the cost of guessing is a real modal disappearing.
+>
+> ⚠️ **Round 5: transitive ownership was still an INFERENCE, and the fourth topology defeated it.**
+> Round 4's traversal collected only the roots reachable *through ownership chains*, so an **unowned**
+> credential host that happened to own one **enabled tooltip** became the sole collected root — and was
+> crowned the application. Measured, with our own refresh in flight:
+>
+> | window | what it exposed |
+> |---|---|
+> | real unowned frame | `Refresh`, `Evaluating...` — suppressed as our own progress, in flight |
+> | unowned `Internet Explorer_Hidden` | `Enter your credentials` — **excluded as "the frame"** |
+> | enabled tooltip owned by that host | the only owned window, so the only ownership root was its owner |
+>
+> → `modal=None dialog=None unknown_reason=None desktop_unready=None process_gone=None`. A false clean
+> on the gate of record. **So identity is now ENUMERATED**: every rendering unowned window is a
+> possible root *alongside* every ownership root, and an ownership-derived root gets no priority —
+> a root reached through a tooltip is not better evidence than a window sitting there rendering pixels.
+> Exactly one possible root identifies the frame; anything else returns `None` and excludes nothing.
+>
+> ⚠️ **There is no authority to ask — MEASURED, not assumed.** `Process.MainWindowHandle` looks like
+> independent evidence and is not: .NET's `ProcessManager.MainWindowFinder` runs `EnumWindows` and
+> stops at the **first visible, unowned window** of the pid — `main_frame`'s own fallback convention,
+> in another process, *without* the `renders_nothing` guard. Measured natively against real
+> `CreateWindowExW` windows:
+>
+> | experiment | what the authority returned |
+> |---|---|
+> | round 5's topology, 6 runs | the **credential host** in 5, the real frame in 1 — wrong *and* unstable |
+> | an unowned **0×0** window created last | the **0×0 window**, which can show a human nothing |
+> | raise either window to `HWND_TOPMOST` in turn | the answer **follows Z-order** — same window set, two answers |
+> | the classic shape: a genuinely **owned** modal | the real frame ✅ — but the ownership walk already agrees there, so it adds nothing |
+>
+> It is therefore never consulted: as primary evidence it re-crowns the credential host, and as a
+> tie-breaker it lets a hidden 0×0 helper unseat the real frame on a healthy Desktop.
+> `test_the_process_main_window_handle_is_a_z_order_answer_not_an_identity` pins the measurement so a
+> future .NET change is noticed rather than assumed.
+>
+> **What excluding nothing costs, stated plainly:** a spurious `DIALOG_UNRECOGNIZED` (exit 3) on the
+> real frame — or, for a report titled like a prompt, a spurious `CREDENTIAL_MISSING` (exit 1). Both
+> are loud: somebody looks at the screen and sees no dialog. Excluding the *wrong* window is silent,
+> and produces a finished model for a source nobody reached.
 >
 > The arbiter's one-way enabled-owner exoneration is therefore **ported**, not skipped — that
 > divergence note in the module docstring is gone.

--- a/.github/skills/pbip-model-refresh/scripts/_credential_modal.py
+++ b/.github/skills/pbip-model-refresh/scripts/_credential_modal.py
@@ -43,6 +43,13 @@ time by collapsing a real blocker into the healthy state. Win32 answers the ques
 disables its owner. So :func:`main_frame`, :func:`is_proven_non_blocking` and :func:`renders_nothing`
 decide from ``GetWindow(GW_OWNER)`` and ``IsWindowEnabled(owner)``, and the arbiter's one-way
 enabled-owner exoneration is now ported here rather than skipped.
+
+⚠️ **Frame identity is ENUMERATED, and ambiguity excludes nothing (#400 review round 5).** The one
+thing this module does with the frame is EXCLUDE it, so a wrong identity is a silently missed prompt.
+:func:`main_frame` therefore counts every rendering unowned window as a possible root - not only those
+reachable through ownership chains, which is how an unowned credential host owning one enabled tooltip
+was crowned the application - and returns ``None`` for anything else. ``Process.MainWindowHandle`` is
+no authority either: measured, it is a Z-ORDER answer (see :func:`main_frame`).
 """
 
 from __future__ import annotations
@@ -463,9 +470,9 @@ def _ownership_root(window: DesktopWindow, by_hwnd: dict[int, DesktopWindow]) ->
     """Walk ``window``'s owner links to the UNOWNED root, or ``None`` if the chain cannot be resolved.
 
     Returns ``None`` when a link points at a window this enumeration did not see (an owner in another
-    process, or one that is not top-level) or when the links form a cycle. Both mean the root is
-    unknown from here, and an unknown root must not be guessed: whatever :func:`main_frame` picks is
-    excluded from the credential prepass AND from classification.
+    process, or one that is not top-level) or when the links form a cycle. Both mean the root is unknown
+    from here, and an unknown root must not be guessed: whatever :func:`main_frame` picks is excluded
+    from the credential prepass AND from classification.
     """
     seen = {id(window)}
     current = window
@@ -479,51 +486,54 @@ def _ownership_root(window: DesktopWindow, by_hwnd: dict[int, DesktopWindow]) ->
 
 
 def main_frame(windows: Iterable[DesktopWindow]) -> DesktopWindow | None:
-    """The application FRAME - the window dialogs block - by ownership evidence, never by class.
+    """The application FRAME - the window dialogs block - or ``None`` when its identity is AMBIGUOUS.
 
-    ⚠️ **Ownership is followed TRANSITIVELY, to the unowned root (#400 review round 4).** It used to
-    stop at the first owner it found, and "first owner" is itself a proxy for "the root": an owned
-    window can own another popup, so a Z-order of ``tooltip -> credential dialog -> frame`` made the
-    CREDENTIAL DIALOG the frame - and the frame is excluded from both the prepass and classification,
-    so the modal vanished. Three native reproductions, all missing the modal.
+    Four review rounds have defeated four ways of *inferring* which window is the application: its SIZE
+    (round 1), a CLASS prefix plus a helper-name allowlist (round 2), the FIRST ownership edge (round
+    3), and transitive ownership that collected only the roots reachable from OWNED windows (round 4's
+    fix, broken in round 5 - an UNOWNED credential host owning one enabled tooltip was the only root
+    anybody collected, so it was crowned the frame and excluded from the prepass AND from
+    classification, while the real frame's progress text was suppressed in flight). Measured:
+    ``modal=None dialog=None unknown_reason=None`` - a false clean on the gate of record.
 
-    ⚠️ **A class prefix is not an identity either (#400 review round 3, finding 2).**
-    ``WindowsForms10.Window.8`` names a WinForms *family*, not one HWND: an owner and its owned
-    ``FixedDialog`` both reported the exact class ``WindowsForms10.Window.8.app.0.2b2196a_r3_ad1``.
+    So this stops inferring and ENUMERATES. A window is a possible root in exactly two ways: it is
+    UNOWNED and renders something (:func:`renders_nothing` is the only filter, and it is the modality
+    rule rather than a size test); or it is the unowned root of some owned window's chain, walked
+    TRANSITIVELY - an owned window can own another popup, so "first owner" was itself a proxy for "the
+    root". An ownership-derived root gets NO priority over the rest; that is the round-5 fix, because a
+    root reached through a tooltip is not better evidence than a window rendering pixels.
 
-    Evidence, in order, and **ambiguity fails closed** - returning ``None`` excludes nothing, which
-    costs a loud exit 3 at worst; guessing excludes a window, which is how a real modal disappears:
+    Exactly one possible root identifies the frame. **Everything else returns ``None``, and ``None``
+    excludes NOTHING.** Excluding nothing costs a spurious ``DIALOG_UNRECOGNIZED`` (exit 3) - or, for a
+    report titled like a prompt, a spurious ``CREDENTIAL_MISSING`` (exit 1); both are LOUD. Excluding
+    the WRONG window is silent, and finishes a model for a source nobody reached.
 
-    1. **Transitive ownership.** Every owned window is walked to its unowned root. Exactly one root
-       across the whole enumeration identifies the frame; two or more, or a chain that cannot be
-       resolved, is ambiguous.
-    2. **The process main-handle convention**, reached only when nothing is owned - i.e. when there are
-       no dialogs at all. Even here it must be UNAMBIGUOUS: one unowned window that actually renders.
-       Several is ambiguous, because "first in Z-order" would let a topmost unowned dialog present
-       itself as the application (round 4's second reproduction: an unowned ``Internet Explorer_Hidden``
-       ahead of the real frame, reading ``Enter your credentials``).
+    ⚠️ **There is no authority to ask, and that was MEASURED (#400 review round 5).** .NET's
+    ``Process.MainWindowHandle`` is ``EnumWindows`` stopping at the first VISIBLE, UNOWNED window of the
+    pid - this function's own former fallback, in another process, minus the :func:`renders_nothing`
+    guard. Pinned by ``test_the_process_main_window_handle_is_a_z_order_answer_not_an_identity``: on
+    round 5's topology it named the CREDENTIAL HOST in 5 of 6 runs, it named an unowned **0x0** window
+    created last, and raising either of two windows to ``HWND_TOPMOST`` moved the answer - it reports
+    Z-ORDER. Only a genuinely OWNED modal gets a right answer out of it, where the ownership walk
+    already agrees, so it is not consulted. Full evidence: ``SKILL.md``, "Round 5".
     """
     windows = list(windows)
     by_hwnd = {window.hwnd: window for window in windows if window.hwnd}
     roots: list[DesktopWindow] = []
-    resolved_all = True
-    owned_present = False
     for window in windows:
-        if not window.owner_hwnd:
+        if window.owner_hwnd:
+            root = _ownership_root(window, by_hwnd)
+            if root is None:
+                # Chain leaves this enumeration, or loops: the root is UNKNOWN, and an unknown root must
+                # not be guessed at - the failure mode is excluding the wrong window.
+                return None
+        elif renders_nothing(window):
             continue
-        owned_present = True
-        root = _ownership_root(window, by_hwnd)
-        if root is None:
-            resolved_all = False
-            continue
+        else:
+            root = window
         if not any(root is known for known in roots):
             roots.append(root)
-    if owned_present:
-        # A dialog IS present, so the convention below does not apply - its premise is that nothing is
-        # owned. An unresolved chain here means the root is unknown, and unknown must not be guessed.
-        return roots[0] if len(roots) == 1 and resolved_all else None
-    candidates = [window for window in windows if not window.owner_hwnd and not renders_nothing(window)]
-    return candidates[0] if len(candidates) == 1 else None
+    return roots[0] if len(roots) == 1 else None
 
 
 def is_proven_non_blocking(window: DesktopWindow) -> bool:
@@ -573,7 +583,10 @@ def dialog_candidates(
     Win32 answers the question directly, so ask it directly. The three exclusions below are the only
     ones, and each is a POSITIVE claim rather than a correlate:
 
-    * the identified :func:`main_frame` - it is the application, and the thing dialogs block;
+    * the identified :func:`main_frame` - it is the application, and the thing dialogs block. When
+      identity is AMBIGUOUS that function returns ``None`` and this exclusion simply does not happen
+      (#400 review round 5): a spurious finding on the real frame is loud and recoverable, whereas
+      excluding the wrong window is how a credential prompt disappears;
     * :func:`is_proven_non_blocking` - an enabled owner proves this window blocks nothing;
     * :func:`renders_nothing` - unowned AND zero-area: no owner to disable and no pixels to show.
 

--- a/.github/skills/pbip-model-refresh/scripts/_credential_modal.py
+++ b/.github/skills/pbip-model-refresh/scripts/_credential_modal.py
@@ -459,34 +459,71 @@ def _finding(kind: str, window: DesktopWindow, evidence: str) -> DialogFinding:
     return DialogFinding(kind=kind, verdict=DIALOG_KIND_VERDICTS[kind], window=window, evidence=evidence)
 
 
+def _ownership_root(window: DesktopWindow, by_hwnd: dict[int, DesktopWindow]) -> DesktopWindow | None:
+    """Walk ``window``'s owner links to the UNOWNED root, or ``None`` if the chain cannot be resolved.
+
+    Returns ``None`` when a link points at a window this enumeration did not see (an owner in another
+    process, or one that is not top-level) or when the links form a cycle. Both mean the root is
+    unknown from here, and an unknown root must not be guessed: whatever :func:`main_frame` picks is
+    excluded from the credential prepass AND from classification.
+    """
+    seen = {id(window)}
+    current = window
+    while current.owner_hwnd:
+        owner = by_hwnd.get(current.owner_hwnd)
+        if owner is None or id(owner) in seen:
+            return None
+        seen.add(id(owner))
+        current = owner
+    return current
+
+
 def main_frame(windows: Iterable[DesktopWindow]) -> DesktopWindow | None:
     """The application FRAME - the window dialogs block - by ownership evidence, never by class.
 
-    ⚠️ **A class prefix is not an identity (#400 review round 3, finding 2).**
-    ``WindowsForms10.Window.8`` names a WinForms *family*, not one HWND: a native experiment showed an
-    owner **and its owned `FixedDialog`** both reporting the exact class
-    ``WindowsForms10.Window.8.app.0.2b2196a_r3_ad1``. Treating that prefix as "the main window" removed
-    a real credential dialog from both the prepass and classification - the detector returned nothing
-    at all for an owned dialog reading ``Enter your credentials``.
+    ⚠️ **Ownership is followed TRANSITIVELY, to the unowned root (#400 review round 4).** It used to
+    stop at the first owner it found, and "first owner" is itself a proxy for "the root": an owned
+    window can own another popup, so a Z-order of ``tooltip -> credential dialog -> frame`` made the
+    CREDENTIAL DIALOG the frame - and the frame is excluded from both the prepass and classification,
+    so the modal vanished. Three native reproductions, all missing the modal.
 
-    Two sources of evidence, in order:
+    ⚠️ **A class prefix is not an identity either (#400 review round 3, finding 2).**
+    ``WindowsForms10.Window.8`` names a WinForms *family*, not one HWND: an owner and its owned
+    ``FixedDialog`` both reported the exact class ``WindowsForms10.Window.8.app.0.2b2196a_r3_ad1``.
 
-    1. **Direct ownership.** If an enumerated window names another enumerated window as its owner, the
-       owner is the frame. This is the strongest signal available and it is exactly the relationship
-       that matters: the frame is the thing a modal disables.
-    2. **The process main-handle convention.** Otherwise the first VISIBLE UNOWNED window, which is how
-       Win32/.NET derive ``Process.MainWindowHandle``. Reached only when no window is owned - i.e. when
-       there are no dialogs at all - so the choice cannot hide one.
+    Evidence, in order, and **ambiguity fails closed** - returning ``None`` excludes nothing, which
+    costs a loud exit 3 at worst; guessing excludes a window, which is how a real modal disappears:
+
+    1. **Transitive ownership.** Every owned window is walked to its unowned root. Exactly one root
+       across the whole enumeration identifies the frame; two or more, or a chain that cannot be
+       resolved, is ambiguous.
+    2. **The process main-handle convention**, reached only when nothing is owned - i.e. when there are
+       no dialogs at all. Even here it must be UNAMBIGUOUS: one unowned window that actually renders.
+       Several is ambiguous, because "first in Z-order" would let a topmost unowned dialog present
+       itself as the application (round 4's second reproduction: an unowned ``Internet Explorer_Hidden``
+       ahead of the real frame, reading ``Enter your credentials``).
     """
+    windows = list(windows)
     by_hwnd = {window.hwnd: window for window in windows if window.hwnd}
-    for window in windows:
-        owner = by_hwnd.get(window.owner_hwnd) if window.owner_hwnd else None
-        if owner is not None:
-            return owner
+    roots: list[DesktopWindow] = []
+    resolved_all = True
+    owned_present = False
     for window in windows:
         if not window.owner_hwnd:
-            return window
-    return None
+            continue
+        owned_present = True
+        root = _ownership_root(window, by_hwnd)
+        if root is None:
+            resolved_all = False
+            continue
+        if not any(root is known for known in roots):
+            roots.append(root)
+    if owned_present:
+        # A dialog IS present, so the convention below does not apply - its premise is that nothing is
+        # owned. An unresolved chain here means the root is unknown, and unknown must not be guessed.
+        return roots[0] if len(roots) == 1 and resolved_all else None
+    candidates = [window for window in windows if not window.owner_hwnd and not renders_nothing(window)]
+    return candidates[0] if len(candidates) == 1 else None
 
 
 def is_proven_non_blocking(window: DesktopWindow) -> bool:

--- a/.github/skills/pbip-model-refresh/scripts/_credential_modal.py
+++ b/.github/skills/pbip-model-refresh/scripts/_credential_modal.py
@@ -59,6 +59,7 @@ from _lock import _process_alive
 
 SIGNATURE_PATH = Path(__file__).resolve().with_name("credential_modal_signature.regex")
 BENIGN_SIGNATURE_PATH = Path(__file__).resolve().with_name("benign_dialog_signature.regex")
+BENIGN_CHROME_SIGNATURE_PATH = Path(__file__).resolve().with_name("benign_chrome_signature.regex")
 BLOCKING_SIGNATURE_PATH = Path(__file__).resolve().with_name("blocking_prompt_signature.regex")
 CONNECTOR_SOURCE_RE = re.compile(
     r"\b(?P<kind>Sql\.Database|Snowflake\.Databases|Databricks\.[A-Za-z]+|Odbc\.DataSource|Web\.Contents)\s*\("
@@ -213,14 +214,16 @@ WindowEnumerator = Callable[[int], Iterable[DesktopWindow]]
 ProcessLivenessCheck = Callable[[int], bool]
 
 DESKTOP_MAIN_CLASS_PREFIX = "WindowsForms10.Window.8"
-MIN_DIALOG_WIDTH = 100
-MIN_DIALOG_HEIGHT = 100
 
-# A content element with at least this many words is PROSE - something written to be read by a human.
-# If it is not itself a recognised progress status, the window is not provably a progress dialog
-# however much progress text sits beside it. Mirrors `$MinPromptWords` in probe_desktop_credential.ps1.
-# The cost of it firing wrongly is one more exit 3, which is loud and recoverable.
-MIN_PROMPT_WORDS = 5
+# Windows a Power BI Desktop process owns that are NOT dialogs, excluded by NAME rather than by size
+# (issue #376 review, finding 3). `Internet Explorer_Hidden` is the WebOC host every healthy instance
+# owns; the corpus has always carried it at 0x0.
+#
+# ⚠️ This list is the ONLY sanctioned way to stop classifying a visible non-main window. Adding to it
+# is a positive claim - "this window is identified, and it displays nothing a human must act on" - and
+# needs evidence in the commit that adds it. Do NOT re-introduce a geometry threshold: an arbitrary
+# size is not evidence of harmlessness, which is the whole of issue #376.
+HELPER_WINDOW_CLASSES = frozenset({"Internet Explorer_Hidden"})
 
 # Classifier vocabulary, shared verbatim with the PowerShell arbiter's `Get-DialogClassification` so a
 # reader moving between the two detectors meets one set of words, not two.
@@ -293,11 +296,32 @@ def credential_signature() -> re.Pattern[str]:
 def benign_dialog_signature() -> re.Pattern[str]:
     """Compile the shared progress-dialog ("Power BI is working") signature.
 
-    ⚠️ This is the ONLY file that can cause a dialog to be dismissed, so a broad pattern in it is the
-    one way to hide a genuine blocker. Its alternatives are whole-element and anchored on purpose:
-    ``\\bLoading data\\b`` once matched inside *"Loading data requires authentication"*.
+    ⚠️ This file and :func:`benign_chrome_signature` are the ONLY two that can cause a dialog to be
+    dismissed, so a broad pattern in either is the one way to hide a genuine blocker. Its alternatives
+    are whole-element and anchored on purpose: ``\\bLoading data\\b`` once matched inside
+    *"Loading data requires authentication"*.
     """
     return _compile_signature(BENIGN_SIGNATURE_PATH)
+
+
+def benign_chrome_signature() -> re.Pattern[str]:
+    """Compile the enumerated allowlist of window chrome that cannot be a prompt (#376 review, 5).
+
+    This exists because the rule it replaced was a **length heuristic**, and length is not evidence.
+    ``MIN_PROMPT_WORDS = 5`` accepted any unmatched element under five words, so
+    ``Refresh`` + ``Evaluating...`` + ``Please enter your password`` classified ``benign`` and was
+    SUPPRESSED in flight - a real prompt swallowed in silence, on the very code path added to stop
+    that happening. Measured in review; ``Password:`` (two words) did it too.
+
+    The replacement is a **positive claim about specific strings**, not about their size: each
+    alternative is a whole-element, anchored control label that carries no prompt at all, so a window
+    whose only unexplained content is one of these still shows a human nothing to act on. Anything
+    else - a table name, a status phrase nobody recognised, a four-word prompt - VETOES dismissal and
+    lands in the exit-3 indeterminate band, which is exactly what that band is for.
+
+    Keep it tiny. Every alternative added here is a string that can never again veto a dismissal.
+    """
+    return _compile_signature(BENIGN_CHROME_SIGNATURE_PATH)
 
 
 def blocking_prompt_signature() -> re.Pattern[str]:
@@ -366,18 +390,25 @@ def classify_dialog(window: DesktopWindow) -> DialogFinding:
     ``credential``        the credential signature matched a text element -> hard stop.
     ``needs-human``       a KNOWN human-blocking prompt that is not a sign-in prompt. Tested BEFORE
                           benign so a progress element in the same window cannot erase it.
-    ``mixed-content``     progress text AND unaccounted prose in the same window. A first-match-wins
-                          loop would let one benign element erase everything after it, which is how
-                          ``Evaluating`` beside *"Permission is required to run this native database
-                          query"* cleared the arbiter at exit 0.
-    ``benign``            every content element is either recognised progress status or too short to be
-                          a human-directed prompt, AND at least one IS progress status. The one
-                          dismissible kind.
+    ``mixed-content``     progress text AND content nobody could account for, in the same window. A
+                          first-match-wins loop would let one benign element erase everything after
+                          it, which is how ``Evaluating`` beside *"Permission is required to run this
+                          native database query"* cleared the arbiter at exit 0.
+    ``benign``            EVERY content element is either recognised progress status or enumerated
+                          chrome, and at least one IS progress status. The one dismissible kind.
     ``benign-title-only`` the CAPTION matched the benign signature and no content did. A caption is not
                           content, so this joins the unreadable band.
     ``unreadable``        no readable text at all.
     ``unrecognized``      readable text that matched no signature: we looked, and it is not a sign-in
                           prompt. Distinct from ``unreadable`` on purpose - absent is not empty.
+
+    ⚠️ **There is no length amnesty, and there must never be one again (#376 review, finding 5).**
+    This used to accept any unmatched element of fewer than ``MIN_PROMPT_WORDS`` words, which meant
+    ``benign`` did not mean *positively benign*: ``Please enter your password`` (4 words) and
+    ``Password:`` (2) both classified ``benign`` beside ``Evaluating...``, and ``dialog_verdict`` then
+    SUPPRESSED them in flight. That is the same defect class this module was written to remove,
+    reintroduced on the new code path - and in that shape strictly worse than the bug it replaced,
+    because the repo's rule is that a credential modal is never worked around.
     """
     title, all_texts, content = dialog_text_set(window)
     signature_hit = _match_dialog_signatures(window, all_texts)
@@ -385,6 +416,7 @@ def classify_dialog(window: DesktopWindow) -> DialogFinding:
         return signature_hit
 
     benign = benign_dialog_signature()
+    chrome = benign_chrome_signature()
     benign_hit: str | None = None
     unaccounted: str | None = None
     for text in content:
@@ -392,7 +424,9 @@ def classify_dialog(window: DesktopWindow) -> DialogFinding:
             if benign_hit is None:
                 benign_hit = text
             continue
-        if unaccounted is None and len(text.split()) >= MIN_PROMPT_WORDS:
+        if chrome.search(text):
+            continue
+        if unaccounted is None:
             unaccounted = text
     if benign_hit is not None:
         if unaccounted is not None:
@@ -410,19 +444,46 @@ def _finding(kind: str, window: DesktopWindow, evidence: str) -> DialogFinding:
     return DialogFinding(kind=kind, verdict=DIALOG_KIND_VERDICTS[kind], window=window, evidence=evidence)
 
 
-def dialog_candidates(windows: Iterable[DesktopWindow]) -> list[DesktopWindow]:
-    """Windows big enough, and of the right class, to be worth CLASSIFYING.
+def is_desktop_main_window(window: DesktopWindow) -> bool:
+    """Is ``window`` the Power BI Desktop MAIN window (not a dialog)?
 
-    Size selects what to LOOK AT; it is not itself evidence of anything (issue #376). The old
-    ``blocking_dialog_candidates`` returned the first window past this filter as a blocking dialog,
-    which is why a Refresh progress dialog read as a credential wall at exit 1.
+    Identified by the Win32 class prefix, which is what every other main-window test in this module
+    already uses. It is deliberately the ONLY thing excluded from the credential prepass and from
+    classification: every other window, whatever its class and whatever its size, is still read.
+    """
+    return window.class_name.startswith(DESKTOP_MAIN_CLASS_PREFIX)
+
+
+def dialog_candidates(windows: Iterable[DesktopWindow]) -> list[DesktopWindow]:
+    """Every visible window worth CLASSIFYING - which is every one that is not positively excluded.
+
+    ⚠️ **There is no size threshold here any more (#376 review, finding 3).** It used to require
+    >= 100x100, and the review measured the consequence: a visible 80x60 owned window with no readable
+    text returned ``modal=None, dialog=None, unknown_reason=None`` - byte-identical to a healthy
+    Desktop. The all-window credential prepass only rescued windows whose text matched the credential
+    regex, so a small unreadable, caption-only or differently-worded prompt still vanished. That is the
+    ORIGINAL defect of issue #376, surviving inside its own fix: an arbitrary geometry threshold is not
+    evidence of harmlessness.
+
+    Two exclusions remain, and each is a positive claim rather than a threshold:
+
+    * the **main window** (:func:`is_desktop_main_window`) - it is the application, not a dialog;
+    * **zero-area** windows and named :data:`HELPER_WINDOW_CLASSES` - a window with no width or no
+      height rasterises nothing, so it cannot be showing a human anything to act on, and the named
+      helpers are identified Desktop infrastructure (``Internet Explorer_Hidden``).
+
+    ⚠️ Known cost, stated rather than hidden: if a real Desktop turns out to own OTHER visible,
+    non-zero-area, non-main windows, they will now be classified - most likely ``unreadable``, i.e.
+    exit 3. Unobserved in this corpus (no Desktop was available). The fix for that is to identify the
+    window and add it to :data:`HELPER_WINDOW_CLASSES` **with evidence**, never to restore a size test.
     """
     return [
         window
         for window in windows
-        if not window.class_name.startswith(DESKTOP_MAIN_CLASS_PREFIX)
-        and window.width >= MIN_DIALOG_WIDTH
-        and window.height >= MIN_DIALOG_HEIGHT
+        if not is_desktop_main_window(window)
+        and window.class_name not in HELPER_WINDOW_CLASSES
+        and window.width > 0
+        and window.height > 0
     ]
 
 
@@ -454,16 +515,24 @@ def dialog_verdict(
 
 
 def match_credential_modal(windows: Iterable[DesktopWindow]) -> CredentialModal | None:
-    """First credential-signature match across EVERY window - any class, any size.
+    """First credential-signature match across every DIALOG - any class, any size.
 
-    Deliberately NOT restricted to :func:`dialog_candidates` (issue #376). It used to be, and that
-    made the 100x100 filter gate the hard stop as well as the classification: a credential prompt in a
-    smaller window returned NO FINDING AT ALL, i.e. a silent false negative on the one verdict that
-    matters most. ``Test-CredentialModal`` in the arbiter has always scanned every window; this now
-    matches it.
+    Not restricted to :func:`dialog_candidates`' classification set (issue #376): it used to be, and
+    the 100x100 filter therefore gated the HARD STOP as well as the classification, so a credential
+    prompt in a smaller window returned no finding at all - a silent false negative on the one verdict
+    that matters most.
+
+    ⚠️ The MAIN window is excluded (#376 review, finding 4). An unrestricted scan read the Desktop
+    caption and its child text, so a report legitimately named ``Account Key``,
+    ``Personal Access Token`` or ``Databricks Client Credentials`` produced ``CREDENTIAL_MISSING`` at
+    exit 1 - measured with a main window titled ``Account Key - Power BI Desktop``, on both consumers.
+    Only the main window is excluded: every real dialog is still scanned at every size and in every
+    class, so an unusual modal class stays detectable.
     """
     signature = credential_signature()
     for window in windows:
+        if is_desktop_main_window(window):
+            continue
         for text in normalize_texts(window.texts):
             if signature.search(text):
                 return CredentialModal(matched_text=text, window=window)
@@ -854,17 +923,49 @@ def print_dialog_observed_notice(pid: int, finding: DialogFinding) -> None:
     )
 
 
-def _raise_detection(pid: int, state: CredentialDetection, source_hint: str | None) -> None:
+def raise_terminal_detection(pid: int, state: CredentialDetection, source_hint: str | None = None) -> None:
     """Raise for the two observations that end a bounded wait IMMEDIATELY.
 
     Only a matched credential signature and a confirmed-dead process qualify. A :class:`DialogFinding`
-    deliberately does NOT (issue #376): it is latched by :func:`join_with_credential_poll` and surfaced
-    at the deadline, so a dialog we could not read cannot cut short a refresh that was going to succeed.
+    deliberately does NOT (issue #376): it is latched by the caller and surfaced at the deadline via
+    :func:`raise_latched_verdict`, so a dialog we could not read cannot cut short a refresh that was
+    going to succeed.
+
+    Public because ``refresh_pbip_model`` has a SECOND wait loop - the progress-monitor branch - which
+    must behave identically. It used to call the t=0 helper instead, so a proven-benign progress dialog
+    belonging to the current refresh aborted that refresh (#376 review, finding 1).
     """
     if state.modal is not None:
         raise CredentialMissingError(pid, state.modal, source_hint)
     if state.process_gone is not None:
         raise DesktopGoneError(pid, state.process_gone)
+
+
+def raise_latched_verdict(
+    pid: int,
+    *,
+    desktop_unready: str | None = None,
+    dialog: DialogFinding | None = None,
+    unknown: str | None = None,
+) -> None:
+    """Raise whichever latched observation a bounded wait ended with, in precedence order.
+
+    Local Desktop failure first (nothing was learned about the source at all), then a dialog we could
+    not account for, then the indeterminate credential state. Shared by both wait loops so they cannot
+    disagree - the progress-monitor branch used to compute its latches and then DISCARD them, ending
+    on a bare ``TimeoutError`` that the parent blames on a slow source.
+    """
+    if desktop_unready is not None:
+        raise DesktopUnreadyError(pid, desktop_unready)
+    if dialog is not None:
+        raise DialogFoundError(pid, dialog)
+    if unknown is not None:
+        raise CredentialUnknownError(pid, unknown)
+
+
+def _raise_detection(pid: int, state: CredentialDetection, source_hint: str | None) -> None:
+    """Backwards-compatible alias for :func:`raise_terminal_detection`."""
+    raise_terminal_detection(pid, state, source_hint)
 
 
 # pylint: disable=too-many-arguments
@@ -955,15 +1056,12 @@ def join_with_credential_poll(
     if worker.is_alive():
         state = detector(pid)
         _raise_detection(pid, state, source_hint)
-        latched_desktop_unready = latched_desktop_unready or state.desktop_unready
-        if latched_desktop_unready is not None:
-            raise DesktopUnreadyError(pid, latched_desktop_unready)
-        latched_dialog = latched_dialog or state.dialog
-        if latched_dialog is not None:
-            raise DialogFoundError(pid, latched_dialog)
-        latched_unknown = latched_unknown or state.unknown_reason
-        if latched_unknown is not None:
-            raise CredentialUnknownError(pid, latched_unknown)
+        raise_latched_verdict(
+            pid,
+            desktop_unready=latched_desktop_unready or state.desktop_unready,
+            dialog=latched_dialog or state.dialog,
+            unknown=latched_unknown or state.unknown_reason,
+        )
         return False
     return True
 

--- a/.github/skills/pbip-model-refresh/scripts/_credential_modal.py
+++ b/.github/skills/pbip-model-refresh/scripts/_credential_modal.py
@@ -30,14 +30,19 @@ strictly LESS evidence than the arbiter (Win32 child-HWND text only; no UI Autom
   from, so matching here stays per-element. The recall this costs routes to ``unrecognized`` /
   ``unreadable`` (exit 3, loud), and the arbiter - which HAS the control-type signal - is the
   escalation path.
-* **No enabled-owner exoneration.** The arbiter uses modality one way: an ENABLED owner proves a
-  window blocks nothing. That is a SUPPRESSION path, it needs Win32 owner/enabled state this module
-  does not harvest, and it cannot be verified here without a live Desktop. Omitting it only ever
-  costs one more exit 3.
 * **No ``benign-unverified`` kind.** The arbiter needs it because a UIA harvest can be truncated while
   still returning text. Here a text read that throws fails the WHOLE enumeration
   (``Win32EnumerationError`` -> ``unknown_reason``), so a partial read cannot reach the classifier in
   the first place.
+
+⚠️ **Blocking is decided from MODALITY, never from class, size or name (#400 review round 3).** An
+earlier pass answered *"is this window blocking a human?"* with three correlates in turn - a
+``>= 100x100`` size test, a ``WindowsForms10.Window.8`` class prefix, and an
+``Internet Explorer_Hidden`` name allowlist - and native Win32 experiments defeated all three, each
+time by collapsing a real blocker into the healthy state. Win32 answers the question directly: a modal
+disables its owner. So :func:`main_frame`, :func:`is_proven_non_blocking` and :func:`renders_nothing`
+decide from ``GetWindow(GW_OWNER)`` and ``IsWindowEnabled(owner)``, and the arbiter's one-way
+enabled-owner exoneration is now ported here rather than skipped.
 """
 
 from __future__ import annotations
@@ -70,8 +75,23 @@ CONNECTOR_SOURCE_RE = re.compile(
 
 @dataclass(frozen=True)
 class DesktopWindow:
-    """Visible top-level Power BI Desktop window plus descendant Win32 text."""
+    """Visible top-level Power BI Desktop window plus descendant Win32 text and its MODALITY facts.
 
+    ``owner_hwnd`` / ``owner_enabled`` carry the only evidence that actually answers *"is this window
+    blocking a human?"* (#400 review round 3). They are THREE-valued on purpose:
+
+    * ``owner_enabled is True``  - the owner is enabled, which PROVES this window blocks nothing. A
+      modal disables its owner; an enabled owner is therefore a positive exoneration.
+    * ``owner_enabled is False`` - the owner is disabled. This does NOT convict: Power BI's own refresh
+      dialog disables the owner too. It only means the exoneration does not apply.
+    * ``owner_enabled is None``  - no owner, so the test did not apply. Not the same as passing it.
+
+    Nine fields, waived rather than split: this is one Win32 window record and every field is read
+    straight from the API. Grouping the modality pair behind a nested object would put an indirection
+    between a reader and the two values three review rounds turned on.
+    """
+
+    # pylint: disable=too-many-instance-attributes
     title: str
     class_name: str
     width: int
@@ -79,6 +99,8 @@ class DesktopWindow:
     texts: tuple[str, ...] = ()
     minimized: bool = False
     hwnd: int = 0
+    owner_hwnd: int = 0
+    owner_enabled: bool | None = None
 
 
 @dataclass(frozen=True)
@@ -215,15 +237,8 @@ ProcessLivenessCheck = Callable[[int], bool]
 
 DESKTOP_MAIN_CLASS_PREFIX = "WindowsForms10.Window.8"
 
-# Windows a Power BI Desktop process owns that are NOT dialogs, excluded by NAME rather than by size
-# (issue #376 review, finding 3). `Internet Explorer_Hidden` is the WebOC host every healthy instance
-# owns; the corpus has always carried it at 0x0.
-#
-# ⚠️ This list is the ONLY sanctioned way to stop classifying a visible non-main window. Adding to it
-# is a positive claim - "this window is identified, and it displays nothing a human must act on" - and
-# needs evidence in the commit that adds it. Do NOT re-introduce a geometry threshold: an arbitrary
-# size is not evidence of harmlessness, which is the whole of issue #376.
-HELPER_WINDOW_CLASSES = frozenset({"Internet Explorer_Hidden"})
+# `GetWindow(hwnd, GW_OWNER)`. The owner of a top-level window - the window a modal disables.
+GW_OWNER = 4
 
 # Classifier vocabulary, shared verbatim with the PowerShell arbiter's `Get-DialogClassification` so a
 # reader moving between the two detectors meets one set of words, not two.
@@ -444,46 +459,95 @@ def _finding(kind: str, window: DesktopWindow, evidence: str) -> DialogFinding:
     return DialogFinding(kind=kind, verdict=DIALOG_KIND_VERDICTS[kind], window=window, evidence=evidence)
 
 
-def is_desktop_main_window(window: DesktopWindow) -> bool:
-    """Is ``window`` the Power BI Desktop MAIN window (not a dialog)?
+def main_frame(windows: Iterable[DesktopWindow]) -> DesktopWindow | None:
+    """The application FRAME - the window dialogs block - by ownership evidence, never by class.
 
-    Identified by the Win32 class prefix, which is what every other main-window test in this module
-    already uses. It is deliberately the ONLY thing excluded from the credential prepass and from
-    classification: every other window, whatever its class and whatever its size, is still read.
+    ⚠️ **A class prefix is not an identity (#400 review round 3, finding 2).**
+    ``WindowsForms10.Window.8`` names a WinForms *family*, not one HWND: a native experiment showed an
+    owner **and its owned `FixedDialog`** both reporting the exact class
+    ``WindowsForms10.Window.8.app.0.2b2196a_r3_ad1``. Treating that prefix as "the main window" removed
+    a real credential dialog from both the prepass and classification - the detector returned nothing
+    at all for an owned dialog reading ``Enter your credentials``.
+
+    Two sources of evidence, in order:
+
+    1. **Direct ownership.** If an enumerated window names another enumerated window as its owner, the
+       owner is the frame. This is the strongest signal available and it is exactly the relationship
+       that matters: the frame is the thing a modal disables.
+    2. **The process main-handle convention.** Otherwise the first VISIBLE UNOWNED window, which is how
+       Win32/.NET derive ``Process.MainWindowHandle``. Reached only when no window is owned - i.e. when
+       there are no dialogs at all - so the choice cannot hide one.
     """
-    return window.class_name.startswith(DESKTOP_MAIN_CLASS_PREFIX)
+    by_hwnd = {window.hwnd: window for window in windows if window.hwnd}
+    for window in windows:
+        owner = by_hwnd.get(window.owner_hwnd) if window.owner_hwnd else None
+        if owner is not None:
+            return owner
+    for window in windows:
+        if not window.owner_hwnd:
+            return window
+    return None
 
 
-def dialog_candidates(windows: Iterable[DesktopWindow]) -> list[DesktopWindow]:
-    """Every visible window worth CLASSIFYING - which is every one that is not positively excluded.
+def is_proven_non_blocking(window: DesktopWindow) -> bool:
+    """Does POSITIVE evidence show ``window`` blocks nothing?
 
-    ⚠️ **There is no size threshold here any more (#376 review, finding 3).** It used to require
-    >= 100x100, and the review measured the consequence: a visible 80x60 owned window with no readable
-    text returned ``modal=None, dialog=None, unknown_reason=None`` - byte-identical to a healthy
-    Desktop. The all-window credential prepass only rescued windows whose text matched the credential
-    regex, so a small unreadable, caption-only or differently-worded prompt still vanished. That is the
-    ORIGINAL defect of issue #376, surviving inside its own fix: an arbitrary geometry threshold is not
-    evidence of harmlessness.
-
-    Two exclusions remain, and each is a positive claim rather than a threshold:
-
-    * the **main window** (:func:`is_desktop_main_window`) - it is the application, not a dialog;
-    * **zero-area** windows and named :data:`HELPER_WINDOW_CLASSES` - a window with no width or no
-      height rasterises nothing, so it cannot be showing a human anything to act on, and the named
-      helpers are identified Desktop infrastructure (``Internet Explorer_Hidden``).
-
-    ⚠️ Known cost, stated rather than hidden: if a real Desktop turns out to own OTHER visible,
-    non-zero-area, non-main windows, they will now be classified - most likely ``unreadable``, i.e.
-    exit 3. Unobserved in this corpus (no Desktop was available). The fix for that is to identify the
-    window and add it to :data:`HELPER_WINDOW_CLASSES` **with evidence**, never to restore a size test.
+    Modality is a ONE-WAY test. An ENABLED owner proves this window is not blocking it, because a modal
+    disables its owner. The converse does not hold - Power BI's refresh dialog also disables the owner -
+    so a disabled owner never convicts, and ``None`` (no owner) means the test did not apply, which is
+    not the same as passing it.
     """
+    return window.owner_enabled is True
+
+
+def renders_nothing(window: DesktopWindow) -> bool:
+    """Is ``window`` incapable of showing a human anything, on TWO independent grounds?
+
+    Zero area alone is NOT sufficient and must never be used alone (#400 review round 3, finding 3): a
+    native experiment built a real ``WS_VISIBLE`` **owned 0x0** window and disabled its owner -
+    ``owned-visible=True owner-win32-enabled=False rect=0x0`` - which is a genuinely blocking shape. On
+    the unbounded query-poll path suppressing it leaves the worker blocked while every poll reports no
+    finding: a false clear that is also a hang.
+
+    So this requires BOTH: no owner to disable, AND no pixels to display. A window with neither
+    mechanism cannot block anyone.
+    """
+    return not window.owner_hwnd and (window.width <= 0 or window.height <= 0)
+
+
+def dialog_candidates(
+    windows: Iterable[DesktopWindow],
+    *,
+    frame: DesktopWindow | None = None,
+) -> list[DesktopWindow]:
+    """Every visible window worth CLASSIFYING - which is every one not POSITIVELY proven harmless.
+
+    ⚠️ **Three proxies died here across two review rounds. Do not add a fourth.** Size (>= 100x100),
+    class prefix, and a helper-class NAME allowlist were each an attempt to answer *"is this window
+    blocking a human?"* by looking at something else, and each one collapsed a real blocker into the
+    healthy state:
+
+    | proxy | what it hid |
+    |---|---|
+    | ``>= 100x100`` | a visible 80x60 unreadable owned dialog |
+    | ``WindowsForms10.Window.8`` prefix | an owned ``FixedDialog`` sharing its owner's exact class |
+    | ``Internet Explorer_Hidden`` name | the AAD sign-in host, whatever it displayed |
+
+    Win32 answers the question directly, so ask it directly. The three exclusions below are the only
+    ones, and each is a POSITIVE claim rather than a correlate:
+
+    * the identified :func:`main_frame` - it is the application, and the thing dialogs block;
+    * :func:`is_proven_non_blocking` - an enabled owner proves this window blocks nothing;
+    * :func:`renders_nothing` - unowned AND zero-area: no owner to disable and no pixels to show.
+
+    Nothing is excluded for its size, its class, or its name.
+    """
+    windows = list(windows)
+    frame = frame if frame is not None else main_frame(windows)
     return [
         window
         for window in windows
-        if not is_desktop_main_window(window)
-        and window.class_name not in HELPER_WINDOW_CLASSES
-        and window.width > 0
-        and window.height > 0
+        if window is not frame and not is_proven_non_blocking(window) and not renders_nothing(window)
     ]
 
 
@@ -491,6 +555,7 @@ def dialog_verdict(
     windows: Iterable[DesktopWindow],
     *,
     operation_in_flight: bool = False,
+    frame: DesktopWindow | None = None,
 ) -> DialogFinding | None:
     """Fold per-window classifications into ONE finding, or ``None`` when nothing needs reporting.
 
@@ -500,7 +565,7 @@ def dialog_verdict(
     report had to unpick by hand.
     """
     found: dict[str, DialogFinding] = {}
-    for window in dialog_candidates(windows):
+    for window in dialog_candidates(windows, frame=frame):
         finding = classify_dialog(window)
         if finding.kind == DIALOG_KIND_CREDENTIAL:
             return finding
@@ -514,24 +579,31 @@ def dialog_verdict(
     return None
 
 
-def match_credential_modal(windows: Iterable[DesktopWindow]) -> CredentialModal | None:
-    """First credential-signature match across every DIALOG - any class, any size.
+def match_credential_modal(
+    windows: Iterable[DesktopWindow],
+    *,
+    frame: DesktopWindow | None = None,
+) -> CredentialModal | None:
+    """First credential-signature match across every window EXCEPT the application frame.
 
-    Not restricted to :func:`dialog_candidates`' classification set (issue #376): it used to be, and
-    the 100x100 filter therefore gated the HARD STOP as well as the classification, so a credential
-    prompt in a smaller window returned no finding at all - a silent false negative on the one verdict
-    that matters most.
+    Not restricted to :func:`dialog_candidates` (issue #376): it used to be, and the 100x100 filter
+    therefore gated the HARD STOP as well as the classification, so a credential prompt in a smaller
+    window returned no finding at all - a silent false negative on the one verdict that matters most.
+    It reads windows classification skips, too: an owned zero-area window, or one whose owner is
+    enabled, can still be carrying credential text.
 
-    ⚠️ The MAIN window is excluded (#376 review, finding 4). An unrestricted scan read the Desktop
-    caption and its child text, so a report legitimately named ``Account Key``,
+    ⚠️ The application frame is excluded (#376 review, finding 4). An unrestricted scan read the
+    Desktop caption and its child text, so a report legitimately named ``Account Key``,
     ``Personal Access Token`` or ``Databricks Client Credentials`` produced ``CREDENTIAL_MISSING`` at
-    exit 1 - measured with a main window titled ``Account Key - Power BI Desktop``, on both consumers.
-    Only the main window is excluded: every real dialog is still scanned at every size and in every
-    class, so an unusual modal class stays detectable.
+    exit 1. The frame is identified by :func:`main_frame` - by OWNERSHIP, never by class - because a
+    class-prefix test also excluded a real owned credential dialog that shared its owner's class
+    (#400 review round 3, finding 2).
     """
+    windows = list(windows)
+    frame = frame if frame is not None else main_frame(windows)
     signature = credential_signature()
     for window in windows:
-        if is_desktop_main_window(window):
+        if window is frame:
             continue
         for text in normalize_texts(window.texts):
             if signature.search(text):
@@ -556,6 +628,10 @@ def _configure_user32(user32) -> None:
     user32.GetWindowThreadProcessId.restype = wintypes.DWORD
     user32.IsWindowVisible.argtypes = [wintypes.HWND]
     user32.IsWindowVisible.restype = wintypes.BOOL
+    user32.IsWindowEnabled.argtypes = [wintypes.HWND]
+    user32.IsWindowEnabled.restype = wintypes.BOOL
+    user32.GetWindow.argtypes = [wintypes.HWND, wintypes.UINT]
+    user32.GetWindow.restype = wintypes.HWND
     user32.IsIconic.argtypes = [wintypes.HWND]
     user32.IsIconic.restype = wintypes.BOOL
     user32.GetWindowTextLengthW.argtypes = [wintypes.HWND]
@@ -634,6 +710,11 @@ def _enumerate_pid_windows_with_count(pid: int) -> tuple[list[DesktopWindow], in
             user32.GetWindowRect(hwnd_int, ctypes.byref(rect))
             title = _window_text(user32, hwnd_int)
             texts = tuple(text for text in (title, *_child_texts(user32, hwnd_int)) if text)
+            # The modality facts. `GW_OWNER` is the window a modal disables, and its enabled state is
+            # the only direct evidence of whether this window is blocking anyone (#400 review round 3).
+            # Deliberately three-valued: no owner means the test did not apply, which is NOT "passed".
+            owner_hwnd = _hwnd_value(user32.GetWindow(hwnd_int, GW_OWNER))
+            owner_enabled = bool(user32.IsWindowEnabled(owner_hwnd)) if owner_hwnd else None
             windows.append(
                 DesktopWindow(
                     title=title,
@@ -643,6 +724,8 @@ def _enumerate_pid_windows_with_count(pid: int) -> tuple[list[DesktopWindow], in
                     texts=texts,
                     minimized=bool(user32.IsIconic(hwnd_int)),
                     hwnd=hwnd_int,
+                    owner_hwnd=owner_hwnd,
+                    owner_enabled=owner_enabled,
                 )
             )
         except BaseException as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught
@@ -684,16 +767,14 @@ def inspect_credential_modal(
         windows = tuple(enumerate_windows(pid))
     except Win32EnumerationError as exc:
         return CredentialDetection(unknown_reason=f"window enumeration failed: {exc}")
-    modal = match_credential_modal(windows)
+    frame = main_frame(windows)
+    modal = match_credential_modal(windows, frame=frame)
     if modal is not None:
         return CredentialDetection(modal=modal, windows=windows)
-    finding = dialog_verdict(windows, operation_in_flight=operation_in_flight)
+    finding = dialog_verdict(windows, operation_in_flight=operation_in_flight, frame=frame)
     if finding is not None:
         return CredentialDetection(dialog=finding, windows=windows)
-    minimized = [
-        window for window in windows if window.minimized and window.class_name.startswith(DESKTOP_MAIN_CLASS_PREFIX)
-    ]
-    if minimized:
+    if frame is not None and frame.minimized:
         return CredentialDetection(
             unknown_reason=(
                 "Power BI Desktop owner window is minimized; owned modal dialogs are hidden from enumeration"

--- a/.github/skills/pbip-model-refresh/scripts/_credential_modal.py
+++ b/.github/skills/pbip-model-refresh/scripts/_credential_modal.py
@@ -1,8 +1,43 @@
 """Credential modal detection shared by the PBIP refresh/query scripts.
 
-The regex in ``credential_modal_signature.regex`` is the same signature used by
-``probe_desktop_credential.ps1``. Keep the detector's matching rule here and the signature in that
-resource so the fast Python checks and the PowerShell arbiter cannot drift.
+All three regexes in ``*_signature.regex`` beside this file are the same signatures used by
+``probe_desktop_credential.ps1``. Keep the detector's matching rules here and the signatures in those
+resources so the fast Python checks and the PowerShell arbiter cannot drift.
+
+⚠️ **A big window is NOT evidence of anything (issue #376).** Until this module was fixed,
+``inspect_credential_modal`` returned the FIRST visible non-main window >= 100x100 as a
+``blocking_dialog``, and both callers mapped that to ``BLOCKED_BY_DIALOG`` at **exit 1** - the same
+hard-stop band as a real credential wall, which ``probe_live_source`` then classifies ``NO_CREDENTIAL``
+("you may NOT build; a human must sign in"). A Power BI Refresh progress dialog satisfies >= 100x100
+trivially, so a working refresh could halt a migration and send someone to a sign-in screen that was
+never on show. That is the same defect #367 removed from the PowerShell arbiter, on a more dangerous
+path: this detector feeds ``probe_desktop_query.py``, the gate of record.
+
+**The burden of proof runs ONE WAY, exactly as in the arbiter:** a dialog is dismissed only when its
+CONTENT positively reads as recognised progress status. It is never dismissed because the caption
+looked reassuring, and never because we merely read *something*. Everything we could not account for -
+unreadable, caption-only, unrecognised, or progress text mixed with prose - surfaces as its own
+non-credential finding at **exit 3**, which is loud and recoverable, and never as a credential wall.
+
+Three deliberate divergences from ``probe_desktop_credential.ps1``, each because this detector has
+strictly LESS evidence than the arbiter (Win32 child-HWND text only; no UI Automation):
+
+* **No prose join.** The arbiter joins non-interactive elements before matching the credential
+  signature, which needs a control-type signal to exclude an interposed ``Cancel``. Win32 gives no
+  control type, so the only join available here is the naive whole-window one the arbiter discarded in
+  review - and a join can MANUFACTURE a phrase (two adjacent labels ``Account`` + ``Key`` join to the
+  signature ``Account Key``). That error would land on the one verdict issue #376 says to err away
+  from, so matching here stays per-element. The recall this costs routes to ``unrecognized`` /
+  ``unreadable`` (exit 3, loud), and the arbiter - which HAS the control-type signal - is the
+  escalation path.
+* **No enabled-owner exoneration.** The arbiter uses modality one way: an ENABLED owner proves a
+  window blocks nothing. That is a SUPPRESSION path, it needs Win32 owner/enabled state this module
+  does not harvest, and it cannot be verified here without a live Desktop. Omitting it only ever
+  costs one more exit 3.
+* **No ``benign-unverified`` kind.** The arbiter needs it because a UIA harvest can be truncated while
+  still returning text. Here a text read that throws fails the WHOLE enumeration
+  (``Win32EnumerationError`` -> ``unknown_reason``), so a partial read cannot reach the classifier in
+  the first place.
 """
 
 from __future__ import annotations
@@ -23,6 +58,8 @@ from pathlib import Path
 from _lock import _process_alive
 
 SIGNATURE_PATH = Path(__file__).resolve().with_name("credential_modal_signature.regex")
+BENIGN_SIGNATURE_PATH = Path(__file__).resolve().with_name("benign_dialog_signature.regex")
+BLOCKING_SIGNATURE_PATH = Path(__file__).resolve().with_name("blocking_prompt_signature.regex")
 CONNECTOR_SOURCE_RE = re.compile(
     r"\b(?P<kind>Sql\.Database|Snowflake\.Databases|Databricks\.[A-Za-z]+|Odbc\.DataSource|Web\.Contents)\s*\("
     r"\s*(?:\"(?P<double>[^\"]+)\"|'(?P<single>[^']+)')?",
@@ -57,10 +94,28 @@ class CredentialModal:
 
 
 @dataclass(frozen=True)
-class BlockingDialog:
-    """Evidence that Desktop is blocked by a visible dialog whose text may be unreadable."""
+class DialogFinding:
+    """A candidate dialog we could NOT dismiss, plus the classification that says why.
 
+    Replaces the old ``BlockingDialog`` (issue #376). The rename is the finding: this module can
+    establish that a window is UP and what it SAYS, never that it BLOCKS anything - so every
+    ``BLOCKED_BY_DIALOG`` it used to emit was an inference dressed as a finding, in the one verdict
+    class the toolkit treats as a hard stop.
+
+    ``kind`` is the classifier's own vocabulary (see :func:`classify_dialog`); ``verdict`` is the
+    machine-readable token the callers print. Both are carried so a caller can print the token and a
+    reader can still see which evidence produced it.
+    """
+
+    kind: str
+    verdict: str
     window: DesktopWindow
+    evidence: str = ""
+
+    @property
+    def excerpt(self) -> str:
+        """Short UI text excerpt suitable for a verdict line."""
+        return self.evidence[:80]
 
 
 @dataclass(frozen=True)
@@ -68,7 +123,7 @@ class CredentialDetection:
     """Credential-dialog inspection result for a Desktop PID."""
 
     modal: CredentialModal | None = None
-    blocking_dialog: BlockingDialog | None = None
+    dialog: DialogFinding | None = None
     unknown_reason: str | None = None
     desktop_unready: str | None = None
     process_gone: str | None = None
@@ -85,13 +140,21 @@ class CredentialMissingError(RuntimeError):
         super().__init__(describe_modal(modal, source_hint))
 
 
-class DialogBlockedError(RuntimeError):
-    """Power BI Desktop is showing an unreadable/non-credential blocking dialog."""
+class DialogFoundError(RuntimeError):
+    """Power BI Desktop is showing a dialog that could NOT be shown to be harmless (issue #376).
 
-    def __init__(self, pid: int, dialog: BlockingDialog) -> None:
+    Deliberately not named "blocked": this detector reads Win32 child-HWND text and can establish that
+    a window is up and what it says, never that it blocks anything. It replaces ``DialogBlockedError``,
+    whose ``BLOCKED_BY_DIALOG`` verdict sat in the exit-1 hard-stop band and was reached from a
+    SIZE-ONLY test - so a Power BI Refresh progress dialog produced the same verdict as a sign-in
+    prompt. Every outcome here is now exit 3: a human should look at the screen, but no sign-in is
+    implied and nothing about the data source has been established.
+    """
+
+    def __init__(self, pid: int, finding: DialogFinding) -> None:
         self.pid = pid
-        self.dialog = dialog
-        super().__init__(describe_blocking_dialog(dialog))
+        self.finding = finding
+        super().__init__(describe_dialog_finding(finding))
 
 
 class CredentialUnknownError(RuntimeError):
@@ -100,7 +163,7 @@ class CredentialUnknownError(RuntimeError):
     Raised by :func:`join_with_credential_poll` when it LATCHED an indeterminate observation - the
     owner window went iconic, which hides its owned modal dialogs from enumeration - that a later
     ``none`` could not erase. It is a mandatory THIRD outcome, distinct from a detected block
-    (:class:`CredentialMissingError` / :class:`DialogBlockedError`) and from a healthy deadline:
+    (:class:`CredentialMissingError` / :class:`DialogFoundError`) and from a healthy deadline:
     minimizing then restoring the owner destroys the dialog evidence for good (measured 2026-08-14,
     issue #154), so ``none`` after the fact is indistinguishable from a genuinely healthy Desktop and
     is NOT proof of health. Reporting a bare timeout here would blame a slow source for what is really
@@ -153,6 +216,58 @@ DESKTOP_MAIN_CLASS_PREFIX = "WindowsForms10.Window.8"
 MIN_DIALOG_WIDTH = 100
 MIN_DIALOG_HEIGHT = 100
 
+# A content element with at least this many words is PROSE - something written to be read by a human.
+# If it is not itself a recognised progress status, the window is not provably a progress dialog
+# however much progress text sits beside it. Mirrors `$MinPromptWords` in probe_desktop_credential.ps1.
+# The cost of it firing wrongly is one more exit 3, which is loud and recoverable.
+MIN_PROMPT_WORDS = 5
+
+# Classifier vocabulary, shared verbatim with the PowerShell arbiter's `Get-DialogClassification` so a
+# reader moving between the two detectors meets one set of words, not two.
+DIALOG_KIND_CREDENTIAL = "credential"
+DIALOG_KIND_NEEDS_HUMAN = "needs-human"
+DIALOG_KIND_MIXED_CONTENT = "mixed-content"
+DIALOG_KIND_BENIGN = "benign"
+DIALOG_KIND_BENIGN_TITLE_ONLY = "benign-title-only"
+DIALOG_KIND_UNREADABLE = "unreadable"
+DIALOG_KIND_UNRECOGNIZED = "unrecognized"
+
+# Machine-readable verdict tokens, also shared with the arbiter. `BLOCKED_BY_DIALOG` is deliberately
+# absent (issue #376): it is the token this module used to emit at exit 1 from a size-only test.
+VERDICT_CREDENTIAL_MISSING = "CREDENTIAL_MISSING"
+VERDICT_DIALOG_NEEDS_HUMAN = "DIALOG_NEEDS_HUMAN"
+VERDICT_DIALOG_UNREADABLE = "DIALOG_UNREADABLE"
+VERDICT_DIALOG_UNRECOGNIZED = "DIALOG_UNRECOGNIZED"
+VERDICT_REFRESH_IN_PROGRESS = "REFRESH_IN_PROGRESS"
+
+# kind -> the token a caller prints for it. The unreadable BAND (nothing readable, or a reassuring
+# CAPTION with no content behind it) is deliberately NOT folded into `unrecognized`: "we could not
+# establish it" is a weaker state of knowledge than "we read it and it did not match", and collapsing
+# the two is the bug this repo keeps finding (absent is not empty).
+DIALOG_KIND_VERDICTS = {
+    DIALOG_KIND_CREDENTIAL: VERDICT_CREDENTIAL_MISSING,
+    DIALOG_KIND_NEEDS_HUMAN: VERDICT_DIALOG_NEEDS_HUMAN,
+    DIALOG_KIND_UNREADABLE: VERDICT_DIALOG_UNREADABLE,
+    DIALOG_KIND_BENIGN_TITLE_ONLY: VERDICT_DIALOG_UNREADABLE,
+    DIALOG_KIND_MIXED_CONTENT: VERDICT_DIALOG_UNRECOGNIZED,
+    DIALOG_KIND_UNRECOGNIZED: VERDICT_DIALOG_UNRECOGNIZED,
+    DIALOG_KIND_BENIGN: VERDICT_REFRESH_IN_PROGRESS,
+}
+
+# Fold order for `dialog_verdict`, after `credential` (which short-circuits). It is not arbitrary:
+# `benign` is the ONLY kind carrying positive evidence of harmlessness, so it must never outrank a
+# window we could not account for - otherwise one progress dialog masks a real modal. The unreadable
+# band outranks `unrecognized` because it is the weaker state of knowledge, and the weaker state is
+# what must stay visible.
+DIALOG_KIND_PRECEDENCE = (
+    DIALOG_KIND_NEEDS_HUMAN,
+    DIALOG_KIND_UNREADABLE,
+    DIALOG_KIND_BENIGN_TITLE_ONLY,
+    DIALOG_KIND_MIXED_CONTENT,
+    DIALOG_KIND_UNRECOGNIZED,
+    DIALOG_KIND_BENIGN,
+)
+
 
 class Win32EnumerationError(RuntimeError):
     """Win32 window enumeration failed before a reliable modal verdict could be formed."""
@@ -165,31 +280,194 @@ def _winenumproc_type():
     return ctypes.WINFUNCTYPE(wintypes.BOOL, wintypes.HWND, wintypes.LPARAM)
 
 
+def _compile_signature(path: Path) -> re.Pattern[str]:
+    """Compile one shared ``*_signature.regex`` resource."""
+    return re.compile(path.read_text(encoding="utf-8").strip(), re.IGNORECASE)
+
+
 def credential_signature() -> re.Pattern[str]:
     """Compile the shared credential-dialog signature."""
-    return re.compile(SIGNATURE_PATH.read_text(encoding="utf-8").strip(), re.IGNORECASE)
+    return _compile_signature(SIGNATURE_PATH)
 
 
-def match_credential_modal(windows: Iterable[DesktopWindow]) -> CredentialModal | None:
-    """Return the first window whose descendant text matches the shared credential signature."""
+def benign_dialog_signature() -> re.Pattern[str]:
+    """Compile the shared progress-dialog ("Power BI is working") signature.
+
+    ⚠️ This is the ONLY file that can cause a dialog to be dismissed, so a broad pattern in it is the
+    one way to hide a genuine blocker. Its alternatives are whole-element and anchored on purpose:
+    ``\\bLoading data\\b`` once matched inside *"Loading data requires authentication"*.
+    """
+    return _compile_signature(BENIGN_SIGNATURE_PATH)
+
+
+def blocking_prompt_signature() -> re.Pattern[str]:
+    """Compile the shared signature for KNOWN human-blocking prompts that are not sign-in prompts.
+
+    The native-database-query approval modal above all: migrated custom-SQL sources emit exactly the
+    shape that triggers it, and this bundle's own guidance says to check for it before concluding
+    anything about a data source. Matched BEFORE the benign signature, so one progress element in the
+    same window cannot erase it.
+    """
+    return _compile_signature(BLOCKING_SIGNATURE_PATH)
+
+
+def normalize_texts(texts: Iterable[str]) -> tuple[str, ...]:
+    """Whitespace-normalised, de-duplicated, order-preserving text (mirrors ``Get-NormalizedText``)."""
+    clean: list[str] = []
+    for text in texts:
+        if not text:
+            continue
+        normalized = re.sub(r"\s+", " ", str(text)).strip()
+        if normalized and normalized not in clean:
+            clean.append(normalized)
+    return tuple(clean)
+
+
+def dialog_text_set(window: DesktopWindow) -> tuple[str, tuple[str, ...], tuple[str, ...]]:
+    """Return ``(title, all_texts, content_texts)`` for ``window``.
+
+    ``content`` is everything that is NOT the caption, and it is the ONLY view the benign signature may
+    read. A caption cannot establish that a dialog is harmless: a real owned WPF modal captioned
+    ``Refresh`` whose content read ``Enter your credentials`` was dismissed on exactly that mistake in
+    the arbiter's review. Dropping content that merely EQUALS the caption errs in the safe direction -
+    it can only make a window harder to dismiss, never easier.
+    """
+    title = re.sub(r"\s+", " ", window.title or "").strip()
+    all_texts = normalize_texts(window.texts)
+    content = tuple(text for text in all_texts if text != title)
+    return title, all_texts, content
+
+
+def _match_dialog_signatures(window: DesktopWindow, texts: Iterable[str]) -> DialogFinding | None:
+    """First ``credential`` then ``needs-human`` signature hit across ``texts``, or ``None``.
+
+    Order is load-bearing: a window can carry both, and the credential signature is the only one that
+    earns a hard stop. ``needs-human`` is tested BEFORE any benign scan so one progress element in the
+    same window cannot erase a known human-blocking prompt (the round-3 defect in #390).
+    """
+    all_texts = tuple(texts)
     signature = credential_signature()
-    for window in windows:
-        for text in window.texts:
-            if text and signature.search(text):
-                return CredentialModal(matched_text=text, window=window)
+    for text in all_texts:
+        if signature.search(text):
+            return _finding(DIALOG_KIND_CREDENTIAL, window, text)
+    blocking = blocking_prompt_signature()
+    for text in all_texts:
+        if blocking.search(text):
+            return _finding(DIALOG_KIND_NEEDS_HUMAN, window, text)
     return None
 
 
-def blocking_dialog_candidates(windows: Iterable[DesktopWindow]) -> list[BlockingDialog]:
-    """Visible non-main, non-zero-size windows that can block Desktop operations."""
-    candidates: list[BlockingDialog] = []
+def classify_dialog(window: DesktopWindow) -> DialogFinding:
+    """Classify ONE candidate window. Only ``benign`` is dismissible, and only it needs positive proof.
+
+    Kinds, in the order they are tested (see the module docstring for the divergences from
+    ``probe_desktop_credential.ps1``):
+
+    ``credential``        the credential signature matched a text element -> hard stop.
+    ``needs-human``       a KNOWN human-blocking prompt that is not a sign-in prompt. Tested BEFORE
+                          benign so a progress element in the same window cannot erase it.
+    ``mixed-content``     progress text AND unaccounted prose in the same window. A first-match-wins
+                          loop would let one benign element erase everything after it, which is how
+                          ``Evaluating`` beside *"Permission is required to run this native database
+                          query"* cleared the arbiter at exit 0.
+    ``benign``            every content element is either recognised progress status or too short to be
+                          a human-directed prompt, AND at least one IS progress status. The one
+                          dismissible kind.
+    ``benign-title-only`` the CAPTION matched the benign signature and no content did. A caption is not
+                          content, so this joins the unreadable band.
+    ``unreadable``        no readable text at all.
+    ``unrecognized``      readable text that matched no signature: we looked, and it is not a sign-in
+                          prompt. Distinct from ``unreadable`` on purpose - absent is not empty.
+    """
+    title, all_texts, content = dialog_text_set(window)
+    signature_hit = _match_dialog_signatures(window, all_texts)
+    if signature_hit is not None:
+        return signature_hit
+
+    benign = benign_dialog_signature()
+    benign_hit: str | None = None
+    unaccounted: str | None = None
+    for text in content:
+        if benign.search(text):
+            if benign_hit is None:
+                benign_hit = text
+            continue
+        if unaccounted is None and len(text.split()) >= MIN_PROMPT_WORDS:
+            unaccounted = text
+    if benign_hit is not None:
+        if unaccounted is not None:
+            return _finding(DIALOG_KIND_MIXED_CONTENT, window, unaccounted)
+        return _finding(DIALOG_KIND_BENIGN, window, benign_hit)
+    if title and benign.search(title):
+        return _finding(DIALOG_KIND_BENIGN_TITLE_ONLY, window, title)
+    if not all_texts:
+        return _finding(DIALOG_KIND_UNREADABLE, window, "")
+    return _finding(DIALOG_KIND_UNRECOGNIZED, window, all_texts[0])
+
+
+def _finding(kind: str, window: DesktopWindow, evidence: str) -> DialogFinding:
+    """Build a :class:`DialogFinding` with the verdict token this ``kind`` maps to."""
+    return DialogFinding(kind=kind, verdict=DIALOG_KIND_VERDICTS[kind], window=window, evidence=evidence)
+
+
+def dialog_candidates(windows: Iterable[DesktopWindow]) -> list[DesktopWindow]:
+    """Windows big enough, and of the right class, to be worth CLASSIFYING.
+
+    Size selects what to LOOK AT; it is not itself evidence of anything (issue #376). The old
+    ``blocking_dialog_candidates`` returned the first window past this filter as a blocking dialog,
+    which is why a Refresh progress dialog read as a credential wall at exit 1.
+    """
+    return [
+        window
+        for window in windows
+        if not window.class_name.startswith(DESKTOP_MAIN_CLASS_PREFIX)
+        and window.width >= MIN_DIALOG_WIDTH
+        and window.height >= MIN_DIALOG_HEIGHT
+    ]
+
+
+def dialog_verdict(
+    windows: Iterable[DesktopWindow],
+    *,
+    operation_in_flight: bool = False,
+) -> DialogFinding | None:
+    """Fold per-window classifications into ONE finding, or ``None`` when nothing needs reporting.
+
+    ``operation_in_flight`` is set only once THIS process has started the refresh/query it is waiting
+    on. There, a PROVEN-benign progress dialog is our own and is ignored - and nothing else is. At t=0
+    it is somebody else's, and stacking a second refresh on it is exactly what the 2026-08-28 field
+    report had to unpick by hand.
+    """
+    found: dict[str, DialogFinding] = {}
+    for window in dialog_candidates(windows):
+        finding = classify_dialog(window)
+        if finding.kind == DIALOG_KIND_CREDENTIAL:
+            return finding
+        found.setdefault(finding.kind, finding)
+    for kind in DIALOG_KIND_PRECEDENCE:
+        if kind not in found:
+            continue
+        if kind == DIALOG_KIND_BENIGN and operation_in_flight:
+            continue
+        return found[kind]
+    return None
+
+
+def match_credential_modal(windows: Iterable[DesktopWindow]) -> CredentialModal | None:
+    """First credential-signature match across EVERY window - any class, any size.
+
+    Deliberately NOT restricted to :func:`dialog_candidates` (issue #376). It used to be, and that
+    made the 100x100 filter gate the hard stop as well as the classification: a credential prompt in a
+    smaller window returned NO FINDING AT ALL, i.e. a silent false negative on the one verdict that
+    matters most. ``Test-CredentialModal`` in the arbiter has always scanned every window; this now
+    matches it.
+    """
+    signature = credential_signature()
     for window in windows:
-        if window.class_name.startswith(DESKTOP_MAIN_CLASS_PREFIX):
-            continue
-        if window.width < MIN_DIALOG_WIDTH or window.height < MIN_DIALOG_HEIGHT:
-            continue
-        candidates.append(BlockingDialog(window))
-    return candidates
+        for text in normalize_texts(window.texts):
+            if signature.search(text):
+                return CredentialModal(matched_text=text, window=window)
+    return None
 
 
 def _hwnd_value(hwnd) -> int:
@@ -323,20 +601,26 @@ def inspect_credential_modal(
     pid: int,
     enumerate_windows: WindowEnumerator = enumerate_pid_windows,
     process_is_alive: ProcessLivenessCheck = _process_alive,
+    *,
+    operation_in_flight: bool = False,
 ) -> CredentialDetection:
-    """Inspect ``pid`` for a credential modal, preserving indeterminate states."""
+    """Inspect ``pid`` for a credential modal, preserving indeterminate states.
+
+    Order is load-bearing and mirrors the arbiter's main flow: credential signature (every window, any
+    size) -> a classified dialog finding -> minimized owner -> zero windows. ``operation_in_flight``
+    is forwarded to :func:`dialog_verdict`; see :func:`inspect_credential_modal_in_flight`.
+    """
     # pylint: disable=too-many-return-statements
     try:
         windows = tuple(enumerate_windows(pid))
     except Win32EnumerationError as exc:
         return CredentialDetection(unknown_reason=f"window enumeration failed: {exc}")
-    candidates = blocking_dialog_candidates(windows)
-    candidate_windows = [candidate.window for candidate in candidates]
-    modal = match_credential_modal(candidate_windows)
+    modal = match_credential_modal(windows)
     if modal is not None:
         return CredentialDetection(modal=modal, windows=windows)
-    if candidates:
-        return CredentialDetection(blocking_dialog=candidates[0], windows=windows)
+    finding = dialog_verdict(windows, operation_in_flight=operation_in_flight)
+    if finding is not None:
+        return CredentialDetection(dialog=finding, windows=windows)
     minimized = [
         window for window in windows if window.minimized and window.class_name.startswith(DESKTOP_MAIN_CLASS_PREFIX)
     ]
@@ -382,12 +666,73 @@ def describe_modal(modal: CredentialModal, source_hint: str | None = None) -> st
     return f"{source} window title={title!r}, class={window.class_name!r}, size={size}, text={modal.excerpt!r}"
 
 
-def describe_blocking_dialog(dialog: BlockingDialog) -> str:
-    """Human-readable evidence for an unreadable/non-credential blocking dialog."""
-    window = dialog.window
+def describe_dialog_finding(finding: DialogFinding) -> str:
+    """Human-readable evidence for a dialog we could not dismiss."""
+    window = finding.window
     size = f"{window.width}x{window.height}" if window.width and window.height else "unknown size"
     title = window.title or "(empty title)"
-    return f"window title={title!r}, class={window.class_name!r}, size={size}, text=<unreadable or non-credential>"
+    return (
+        f"kind={finding.kind}, window title={title!r}, class={window.class_name!r}, "
+        f"size={size}, evidence={finding.excerpt!r}"
+    )
+
+
+# Per-kind operator guidance. Every string here is deliberately MARKER-FREE (issue #153): it must not
+# contain any `probe_live_source.CREDENTIAL_MARKERS` substring - "credential", "sign in", "signed in",
+# "authentication", "login", "oauth", "access token", "unauthorized" - because the parent classifier
+# scans a failing child's whole transcript as free text. These verdicts mean "we could not probe", and
+# prose that reads as a sign-on problem would relabel them the very hard stop they exist to avoid.
+# `tests/test_probe_live_source_verdict.py` drives the real emitters through the real classifier so
+# this property is gated rather than merely intended.
+DIALOG_KIND_GUIDANCE = {
+    DIALOG_KIND_NEEDS_HUMAN: (
+        "this is a KNOWN human-blocking prompt (e.g. the native database query approval), not a "
+        "data-source sign-on prompt - approve it at the Desktop screen; no account details are implied"
+    ),
+    DIALOG_KIND_MIXED_CONTENT: (
+        "it shows refresh progress AND prose that is not progress status - a progress dialog does not "
+        "explain the rest of this window; look at the Desktop screen"
+    ),
+    DIALOG_KIND_BENIGN_TITLE_ONLY: (
+        "its CAPTION looks like a progress dialog, but no content confirmed it - a caption is not "
+        "content; look at the Desktop screen"
+    ),
+    DIALOG_KIND_UNREADABLE: (
+        "this window exposes no readable text, so it could not be classified at all - look at the Desktop screen"
+    ),
+    DIALOG_KIND_UNRECOGNIZED: (
+        "its text matched no known prompt signature, so nothing here says a person must supply account "
+        "details - look at the Desktop screen"
+    ),
+    DIALOG_KIND_BENIGN: (
+        "a refresh is already running on this pid - wait for it, or cancel the stale one; do not stack "
+        "a second refresh on it"
+    ),
+}
+
+
+def dialog_guidance(finding: DialogFinding) -> str:
+    """Operator guidance for ``finding``, or a safe generic line for an unmapped kind."""
+    return DIALOG_KIND_GUIDANCE.get(finding.kind, "look at the Desktop screen before continuing")
+
+
+def inspect_credential_modal_in_flight(
+    pid: int,
+    enumerate_windows: WindowEnumerator = enumerate_pid_windows,
+    process_is_alive: ProcessLivenessCheck = _process_alive,
+) -> CredentialDetection:
+    """:func:`inspect_credential_modal` for a poll running AFTER this process started the operation.
+
+    The only difference is that a PROVEN-benign progress dialog is ignored: at that point it is almost
+    certainly the refresh we ourselves triggered, and aborting on it would abort a healthy run. Nothing
+    else is ignored - an unreadable, caption-only, mixed or unrecognised dialog still surfaces.
+    """
+    return inspect_credential_modal(
+        pid,
+        enumerate_windows,
+        process_is_alive,
+        operation_in_flight=True,
+    )
 
 
 def source_hint_from_model(model_dir: Path | None) -> str | None:
@@ -493,12 +838,31 @@ def print_indeterminate_state_notice(pid: int, reason: str) -> None:
     )
 
 
+def print_dialog_observed_notice(pid: int, finding: DialogFinding) -> None:
+    """Loudly note the first time a bounded wait sees a dialog it could not dismiss (issue #376).
+
+    Latched rather than acted on: it is not a sign-on prompt, so it must not abort a refresh that is
+    otherwise healthy and may still finish - but it also means "no modal appeared" is no longer
+    established, so a quiet deadline must not erase it either. Marker-free, and not a ``REFRESH:``
+    verdict line, so the parent classifier cannot mistake it for a verdict (issue #153).
+    """
+    print(
+        f"PID {pid} has a dialog up that could not be shown to be harmless ({finding.kind}); latching "
+        f"it - {dialog_guidance(finding)}. The wait continues, because this is not a prompt for account "
+        "details and an otherwise healthy refresh must not be aborted by it.",
+        flush=True,
+    )
+
+
 def _raise_detection(pid: int, state: CredentialDetection, source_hint: str | None) -> None:
-    """Raise for a visible block or definitive local Desktop failure."""
+    """Raise for the two observations that end a bounded wait IMMEDIATELY.
+
+    Only a matched credential signature and a confirmed-dead process qualify. A :class:`DialogFinding`
+    deliberately does NOT (issue #376): it is latched by :func:`join_with_credential_poll` and surfaced
+    at the deadline, so a dialog we could not read cannot cut short a refresh that was going to succeed.
+    """
     if state.modal is not None:
         raise CredentialMissingError(pid, state.modal, source_hint)
-    if state.blocking_dialog is not None:
-        raise DialogBlockedError(pid, state.blocking_dialog)
     if state.process_gone is not None:
         raise DesktopGoneError(pid, state.process_gone)
 
@@ -512,14 +876,24 @@ def join_with_credential_poll(
     heartbeat_seconds: float,
     poll_seconds: float,
     source_hint: str | None = None,
-    detector: Callable[[int], CredentialDetection] = inspect_credential_modal,
+    detector: Callable[[int], CredentialDetection] = inspect_credential_modal_in_flight,
     initial_state: CredentialDetection | None = None,
 ) -> bool:
     """Wait for ``worker`` while polling for a late credential dialog.
 
     Returns True when the worker finished before the wall-clock deadline, False when the deadline
     elapsed with the dialog state observably HEALTHY throughout. Raises immediately when the shared
-    detector sees a credential modal or a blocking dialog.
+    detector matches the credential signature, or confirms Desktop is gone.
+
+    The default ``detector`` is the IN-FLIGHT variant: by the time this runs, the refresh being waited
+    on is ours, so a PROVEN-benign progress dialog is ours too and is ignored. Nothing else is.
+
+    A :class:`DialogFinding` - a dialog we could not dismiss - is LATCHED, not raised (issue #376). It
+    is not a prompt for account details, so it must not abort a refresh that may still finish; but it
+    also means "no modal appeared" is no longer established, so it surfaces at the deadline as
+    :class:`DialogFoundError` rather than as a bare timeout blaming a slow source. Before #376 this
+    raised at once, on a SIZE-ONLY test, at the same exit code as a real sign-on wall - so a Power BI
+    refresh progress dialog aborted the very refresh it was reporting on.
 
     Indeterminate (``unknown_reason``) observations are LATCHED, not ignored (issue #154). The owner
     window going iconic hides its owned modal dialogs from enumeration, and - measured 2026-08-14 -
@@ -549,10 +923,15 @@ def join_with_credential_poll(
     seeded from ``initial_state`` so an observation made only by the caller's t=0 pre-check cannot be
     lost before the first poll.
     """
+    # Waived, not shaved: the locals are eight injected parameters plus one latch per observation this
+    # wait must not lose (unknown / desktop-unready / dialog). Folding the latches into a container
+    # would hide exactly the thing this function exists to keep visible.
+    # pylint: disable=too-many-locals
     started = time.monotonic()
     next_heartbeat = heartbeat_seconds
     latched_unknown = initial_state.unknown_reason if initial_state else None
     latched_desktop_unready = initial_state.desktop_unready if initial_state else None
+    latched_dialog = initial_state.dialog if initial_state else None
     while worker.is_alive():
         elapsed = time.monotonic() - started
         remaining = max(0.0, total_timeout - elapsed)
@@ -562,6 +941,9 @@ def join_with_credential_poll(
         elapsed = time.monotonic() - started
         state = detector(pid)
         _raise_detection(pid, state, source_hint)
+        if state.dialog is not None and latched_dialog is None:
+            latched_dialog = state.dialog
+            print_dialog_observed_notice(pid, state.dialog)
         if state.desktop_unready and latched_desktop_unready is None:
             latched_desktop_unready = state.desktop_unready
         if state.unknown_reason and latched_unknown is None:
@@ -576,6 +958,9 @@ def join_with_credential_poll(
         latched_desktop_unready = latched_desktop_unready or state.desktop_unready
         if latched_desktop_unready is not None:
             raise DesktopUnreadyError(pid, latched_desktop_unready)
+        latched_dialog = latched_dialog or state.dialog
+        if latched_dialog is not None:
+            raise DialogFoundError(pid, latched_dialog)
         latched_unknown = latched_unknown or state.unknown_reason
         if latched_unknown is not None:
             raise CredentialUnknownError(pid, latched_unknown)

--- a/.github/skills/pbip-model-refresh/scripts/benign_chrome_signature.regex
+++ b/.github/skills/pbip-model-refresh/scripts/benign_chrome_signature.regex
@@ -1,0 +1,1 @@
+^&?Cancel$|^&?OK$|^&?Close$

--- a/.github/skills/pbip-model-refresh/scripts/probe_desktop_query.py
+++ b/.github/skills/pbip-model-refresh/scripts/probe_desktop_query.py
@@ -44,8 +44,10 @@ from typing import NoReturn
 from _credential_modal import (
     CredentialDetection,
     CredentialModal,
-    describe_blocking_dialog,
+    DialogFinding,
+    describe_dialog_finding,
     describe_modal,
+    dialog_guidance,
     inspect_credential_modal,
 )
 
@@ -371,11 +373,17 @@ def probe(port: int, tables: list[str] | None, emit=print) -> int:
         conn.Close()
 
 
-def _credential_state(pid: int) -> CredentialDetection:
-    """Return the credential-modal inspection state for ``pid``."""
+def _credential_state(pid: int, *, in_flight: bool = False) -> CredentialDetection:
+    """Return the credential-modal inspection state for ``pid``.
+
+    ``in_flight`` is set for the polls that run WHILE the DAX probe is executing. There a
+    positively-read progress dialog is ignored: Desktop working is not a reason to abandon a read-only
+    one-row query, and aborting on it is the false stop issue #376 removed. Everything else - including
+    a dialog we could not read - still surfaces.
+    """
     if os.name != "nt":
         return CredentialDetection()
-    return inspect_credential_modal(pid)
+    return inspect_credential_modal(pid, operation_in_flight=in_flight)
 
 
 def _emit_credential_missing(pid: int, modal: CredentialModal) -> None:
@@ -383,9 +391,17 @@ def _emit_credential_missing(pid: int, modal: CredentialModal) -> None:
     print(f"PREFLIGHT: CREDENTIAL_MISSING pid={pid}; {describe_modal(modal)}")
 
 
-def _emit_blocked_by_dialog(pid: int, dialog) -> None:
-    """Print the distinct generic blocking-dialog verdict."""
-    print(f"PREFLIGHT: BLOCKED_BY_DIALOG pid={pid}; {describe_blocking_dialog(dialog)}")
+def _emit_dialog_finding(pid: int, finding: DialogFinding) -> None:
+    """Print the verdict for a dialog that could NOT be shown to be harmless (issue #376).
+
+    Replaces ``_emit_blocked_by_dialog``, whose ``BLOCKED_BY_DIALOG`` token sat at exit 1 - the
+    hard-stop band - and was reached from a SIZE-ONLY test, so a Power BI Refresh progress dialog
+    aborted THE GATE OF RECORD with a verdict the parent classifier reads as ``NO_CREDENTIAL``. The
+    token now names what was observed and every one of them is exit 3: "could not probe", never "a
+    person must supply account details". Both lines are marker-free (issue #153).
+    """
+    print(f"PREFLIGHT: {finding.verdict} pid={pid}; {describe_dialog_finding(finding)}")
+    print(f"  {dialog_guidance(finding)}")
 
 
 def _emit_credential_unknown(pid: int, reason: str) -> None:
@@ -408,13 +424,20 @@ def _emit_desktop_unready(pid: int, reason: str) -> None:
 
 
 def _credential_verdict(pid: int, state: CredentialDetection) -> int | None:
-    """Emit and return a terminal inspection verdict, or None when probing may continue."""
+    """Emit and return a terminal inspection verdict, or None when probing may continue.
+
+    Exit-code bands, and why a dialog finding is no longer in the first one (issue #376):
+      1  ``CREDENTIAL_MISSING`` - the credential signature matched. The ONLY hard stop.
+      2  ``DESKTOP_GONE`` / ``DESKTOP_UNREADY`` - local Desktop failure; the source was never tested.
+      3  a dialog finding, or ``UNKNOWN`` - we could not probe. Loud, recoverable, and no claim about
+         the data source or about anyone needing to supply account details.
+    """
     if state.modal is not None:
         _emit_credential_missing(pid, state.modal)
         return 1
-    if state.blocking_dialog is not None:
-        _emit_blocked_by_dialog(pid, state.blocking_dialog)
-        return 1
+    if state.dialog is not None:
+        _emit_dialog_finding(pid, state.dialog)
+        return 3
     if state.process_gone is not None:
         _emit_desktop_gone(pid, state.process_gone)
         return 2
@@ -452,7 +475,11 @@ def _probe_with_credential_poll(pid: int | None, port: int, tables: list[str] | 
     worker.start()
     while worker.is_alive():
         worker.join(PREFLIGHT_CREDENTIAL_POLL_SECONDS)
-        verdict = _credential_verdict(pid, _credential_state(pid))
+        # ACT on a finding here rather than latching it the way `join_with_credential_poll` does: this
+        # loop has NO deadline of its own (it runs until the probe thread returns), so a latched dialog
+        # behind a wedged query would wait for ever. The in-flight detector already ignores a
+        # positively-read progress dialog, so what reaches this point is something we could not read.
+        verdict = _credential_verdict(pid, _credential_state(pid, in_flight=True))
         if verdict is not None:
             return verdict
 

--- a/.github/skills/pbip-model-refresh/scripts/refresh_pbip_model.py
+++ b/.github/skills/pbip-model-refresh/scripts/refresh_pbip_model.py
@@ -146,9 +146,11 @@ from _credential_modal import (
     CredentialUnknownError,
     DesktopGoneError,
     DesktopUnreadyError,
-    DialogBlockedError,
-    describe_blocking_dialog,
+    DialogFinding,
+    DialogFoundError,
+    describe_dialog_finding,
     describe_modal,
+    dialog_guidance,
     inspect_credential_modal,
     join_with_credential_poll,
     print_indeterminate_state_notice,
@@ -218,11 +220,17 @@ def _credential_state(pid: int) -> CredentialDetection:
 
 
 def _raise_if_blocked(pid: int, state: CredentialDetection, source_hint: str | None = None) -> None:
-    """Raise the appropriate exception when ``state`` contains a blocking or terminal condition."""
+    """Raise the appropriate exception for a t=0 observation that must stop the run before it starts.
+
+    Unlike the in-flight poll (``_credential_modal._raise_detection``), a :class:`DialogFinding` DOES
+    raise here: at t=0 the dialog is somebody else's, we have not started anything, and stacking a
+    refresh on top of an unclassified dialog is exactly what the 2026-08-28 field report had to unpick
+    by hand. Mid-wait the same finding is latched instead, so it cannot abort a refresh already running.
+    """
     if state.modal is not None:
         raise CredentialMissingError(pid, state.modal, source_hint)
-    if state.blocking_dialog is not None:
-        raise DialogBlockedError(pid, state.blocking_dialog)
+    if state.dialog is not None:
+        raise DialogFoundError(pid, state.dialog)
     if state.process_gone is not None:
         raise DesktopGoneError(pid, state.process_gone)
 
@@ -232,16 +240,29 @@ def _emit_credential_missing(pid: int, modal: CredentialModal, source_hint: str 
     print(f"REFRESH: CREDENTIAL_MISSING pid={pid}; {describe_modal(modal, source_hint)}")
 
 
-def _emit_blocked_by_dialog(pid: int, dialog) -> None:
-    """Print the distinct generic blocking-dialog verdict."""
-    print(f"REFRESH: BLOCKED_BY_DIALOG pid={pid}; {describe_blocking_dialog(dialog)}")
+def _emit_dialog_finding(pid: int, finding: DialogFinding) -> None:
+    """Print the verdict for a dialog that could NOT be shown to be harmless (issue #376).
+
+    Replaces ``_emit_blocked_by_dialog``. The token now names what was actually observed -
+    ``DIALOG_NEEDS_HUMAN`` / ``DIALOG_UNREADABLE`` / ``DIALOG_UNRECOGNIZED`` / ``REFRESH_IN_PROGRESS``,
+    the same vocabulary ``probe_desktop_credential.ps1`` speaks - instead of ``BLOCKED_BY_DIALOG``,
+    which this module emitted at exit 1 from a SIZE-ONLY test and which the parent classifier maps to
+    ``NO_CREDENTIAL``. Nothing here can establish that a dialog BLOCKS anything, so nothing here may
+    enter the hard-stop band; all of these are exit 3.
+
+    Both lines are deliberately MARKER-FREE (issue #153): a failing child's whole transcript is scanned
+    as free text by ``probe_live_source``, so prose naming a sign-on problem would re-create exactly
+    the false hard stop this verdict exists to avoid.
+    """
+    print(f"REFRESH: {finding.verdict} pid={pid}; {describe_dialog_finding(finding)}")
+    print(f"  {dialog_guidance(finding)}")
 
 
 def _emit_credential_unknown(pid: int, reason: str) -> None:
     """Print the distinct indeterminate verdict for a latched, unrecoverable UNKNOWN (issue #154).
 
-    ``CREDENTIAL_UNKNOWN`` is a THIRD verdict, deliberately not collapsed into ``BLOCKED_BY_DIALOG``
-    (we did not SEE a block) nor into a bare ``TIMEOUT`` (we did not observe a healthy source): the
+    ``CREDENTIAL_UNKNOWN`` is a THIRD verdict, deliberately not collapsed into a dialog finding
+    (we did not SEE a dialog) nor into a bare ``TIMEOUT`` (we did not observe a healthy source): the
     owner window went iconic, hiding its owned modal dialogs, and that evidence provably does not come
     back. ``reason`` is the detector's marker-free string, and the guidance below is marker-free too,
     so the classification is carried STRUCTURALLY by the ``REFRESH: CREDENTIAL_UNKNOWN`` verdict line
@@ -1617,9 +1638,9 @@ def _refresh_and_save(  # pylint: disable=too-many-return-statements,too-many-br
         if isinstance(exc, CredentialMissingError):
             _emit_credential_missing(exc.pid, exc.modal, exc.source_hint)
             return 1
-        if isinstance(exc, DialogBlockedError):
-            _emit_blocked_by_dialog(exc.pid, exc.dialog)
-            return 1
+        if isinstance(exc, DialogFoundError):
+            _emit_dialog_finding(exc.pid, exc.finding)
+            return 3
         if isinstance(exc, CredentialUnknownError):
             _emit_credential_unknown(exc.pid, exc.reason)
             return 3
@@ -1852,9 +1873,9 @@ def main(argv: list[str] | None = None) -> int:  # pylint: disable=too-many-retu
     if credential_state.modal is not None:
         _emit_credential_missing(pid, credential_state.modal, source_hint)
         return 1
-    if credential_state.blocking_dialog is not None:
-        _emit_blocked_by_dialog(pid, credential_state.blocking_dialog)
-        return 1
+    if credential_state.dialog is not None:
+        _emit_dialog_finding(pid, credential_state.dialog)
+        return 3
     if credential_state.process_gone is not None:
         _emit_desktop_gone(pid, credential_state.process_gone)
         return 2

--- a/.github/skills/pbip-model-refresh/scripts/refresh_pbip_model.py
+++ b/.github/skills/pbip-model-refresh/scripts/refresh_pbip_model.py
@@ -153,9 +153,12 @@ from _credential_modal import (
     dialog_guidance,
     inspect_credential_modal,
     join_with_credential_poll,
+    print_dialog_observed_notice,
     print_indeterminate_state_notice,
     print_refresh_banner,
     print_refresh_unknown_banner,
+    raise_latched_verdict,
+    raise_terminal_detection,
     source_hint_from_model,
 )
 
@@ -212,11 +215,26 @@ GENERATED_EDIT_DECLARATIONS_DIR = Path("_build") / "generated-edit-declarations"
 CREDENTIAL_PROBE = Path(__file__).resolve().parent / "probe_desktop_credential.ps1"
 
 
-def _credential_state(pid: int) -> CredentialDetection:
-    """Return the credential-modal inspection state for ``pid``."""
+def _credential_state(pid: int, *, in_flight: bool = False) -> CredentialDetection:
+    """Return the credential-modal inspection state for ``pid``.
+
+    ``in_flight`` is set for every poll that runs AFTER this process started the refresh it is waiting
+    on: there a positively-read progress dialog is our own, and aborting on it aborts a healthy run.
+    Only ``benign`` is affected; everything else still surfaces.
+    """
     if os.name != "nt":
         return CredentialDetection()
-    return inspect_credential_modal(pid)
+    return inspect_credential_modal(pid, operation_in_flight=in_flight)
+
+
+def _in_flight_credential_state(pid: int) -> CredentialDetection:
+    """Single-argument in-flight detector for the two wait loops (#376 review, finding 1).
+
+    Deliberately looks ``_credential_state`` up through the module global on every call, so a test that
+    monkeypatches ``_credential_state`` still takes effect through this indirection - and so production
+    and the tests exercise one function rather than two.
+    """
+    return _credential_state(pid, in_flight=True)
 
 
 def _raise_if_blocked(pid: int, state: CredentialDetection, source_hint: str | None = None) -> None:
@@ -343,7 +361,15 @@ def _join_refresh_worker(
     total_timeout: float,
     progress_monitor: RefreshProgressMonitor | None,
 ) -> bool:
-    """Wait for the refresh thread, with credential polling and optional progress liveness."""
+    """Wait for the refresh thread, with credential polling and optional progress liveness.
+
+    Both branches use the IN-FLIGHT detector and latch non-terminal findings until the deadline
+    (#376 review, finding 1). They used not to: the no-trace branch overrode
+    ``join_with_credential_poll``'s correct default with the t=0 ``_credential_state``, and the
+    progress branch called the t=0 raise helper - so Power BI's own progress dialog aborted the very
+    refresh it was reporting on. Measured: ``DialogFoundError(REFRESH_IN_PROGRESS)`` on the first poll,
+    with no ``in_flight`` argument reaching the detector at all.
+    """
     if progress_monitor is None:
         if desktop_pid is None:
             worker.join(total_timeout)
@@ -355,7 +381,7 @@ def _join_refresh_worker(
             heartbeat_seconds=REFRESH_HEARTBEAT_SECONDS,
             poll_seconds=REFRESH_CREDENTIAL_POLL_SECONDS,
             source_hint=source_hint,
-            detector=_credential_state,
+            detector=_in_flight_credential_state,
             initial_state=initial_state,
         )
 
@@ -363,6 +389,7 @@ def _join_refresh_worker(
     next_heartbeat = REFRESH_HEARTBEAT_SECONDS
     latched_unknown = initial_state.unknown_reason if initial_state else None
     latched_desktop_unready = initial_state.desktop_unready if initial_state else None
+    latched_dialog = initial_state.dialog if initial_state else None
     while worker.is_alive():
         elapsed = time.monotonic() - started
         absolute_remaining = max(0.0, total_timeout - elapsed)
@@ -377,8 +404,11 @@ def _join_refresh_worker(
         )
         worker.join(max(0.01, wait_for))
         if desktop_pid is not None:
-            state = _credential_state(desktop_pid)
-            _raise_if_blocked(desktop_pid, state, source_hint)
+            state = _in_flight_credential_state(desktop_pid)
+            raise_terminal_detection(desktop_pid, state, source_hint)
+            if state.dialog is not None and latched_dialog is None:
+                latched_dialog = state.dialog
+                print_dialog_observed_notice(desktop_pid, state.dialog)
             if state.desktop_unready and latched_desktop_unready is None:
                 latched_desktop_unready = state.desktop_unready
             if state.unknown_reason and latched_unknown is None:
@@ -389,6 +419,16 @@ def _join_refresh_worker(
             progress_monitor.print_evidence_heartbeat(elapsed, total_timeout)
             next_heartbeat += REFRESH_HEARTBEAT_SECONDS
     if worker.is_alive():
+        # The latches used to be computed here and DISCARDED, so this branch always degraded to the
+        # caller's bare TimeoutError - which the parent classifier blames on a slow source. Raise them
+        # exactly as `join_with_credential_poll` does, from the same shared helper.
+        if desktop_pid is not None:
+            raise_latched_verdict(
+                desktop_pid,
+                desktop_unready=latched_desktop_unready,
+                dialog=latched_dialog,
+                unknown=latched_unknown,
+            )
         return False
     return True
 
@@ -572,7 +612,18 @@ def refresh(
         )
         if worker.is_alive():
             if desktop_pid is not None:
-                _raise_if_blocked(desktop_pid, _credential_state(desktop_pid), source_hint)
+                # The FINAL check, and it is in-flight too (#376 review, finding 1): by here the
+                # refresh is ours, so a proven-benign progress dialog is ours and must not decide the
+                # verdict. A finding we could NOT account for still does - via the latch helper, not
+                # the t=0 raise helper, which would have converted our own progress dialog into a stop.
+                state = _in_flight_credential_state(desktop_pid)
+                raise_terminal_detection(desktop_pid, state, source_hint)
+                raise_latched_verdict(
+                    desktop_pid,
+                    desktop_unready=state.desktop_unready,
+                    dialog=state.dialog,
+                    unknown=state.unknown_reason,
+                )
             raise TimeoutError(
                 f"refresh did not return within {total_timeout}s "
                 f"(XMLA CommandTimeout was {command_timeout}s and did not fire, which is the signature of a "

--- a/.github/skills/pbip-model-refresh/tests/conftest.py
+++ b/.github/skills/pbip-model-refresh/tests/conftest.py
@@ -56,8 +56,12 @@ def pytest_configure(config: pytest.Config) -> None:
 from _credential_modal import CredentialDetection  # noqa: E402
 
 
-def _healthy_desktop(_pid: int) -> CredentialDetection:
-    """The baseline every CLI test implicitly assumes: a Desktop that is up, windowed and unblocked."""
+def _healthy_desktop(_pid: int, **_kwargs) -> CredentialDetection:
+    """The baseline every CLI test implicitly assumes: a Desktop that is up, windowed and unblocked.
+
+    ``**_kwargs`` swallows ``probe_desktop_query._credential_state``'s keyword-only ``in_flight``
+    (issue #376) so ONE stub still stands in for both entry points' signatures.
+    """
     return CredentialDetection()
 
 

--- a/.github/skills/pbip-model-refresh/tests/test_credential_modal_detection.py
+++ b/.github/skills/pbip-model-refresh/tests/test_credential_modal_detection.py
@@ -1658,35 +1658,76 @@ def test_no_proxy_for_blocking_survives_in_the_candidate_rule() -> None:
 
     Three review rounds killed three correlates. This asserts the module has no surface for a fourth,
     and that the only exclusions left are the modality ones.
+
+    ⚠️ **Asserted BEHAVIOURALLY, not by reading the source (#400 review round 5).** This used to grep
+    ``inspect.getsource(dialog_candidates)`` for the tokens ``class_name`` and ``width``. That caught
+    an inline mutation and nothing else: a helper called from that function could consult either
+    without those tokens appearing in it, and the test would still pass. So instead the matrix below
+    feeds windows that differ ONLY in class and size and requires candidacy to be identical - which no
+    proxy anywhere behind :func:`dialog_candidates` can satisfy.
     """
     for gone in ("MIN_DIALOG_WIDTH", "MIN_DIALOG_HEIGHT", "HELPER_WINDOW_CLASSES", "is_desktop_main_window"):
         assert not hasattr(_credential_modal, gone), f"{gone} is a proxy for blocking and must stay deleted"
 
-    source = inspect.getsource(_credential_modal.dialog_candidates)
-    assert "class_name" not in source, "candidacy must not consult a window's class"
-    assert "width" not in source, "candidacy must not consult a window's size"
+    classes = (
+        DESKTOP_MAIN_CLASS_PREFIX + ".app.0.33c0d9d",  # the frame's own WinForms family (round 2)
+        "Internet Explorer_Hidden",  # the AAD sign-in host's class (round 3)
+        "#32770",
+        "tooltips_class32",
+    )
+    # Every size is > 0 in both axes: `renders_nothing` is a MODALITY rule (unowned AND no pixels), not
+    # a size test, so a genuinely zero-area unowned window is excluded on purpose and does not belong
+    # in a matrix asserting that size is never consulted.
+    sizes = ((2011, 1298), (900, 700), (80, 60), (1, 1))
+    frame = main_window()
+
+    verdicts: dict[tuple[bool, str, tuple[int, int]], bool] = {}
+    for owned in (True, False):
+        for class_name in classes:
+            for width, height in sizes:
+                window = DesktopWindow(
+                    "",
+                    class_name,
+                    width,
+                    height,
+                    ("Enter your credentials",),
+                    hwnd=0x80008,
+                    owner_hwnd=MAIN_HWND if owned else 0,
+                    owner_enabled=False if owned else None,
+                )
+                kept = _credential_modal.dialog_candidates([frame, window], frame=frame)
+                verdicts[(owned, class_name, (width, height))] = window in kept
+
+    assert all(verdicts.values()), (
+        "candidacy must not vary with class or size; these combinations were dropped: "
+        f"{sorted(key for key, kept in verdicts.items() if not kept)}"
+    )
 
 
 def test_the_frame_is_identified_by_ownership_before_any_convention() -> None:
-    """`main_frame` prefers DIRECT ownership evidence, and only then the main-handle convention.
+    """`main_frame` names the frame from ownership evidence - and only when it is UNAMBIGUOUS.
 
     Ownership names the frame outright when a dialog is up, which is the case where getting it wrong
-    removes a real blocker. The first-visible-unowned convention is a fallback reached only when no
-    window is owned - i.e. when there are no dialogs to hide.
+    removes a real blocker: the credential dialog's chain roots at the frame no matter where Z-order
+    puts it in the enumeration.
 
-    The decoy matters: with another UNOWNED window enumerated ahead of the frame, the convention alone
-    picks the decoy and the real frame is then classified as a dialog on every healthy poll. Only the
-    ownership branch gets this right, so the decoy is what makes this test able to fail.
+    ⚠️ The decoy assertion INVERTED in round 5, and that is the fix rather than a regression. A second
+    unowned window that renders pixels is itself a possible frame - a "decoy" and an unowned credential
+    host are structurally the same window - so identity is AMBIGUOUS and nothing is excluded. Believing
+    the ownership-derived root instead is exactly what crowned an unowned credential host that owned
+    one tooltip.
     """
     frame = main_window()
     dialog = owned_dialog(("Enter your credentials",))
     decoy = DesktopWindow("decoy", "Cls", 300, 200, ("decoy",), hwnd=0x60006)
 
-    # Ownership evidence wins even when the dialog is enumerated FIRST (Z-order puts a modal on top)
-    # and even when an unrelated unowned window precedes the frame.
-    assert _credential_modal.main_frame([dialog, decoy, frame]) is frame
-    assert _credential_modal.main_frame([decoy, frame, dialog]) is frame
-    # With nothing owned, the convention applies: the first visible unowned window.
+    # Ownership evidence wins even when the dialog is enumerated FIRST (Z-order puts a modal on top).
+    assert _credential_modal.main_frame([dialog, frame]) is frame
+    assert _credential_modal.main_frame([frame, dialog]) is frame
+    # A second rendering unowned window is a second possible frame, so identity fails closed.
+    assert _credential_modal.main_frame([dialog, decoy, frame]) is None
+    assert _credential_modal.main_frame([decoy, frame, dialog]) is None
+    # With nothing owned, one rendering unowned window is still unambiguous.
     lone = DesktopWindow("only", "Cls", 800, 600, ("only",), hwnd=0x50005)
     assert _credential_modal.main_frame([lone]) is lone
     assert _credential_modal.main_frame([]) is None
@@ -1780,8 +1821,73 @@ def test_a_topmost_unowned_dialog_cannot_present_itself_as_the_application() -> 
     assert state.modal.window is aad
 
 
+def test_an_unowned_credential_host_owning_a_tooltip_is_never_crowned_the_frame() -> None:
+    """Round 5: collecting roots ONLY through ownership chains made a credential host the application.
+
+    The reviewer's construction, and the fourth distinct topology to defeat frame identity. A real
+    unowned frame shows ``Refresh`` / ``Evaluating...``; an unowned host shows
+    ``Enter your credentials``; an ENABLED tooltip is owned by that host. The tooltip is the only owned
+    window, so the only ownership-derived root is the CREDENTIAL HOST - which was then excluded from
+    the prepass and from classification, while the real frame's progress text was suppressed in flight.
+
+    Measured on the round-4 build, exactly the shape this module exists to prevent::
+
+        main_frame selected: the credential host
+        inspect_credential_modal -> modal=None dialog=None unknown_reason=None
+                                    desktop_unready=None process_gone=None
+    """
+    frame_hwnd, cred_hwnd, tip_hwnd = 0xF001, 0x9001, 0x7003
+    frame = DesktopWindow(
+        "", "WindowsForms10.Window.8.app.0.x", 2011, 1298, ("Refresh", "Evaluating..."), hwnd=frame_hwnd
+    )
+    cred = DesktopWindow("", "Internet Explorer_Hidden", 900, 700, ("Enter your credentials",), hwnd=cred_hwnd)
+    tip = DesktopWindow(
+        "", "tooltips_class32", 120, 24, ("hint",), hwnd=tip_hwnd, owner_hwnd=cred_hwnd, owner_enabled=True
+    )
+
+    assert _credential_modal.main_frame([tip, cred, frame]) is None, "two rendering unowned windows are ambiguous"
+    kept = _credential_modal.dialog_candidates([tip, cred, frame])
+    assert cred in kept and frame in kept, "an ambiguous frame must exclude neither of them"
+
+    for in_flight in (False, True):
+        state = inspect_credential_modal(111, lambda _pid: [tip, cred, frame], operation_in_flight=in_flight)
+        assert state.modal is not None, f"the prompt vanished with operation_in_flight={in_flight}"
+        assert state.modal.window is cred
+
+
+def test_an_unowned_host_with_unrecognised_text_still_surfaces_beside_our_own_refresh() -> None:
+    """The same topology without a signature hit must be LOUD, not clean.
+
+    Round 5's danger is not only the missed signature: with the credential host crowned as the frame,
+    the only window left to classify was the real frame, whose benign progress text is suppressed while
+    our own operation is in flight. Every unrecognised window in that shape therefore collapsed into
+    the healthy state. This is the same construction with text nobody can account for.
+    """
+    frame_hwnd, host_hwnd, tip_hwnd = 0xF001, 0x9001, 0x7003
+    frame = DesktopWindow(
+        "", "WindowsForms10.Window.8.app.0.x", 2011, 1298, ("Refresh", "Evaluating..."), hwnd=frame_hwnd
+    )
+    host = DesktopWindow("", "Internet Explorer_Hidden", 900, 700, ("Something nobody enumerated",), hwnd=host_hwnd)
+    tip = DesktopWindow(
+        "", "tooltips_class32", 120, 24, ("hint",), hwnd=tip_hwnd, owner_hwnd=host_hwnd, owner_enabled=True
+    )
+
+    state = inspect_credential_modal(111, lambda _pid: [tip, host, frame], operation_in_flight=True)
+
+    assert state.modal is None
+    assert state.dialog is not None, "an unaccounted window must never collapse into the healthy state"
+    assert state.dialog.verdict == "DIALOG_UNRECOGNIZED"
+    assert state.dialog.window is host
+
+
 def test_ambiguous_frame_identity_excludes_nothing() -> None:
-    """Failing closed means EXCLUDING NOTHING - the cost is a loud exit 3, never a silent clear."""
+    """Failing closed means EXCLUDING NOTHING - the cost is a loud exit 3, never a silent clear.
+
+    Both halves matter, and the second is round 5's: ambiguity has to survive the PRESENCE of owned
+    windows too. An ownership-derived root is not better evidence than a window sitting there rendering
+    pixels - believing it was the whole defect - so a tooltip owned by either candidate must not
+    promote its owner into the application.
+    """
     frame = DesktopWindow("sample", "WindowsForms10.Window.8.app.0.x", 2011, 1298, ("sample",), hwnd=0xF001)
     other = DesktopWindow("second", "Cls", 800, 600, ("second",), hwnd=0x9001)
 
@@ -1789,6 +1895,13 @@ def test_ambiguous_frame_identity_excludes_nothing() -> None:
     kept = _credential_modal.dialog_candidates([frame, other])
 
     assert frame in kept and other in kept, "an ambiguous frame must not exclude a window"
+
+    for owner_hwnd in (0xF001, 0x9001):
+        tip = DesktopWindow("", "tooltips_class32", 120, 24, (), hwnd=0x7003, owner_hwnd=owner_hwnd, owner_enabled=True)
+        windows = [tip, frame, other]
+        assert _credential_modal.main_frame(windows) is None, f"an owned tooltip must not crown hwnd {owner_hwnd:#x}"
+        kept = _credential_modal.dialog_candidates(windows)
+        assert frame in kept and other in kept, "neither possible frame may be excluded"
 
 
 def test_an_unresolvable_owner_chain_fails_closed() -> None:
@@ -1893,6 +2006,245 @@ def test_the_win32_harvest_reads_real_ownership_and_owner_enabled_state() -> Non
         user32.DestroyWindow(owned_hwnd)
         user32.DestroyWindow(frame_hwnd)
         user32.UnregisterClassW(klass.lpszClassName, klass.hInstance)
+
+
+class _NativeWindowProbe:
+    """A disposable set of REAL Win32 windows, for the topology tests that synthesised data cannot gate.
+
+    Every signature is set explicitly, for the reason measured in round 3: a default ctypes ``restype``
+    is a 32-bit ``c_int``, so an untyped ``GetModuleHandleW`` TRUNCATES the 64-bit ``HINSTANCE`` and
+    ``RegisterClassW`` then faults on the garbage - an access violation that showed up as a
+    ``faulthandler`` dump while the test still reported a pass.
+
+    ``DefWindowProcW`` is used DIRECTLY as the window procedure, cast to the callback type rather than
+    wrapped in a Python callable: Windows calls a wndproc synchronously from inside ``CreateWindowExW``
+    and ``DestroyWindow``, so keeping Python off the message path removes both the marshalling risk and
+    the need for a message pump.
+
+    Nothing Windows-only runs at import time. ``ctypes.WINFUNCTYPE`` does not EXIST off Windows, and
+    this module is imported (and mostly run) on the ubuntu CI leg as well, so the callback type and the
+    ``WNDCLASSW`` structure are both built inside ``__init__``, behind the callers' ``skipif``.
+    """
+
+    WS_OVERLAPPEDWINDOW, WS_VISIBLE, WS_POPUP, WS_CHILD = 0x00CF0000, 0x10000000, 0x80000000, 0x40000000
+    HWND_TOPMOST, SWP_NOMOVE, SWP_NOSIZE, SWP_NOACTIVATE = -1, 0x0002, 0x0001, 0x0010
+
+    def __init__(self, tag: str) -> None:
+        self.user32 = ctypes.WinDLL("user32", use_last_error=True)
+        self.kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        self.wndproc_type = ctypes.WINFUNCTYPE(
+            ctypes.c_longlong, wintypes.HWND, wintypes.UINT, wintypes.WPARAM, wintypes.LPARAM
+        )
+
+        class WndClass(ctypes.Structure):
+            """Minimal ``WNDCLASSW``."""
+
+            _fields_ = [
+                ("style", wintypes.UINT),
+                ("lpfnWndProc", self.wndproc_type),
+                ("cbClsExtra", ctypes.c_int),
+                ("cbWndExtra", ctypes.c_int),
+                ("hInstance", wintypes.HINSTANCE),
+                ("hIcon", wintypes.HICON),
+                ("hCursor", wintypes.HANDLE),
+                ("hbrBackground", wintypes.HBRUSH),
+                ("lpszMenuName", wintypes.LPCWSTR),
+                ("lpszClassName", wintypes.LPCWSTR),
+            ]
+
+        self.wndclass_type = WndClass
+        self._configure()
+        self.klass = WndClass()
+        self.klass.lpfnWndProc = ctypes.cast(self.user32.DefWindowProcW, self.wndproc_type)
+        self.klass.hInstance = self.kernel32.GetModuleHandleW(None)
+        self.klass.lpszClassName = f"T2P{tag}{os.getpid()}"
+        assert self.user32.RegisterClassW(ctypes.byref(self.klass)), f"RegisterClassW: {ctypes.get_last_error()}"
+        self.created: list[int] = []
+
+    def _configure(self) -> None:
+        """Type every call this probe makes."""
+        self.user32.DefWindowProcW.argtypes = [wintypes.HWND, wintypes.UINT, wintypes.WPARAM, wintypes.LPARAM]
+        self.user32.DefWindowProcW.restype = ctypes.c_longlong
+        self.user32.CreateWindowExW.restype = wintypes.HWND
+        self.user32.CreateWindowExW.argtypes = [
+            wintypes.DWORD, wintypes.LPCWSTR, wintypes.LPCWSTR, wintypes.DWORD,
+            ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int,
+            wintypes.HWND, wintypes.HMENU, wintypes.HINSTANCE, wintypes.LPVOID,
+        ]  # fmt: skip
+        self.kernel32.GetModuleHandleW.argtypes = [wintypes.LPCWSTR]
+        self.kernel32.GetModuleHandleW.restype = wintypes.HMODULE
+        self.user32.RegisterClassW.argtypes = [ctypes.POINTER(self.wndclass_type)]
+        self.user32.RegisterClassW.restype = wintypes.ATOM
+        self.user32.UnregisterClassW.argtypes = [wintypes.LPCWSTR, wintypes.HINSTANCE]
+        self.user32.UnregisterClassW.restype = wintypes.BOOL
+        self.user32.DestroyWindow.argtypes = [wintypes.HWND]
+        self.user32.DestroyWindow.restype = wintypes.BOOL
+        self.user32.SetWindowPos.argtypes = [
+            wintypes.HWND,
+            wintypes.HWND,
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_int,
+            wintypes.UINT,
+        ]
+        self.user32.SetWindowPos.restype = wintypes.BOOL
+
+    def top(self, style: int, x: int, y: int, width: int, height: int, owner: int | None = None) -> int:
+        """Create a visible top-level window, optionally OWNED by ``owner``."""
+        hwnd = self.user32.CreateWindowExW(
+            0, self.klass.lpszClassName, "", style | self.WS_VISIBLE, x, y, width, height,
+            owner, None, self.klass.hInstance, None,
+        )  # fmt: skip
+        assert hwnd, f"CreateWindowExW: {ctypes.get_last_error()}"
+        self.created.append(hwnd)
+        return hwnd
+
+    def label(self, parent: int, text: str, y: int) -> int:
+        """Create a real STATIC child, so the harvest reads ``text`` as CONTENT rather than a caption."""
+        hwnd = self.user32.CreateWindowExW(
+            0, "STATIC", text, self.WS_CHILD | self.WS_VISIBLE, 5, y, 260, 20,
+            parent, None, self.klass.hInstance, None,
+        )  # fmt: skip
+        assert hwnd, f"CreateWindowExW(STATIC): {ctypes.get_last_error()}"
+        return hwnd
+
+    def raise_topmost(self, hwnd: int) -> None:
+        """Put ``hwnd`` at the top of the TOPMOST band, which is where EnumWindows starts."""
+        flags = self.SWP_NOMOVE | self.SWP_NOSIZE | self.SWP_NOACTIVATE
+        assert self.user32.SetWindowPos(hwnd, self.HWND_TOPMOST, 0, 0, 0, 0, flags), (
+            f"SetWindowPos: {ctypes.get_last_error()}"
+        )
+        time.sleep(0.2)
+
+    def close(self) -> None:
+        """Destroy every window this probe created, then unregister its class."""
+        for hwnd in reversed(self.created):
+            self.user32.DestroyWindow(hwnd)
+        self.created.clear()
+        self.user32.UnregisterClassW(self.klass.lpszClassName, self.klass.hInstance)
+
+
+def _dotnet_main_window_handle(pid: int) -> int:
+    """.NET ``System.Diagnostics.Process.MainWindowHandle`` for ``pid``, read from ANOTHER process.
+
+    Deliberately out-of-process: reading it in-process through pythonnet would add a dependency this
+    detector does not have, and the question being asked is what the AUTHORITY says, not what a
+    convenient reimplementation of it says.
+    """
+    proc = subprocess.run(
+        [_powershell(), "-NoProfile", "-Command", f"[int64](Get-Process -Id {pid}).MainWindowHandle"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, f"Get-Process failed: {proc.stderr.strip()}"
+    return int((proc.stdout or "0").strip() or 0)
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="creates real Win32 windows")
+def test_a_native_unowned_credential_host_owning_a_tooltip_is_not_the_application() -> None:
+    """Round 5's reproduction, built natively - the fourth topology to defeat frame identity.
+
+    The synthesised twin of this test proves the RULE; this one proves the rule is applied to what
+    Win32 actually reports. Three real windows: an unowned frame whose only content is progress status,
+    an unowned host reading ``Enter your credentials``, and an ENABLED tooltip owned by that host. The
+    tooltip is the only owned window, so ownership alone yields exactly one root - the credential host -
+    and believing it returned ``modal=None dialog=None unknown_reason=None`` while our own refresh was
+    in flight.
+    """
+    probe = _NativeWindowProbe("Round5Probe")
+    try:
+        frame_hwnd = probe.top(probe.WS_OVERLAPPEDWINDOW, 10, 10, 400, 300)
+        probe.label(frame_hwnd, "Refresh", 10)
+        probe.label(frame_hwnd, "Evaluating...", 40)
+        cred_hwnd = probe.top(probe.WS_POPUP, 500, 10, 900, 700)
+        probe.label(cred_hwnd, "Enter your credentials", 10)
+        tip_hwnd = probe.top(probe.WS_POPUP, 520, 40, 120, 24, owner=cred_hwnd)
+        time.sleep(0.2)
+
+        harvested, _visited = _enumerate_pid_windows_with_count(os.getpid())
+        ours = [window for window in harvested if window.hwnd in {frame_hwnd, cred_hwnd, tip_hwnd}]
+        by_hwnd = {window.hwnd: window for window in ours}
+
+        assert set(by_hwnd) == {frame_hwnd, cred_hwnd, tip_hwnd}, "the harvest missed a native probe window"
+        assert by_hwnd[frame_hwnd].owner_hwnd == 0, "the real frame is unowned"
+        assert by_hwnd[cred_hwnd].owner_hwnd == 0, "the credential host is unowned - that is the whole shape"
+        assert by_hwnd[tip_hwnd].owner_hwnd == cred_hwnd, "the tooltip is owned BY the credential host"
+        assert by_hwnd[tip_hwnd].owner_enabled is True, "an enabled owner exonerates the tooltip itself"
+        assert by_hwnd[frame_hwnd].texts == ("Refresh", "Evaluating..."), "the frame reads as pure progress status"
+
+        assert _credential_modal.main_frame(ours) is None, "two rendering unowned windows cannot name one frame"
+        kept = _credential_modal.dialog_candidates(ours)
+        assert by_hwnd[cred_hwnd] in kept and by_hwnd[frame_hwnd] in kept, "ambiguity must exclude neither"
+
+        state = inspect_credential_modal(os.getpid(), lambda _pid: ours, operation_in_flight=True)
+
+        assert state.modal is not None, "the credential prompt vanished from a real three-window harvest"
+        assert state.modal.window.hwnd == cred_hwnd
+    finally:
+        probe.close()
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="creates real Win32 windows and shells out to PowerShell")
+def test_the_process_main_window_handle_is_a_z_order_answer_not_an_identity() -> None:
+    """MEASURED, because "ask the authority" was the obvious fix and it does not work (#400 round 5).
+
+    .NET's ``Process.MainWindowHandle`` looks like independent evidence about which window is the
+    application. It is not: ``ProcessManager.MainWindowFinder`` runs ``EnumWindows`` and stops at the
+    first VISIBLE, UNOWNED window of the pid - :func:`main_frame`'s own fallback convention, evaluated
+    in another process, minus the :func:`renders_nothing` guard. This test pins that with the two
+    experiments that decide it:
+
+    * **it follows Z-order.** The same two windows are raised in turn to ``HWND_TOPMOST``, and the
+      answer follows whichever was raised last. An identity does not change when a human clicks a
+      window;
+    * **it will name a window that renders nothing.** An unowned **0x0** window created last is
+      returned as the "main window" - a window that cannot show a human anything, and one this
+      module's own :func:`renders_nothing` refuses as a possible frame.
+
+    Measured across six runs of the round-5 topology while writing this: the authority named the
+    CREDENTIAL HOST in five of them and the real frame in one - so it is not merely wrong, it is
+    unstable. That is why nothing in this module consults it, as primary evidence or as a tie-breaker.
+    """
+    probe = _NativeWindowProbe("AuthorityProbe")
+    try:
+        frame_hwnd = probe.top(probe.WS_OVERLAPPEDWINDOW, 10, 10, 400, 300)
+        cred_hwnd = probe.top(probe.WS_POPUP, 500, 10, 900, 700)
+        time.sleep(0.2)
+
+        probe.raise_topmost(frame_hwnd)
+        frame_on_top = _dotnet_main_window_handle(os.getpid())
+        probe.raise_topmost(cred_hwnd)
+        cred_on_top = _dotnet_main_window_handle(os.getpid())
+
+        assert {frame_on_top, cred_on_top} <= {frame_hwnd, cred_hwnd}, (
+            f"expected the authority to name one of our two unowned windows, got {frame_on_top}/{cred_on_top}"
+        )
+        assert frame_on_top != cred_on_top, (
+            "the same two windows produced one answer, so this run cannot show Z-order dependence; "
+            f"both reads returned {frame_on_top}"
+        )
+        assert frame_on_top == frame_hwnd and cred_on_top == cred_hwnd, (
+            "the authority is expected to name whichever window was raised last"
+        )
+
+        ghost_hwnd = probe.top(probe.WS_POPUP, 0, 0, 0, 0)
+        probe.raise_topmost(ghost_hwnd)
+        harvested, _visited = _enumerate_pid_windows_with_count(os.getpid())
+        ghost = next(window for window in harvested if window.hwnd == ghost_hwnd)
+
+        assert (ghost.width, ghost.height) == (0, 0), "the ghost really is 0x0"
+        assert _credential_modal.renders_nothing(ghost), "this module refuses a 0x0 unowned window as a frame"
+        assert _dotnet_main_window_handle(os.getpid()) == ghost_hwnd, (
+            "the authority names a window that can show a human nothing"
+        )
+
+        # The load-bearing consequence: whatever the authority says, identity here stays ambiguous.
+        ours = [window for window in harvested if window.hwnd in {frame_hwnd, cred_hwnd}]
+        assert _credential_modal.main_frame(ours) is None
+    finally:
+        probe.close()
 
 
 @pytest.mark.parametrize(

--- a/.github/skills/pbip-model-refresh/tests/test_credential_modal_detection.py
+++ b/.github/skills/pbip-model-refresh/tests/test_credential_modal_detection.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import threading
 import time
+import inspect
 import json
 import os
 import re
@@ -21,15 +22,16 @@ import _credential_modal
 import probe_desktop_query
 import refresh_pbip_model
 from _credential_modal import (
-    BlockingDialog,
     CredentialDetection,
     CredentialModal,
     CredentialUnknownError,
     DesktopGoneError,
     DesktopUnreadyError,
-    DialogBlockedError,
+    DialogFinding,
+    DialogFoundError,
     DesktopWindow,
     _enumerate_pid_windows_with_count,
+    classify_dialog,
     inspect_credential_modal,
     join_with_credential_poll,
 )
@@ -92,14 +94,34 @@ def modal_state() -> CredentialDetection:
     return CredentialDetection(modal=modal())
 
 
-def blocking_dialog() -> BlockingDialog:
-    """Unreadable owned dialog matching the live SQL credential-dialog shape."""
-    return BlockingDialog(DesktopWindow("", "WindowsForms10.Window.20008", 702, 355, ()))
+def unreadable_dialog_window() -> DesktopWindow:
+    """The live SQL credential-dialog shape: visible, owned, empty title, NO readable text at all."""
+    return DesktopWindow("", "WindowsForms10.Window.20008", 702, 355, ())
 
 
-def blocking_state() -> CredentialDetection:
-    """CredentialDetection containing an unreadable blocking dialog."""
-    return CredentialDetection(blocking_dialog=blocking_dialog())
+def progress_dialog_window() -> DesktopWindow:
+    """Power BI's own Refresh progress dialog: a caption AND content that positively reads as status.
+
+    This is the shape the size-only rule reported as a hard stop (issue #376) - >= 100x100, non-main
+    class, and therefore indistinguishable from a sign-in prompt to a detector that never read it.
+    """
+    return DesktopWindow(
+        "Refresh",
+        "WindowsForms10.Window.20008.app.0.33c0d9d",
+        702,
+        355,
+        ("Refresh", "Evaluating...", "Cancel"),
+    )
+
+
+def dialog_finding(window: DesktopWindow | None = None) -> DialogFinding:
+    """A real classification of ``window`` (default: the unreadable owned dialog)."""
+    return classify_dialog(window or unreadable_dialog_window())
+
+
+def dialog_state(window: DesktopWindow | None = None) -> CredentialDetection:
+    """CredentialDetection carrying a real dialog finding."""
+    return CredentialDetection(dialog=dialog_finding(window))
 
 
 def minimized_main_windows() -> list[DesktopWindow]:
@@ -116,10 +138,18 @@ def restored_main_windows() -> list[DesktopWindow]:
     ]
 
 
-def visible_blocking_windows() -> list[DesktopWindow]:
+def visible_unreadable_dialog_windows() -> list[DesktopWindow]:
     """A visible owned dialog (empty title, unreadable) alongside the healthy main window."""
     return [
         DesktopWindow("", "WindowsForms10.Window.20008.app.0.1a2b3c", 702, 355, ()),
+        DesktopWindow("Report", "WindowsForms10.Window.8.app.0.1a2b3c", 2011, 1298, ("Report",)),
+    ]
+
+
+def visible_progress_dialog_windows() -> list[DesktopWindow]:
+    """Power BI's own Refresh progress dialog alongside the healthy main window (issue #376)."""
+    return [
+        progress_dialog_window(),
         DesktopWindow("Report", "WindowsForms10.Window.8.app.0.1a2b3c", 2011, 1298, ("Report",)),
     ]
 
@@ -180,7 +210,7 @@ def real_detector_for_zero_windows(*, alive: bool):
     `CredentialDetection`.
     """
 
-    def detect(pid: int) -> CredentialDetection:
+    def detect(pid: int, **_kwargs) -> CredentialDetection:
         return inspect_credential_modal(pid, lambda _pid: [], process_is_alive=lambda _pid: alive)
 
     return detect
@@ -217,8 +247,11 @@ def test_win32_fixture_finds_owned_dialog_and_keeps_instances_separate() -> None
     assert miss.unknown_reason is None
 
 
-def test_unreadable_owned_dialog_reports_blocked_not_no_modal() -> None:
-    """Live SQL dialog shape: visible owned dialog, empty title, no readable text."""
+def test_unreadable_owned_dialog_reports_unreadable_not_no_modal() -> None:
+    """Live SQL dialog shape: visible owned dialog, empty title, no readable text.
+
+    Absence of text is its own finding - ``DIALOG_UNREADABLE`` - and must never decay into "healthy".
+    """
     windows_by_pid = {
         58104: [
             DesktopWindow("", "WindowsForms10.Window.20008.app.0.33c0d9d", 702, 355, ()),
@@ -231,10 +264,12 @@ def test_unreadable_owned_dialog_reports_blocked_not_no_modal() -> None:
     healthy = inspect_credential_modal(46256, lambda pid: windows_by_pid[pid])
 
     assert blocked.modal is None
-    assert blocked.blocking_dialog is not None
-    assert blocked.blocking_dialog.window.width == 702
+    assert blocked.dialog is not None
+    assert blocked.dialog.kind == "unreadable"
+    assert blocked.dialog.verdict == "DIALOG_UNREADABLE"
+    assert blocked.dialog.window.width == 702
     assert healthy.modal is None
-    assert healthy.blocking_dialog is None
+    assert healthy.dialog is None
 
 
 def test_zero_size_helper_window_does_not_block() -> None:
@@ -248,7 +283,7 @@ def test_zero_size_helper_window_does_not_block() -> None:
     )
 
     assert state.modal is None
-    assert state.blocking_dialog is None
+    assert state.dialog is None
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="real Win32 EnumWindows callback is Windows-only")
@@ -291,7 +326,7 @@ def test_zero_windows_alive_reports_desktop_unready_not_no_dialog() -> None:
     state = inspect_credential_modal(111, lambda _pid: [], process_is_alive=lambda _pid: True)
 
     assert state.modal is None
-    assert state.blocking_dialog is None
+    assert state.dialog is None
     assert state.process_gone is None
     assert state.unknown_reason is None
     assert state.desktop_unready is not None
@@ -310,7 +345,7 @@ def test_zero_windows_dead_reports_process_gone_not_no_dialog() -> None:
     state = inspect_credential_modal(111, lambda _pid: [], process_is_alive=lambda _pid: False)
 
     assert state.modal is None
-    assert state.blocking_dialog is None
+    assert state.dialog is None
     assert state.unknown_reason is None
     assert state.process_gone is not None
     assert "no longer running" in state.process_gone
@@ -332,16 +367,22 @@ def test_direct_refresh_returns_credential_missing_fast_at_t0(monkeypatch) -> No
 
 
 @pytest.mark.timing
-def test_direct_refresh_returns_blocked_by_dialog_fast_at_t0(monkeypatch) -> None:
-    """Unreadable blocking dialog must stop immediately instead of waiting for XMLA."""
-    monkeypatch.setattr(refresh_pbip_model, "_credential_state", lambda _pid: blocking_state())
+def test_direct_refresh_stops_at_t0_for_a_dialog_it_could_not_read(monkeypatch) -> None:
+    """An unreadable dialog present BEFORE we start anything must stop immediately, not wait for XMLA.
+
+    t=0 is the one moment a dialog finding is acted on rather than latched: nothing of ours is running,
+    the dialog is somebody else's, and stacking a refresh on an unclassified dialog is what the
+    2026-08-28 field report had to unpick by hand.
+    """
+    monkeypatch.setattr(refresh_pbip_model, "_credential_state", lambda _pid: dialog_state())
     monkeypatch.setattr(refresh_pbip_model, "_load_adomd", explode("_load_adomd"))
 
     started = time.monotonic()
-    with pytest.raises(DialogBlockedError):
+    with pytest.raises(DialogFoundError) as excinfo:
         refresh(port=1234, tables=["Orders"], timeout_sec=5, desktop_pid=111)
     elapsed = time.monotonic() - started
 
+    assert excinfo.value.finding.verdict == "DIALOG_UNREADABLE"
     assert elapsed < 0.5
 
 
@@ -531,13 +572,18 @@ class _ScriptedEnumerator:
         return list(phase)
 
 
-def _real_detector(enumerator: _ScriptedEnumerator, process_is_alive=lambda _pid: True):
+def _real_detector(enumerator: _ScriptedEnumerator, process_is_alive=lambda _pid: True, *, in_flight: bool = False):
     """A detector that drives the REAL inspect_credential_modal through the scripted enumerator.
 
     ``process_is_alive`` is injected too (issue #158) so the zero-window liveness split is exercised
     deterministically without a live PID; it defaults to "alive" and is only consulted when the
-    enumerator yields an empty window list.
+    enumerator yields an empty window list. ``in_flight`` (issue #376) selects the variant
+    ``join_with_credential_poll`` uses by default, which ignores a positively-read progress dialog.
     """
+    if in_flight:
+        return lambda pid: _credential_modal.inspect_credential_modal_in_flight(
+            pid, enumerator, process_is_alive=process_is_alive
+        )
     return lambda pid: inspect_credential_modal(pid, enumerator, process_is_alive=process_is_alive)
 
 
@@ -594,18 +640,20 @@ def test_poll_loop_without_unknown_returns_false(monkeypatch) -> None:
     assert enumerator.calls >= 1
 
 
-def test_poll_loop_raises_blocked_on_visible_dialog(monkeypatch) -> None:
-    """A visible owned dialog is a hard block: the loop raises DialogBlockedError, not UNKNOWN.
+def test_poll_loop_latches_unreadable_dialog_and_raises_at_the_deadline(monkeypatch) -> None:
+    """#376: a dialog we could not read is LATCHED mid-wait and surfaced at the deadline, not raised.
 
-    Latching UNKNOWN must not swallow a genuinely visible blocking dialog - that is still a distinct,
-    immediately-raised verdict.
+    Before #376 this raised on the first poll, which meant a Power BI Refresh progress dialog aborted
+    the very refresh it was reporting on. It must not abort a run that may still finish - but it also
+    means "no modal appeared" is no longer established, so it cannot be erased by a quiet deadline
+    either. ``enumerator.calls >= 2`` is the part that fails if the raise is restored.
     """
     clock = _FakeClock()
     monkeypatch.setattr(_credential_modal, "time", clock)
     worker = _ImmortalWorker(clock, step=0.4)
-    enumerator = _ScriptedEnumerator([visible_blocking_windows()])
+    enumerator = _ScriptedEnumerator([visible_unreadable_dialog_windows()])
 
-    with pytest.raises(DialogBlockedError):
+    with pytest.raises(DialogFoundError) as excinfo:
         join_with_credential_poll(
             worker,
             pid=111,
@@ -614,6 +662,49 @@ def test_poll_loop_raises_blocked_on_visible_dialog(monkeypatch) -> None:
             poll_seconds=0.1,
             detector=_real_detector(enumerator),
         )
+
+    assert excinfo.value.pid == 111
+    assert excinfo.value.finding.verdict == "DIALOG_UNREADABLE"
+    assert enumerator.calls >= 2, "a dialog finding is latch-and-wait, not terminal"
+
+
+def test_poll_loop_ignores_our_own_refresh_progress_dialog(monkeypatch) -> None:
+    """#376 core: Power BI's own progress dialog must not end the wait it is reporting on.
+
+    The fails-before/passes-after test for the size-only rule. Master returned this >= 100x100 non-main
+    window as a ``blocking_dialog`` and the loop raised at once; now its CONTENT is read, it classifies
+    ``benign``, and the in-flight detector ignores it - so the loop reaches its ordinary deadline and
+    returns ``False``.
+    """
+    clock = _FakeClock()
+    monkeypatch.setattr(_credential_modal, "time", clock)
+    worker = _ImmortalWorker(clock, step=0.4)
+    enumerator = _ScriptedEnumerator([visible_progress_dialog_windows()])
+
+    result = join_with_credential_poll(
+        worker,
+        pid=111,
+        total_timeout=1.0,
+        heartbeat_seconds=1000.0,
+        poll_seconds=0.1,
+        detector=_real_detector(enumerator, in_flight=True),
+    )
+
+    assert result is False
+    assert enumerator.calls >= 2
+
+
+def test_poll_loop_default_detector_is_the_in_flight_one() -> None:
+    """The in-flight variant must be the DEFAULT, not merely available (issue #376).
+
+    Every production caller relies on the default: `refresh()` passes no `detector`. A wiring test is
+    the only thing that catches "the right function exists but nothing calls it" - the shape #390 hit
+    when a payload validator was behaviourally tested but never pinned as wired in.
+    """
+    default = inspect.signature(join_with_credential_poll).parameters["detector"].default
+
+    assert default is _credential_modal.inspect_credential_modal_in_flight
+    assert default is not inspect_credential_modal
 
 
 def test_poll_loop_raises_desktop_gone_when_process_dead(monkeypatch) -> None:
@@ -699,6 +790,52 @@ def test_refresh_and_save_wires_credential_unknown_to_exit_3(monkeypatch, capsys
     assert exit_code == 3, "CREDENTIAL_UNKNOWN must be exit 3, distinct from blocked's exit 1"
     assert "REFRESH: CREDENTIAL_UNKNOWN pid=111" in out
     assert reason in out
+
+
+def test_refresh_and_save_wires_a_dialog_finding_to_exit_3(monkeypatch, capsys) -> None:
+    """#376 wiring: a DialogFoundError must surface at exit 3, never in the exit-1 hard-stop band.
+
+    Exit 1 is reserved for a matched credential signature. This module cannot establish that a dialog
+    BLOCKS anything, so nothing it observes about one may enter that band - and ``probe_live_source``
+    maps the exit-1 credential family to "you may NOT build; a person must sign in". The finding is a
+    real classification and the verdict line is the real emitter's, so this pins raise -> emit -> exit
+    code with no hand-written text.
+    """
+
+    def _raise_dialog(*_args, **_kwargs):
+        raise DialogFoundError(111, dialog_finding())
+
+    monkeypatch.setattr(refresh_pbip_model, "refresh", _raise_dialog)
+    args = refresh_pbip_model._build_arg_parser().parse_args(["--pid", "111", "--tables", "Orders"])
+
+    exit_code = refresh_pbip_model._refresh_and_save(111, 5000, None, args)
+    out = capsys.readouterr().out
+
+    assert exit_code == 3, "a dialog finding must not reuse the credential hard stop's exit 1"
+    assert "REFRESH: DIALOG_UNREADABLE pid=111" in out
+    assert "BLOCKED_BY_DIALOG" not in out
+
+
+def test_refresh_main_reports_a_t0_dialog_at_exit_3_before_any_mutation(monkeypatch, tmp_path: Path, capsys) -> None:
+    """#376: the MUTATING CLI stops at t=0 for a dialog it could not read - at exit 3, and before XMLA.
+
+    Two properties in one, and both matter: it must not stack a refresh on somebody else's dialog
+    (``discover_port`` explodes if it gets that far), and it must not call it a credential wall.
+    """
+    model_folder(tmp_path, "MyMigration")
+    monkeypatch.setattr(
+        refresh_pbip_model,
+        "_bridge_status",
+        lambda: {"instances": [{"pid": 111, "currentFilePath": str(tmp_path / "MyMigration.pbip")}]},
+    )
+    monkeypatch.setattr(refresh_pbip_model, "_credential_state", lambda _pid: dialog_state())
+    monkeypatch.setattr(refresh_pbip_model, "discover_port", explode("discover_port"))
+
+    exit_code = refresh_pbip_model.main(["--pid", "111"])
+    out = capsys.readouterr().out
+
+    assert exit_code == 3
+    assert out.startswith("REFRESH: DIALOG_UNREADABLE")
 
 
 def test_refresh_and_save_wires_desktop_gone_to_exit_2(monkeypatch, capsys) -> None:
@@ -903,16 +1040,84 @@ def test_the_two_entry_points_get_an_explicit_desktop_state_baseline() -> None:
         )
 
 
-def test_probe_query_returns_blocked_by_dialog_fast_at_t0(monkeypatch, capsys) -> None:
-    """probe_desktop_query stops for an unreadable blocking dialog."""
-    monkeypatch.setattr(probe_desktop_query, "_credential_state", lambda _pid: blocking_state())
+def test_probe_query_stops_at_exit_3_for_a_dialog_it_could_not_read(monkeypatch, capsys) -> None:
+    """#376: an unreadable dialog stops the GATE OF RECORD at exit 3, never in the exit-1 hard-stop band.
+
+    Master emitted ``PREFLIGHT: BLOCKED_BY_DIALOG`` at exit 1 from a SIZE-ONLY test, which
+    ``probe_live_source`` maps to ``NO_CREDENTIAL`` ("you may NOT build; a person must sign in"). Exit 3
+    means "could not probe" and makes no claim about the source at all.
+    """
+    monkeypatch.setattr(probe_desktop_query, "_credential_state", lambda _pid, **_kw: dialog_state())
     monkeypatch.setattr(probe_desktop_query, "discover_port", explode("discover_port"))
 
     exit_code = probe_desktop_query.main(["--pid", "111"])
     out = capsys.readouterr().out
 
-    assert exit_code == 1
-    assert out.startswith("PREFLIGHT: BLOCKED_BY_DIALOG")
+    assert exit_code == 3, "a dialog we could not read must not enter the exit-1 hard-stop band"
+    assert out.startswith("PREFLIGHT: DIALOG_UNREADABLE")
+    assert "BLOCKED_BY_DIALOG" not in out
+
+
+def test_probe_query_does_not_stop_for_power_bi_s_own_progress_dialog(monkeypatch, capsys) -> None:
+    """#376 acceptance 1: a Refresh progress dialog is not reported as a credential wall.
+
+    Driven through the REAL detector so the classification and the CLI branch on it are proven as one
+    chain. On master this window (>= 100x100, non-main class) produced ``BLOCKED_BY_DIALOG`` at exit 1;
+    now its content is read, it classifies ``benign``, and at t=0 it reports ``REFRESH_IN_PROGRESS`` at
+    exit 3 - Desktop is busy, so a one-row probe of a mid-refresh model would not be trustworthy anyway.
+    """
+    windows = visible_progress_dialog_windows()
+    monkeypatch.setattr(
+        probe_desktop_query,
+        "_credential_state",
+        lambda pid, **kw: inspect_credential_modal(pid, lambda _pid: windows, **kw),
+    )
+    monkeypatch.setattr(probe_desktop_query, "discover_port", explode("discover_port"))
+
+    exit_code = probe_desktop_query.main(["--pid", "111"])
+    out = capsys.readouterr().out
+
+    assert exit_code == 3
+    assert out.startswith("PREFLIGHT: REFRESH_IN_PROGRESS")
+    assert "CREDENTIAL_MISSING" not in out
+    assert "BLOCKED_BY_DIALOG" not in out
+
+
+def test_probe_query_poll_ignores_a_progress_dialog_while_the_query_runs(monkeypatch, capsys) -> None:
+    """#376: a progress dialog appearing DURING the read-only probe must not abort it.
+
+    The poll runs with ``in_flight=True``, so a positively-read progress dialog is ignored and the DAX
+    result - the gate of record - is what decides. On master the same window returned exit 1 on the
+    first poll and the probe's own answer was never heard.
+    """
+    windows = visible_progress_dialog_windows()
+    seen = {"in_flight": []}
+
+    def state(pid: int, *, in_flight: bool = False) -> CredentialDetection:
+        seen["in_flight"].append(in_flight)
+        # Healthy at t=0; the progress dialog appears once the probe is already running.
+        if not in_flight:
+            return CredentialDetection()
+        return inspect_credential_modal(pid, lambda _pid: windows, operation_in_flight=in_flight)
+
+    def fake_probe(_port: int, _tables: list[str] | None, emit=print) -> int:
+        time.sleep(0.15)
+        emit("PREFLIGHT: DATA_OK")
+        return 0
+
+    monkeypatch.setattr(probe_desktop_query, "_credential_state", state)
+    monkeypatch.setattr(probe_desktop_query, "PREFLIGHT_CREDENTIAL_POLL_SECONDS", 0.02)
+    monkeypatch.setattr(probe_desktop_query, "discover_port", lambda _pid: 52001)
+    monkeypatch.setattr(probe_desktop_query, "probe", fake_probe)
+
+    exit_code = probe_desktop_query._probe_with_credential_poll(111, 52001, ["Orders"])
+    out = capsys.readouterr().out
+
+    assert exit_code == 0, "a progress dialog must not abort a probe that was going to succeed"
+    assert "PREFLIGHT: DATA_OK" in out
+    assert seen["in_flight"][1:], "the poll must have run at least once"
+    assert all(seen["in_flight"][1:]), "every poll after t=0 must use the in-flight detector"
+    assert seen["in_flight"][0] is False, "the t=0 check must NOT be in-flight"
 
 
 def test_probe_query_returns_unknown_for_minimized_owner(monkeypatch, capsys) -> None:
@@ -951,7 +1156,7 @@ def test_probe_query_poll_catches_late_modal(monkeypatch, capsys) -> None:
     monkeypatch.setattr(
         probe_desktop_query,
         "_credential_state",
-        lambda pid: CredentialDetection(modal=late_modal(pid)),
+        lambda pid, **_kw: CredentialDetection(modal=late_modal(pid)),
     )
     monkeypatch.setattr(probe_desktop_query, "PREFLIGHT_CREDENTIAL_POLL_SECONDS", 0.05)
     monkeypatch.setattr(probe_desktop_query, "discover_port", lambda _pid: 52001)
@@ -987,7 +1192,7 @@ def test_probe_query_worker_cannot_print_after_credential_verdict(monkeypatch, c
     monkeypatch.setattr(
         probe_desktop_query,
         "_credential_state",
-        lambda pid: CredentialDetection(modal=late_modal(pid)),
+        lambda pid, **_kw: CredentialDetection(modal=late_modal(pid)),
     )
     monkeypatch.setattr(probe_desktop_query, "PREFLIGHT_CREDENTIAL_POLL_SECONDS", 0.05)
     monkeypatch.setattr(probe_desktop_query, "discover_port", lambda _pid: 52001)
@@ -1004,6 +1209,186 @@ def test_probe_query_worker_cannot_print_after_credential_verdict(monkeypatch, c
     assert first_out.startswith("PREFLIGHT: CREDENTIAL_MISSING")
     assert "DATA_OK_FROM_WORKER_AFTER_RELEASE" not in first_out
     assert later_out == ""
+
+
+# ==================================================================================================
+# _credential_modal.classify_dialog - the PYTHON detector's own dialog classifiers (issue #376)
+# ==================================================================================================
+#
+# The Python fast path had the same defect the PowerShell arbiter shed in #367, on a more dangerous
+# route: `inspect_credential_modal` returned the FIRST visible non-main window >= 100x100 as a
+# `blocking_dialog`, and both callers mapped that to `BLOCKED_BY_DIALOG` at exit 1 - which
+# `probe_live_source` classifies `NO_CREDENTIAL`. It feeds `probe_desktop_query.py`, the gate of
+# record, so a Power BI Refresh progress dialog could halt a migration and send an operator to a
+# sign-in screen that was never on show.
+#
+# These drive the REAL classifier against synthesised windows: no Desktop, no Win32, every platform.
+
+
+@pytest.mark.parametrize(
+    ("texts", "title", "kind", "verdict"),
+    [
+        # 1. A progress dialog is NOT a credential wall. The whole point of the issue.
+        (("Refresh", "Evaluating...", "Cancel"), "Refresh", "benign", "REFRESH_IN_PROGRESS"),
+        (("Refresh", "1,204 rows loaded"), "Refresh", "benign", "REFRESH_IN_PROGRESS"),
+        # 2. A genuine credential prompt still is - fixing the false positive must not break this.
+        (("Please specify how to connect",), "", "credential", "CREDENTIAL_MISSING"),
+        (("You aren't signed in",), "", "credential", "CREDENTIAL_MISSING"),
+        # 3. Could-not-determine is its own state, never folded into either of the first two.
+        ((), "", "unreadable", "DIALOG_UNREADABLE"),
+        (("Refresh",), "Refresh", "benign-title-only", "DIALOG_UNREADABLE"),
+        (("Save changes?", "Discard"), "Save changes?", "unrecognized", "DIALOG_UNRECOGNIZED"),
+        # 4. Known human-blocking prompts that are NOT sign-in prompts get their own verdict, and
+        #    outrank progress text in the same window (the round-3 defect in #390).
+        (
+            ("Permission is required to run this native database query",),
+            "",
+            "needs-human",
+            "DIALOG_NEEDS_HUMAN",
+        ),
+        (
+            ("Refresh", "Evaluating...", "Permission is required to run this native database query"),
+            "Refresh",
+            "needs-human",
+            "DIALOG_NEEDS_HUMAN",
+        ),
+        # 5. Progress text cannot account for prose nobody explained.
+        (
+            ("Refresh", "Evaluating...", "Your workbook contains unsaved changes that will be lost"),
+            "Refresh",
+            "mixed-content",
+            "DIALOG_UNRECOGNIZED",
+        ),
+    ],
+)
+def test_classify_dialog_reads_the_window_instead_of_measuring_it(texts, title, kind, verdict) -> None:
+    """Every one of these windows is 702x355 and non-main, so SIZE cannot separate them - text must."""
+    finding = classify_dialog(DesktopWindow(title, "WindowsForms10.Window.20008.app.0.x", 702, 355, texts))
+
+    assert (finding.kind, finding.verdict) == (kind, verdict)
+
+
+def test_only_the_credential_verdict_is_a_hard_stop() -> None:
+    """#376's failure direction: nothing but a matched credential signature may reach exit 1.
+
+    A false hard stop halts a migration and demands a human; a false clear lands on a verdict the repo
+    already treats as untrustworthy on its own. One direction has a backstop, the other does not - so
+    every non-credential kind is exit 3 by construction, not by each caller remembering to make it so.
+    """
+    hard_stop = {
+        kind
+        for kind, verdict in _credential_modal.DIALOG_KIND_VERDICTS.items()
+        if verdict == _credential_modal.VERDICT_CREDENTIAL_MISSING
+    }
+
+    assert hard_stop == {"credential"}, f"a non-credential kind reaches the hard-stop verdict: {hard_stop}"
+
+
+def test_a_caption_alone_can_never_dismiss_a_dialog() -> None:
+    """#390's round-1 lesson, ported: benign reads CONTENT only, never the caption.
+
+    Win32 child-HWND enumeration sees nothing inside a WPF dialog, so a caption is frequently all there
+    is. If the caption could dismiss, an owned WPF modal captioned `Refresh` whose real content asks
+    for a sign-in would be waved through in silence.
+    """
+    caption_only = classify_dialog(DesktopWindow("Refresh", "Cls", 702, 355, ("Refresh",)))
+    with_content = classify_dialog(DesktopWindow("Refresh", "Cls", 702, 355, ("Refresh", "Evaluating...")))
+
+    assert caption_only.kind == "benign-title-only"
+    assert caption_only.verdict == "DIALOG_UNREADABLE"
+    assert with_content.kind == "benign"
+
+
+def test_the_credential_scan_is_not_gated_by_the_size_filter() -> None:
+    """#376's silent false NEGATIVE: the 100x100 filter used to gate the HARD STOP as well.
+
+    `match_credential_modal` was fed only `blocking_dialog_candidates(...)`, so a credential prompt in
+    a smaller window produced NO finding at all - not even a dialog one. `Test-CredentialModal` in the
+    PowerShell arbiter has always scanned every window; the two now agree.
+    """
+    small = DesktopWindow("", "WindowsForms10.Window.20008.app.0.x", 80, 60, ("Enter your credentials",))
+    main = DesktopWindow("sample", "WindowsForms10.Window.8.app.0.x", 2011, 1298, ("sample",))
+
+    state = inspect_credential_modal(111, lambda _pid: [small, main])
+
+    assert state.modal is not None, "a credential prompt below the size filter must still be a hard stop"
+    assert state.modal.window.width == 80
+
+
+def test_benign_is_suppressed_only_while_our_own_operation_is_in_flight() -> None:
+    """The one asymmetry: at t=0 a progress dialog is somebody ELSE's refresh, so it is reported.
+
+    Stacking a second refresh on a running one is exactly what the 2026-08-28 field report had to
+    unpick by hand. Once we have started our own, the same dialog is ours and must not end the wait.
+    Nothing but `benign` is affected - an unreadable dialog surfaces either way.
+    """
+    windows = visible_progress_dialog_windows()
+
+    at_t0 = inspect_credential_modal(111, lambda _pid: windows)
+    in_flight = inspect_credential_modal(111, lambda _pid: windows, operation_in_flight=True)
+    unreadable_in_flight = inspect_credential_modal(
+        111, lambda _pid: visible_unreadable_dialog_windows(), operation_in_flight=True
+    )
+
+    assert at_t0.dialog is not None and at_t0.dialog.verdict == "REFRESH_IN_PROGRESS"
+    assert in_flight.dialog is None
+    assert unreadable_in_flight.dialog is not None, "in-flight must only ever dismiss a PROVEN-benign dialog"
+
+
+def test_a_window_we_could_not_account_for_outranks_a_progress_dialog() -> None:
+    """Precedence: `benign` carries the only positive evidence, so it must never mask another window.
+
+    Two dialogs up at once - one plainly a progress dialog, one unreadable. If `benign` won, a single
+    progress dialog would hide a real modal sitting beside it.
+    """
+    windows = [
+        progress_dialog_window(),
+        DesktopWindow("", "WindowsForms10.Window.20008.app.0.y", 702, 355, ()),
+    ]
+
+    finding = _credential_modal.dialog_verdict(windows)
+
+    assert finding is not None
+    assert finding.verdict == "DIALOG_UNREADABLE"
+
+
+def test_the_python_detector_cannot_emit_blocked_by_dialog_again(capsys) -> None:
+    """Anti-regression: the size-only rule and its verdict token must not come back (issue #376).
+
+    Checked BEHAVIOURALLY, not by grepping the source - the token is named in several docstrings on
+    purpose, because a reader who meets it in an old transcript needs to find out why it went. So this
+    drives every classifiable kind through both real emitters and asserts none of them prints it, and
+    pins that the size-only helper and its field are gone from the module's namespace.
+    """
+    windows = {
+        "unreadable": DesktopWindow("", "Cls", 702, 355, ()),
+        "unrecognized": DesktopWindow("Save?", "Cls", 702, 355, ("Save?", "Discard")),
+        "needs-human": DesktopWindow("", "Cls", 702, 355, ("Permission is required to run this native query",)),
+        "benign": progress_dialog_window(),
+        "benign-title-only": DesktopWindow("Refresh", "Cls", 702, 355, ("Refresh",)),
+        "mixed-content": DesktopWindow(
+            "Refresh", "Cls", 702, 355, ("Refresh", "Evaluating...", "This will discard all unsaved work")
+        ),
+    }
+    for window in windows.values():
+        finding = classify_dialog(window)
+        refresh_pbip_model._emit_dialog_finding(111, finding)
+        probe_desktop_query._emit_dialog_finding(111, finding)
+    out = capsys.readouterr().out
+
+    assert out.strip(), "the emitters printed nothing at all, so this test proved nothing"
+    assert "BLOCKED_BY_DIALOG" not in out, "an emitter still prints the size-only hard-stop token"
+    assert "BLOCKED_BY_DIALOG" not in set(_credential_modal.DIALOG_KIND_VERDICTS.values())
+    assert not hasattr(_credential_modal, "blocking_dialog_candidates"), "the size-only detector came back"
+    assert "blocking_dialog" not in CredentialDetection.__dataclass_fields__, "the size-only field came back"
+
+
+def test_every_finding_kind_has_operator_guidance() -> None:
+    """A verdict with no guidance is a stop with no next step - and every emitter prints this line."""
+    reportable = set(_credential_modal.DIALOG_KIND_PRECEDENCE)
+    documented = set(_credential_modal.DIALOG_KIND_GUIDANCE)
+
+    assert reportable <= documented, f"kinds with no guidance: {sorted(reportable - documented)}"
 
 
 # ==================================================================================================

--- a/.github/skills/pbip-model-refresh/tests/test_credential_modal_detection.py
+++ b/.github/skills/pbip-model-refresh/tests/test_credential_modal_detection.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import threading
 import time
+import ctypes
 import inspect
 import json
 import os
@@ -15,6 +16,7 @@ import re
 import shutil
 import subprocess
 import sys
+from ctypes import wintypes
 from pathlib import Path
 
 import pytest
@@ -25,6 +27,7 @@ from _credential_modal import (
     CredentialDetection,
     CredentialModal,
     CredentialUnknownError,
+    DESKTOP_MAIN_CLASS_PREFIX,
     DesktopGoneError,
     DesktopUnreadyError,
     DialogFinding,
@@ -138,6 +141,58 @@ class _FakeProgressMonitor:
         return "fake"
 
 
+MAIN_HWND = 0x10001
+DIALOG_HWND = 0x20002
+
+
+def main_window(
+    title: str = "sample-superstore",
+    texts: tuple[str, ...] = ("Report",),
+    *,
+    minimized: bool = False,
+    width: int = 2011,
+    height: int = 1298,
+) -> DesktopWindow:
+    """The Power BI Desktop application FRAME: unowned, and the window a modal would disable."""
+    return DesktopWindow(
+        title,
+        DESKTOP_MAIN_CLASS_PREFIX + ".app.0.33c0d9d",
+        width,
+        height,
+        texts,
+        minimized=minimized,
+        hwnd=MAIN_HWND,
+    )
+
+
+def owned_dialog(
+    texts: tuple[str, ...] = (),
+    *,
+    title: str = "",
+    class_name: str = "WindowsForms10.Window.20008.app.0.33c0d9d",
+    width: int = 702,
+    height: int = 355,
+    owner_enabled: bool | None = False,
+    hwnd: int = DIALOG_HWND,
+) -> DesktopWindow:
+    """A dialog OWNED by :func:`main_window`.
+
+    ``owner_enabled=False`` by default - the owner is disabled, which is what a modal does. That does
+    not convict the window (Power BI's own refresh dialog disables the owner too); it only means the
+    one-way enabled-owner exoneration does not apply, so the window has to be classified on its text.
+    """
+    return DesktopWindow(
+        title,
+        class_name,
+        width,
+        height,
+        texts,
+        hwnd=hwnd,
+        owner_hwnd=MAIN_HWND,
+        owner_enabled=owner_enabled,
+    )
+
+
 def modal() -> CredentialModal:
     """A credential dialog matching the measured incident window."""
     return CredentialModal(
@@ -153,7 +208,7 @@ def modal_state() -> CredentialDetection:
 
 def unreadable_dialog_window() -> DesktopWindow:
     """The live SQL credential-dialog shape: visible, owned, empty title, NO readable text at all."""
-    return DesktopWindow("", "WindowsForms10.Window.20008", 702, 355, ())
+    return owned_dialog()
 
 
 def progress_dialog_window() -> DesktopWindow:
@@ -162,13 +217,7 @@ def progress_dialog_window() -> DesktopWindow:
     This is the shape the size-only rule reported as a hard stop (issue #376) - >= 100x100, non-main
     class, and therefore indistinguishable from a sign-in prompt to a detector that never read it.
     """
-    return DesktopWindow(
-        "Refresh",
-        "WindowsForms10.Window.20008.app.0.33c0d9d",
-        702,
-        355,
-        ("Refresh", "Evaluating...", "Cancel"),
-    )
+    return owned_dialog(("Refresh", "Evaluating...", "Cancel"), title="Refresh")
 
 
 def dialog_finding(window: DesktopWindow | None = None) -> DialogFinding:
@@ -183,32 +232,22 @@ def dialog_state(window: DesktopWindow | None = None) -> CredentialDetection:
 
 def minimized_main_windows() -> list[DesktopWindow]:
     """The measured minimized-owner shape: a small, iconic Desktop main window and nothing else."""
-    return [
-        DesktopWindow("Report", "WindowsForms10.Window.8.app.0.1a2b3c", 159, 27, ("Report",), minimized=True),
-    ]
+    return [main_window(title="Report", minimized=True, width=159, height=27)]
 
 
 def restored_main_windows() -> list[DesktopWindow]:
     """The same owner restored: full-size, not iconic, and - measured - the dialog does NOT return."""
-    return [
-        DesktopWindow("Report", "WindowsForms10.Window.8.app.0.1a2b3c", 2011, 1298, ("Report",)),
-    ]
+    return [main_window(title="Report")]
 
 
 def visible_unreadable_dialog_windows() -> list[DesktopWindow]:
     """A visible owned dialog (empty title, unreadable) alongside the healthy main window."""
-    return [
-        DesktopWindow("", "WindowsForms10.Window.20008.app.0.1a2b3c", 702, 355, ()),
-        DesktopWindow("Report", "WindowsForms10.Window.8.app.0.1a2b3c", 2011, 1298, ("Report",)),
-    ]
+    return [owned_dialog(), main_window(title="Report")]
 
 
 def visible_progress_dialog_windows() -> list[DesktopWindow]:
     """Power BI's own Refresh progress dialog alongside the healthy main window (issue #376)."""
-    return [
-        progress_dialog_window(),
-        DesktopWindow("Report", "WindowsForms10.Window.8.app.0.1a2b3c", 2011, 1298, ("Report",)),
-    ]
+    return [progress_dialog_window(), main_window(title="Report")]
 
 
 def harvested_minimized_reason() -> str:
@@ -289,11 +328,11 @@ def test_win32_fixture_finds_owned_dialog_and_keeps_instances_separate() -> None
     """Faithful fixture: owned empty-title dialog on PID A, no dialog on concurrent PID B."""
     windows_by_pid = {
         111: [
-            DesktopWindow("", "WindowsForms10.Window.20008.app.0.33c0d9d", 702, 355, ("Enter your credentials",)),
-            DesktopWindow("sample-superstore", "WindowsForms10.Window.8.app.0.33c0d9d", 2011, 1298, ("Report",)),
+            owned_dialog(("Enter your credentials",)),
+            main_window(),
             DesktopWindow("", "Internet Explorer_Hidden", 0, 0, ()),
         ],
-        222: [DesktopWindow("cached-model", "WindowsForms10.Window.8.app.0.33c0d9d", 2011, 1298, ("Report",))],
+        222: [main_window(title="cached-model")],
     }
     hit = inspect_credential_modal(111, lambda pid: windows_by_pid[pid]).modal
     miss = inspect_credential_modal(222, lambda pid: windows_by_pid[pid])
@@ -311,11 +350,11 @@ def test_unreadable_owned_dialog_reports_unreadable_not_no_modal() -> None:
     """
     windows_by_pid = {
         58104: [
-            DesktopWindow("", "WindowsForms10.Window.20008.app.0.33c0d9d", 702, 355, ()),
-            DesktopWindow("sample-superstore", "WindowsForms10.Window.8.app.0.33c0d9d", 2011, 1298, ("sample",)),
+            owned_dialog(),
+            main_window(texts=("sample",)),
             DesktopWindow("", "Internet Explorer_Hidden", 0, 0, ()),
         ],
-        46256: [DesktopWindow("cached", "WindowsForms10.Window.8.app.0.33c0d9d", 2011, 1298, ("cached",))],
+        46256: [main_window(title="cached", texts=("cached",))],
     }
     blocked = inspect_credential_modal(58104, lambda pid: windows_by_pid[pid])
     healthy = inspect_credential_modal(46256, lambda pid: windows_by_pid[pid])
@@ -329,12 +368,18 @@ def test_unreadable_owned_dialog_reports_unreadable_not_no_modal() -> None:
     assert healthy.dialog is None
 
 
-def test_zero_size_helper_window_does_not_block() -> None:
-    """Internet Explorer_Hidden 0x0 is present on healthy instances and must be ignored."""
+def test_an_unowned_zero_area_helper_window_does_not_block() -> None:
+    """A window with NO owner and NO pixels blocks nothing - on two independent grounds, not on size.
+
+    `Internet Explorer_Hidden` at 0x0 rides along on healthy instances. It is excluded because it has
+    no owner to disable AND nothing to display, never because of its name or its geometry: the same
+    class at 900x700, and the same 0x0 shape with an owner, are both classified (see the round-3
+    tests below).
+    """
     state = inspect_credential_modal(
         111,
         lambda _pid: [
-            DesktopWindow("cached", "WindowsForms10.Window.8.app.0.33c0d9d", 2011, 1298, ("cached",)),
+            main_window(title="cached", texts=("cached",)),
             DesktopWindow("", "Internet Explorer_Hidden", 0, 0, ()),
         ],
     )
@@ -354,19 +399,7 @@ def test_real_win32_enumeration_callback_runs_against_this_process() -> None:
 
 def test_minimized_owner_reports_unknown_not_no_dialog() -> None:
     """When the owner is minimized, Windows hides owned dialogs; absence is indeterminate."""
-    state = inspect_credential_modal(
-        111,
-        lambda _pid: [
-            DesktopWindow(
-                "sample-superstore",
-                "WindowsForms10.Window.8.app.0.33c0d9d",
-                2011,
-                1298,
-                ("Report",),
-                minimized=True,
-            )
-        ],
-    )
+    state = inspect_credential_modal(111, lambda _pid: [main_window(minimized=True)])
 
     assert state.modal is None
     assert state.unknown_reason is not None
@@ -1363,10 +1396,9 @@ def test_the_credential_scan_is_not_gated_by_the_size_filter() -> None:
     a smaller window produced NO finding at all - not even a dialog one. `Test-CredentialModal` in the
     PowerShell arbiter has always scanned every window; the two now agree.
     """
-    small = DesktopWindow("", "WindowsForms10.Window.20008.app.0.x", 80, 60, ("Enter your credentials",))
-    main = DesktopWindow("sample", "WindowsForms10.Window.8.app.0.x", 2011, 1298, ("sample",))
+    small = owned_dialog(("Enter your credentials",), width=80, height=60)
 
-    state = inspect_credential_modal(111, lambda _pid: [small, main])
+    state = inspect_credential_modal(111, lambda _pid: [small, main_window()])
 
     assert state.modal is not None, "a credential prompt below the size filter must still be a hard stop"
     assert state.modal.window.width == 80
@@ -1400,7 +1432,8 @@ def test_a_window_we_could_not_account_for_outranks_a_progress_dialog() -> None:
     """
     windows = [
         progress_dialog_window(),
-        DesktopWindow("", "WindowsForms10.Window.20008.app.0.y", 702, 355, ()),
+        owned_dialog(hwnd=0x30003),
+        main_window(),
     ]
 
     finding = _credential_modal.dialog_verdict(windows)
@@ -1478,12 +1511,10 @@ def test_short_prompt_beside_progress_text_is_never_dismissed(prompt: str) -> No
     ``credential_modal_signature.regex``, so the all-window prepass does not rescue them either -
     which is exactly why an unexplained element must veto rather than be excused.
     """
-    window = DesktopWindow(
-        "Refresh", "WindowsForms10.Window.20008.app.0.x", 702, 355, ("Refresh", "Evaluating...", prompt)
-    )
+    window = owned_dialog(("Refresh", "Evaluating...", prompt), title="Refresh")
 
     finding = classify_dialog(window)
-    in_flight = _credential_modal.dialog_verdict([window], operation_in_flight=True)
+    in_flight = _credential_modal.dialog_verdict([main_window(), window], operation_in_flight=True)
 
     assert finding.kind == "mixed-content", f"{prompt!r} was accounted for by nothing and must veto"
     assert finding.verdict == "DIALOG_UNRECOGNIZED"
@@ -1513,45 +1544,263 @@ def test_only_enumerated_chrome_is_excused_beside_progress_text() -> None:
         (80, 60, ("Refresh",), "benign-title-only"),
         (40, 20, ("Continue?", "Yes"), "unrecognized"),
         (1, 1, (), "unreadable"),
+        # Round 3, finding 3: a real native `WS_VISIBLE` OWNED 0x0 window with a DISABLED owner is a
+        # genuinely blocking shape. Zero area alone must never suppress.
+        (0, 0, (), "unreadable"),
+        (0, 700, ("Password:",), "unrecognized"),
     ],
 )
 def test_a_small_dialog_is_still_classified(width: int, height: int, texts, kind: str) -> None:
-    """Finding 3 (HIGH): the original defect, surviving inside its own fix.
+    """Findings 3 (round 2) and 3 (round 3): geometry is not evidence, at any magnitude.
 
-    ``dialog_candidates`` still rejected everything under 100x100, and the all-window credential
-    prepass only rescued text matching the credential regex. Measured on the PR-#400 build: a visible
-    80x60 non-main unreadable window beside a normal main window returned
-    ``modal=None, dialog=None, unknown_reason=None`` - byte-identical to a healthy Desktop.
+    Round 2 measured a visible 80x60 unreadable owned window returning
+    ``modal=None, dialog=None, unknown_reason=None`` - byte-identical to a healthy Desktop. Round 3
+    then built a real ``WS_VISIBLE`` owned **0x0** window with ``CreateWindowEx`` and disabled its
+    owner (``owned-visible=True owner-win32-enabled=False rect=0x0``) and showed the follow-up fix
+    still suppressed it - which on the unbounded query-poll path is a false clear that is also a hang.
 
-    An arbitrary geometry threshold is not evidence of harmlessness. That sentence is the whole issue.
+    An arbitrary geometry threshold is not evidence of harmlessness, and neither is zero.
     """
-    main = DesktopWindow("sample", "WindowsForms10.Window.8.app.0.x", 2011, 1298, ("sample",))
-    dialog = DesktopWindow(texts[0] if texts else "", "WindowsForms10.Window.20008.app.0.x", width, height, texts)
+    dialog = owned_dialog(texts, title=texts[0] if texts else "", width=width, height=height)
 
-    state = inspect_credential_modal(111, lambda _pid: [dialog, main])
+    state = inspect_credential_modal(111, lambda _pid: [dialog, main_window()])
 
-    assert state.dialog is not None, "a small dialog must not vanish into the healthy state"
+    assert state.dialog is not None, "an owned dialog must not vanish into the healthy state"
     assert state.dialog.kind == kind
     assert state.dialog.window.width == width
 
 
-def test_only_named_helpers_and_zero_area_windows_are_excluded() -> None:
-    """The exclusions that replaced the size test are positive claims, and are the ONLY ones.
+def test_an_owned_dialog_sharing_its_owners_class_is_still_a_credential_wall() -> None:
+    """Round 3, finding 2: a class PREFIX names a WinForms family, not one HWND.
 
-    Zero area rasterises nothing, so such a window cannot be showing a human anything; the named
-    helpers are identified Desktop infrastructure. Everything else is classified whatever its size.
+    A native WinForms experiment showed an owner and its owned ``FixedDialog`` both reporting the exact
+    class ``WindowsForms10.Window.8.app.0.2b2196a_r3_ad1``. The previous ``is_desktop_main_window``
+    predicate treated any such window as the application, so this shape returned **no modal, no dialog
+    finding, no unknown state** - a real credential dialog removed from the prepass AND from
+    classification by the very fix that was meant to stop a report title fabricating one.
     """
-    assert not hasattr(_credential_modal, "MIN_DIALOG_WIDTH"), "a size threshold must not come back"
-    assert not hasattr(_credential_modal, "MIN_DIALOG_HEIGHT"), "a size threshold must not come back"
+    shared_class = "WindowsForms10.Window.8.app.0.2b2196a_r3_ad1"
+    frame = DesktopWindow("sample - Power BI Desktop", shared_class, 2011, 1298, ("sample",), hwnd=MAIN_HWND)
+    dialog = owned_dialog(("Enter your credentials",), class_name=shared_class)
 
-    zero_area = DesktopWindow("", "Internet Explorer_Hidden", 0, 0, ())
-    named_helper = DesktopWindow("", "Internet Explorer_Hidden", 400, 300, ())
-    flat = DesktopWindow("", "WindowsForms10.Window.20008.app.0.x", 900, 0, ())
-    real = DesktopWindow("", "WindowsForms10.Window.20008.app.0.x", 12, 12, ())
+    state = inspect_credential_modal(111, lambda _pid: [frame, dialog])
 
-    kept = _credential_modal.dialog_candidates([zero_area, named_helper, flat, real])
+    assert state.modal is not None, "an owned dialog sharing its owner's class is still a dialog"
+    assert state.modal.window is dialog
+    assert state.modal.window.class_name == shared_class
 
-    assert kept == [real], f"expected only the real 12x12 dialog to be classified; got {kept}"
+
+def test_an_owned_dialog_sharing_its_owners_class_is_classified_when_unreadable() -> None:
+    """The same shape without a signature match must still surface, not disappear."""
+    shared_class = "WindowsForms10.Window.8.app.0.2b2196a_r3_ad1"
+    frame = DesktopWindow("sample", shared_class, 2011, 1298, ("sample",), hwnd=MAIN_HWND)
+    dialog = owned_dialog(class_name=shared_class)
+
+    state = inspect_credential_modal(111, lambda _pid: [frame, dialog])
+
+    assert state.modal is None
+    assert state.dialog is not None
+    assert state.dialog.verdict == "DIALOG_UNREADABLE"
+
+
+@pytest.mark.parametrize(
+    ("texts", "verdict"),
+    [
+        ((), "DIALOG_UNREADABLE"),
+        (("Password:",), "DIALOG_UNRECOGNIZED"),
+        (("Sign in",), "DIALOG_UNRECOGNIZED"),
+        (("Continue?",), "DIALOG_UNRECOGNIZED"),
+    ],
+)
+def test_the_aad_host_is_classified_by_modality_not_by_its_name(texts, verdict: str) -> None:
+    """Round 3, finding 1: a NAME allowlist hid the AAD sign-in host whatever it displayed.
+
+    ``Internet Explorer_Hidden`` was excluded from classification unconditionally, so keeping it in the
+    credential prepass only ever rescued EXACT signature matches. Measured on the round-2 build: a
+    visible 900x700 host reading ``Password:`` / ``Sign in`` / ``Continue?`` - or nothing at all -
+    returned ``modal=None, dialog=None, unknown=None``.
+
+    There is no name allowlist any more. This window is classified because it is OWNED and its owner is
+    not proven enabled, which is what "blocking" means; its class is not consulted at all.
+    """
+    host = owned_dialog(texts, class_name="Internet Explorer_Hidden", width=900, height=700)
+
+    state = inspect_credential_modal(111, lambda _pid: [main_window(), host])
+
+    assert state.dialog is not None, "the AAD host must never collapse into the healthy state"
+    assert state.dialog.verdict == verdict
+
+
+def test_an_enabled_owner_is_the_only_thing_that_exonerates_a_dialog() -> None:
+    """Modality is a ONE-WAY test, and it is the only suppression mechanism left.
+
+    An ENABLED owner proves this window is blocking nothing, because a modal disables its owner. A
+    DISABLED owner proves nothing either way - Power BI's refresh dialog disables the owner too - and
+    ``None`` (no owner) means the test did not apply, which is not the same as passing it.
+    """
+    exonerated = owned_dialog(owner_enabled=True)
+    disabled_owner = owned_dialog(owner_enabled=False)
+    no_owner_test = DesktopWindow("", "Cls", 702, 355, (), hwnd=0x40004, owner_hwnd=MAIN_HWND, owner_enabled=None)
+
+    assert _credential_modal.is_proven_non_blocking(exonerated)
+    assert not _credential_modal.is_proven_non_blocking(disabled_owner)
+    assert not _credential_modal.is_proven_non_blocking(no_owner_test)
+
+    kept = _credential_modal.dialog_candidates([main_window(), exonerated, disabled_owner, no_owner_test])
+
+    assert exonerated not in kept, "an enabled owner is positive proof this window blocks nothing"
+    assert disabled_owner in kept
+    assert no_owner_test in kept, "'the test did not apply' is not 'the test passed'"
+
+
+def test_no_proxy_for_blocking_survives_in_the_candidate_rule() -> None:
+    """Anti-regression: size, class prefix and a name allowlist each hid a real blocker. None returns.
+
+    Three review rounds killed three correlates. This asserts the module has no surface for a fourth,
+    and that the only exclusions left are the modality ones.
+    """
+    for gone in ("MIN_DIALOG_WIDTH", "MIN_DIALOG_HEIGHT", "HELPER_WINDOW_CLASSES", "is_desktop_main_window"):
+        assert not hasattr(_credential_modal, gone), f"{gone} is a proxy for blocking and must stay deleted"
+
+    source = inspect.getsource(_credential_modal.dialog_candidates)
+    assert "class_name" not in source, "candidacy must not consult a window's class"
+    assert "width" not in source, "candidacy must not consult a window's size"
+
+
+def test_the_frame_is_identified_by_ownership_before_any_convention() -> None:
+    """`main_frame` prefers DIRECT ownership evidence, and only then the main-handle convention.
+
+    Ownership names the frame outright when a dialog is up, which is the case where getting it wrong
+    removes a real blocker. The first-visible-unowned convention is a fallback reached only when no
+    window is owned - i.e. when there are no dialogs to hide.
+
+    The decoy matters: with another UNOWNED window enumerated ahead of the frame, the convention alone
+    picks the decoy and the real frame is then classified as a dialog on every healthy poll. Only the
+    ownership branch gets this right, so the decoy is what makes this test able to fail.
+    """
+    frame = main_window()
+    dialog = owned_dialog(("Enter your credentials",))
+    decoy = DesktopWindow("decoy", "Cls", 300, 200, ("decoy",), hwnd=0x60006)
+
+    # Ownership evidence wins even when the dialog is enumerated FIRST (Z-order puts a modal on top)
+    # and even when an unrelated unowned window precedes the frame.
+    assert _credential_modal.main_frame([dialog, decoy, frame]) is frame
+    assert _credential_modal.main_frame([decoy, frame, dialog]) is frame
+    # With nothing owned, the convention applies: the first visible unowned window.
+    lone = DesktopWindow("only", "Cls", 800, 600, ("only",), hwnd=0x50005)
+    assert _credential_modal.main_frame([lone]) is lone
+    assert _credential_modal.main_frame([]) is None
+
+
+def test_an_unowned_window_that_renders_pixels_is_still_classified() -> None:
+    """`renders_nothing` needs BOTH conjuncts: no owner AND no pixels. Neither alone suppresses.
+
+    An unowned 900x700 window displays something to a human even though it disables nobody, so it is
+    accounted for like any other window. Dropping the area conjunct would silently exclude every
+    unowned window - including the AAD host in its unowned form.
+    """
+    frame = main_window()
+    unowned_visible = DesktopWindow("", "Internet Explorer_Hidden", 900, 700, ("Password:",), hwnd=0x70007)
+
+    assert not _credential_modal.renders_nothing(unowned_visible)
+
+    state = inspect_credential_modal(111, lambda _pid: [frame, unowned_visible])
+
+    assert state.dialog is not None, "an unowned window with pixels must not vanish into healthy"
+    assert state.dialog.verdict == "DIALOG_UNRECOGNIZED"
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="creates real Win32 windows")
+def test_the_win32_harvest_reads_real_ownership_and_owner_enabled_state() -> None:
+    """The modality facts must come from Win32, not from a dataclass default (#400 review round 3).
+
+    Every other test here feeds synthesised windows, so none of them can tell whether
+    ``GetWindow(GW_OWNER)`` and ``IsWindowEnabled(owner)`` are actually wired into the harvest - a
+    mutation that hard-codes ``owner_hwnd = 0`` or ``owner_enabled = True`` passes all of them. This
+    builds the reviewer's own reproduction natively: a real ``WS_VISIBLE`` **owned 0x0** popup whose
+    owner is disabled, which is a genuinely blocking shape, and asserts the harvest sees it and the
+    candidate rule keeps it.
+    """
+    user32 = ctypes.WinDLL("user32", use_last_error=True)
+    wndproc_type = ctypes.WINFUNCTYPE(ctypes.c_longlong, wintypes.HWND, wintypes.UINT, wintypes.WPARAM, wintypes.LPARAM)
+
+    class _WndClass(ctypes.Structure):
+        """Minimal ``WNDCLASSW``."""
+
+        _fields_ = [
+            ("style", wintypes.UINT),
+            ("lpfnWndProc", wndproc_type),
+            ("cbClsExtra", ctypes.c_int),
+            ("cbWndExtra", ctypes.c_int),
+            ("hInstance", wintypes.HINSTANCE),
+            ("hIcon", wintypes.HICON),
+            ("hCursor", wintypes.HANDLE),
+            ("hbrBackground", wintypes.HBRUSH),
+            ("lpszMenuName", wintypes.LPCWSTR),
+            ("lpszClassName", wintypes.LPCWSTR),
+        ]
+
+    user32.DefWindowProcW.argtypes = [wintypes.HWND, wintypes.UINT, wintypes.WPARAM, wintypes.LPARAM]
+    user32.DefWindowProcW.restype = ctypes.c_longlong
+    user32.CreateWindowExW.restype = wintypes.HWND
+    user32.CreateWindowExW.argtypes = [
+        wintypes.DWORD, wintypes.LPCWSTR, wintypes.LPCWSTR, wintypes.DWORD,
+        ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int,
+        wintypes.HWND, wintypes.HMENU, wintypes.HINSTANCE, wintypes.LPVOID,
+    ]  # fmt: skip
+    # Signatures set explicitly for the same reason `_configure_user32` does it in production: a
+    # default ctypes restype is a 32-bit `c_int`, so an untyped `GetModuleHandleW` TRUNCATES the
+    # 64-bit HINSTANCE and `RegisterClassW` then faults on the garbage. That access violation showed
+    # up as a `faulthandler` dump on every run of this test while it still reported a pass.
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    kernel32.GetModuleHandleW.argtypes = [wintypes.LPCWSTR]
+    kernel32.GetModuleHandleW.restype = wintypes.HMODULE
+    user32.RegisterClassW.argtypes = [ctypes.POINTER(_WndClass)]
+    user32.RegisterClassW.restype = wintypes.ATOM
+    user32.EnableWindow.argtypes = [wintypes.HWND, wintypes.BOOL]
+    user32.UnregisterClassW.argtypes = [wintypes.LPCWSTR, wintypes.HINSTANCE]
+    user32.DestroyWindow.argtypes = [wintypes.HWND]
+
+    # `DefWindowProcW` is used DIRECTLY as the window procedure, cast to the callback type rather than
+    # wrapped in a Python lambda. Windows calls a wndproc synchronously from inside `CreateWindowEx`
+    # and `DestroyWindow`; keeping Python off the message path removes both the marshalling risk and
+    # the need for a message pump.
+    klass = _WndClass()
+    klass.lpfnWndProc = ctypes.cast(user32.DefWindowProcW, wndproc_type)
+    klass.hInstance = kernel32.GetModuleHandleW(None)
+    klass.lpszClassName = f"T2PModalityProbe{os.getpid()}"
+    assert user32.RegisterClassW(ctypes.byref(klass)), f"RegisterClassW failed: {ctypes.get_last_error()}"
+
+    ws_overlappedwindow, ws_visible, ws_popup = 0x00CF0000, 0x10000000, 0x80000000
+    frame_hwnd = user32.CreateWindowExW(
+        0, klass.lpszClassName, "t2p frame", ws_overlappedwindow | ws_visible,
+        10, 10, 400, 300, None, None, klass.hInstance, None,
+    )  # fmt: skip
+    owned_hwnd = user32.CreateWindowExW(
+        0, klass.lpszClassName, "", ws_popup | ws_visible, 0, 0, 0, 0, frame_hwnd, None, klass.hInstance, None
+    )
+    try:
+        assert frame_hwnd and owned_hwnd, "could not create the native probe windows"
+        user32.EnableWindow(frame_hwnd, False)
+        time.sleep(0.2)
+
+        harvested, _visited = _enumerate_pid_windows_with_count(os.getpid())
+        by_hwnd = {window.hwnd: window for window in harvested}
+        frame = by_hwnd.get(frame_hwnd)
+        owned = by_hwnd.get(owned_hwnd)
+
+        assert frame is not None and owned is not None, "the harvest missed the native probe windows"
+        assert frame.owner_hwnd == 0, "the frame is unowned"
+        assert owned.owner_hwnd == frame_hwnd, "ownership must come from GetWindow(GW_OWNER)"
+        assert owned.owner_enabled is False, "owner_enabled must come from IsWindowEnabled(owner)"
+        assert (owned.width, owned.height) == (0, 0), "the probe window really is 0x0"
+        assert not _credential_modal.renders_nothing(owned), "it HAS an owner, so zero area cannot suppress"
+        assert not _credential_modal.is_proven_non_blocking(owned), "a disabled owner is not an exoneration"
+        assert owned in _credential_modal.dialog_candidates(harvested, frame=frame)
+    finally:
+        user32.DestroyWindow(owned_hwnd)
+        user32.DestroyWindow(frame_hwnd)
+        user32.UnregisterClassW(klass.lpszClassName, klass.hInstance)
 
 
 @pytest.mark.parametrize(
@@ -1579,33 +1828,32 @@ def test_a_report_title_cannot_fabricate_a_credential_prompt(report_name: str, c
 
 
 def test_an_unusual_modal_class_is_still_scanned_for_the_credential_signature() -> None:
-    """The other half of finding 4: excluding the main window must not narrow real dialog coverage."""
-    main = DesktopWindow("sample", "WindowsForms10.Window.8.app.0.x", 2011, 1298, ("sample",))
-    odd = DesktopWindow("", "HwndWrapper[PBIDesktop.exe;;guid]", 30, 20, ("Enter your credentials",))
+    """The other half of finding 4: excluding the frame must not narrow real dialog coverage."""
+    odd = owned_dialog(("Enter your credentials",), class_name="HwndWrapper[PBIDesktop.exe;;guid]", width=30, height=20)
 
-    state = inspect_credential_modal(111, lambda _pid: [odd, main])
+    state = inspect_credential_modal(111, lambda _pid: [main_window(), odd])
 
     assert state.modal is not None
     assert state.modal.window.class_name.startswith("HwndWrapper")
 
 
 def test_the_credential_prepass_reads_windows_that_classification_skips() -> None:
-    """The prepass is narrowed by the MAIN window and by nothing else - not even the helper list.
+    """An exoneration says "not blocking" - it does NOT say "carries no credential text".
 
-    ``Internet Explorer_Hidden`` is the WebOC host, and Power BI's AAD sign-in renders in a web view,
-    so credential text really can appear there. Excluding it from CLASSIFICATION is a claim about what
-    can be a dialog; excluding it from the HARD-STOP scan would be a claim about what can hold a
-    prompt, and that one is false. Recall on the credential path is the thing we never trade away.
+    ``is_proven_non_blocking`` removes a window from CLASSIFICATION, because an enabled owner proves it
+    is blocking nobody. The credential prepass still reads it: recall on the hard-stop path is the one
+    thing this module never trades away, and a sign-in prompt whose owner happens to be enabled is
+    still a sign-in prompt a human has to deal with.
     """
-    main = DesktopWindow("sample", "WindowsForms10.Window.8.app.0.x", 2011, 1298, ("sample",))
-    web_view = DesktopWindow("", "Internet Explorer_Hidden", 900, 700, ("Enter your credentials",))
+    exonerated = owned_dialog(("Enter your credentials",), owner_enabled=True)
+    frame = main_window()
 
-    assert web_view not in _credential_modal.dialog_candidates([web_view, main]), "helper: not classified"
+    assert exonerated not in _credential_modal.dialog_candidates([frame, exonerated]), "not classified"
 
-    state = inspect_credential_modal(111, lambda _pid: [web_view, main])
+    state = inspect_credential_modal(111, lambda _pid: [frame, exonerated])
 
-    assert state.modal is not None, "a helper window is still scanned for the credential signature"
-    assert state.modal.window.class_name == "Internet Explorer_Hidden"
+    assert state.modal is not None, "an exonerated window is still scanned for the credential signature"
+    assert state.modal.window is exonerated
 
 
 @pytest.mark.parametrize("progress_enabled", [False, True])

--- a/.github/skills/pbip-model-refresh/tests/test_credential_modal_detection.py
+++ b/.github/skills/pbip-model-refresh/tests/test_credential_modal_detection.py
@@ -81,6 +81,63 @@ def parked_fixture(monkeypatch):
     released.set()
 
 
+class _ParkedAdomd:
+    """ADOMD stand-in whose command never returns, driven as a whole connection factory result.
+
+    Distinct from the ``parked`` fixture: the finding-1 tests need to control the release event and to
+    run with a fake progress monitor, so they wire the seams themselves.
+    """
+
+    CommandText = ""
+    CommandTimeout = 0
+
+    def __init__(self, released: threading.Event) -> None:
+        self.released = released
+
+    def Open(self) -> None:
+        """Match the ADOMD API surface."""
+
+    def CreateCommand(self):
+        """This object is its own command."""
+        return self
+
+    def ExecuteNonQuery(self) -> None:
+        """Block until the test releases it, so only the deadline can end the wait."""
+        self.released.wait(timeout=600)
+
+    def Close(self) -> None:
+        """Match the ADOMD API surface."""
+
+
+class _FakeProgressMonitor:
+    """Minimal ``RefreshProgressMonitor`` stand-in so the progress-monitor wait branch is reachable.
+
+    That branch needs an AMO trace, which needs pythonnet and a live server; without this the branch is
+    untestable off Windows and its own copy of the poll loop went unexercised - which is how it kept a
+    t=0 raise helper and discarded its latches (#400 review, finding 1).
+    """
+
+    def mark_refresh_started(self) -> None:
+        """No-op."""
+
+    def print_liveness_warning_if_due(self) -> None:
+        """No-op."""
+
+    def seconds_until_liveness_warning(self) -> float:
+        """Never due, so the poll interval is what drives the loop."""
+        return 999.0
+
+    def print_evidence_heartbeat(self, elapsed: float, total: float) -> None:
+        """No-op."""
+
+    def close(self) -> None:
+        """No-op."""
+
+    def summary(self) -> str:
+        """Match the monitor's reporting surface."""
+        return "fake"
+
+
 def modal() -> CredentialModal:
     """A credential dialog matching the measured incident window."""
     return CredentialModal(
@@ -419,7 +476,7 @@ def test_refresh_poll_catches_late_modal(monkeypatch, parked) -> None:
     monkeypatch.setattr(
         refresh_pbip_model,
         "_credential_state",
-        lambda pid: CredentialDetection(modal=late_modal(pid)),
+        lambda pid, **_kw: CredentialDetection(modal=late_modal(pid)),
     )
     monkeypatch.setattr(refresh_pbip_model, "REFRESH_CREDENTIAL_POLL_SECONDS", 0.05)
 
@@ -434,7 +491,7 @@ def test_refresh_poll_catches_late_modal(monkeypatch, parked) -> None:
 
 def test_refresh_banner_is_flushed_and_heartbeat_reports_elapsed_total(monkeypatch, parked, capsys) -> None:
     """The warning arrives before the wait, then emits elapsed/total countdowns."""
-    monkeypatch.setattr(refresh_pbip_model, "_credential_state", lambda _pid: CredentialDetection())
+    monkeypatch.setattr(refresh_pbip_model, "_credential_state", lambda _pid, **_kw: CredentialDetection())
     monkeypatch.setattr(refresh_pbip_model, "REFRESH_CREDENTIAL_POLL_SECONDS", 0.05)
     monkeypatch.setattr(refresh_pbip_model, "REFRESH_HEARTBEAT_SECONDS", 0.05)
     printed: list[dict[str, object]] = []
@@ -467,7 +524,7 @@ def test_unknown_refresh_banner_does_not_claim_no_dialog(monkeypatch, parked, ca
     monkeypatch.setattr(
         refresh_pbip_model,
         "_credential_state",
-        lambda _pid: CredentialDetection(unknown_reason=reason),
+        lambda _pid, **_kw: CredentialDetection(unknown_reason=reason),
     )
     monkeypatch.setattr(refresh_pbip_model, "REFRESH_CREDENTIAL_POLL_SECONDS", 0.05)
     monkeypatch.setattr(refresh_pbip_model, "REFRESH_HEARTBEAT_SECONDS", 0.05)
@@ -487,7 +544,7 @@ def test_refresh_latches_unknown_seen_only_by_initial_precheck(monkeypatch, park
     reason = harvested_minimized_reason()
     states = iter([CredentialDetection(unknown_reason=reason)])
 
-    def initial_unknown_then_healthy(_pid: int) -> CredentialDetection:
+    def initial_unknown_then_healthy(_pid: int, **_kw) -> CredentialDetection:
         return next(states, CredentialDetection())
 
     monkeypatch.setattr(refresh_pbip_model, "_credential_state", initial_unknown_then_healthy)
@@ -514,7 +571,7 @@ def test_refresh_latches_desktop_unready_seen_only_by_initial_precheck(monkeypat
     reason = harvested_zero_window_alive_reason()
     states = iter([CredentialDetection(desktop_unready=reason)])
 
-    def initial_unready_then_healthy(_pid: int) -> CredentialDetection:
+    def initial_unready_then_healthy(_pid: int, **_kw) -> CredentialDetection:
         return next(states, CredentialDetection())
 
     monkeypatch.setattr(refresh_pbip_model, "_credential_state", initial_unready_then_healthy)
@@ -1389,6 +1446,326 @@ def test_every_finding_kind_has_operator_guidance() -> None:
     documented = set(_credential_modal.DIALOG_KIND_GUIDANCE)
 
     assert reportable <= documented, f"kinds with no guidance: {sorted(reportable - documented)}"
+
+
+# --------------------------------------------------------------------------------------------------
+# Blind-review findings on PR #400. Each one is a case where "we could not establish it" was still
+# collapsing into the clean bucket - the same defect class issue #376 exists to remove, found again on
+# the code that removed it. Every test below fails on the PR-#400 build and passes on this one.
+# --------------------------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "prompt",
+    [
+        "Please enter your password",  # 4 words - under the old MIN_PROMPT_WORDS amnesty
+        "Password:",  # 2 words
+        "Sign in",
+        "Enter password",
+    ],
+)
+def test_short_prompt_beside_progress_text_is_never_dismissed(prompt: str) -> None:
+    """Finding 5 (HIGH, safety regression): a length heuristic is not evidence of harmlessness.
+
+    ``MIN_PROMPT_WORDS = 5`` accepted every unmatched element under five words, so a real prompt
+    sitting beside ``Evaluating...`` classified ``benign`` - and ``dialog_verdict`` then SUPPRESSED it
+    entirely while our own operation was in flight. Measured on the PR-#400 build:
+    ``inspect_credential_modal(..., operation_in_flight=True)`` returned ``dialog=None``, i.e. the same
+    state as a healthy Desktop, for a window reading *"Please enter your password"*.
+
+    In that shape the fix was worse than the bug: the repo's standing rule is that a credential modal
+    is never worked around, and this path defeated it silently. None of these strings matches
+    ``credential_modal_signature.regex``, so the all-window prepass does not rescue them either -
+    which is exactly why an unexplained element must veto rather than be excused.
+    """
+    window = DesktopWindow(
+        "Refresh", "WindowsForms10.Window.20008.app.0.x", 702, 355, ("Refresh", "Evaluating...", prompt)
+    )
+
+    finding = classify_dialog(window)
+    in_flight = _credential_modal.dialog_verdict([window], operation_in_flight=True)
+
+    assert finding.kind == "mixed-content", f"{prompt!r} was accounted for by nothing and must veto"
+    assert finding.verdict == "DIALOG_UNRECOGNIZED"
+    assert finding.evidence == prompt
+    assert in_flight is not None, f"{prompt!r} was SUPPRESSED in flight - a prompt swallowed in silence"
+
+
+def test_only_enumerated_chrome_is_excused_beside_progress_text() -> None:
+    """The positive half of finding 5: dismissal needs a POSITIVE claim, not a short string.
+
+    ``Cancel``/``OK``/``Close`` are whole-element, anchored control labels that carry no prompt, so a
+    window whose only unexplained content is one of them still shows a human nothing to act on. A table
+    name does NOT get that excuse - it is short, but shortness was never the property that mattered.
+    """
+    chrome = DesktopWindow("Refresh", "Cls", 702, 355, ("Refresh", "Evaluating...", "Cancel", "OK"))
+    table_name = DesktopWindow("Refresh", "Cls", 702, 355, ("Refresh", "Evaluating...", "Orders"))
+
+    assert classify_dialog(chrome).kind == "benign", "the benign path must stay reachable"
+    assert classify_dialog(table_name).kind == "mixed-content"
+    assert classify_dialog(table_name).verdict == "DIALOG_UNRECOGNIZED"
+
+
+@pytest.mark.parametrize(
+    ("width", "height", "texts", "kind"),
+    [
+        (80, 60, (), "unreadable"),
+        (80, 60, ("Refresh",), "benign-title-only"),
+        (40, 20, ("Continue?", "Yes"), "unrecognized"),
+        (1, 1, (), "unreadable"),
+    ],
+)
+def test_a_small_dialog_is_still_classified(width: int, height: int, texts, kind: str) -> None:
+    """Finding 3 (HIGH): the original defect, surviving inside its own fix.
+
+    ``dialog_candidates`` still rejected everything under 100x100, and the all-window credential
+    prepass only rescued text matching the credential regex. Measured on the PR-#400 build: a visible
+    80x60 non-main unreadable window beside a normal main window returned
+    ``modal=None, dialog=None, unknown_reason=None`` - byte-identical to a healthy Desktop.
+
+    An arbitrary geometry threshold is not evidence of harmlessness. That sentence is the whole issue.
+    """
+    main = DesktopWindow("sample", "WindowsForms10.Window.8.app.0.x", 2011, 1298, ("sample",))
+    dialog = DesktopWindow(texts[0] if texts else "", "WindowsForms10.Window.20008.app.0.x", width, height, texts)
+
+    state = inspect_credential_modal(111, lambda _pid: [dialog, main])
+
+    assert state.dialog is not None, "a small dialog must not vanish into the healthy state"
+    assert state.dialog.kind == kind
+    assert state.dialog.window.width == width
+
+
+def test_only_named_helpers_and_zero_area_windows_are_excluded() -> None:
+    """The exclusions that replaced the size test are positive claims, and are the ONLY ones.
+
+    Zero area rasterises nothing, so such a window cannot be showing a human anything; the named
+    helpers are identified Desktop infrastructure. Everything else is classified whatever its size.
+    """
+    assert not hasattr(_credential_modal, "MIN_DIALOG_WIDTH"), "a size threshold must not come back"
+    assert not hasattr(_credential_modal, "MIN_DIALOG_HEIGHT"), "a size threshold must not come back"
+
+    zero_area = DesktopWindow("", "Internet Explorer_Hidden", 0, 0, ())
+    named_helper = DesktopWindow("", "Internet Explorer_Hidden", 400, 300, ())
+    flat = DesktopWindow("", "WindowsForms10.Window.20008.app.0.x", 900, 0, ())
+    real = DesktopWindow("", "WindowsForms10.Window.20008.app.0.x", 12, 12, ())
+
+    kept = _credential_modal.dialog_candidates([zero_area, named_helper, flat, real])
+
+    assert kept == [real], f"expected only the real 12x12 dialog to be classified; got {kept}"
+
+
+@pytest.mark.parametrize(
+    "report_name",
+    ["Account Key", "Personal Access Token", "Databricks Client Credentials"],
+)
+def test_a_report_title_cannot_fabricate_a_credential_prompt(report_name: str, capsys) -> None:
+    """Finding 4 (MEDIUM): the all-window prepass read the Desktop MAIN window too.
+
+    Measured on the PR-#400 build with a production-shaped main window titled
+    ``Account Key - Power BI Desktop``: both consumers emitted the exit-1 hard stop. A report is
+    allowed to be called that. Only the identified main window is excluded - every real dialog is
+    still scanned at every size and in every class, so an unusual modal class stays detectable.
+    """
+    title = f"{report_name} - Power BI Desktop"
+    main = DesktopWindow(title, "WindowsForms10.Window.8.app.0.x", 2011, 1298, (title,))
+
+    state = inspect_credential_modal(111, lambda _pid: [main])
+    verdict = probe_desktop_query._credential_verdict(111, state)
+
+    assert state.modal is None, f"a report named {report_name!r} is not a credential prompt"
+    assert state.dialog is None
+    assert verdict is None, "the probe must continue"
+    assert capsys.readouterr().out == ""
+
+
+def test_an_unusual_modal_class_is_still_scanned_for_the_credential_signature() -> None:
+    """The other half of finding 4: excluding the main window must not narrow real dialog coverage."""
+    main = DesktopWindow("sample", "WindowsForms10.Window.8.app.0.x", 2011, 1298, ("sample",))
+    odd = DesktopWindow("", "HwndWrapper[PBIDesktop.exe;;guid]", 30, 20, ("Enter your credentials",))
+
+    state = inspect_credential_modal(111, lambda _pid: [odd, main])
+
+    assert state.modal is not None
+    assert state.modal.window.class_name.startswith("HwndWrapper")
+
+
+def test_the_credential_prepass_reads_windows_that_classification_skips() -> None:
+    """The prepass is narrowed by the MAIN window and by nothing else - not even the helper list.
+
+    ``Internet Explorer_Hidden`` is the WebOC host, and Power BI's AAD sign-in renders in a web view,
+    so credential text really can appear there. Excluding it from CLASSIFICATION is a claim about what
+    can be a dialog; excluding it from the HARD-STOP scan would be a claim about what can hold a
+    prompt, and that one is false. Recall on the credential path is the thing we never trade away.
+    """
+    main = DesktopWindow("sample", "WindowsForms10.Window.8.app.0.x", 2011, 1298, ("sample",))
+    web_view = DesktopWindow("", "Internet Explorer_Hidden", 900, 700, ("Enter your credentials",))
+
+    assert web_view not in _credential_modal.dialog_candidates([web_view, main]), "helper: not classified"
+
+    state = inspect_credential_modal(111, lambda _pid: [web_view, main])
+
+    assert state.modal is not None, "a helper window is still scanned for the credential signature"
+    assert state.modal.window.class_name == "Internet Explorer_Hidden"
+
+
+@pytest.mark.parametrize("progress_enabled", [False, True])
+def test_a_dialog_we_could_not_read_does_not_abort_a_refresh_that_completes(monkeypatch, progress_enabled) -> None:
+    """Latch, do not raise: an unreadable dialog must not kill a refresh that was going to succeed.
+
+    Both wait branches have to behave this way, and the progress-monitor branch did not - it called the
+    t=0 raise helper, so any mid-flight finding ended the run on its first poll (#400 review, finding
+    1). The behavioural statement is the assertion: the worker finishes, so the refresh succeeds.
+    """
+    windows = visible_unreadable_dialog_windows()
+    calls = {"n": 0}
+    finished = threading.Event()
+
+    def state(pid: int, **kwargs) -> CredentialDetection:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return CredentialDetection()
+        return inspect_credential_modal(pid, lambda _pid: windows, operation_in_flight=bool(kwargs.get("in_flight")))
+
+    class _SlowThenDone:
+        """A connection whose command returns after a couple of polls."""
+
+        CommandText = ""
+        CommandTimeout = 0
+
+        def Open(self) -> None:
+            """Match the ADOMD API surface."""
+
+        def CreateCommand(self):
+            """This object is its own command."""
+            return self
+
+        def ExecuteNonQuery(self) -> None:
+            """Return once the poll loop has had a chance to observe the dialog."""
+            time.sleep(0.15)
+            finished.set()
+
+        def Close(self) -> None:
+            """Match the ADOMD API surface."""
+
+    monkeypatch.setattr(refresh_pbip_model, "_credential_state", state)
+    monkeypatch.setattr(refresh_pbip_model, "_load_adomd", lambda: lambda _dsn: _SlowThenDone())
+    monkeypatch.setattr(refresh_pbip_model, "_catalog_id", lambda _conn: "catalog-1")
+    monkeypatch.setattr(refresh_pbip_model, "REFRESH_CREDENTIAL_POLL_SECONDS", 0.02)
+    monkeypatch.setattr(refresh_pbip_model, "_start_refresh_progress_trace", lambda *_a, **_k: _FakeProgressMonitor())
+
+    ok, _message = refresh(
+        port=1234,
+        tables=["Orders"],
+        timeout_sec=30,
+        desktop_pid=111,
+        progress_enabled=progress_enabled,
+        absolute_timeout_sec=30.0,
+    )
+
+    assert finished.is_set(), "the worker never ran, so this proves nothing about aborting it"
+    assert ok is True, "an unreadable dialog aborted a refresh that completed"
+    assert calls["n"] >= 2, "the poll never observed the dialog, so the latch was not exercised"
+
+
+@pytest.mark.parametrize("progress_enabled", [False, True])
+def test_a_latched_dialog_surfaces_at_the_deadline_in_both_wait_branches(monkeypatch, progress_enabled) -> None:
+    """The other half of the latch: what is latched must be RAISED, not quietly dropped.
+
+    The dialog here appears mid-refresh and is GONE again before the deadline - the #154 shape. A
+    fresh end-of-run check cannot see it, so only a real latch can report it; without one the run ends
+    on a bare ``TimeoutError``, which the parent classifier blames on a slow source.
+
+    Keeping the dialog on screen throughout is what made the missing latch invisible: ``refresh()``'s
+    own final check re-observed it and raised anyway. A defence-in-depth path masking a missing latch
+    is exactly the shape that makes a test pass for the wrong reason.
+    """
+    released = threading.Event()
+    calls = {"n": 0}
+    healthy = [DesktopWindow("Report", "WindowsForms10.Window.8.app.0.1a2b3c", 2011, 1298, ("Report",))]
+
+    def state(pid: int, **kwargs) -> CredentialDetection:
+        calls["n"] += 1
+        # 1 = the t=0 pre-check, 2-3 = the dialog is up, 4+ = it has gone again.
+        windows = visible_unreadable_dialog_windows() if calls["n"] in (2, 3) else healthy
+        return inspect_credential_modal(pid, lambda _pid: windows, operation_in_flight=bool(kwargs.get("in_flight")))
+
+    monkeypatch.setattr(refresh_pbip_model, "_credential_state", state)
+    monkeypatch.setattr(refresh_pbip_model, "_load_adomd", lambda: lambda _dsn: _ParkedAdomd(released))
+    monkeypatch.setattr(refresh_pbip_model, "_catalog_id", lambda _conn: "catalog-1")
+    monkeypatch.setattr(refresh_pbip_model, "REFRESH_CREDENTIAL_POLL_SECONDS", 0.02)
+    monkeypatch.setattr(refresh_pbip_model, "REFRESH_WALL_CLOCK_GRACE_SECONDS", 0.05)
+    monkeypatch.setattr(refresh_pbip_model, "_start_refresh_progress_trace", lambda *_a, **_k: _FakeProgressMonitor())
+
+    try:
+        with pytest.raises(DialogFoundError) as excinfo:
+            refresh(
+                port=1234,
+                tables=["Orders"],
+                timeout_sec=1,
+                desktop_pid=111,
+                progress_enabled=progress_enabled,
+                absolute_timeout_sec=1.0,
+            )
+    finally:
+        released.set()
+
+    assert excinfo.value.finding.verdict == "DIALOG_UNREADABLE"
+    assert calls["n"] >= 5, "the dialog must have been gone for several polls before the deadline"
+
+
+@pytest.mark.parametrize("progress_enabled", [False, True])
+def test_the_production_refresh_path_polls_with_the_in_flight_detector(monkeypatch, progress_enabled: bool) -> None:
+    """Finding 1 (HIGH): production overrode the very default the other test was checking.
+
+    ``_join_refresh_worker`` passed ``detector=_credential_state`` (the t=0 form) in the no-trace
+    branch and called the t=0 ``_raise_if_blocked`` in the progress-monitor branch, so Power BI's own
+    progress dialog stopped the refresh it belonged to. Measured on the PR-#400 build, BOTH branches:
+    ``DialogFoundError(REFRESH_IN_PROGRESS)`` on the first poll, with the detector receiving no
+    ``in_flight`` argument at all.
+
+    This drives the REAL ``refresh()`` through both branches and asserts on production's CALL SITE -
+    the argument the detector actually receives - not on a helper's default. A mutation that reverts
+    the call site fails here; a mutation that only changes the helper's signature is caught by
+    ``test_poll_loop_default_detector_is_the_in_flight_one``. Both are needed.
+    """
+    seen: list[object] = []
+    calls = {"n": 0}
+    windows = visible_progress_dialog_windows()
+    released = threading.Event()
+
+    def state(pid: int, **kwargs) -> CredentialDetection:
+        calls["n"] += 1
+        seen.append(kwargs.get("in_flight", "<not passed>"))
+        if calls["n"] == 1:
+            return CredentialDetection()
+        return inspect_credential_modal(pid, lambda _pid: windows, operation_in_flight=bool(kwargs.get("in_flight")))
+
+    monkeypatch.setattr(refresh_pbip_model, "_credential_state", state)
+    monkeypatch.setattr(refresh_pbip_model, "_load_adomd", lambda: lambda _dsn: _ParkedAdomd(released))
+    monkeypatch.setattr(refresh_pbip_model, "_catalog_id", lambda _conn: "catalog-1")
+    monkeypatch.setattr(refresh_pbip_model, "REFRESH_CREDENTIAL_POLL_SECONDS", 0.02)
+    monkeypatch.setattr(refresh_pbip_model, "REFRESH_WALL_CLOCK_GRACE_SECONDS", 0.05)
+    monkeypatch.setattr(refresh_pbip_model, "_start_refresh_progress_trace", lambda *_a, **_k: _FakeProgressMonitor())
+
+    try:
+        with pytest.raises(TimeoutError):
+            refresh(
+                port=1234,
+                tables=["Orders"],
+                timeout_sec=1,
+                desktop_pid=111,
+                progress_enabled=progress_enabled,
+                absolute_timeout_sec=1.0,
+            )
+    finally:
+        released.set()
+
+    polls = seen[1:]
+    assert polls, "the refresh never polled, so this test proved nothing"
+    assert all(flag is True for flag in polls), (
+        f"production must poll with in_flight=True after t=0; detector saw {polls}"
+    )
+    assert seen[0] is False or seen[0] == "<not passed>", "the t=0 check must NOT be in-flight"
 
 
 # ==================================================================================================

--- a/.github/skills/pbip-model-refresh/tests/test_credential_modal_detection.py
+++ b/.github/skills/pbip-model-refresh/tests/test_credential_modal_detection.py
@@ -1695,19 +1695,111 @@ def test_the_frame_is_identified_by_ownership_before_any_convention() -> None:
 def test_an_unowned_window_that_renders_pixels_is_still_classified() -> None:
     """`renders_nothing` needs BOTH conjuncts: no owner AND no pixels. Neither alone suppresses.
 
-    An unowned 900x700 window displays something to a human even though it disables nobody, so it is
-    accounted for like any other window. Dropping the area conjunct would silently exclude every
-    unowned window - including the AAD host in its unowned form.
+    An unowned 900x700 window displays something to a human even though it disables nobody. Dropping
+    the area conjunct would silently exclude every unowned window - including the AAD host in its
+    unowned form - and would also empty ``main_frame``'s fallback candidate set.
     """
     frame = main_window()
     unowned_visible = DesktopWindow("", "Internet Explorer_Hidden", 900, 700, ("Password:",), hwnd=0x70007)
 
     assert not _credential_modal.renders_nothing(unowned_visible)
 
+    kept = _credential_modal.dialog_candidates([frame, unowned_visible], frame=frame)
+    assert unowned_visible in kept, "an unowned window with pixels must not vanish into healthy"
+
     state = inspect_credential_modal(111, lambda _pid: [frame, unowned_visible])
 
-    assert state.dialog is not None, "an unowned window with pixels must not vanish into healthy"
+    assert state.dialog is not None
     assert state.dialog.verdict == "DIALOG_UNRECOGNIZED"
+
+
+def test_ownership_is_followed_transitively_to_the_unowned_root() -> None:
+    """Round 4: "first owner" is itself a proxy for "the root", and it hid a credential modal.
+
+    An owned window can own another popup. With a Z-order of ``tooltip -> credential dialog -> frame``
+    the first owner reached is the CREDENTIAL DIALOG, and whatever ``main_frame`` picks is excluded
+    from the prepass AND from classification - so the modal disappeared. Measured on the round-3 build:
+    the frame came back as the ``#32770`` credential dialog and no modal was reported.
+    """
+    frame_hwnd, cred_hwnd, tip_hwnd = 0xF001, 0xC002, 0x7003
+    frame = DesktopWindow("sample", "WindowsForms10.Window.8.app.0.x", 2011, 1298, ("sample",), hwnd=frame_hwnd)
+    cred = DesktopWindow(
+        "", "#32770", 702, 355, ("Enter your credentials",), hwnd=cred_hwnd, owner_hwnd=frame_hwnd, owner_enabled=False
+    )
+    tip = DesktopWindow(
+        "", "tooltips_class32", 120, 24, ("hint",), hwnd=tip_hwnd, owner_hwnd=cred_hwnd, owner_enabled=True
+    )
+
+    # Z-order puts the tooltip first, so a one-edge walk lands on the credential dialog.
+    assert _credential_modal.main_frame([tip, cred, frame]) is frame
+    state = inspect_credential_modal(111, lambda _pid: [tip, cred, frame])
+
+    assert state.modal is not None, "a nested owner chain must not hide the credential dialog"
+    assert state.modal.window is cred
+
+
+def test_a_nested_chain_still_finds_the_modal_while_our_own_refresh_is_in_flight() -> None:
+    """Round 4's third reproduction: the frame is busy with a benign refresh, so nothing else reports.
+
+    With the frame misidentified this returned no modal, no dialog finding and no unknown state - the
+    exact "unassessable input in the clean bucket" shape, at depth two.
+    """
+    frame_hwnd, cred_hwnd, tip_hwnd = 0xF001, 0xC002, 0x7003
+    frame = DesktopWindow(
+        "sample", "WindowsForms10.Window.8.app.0.x", 2011, 1298, ("sample", "Refresh", "Evaluating..."), hwnd=frame_hwnd
+    )
+    cred = DesktopWindow(
+        "", "#32770", 702, 355, ("Enter your credentials",), hwnd=cred_hwnd, owner_hwnd=frame_hwnd, owner_enabled=False
+    )
+    tip = DesktopWindow(
+        "", "tooltips_class32", 120, 24, ("hint",), hwnd=tip_hwnd, owner_hwnd=cred_hwnd, owner_enabled=True
+    )
+
+    state = inspect_credential_modal(111, lambda _pid: [tip, cred, frame], operation_in_flight=True)
+
+    assert state.modal is not None
+    assert state.modal.window is cred
+
+
+def test_a_topmost_unowned_dialog_cannot_present_itself_as_the_application() -> None:
+    """Round 4's second reproduction: the fallback must not crown the FIRST of several unowned windows.
+
+    An unowned ``Internet Explorer_Hidden`` enumerated ahead of the real frame, reading
+    ``Enter your credentials``, was selected as the frame and therefore skipped by the prepass. With no
+    ownership evidence to settle it, identity is AMBIGUOUS and the rule fails closed: ``main_frame``
+    returns ``None``, nothing is excluded, and the prompt is found.
+    """
+    frame = DesktopWindow("sample", "WindowsForms10.Window.8.app.0.x", 2011, 1298, ("sample",), hwnd=0xF001)
+    aad = DesktopWindow("", "Internet Explorer_Hidden", 900, 700, ("Enter your credentials",), hwnd=0x9001)
+
+    assert _credential_modal.main_frame([aad, frame]) is None, "ambiguous identity must fail closed"
+
+    state = inspect_credential_modal(111, lambda _pid: [aad, frame])
+
+    assert state.modal is not None, "a topmost unowned dialog must not skip the prepass"
+    assert state.modal.window is aad
+
+
+def test_ambiguous_frame_identity_excludes_nothing() -> None:
+    """Failing closed means EXCLUDING NOTHING - the cost is a loud exit 3, never a silent clear."""
+    frame = DesktopWindow("sample", "WindowsForms10.Window.8.app.0.x", 2011, 1298, ("sample",), hwnd=0xF001)
+    other = DesktopWindow("second", "Cls", 800, 600, ("second",), hwnd=0x9001)
+
+    assert _credential_modal.main_frame([frame, other]) is None
+    kept = _credential_modal.dialog_candidates([frame, other])
+
+    assert frame in kept and other in kept, "an ambiguous frame must not exclude a window"
+
+
+def test_an_unresolvable_owner_chain_fails_closed() -> None:
+    """An owner this enumeration never saw, or a cycle, leaves the root UNKNOWN - so guess nothing."""
+    frame = DesktopWindow("sample", "WindowsForms10.Window.8.app.0.x", 2011, 1298, ("sample",), hwnd=0xF001)
+    orphan = DesktopWindow("", "#32770", 702, 355, (), hwnd=0xC002, owner_hwnd=0xDEAD, owner_enabled=False)
+    left = DesktopWindow("", "Cls", 400, 300, (), hwnd=0xA001, owner_hwnd=0xA002, owner_enabled=False)
+    right = DesktopWindow("", "Cls", 400, 300, (), hwnd=0xA002, owner_hwnd=0xA001, owner_enabled=False)
+
+    assert _credential_modal.main_frame([frame, orphan]) is None, "an unseen owner leaves the root unknown"
+    assert _credential_modal.main_frame([left, right]) is None, "a cycle leaves the root unknown"
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="creates real Win32 windows")

--- a/.github/skills/powerbi-semantic-model-gotchas/SKILL.md
+++ b/.github/skills/powerbi-semantic-model-gotchas/SKILL.md
@@ -439,7 +439,11 @@ for an already-open data-source dialog are `status` reporting **"Host is not rea
 operations"** and `screenshot` reporting **"Print metadata is not available"**. That combination is
 not enough evidence for a bridge regression; run the bundled refresh/query probes, which check for
 visible non-main dialogs at t=0 and keep polling while the source wakes up. Text-readable credential
-prompts report `CREDENTIAL_MISSING`; unreadable/non-credential dialogs report `BLOCKED_BY_DIALOG`.
+prompts report `CREDENTIAL_MISSING` (exit 1, the only hard stop); a dialog whose content did not
+positively read as harmless reports `REFRESH_IN_PROGRESS` / `DIALOG_NEEDS_HUMAN` /
+`DIALOG_UNRECOGNIZED` / `DIALOG_UNREADABLE`, all **exit 3** — "could not probe", never "sign in".
+(`BLOCKED_BY_DIALOG` was retired in issues #367/#376: it came from a size-only test, so a Power BI
+Refresh progress dialog produced it.)
 
 **Independent confirmation is available and worth taking.** For a serverless warehouse, `STOPPED` with
 `num_active_sessions = 0` proves no query ever arrived, regardless of what any log claims. Prefer

--- a/docs/data-source-credentials.md
+++ b/docs/data-source-credentials.md
@@ -119,9 +119,15 @@ the same verdicts as the arbiter, with only `CREDENTIAL_MISSING` at exit 1 and e
 exit 3. Two consequences worth knowing:
 
 - The same fix closed a **silent false negative** nobody had noticed: the 100x100 filter was gating the
-  credential scan too, so a credential prompt in a *smaller* window produced **no finding at all**. It
-  now scans every window at any size (the **main** window excepted — a report legitimately named
-  `Account Key` is not a prompt), and no size test decides classification either.
+  credential scan too, so a credential prompt in a *smaller* window produced **no finding at all**. No
+  geometry, class or name test decides anything any more — see the next bullet.
+- **Blocking is decided from MODALITY: a modal disables its owner.** `GetWindow(GW_OWNER)` and
+  `IsWindowEnabled(owner)` are harvested, and only three things are excluded from classification: the
+  frame (identified by *ownership*, falling back to the `MainWindowHandle` convention), a window whose
+  **owner is enabled** (positive one-way proof it blocks nothing), and one that is **unowned AND
+  zero-area**. Native Win32 experiments defeated the three proxies this replaced — a class prefix (an
+  owner and its owned `FixedDialog` share the exact class), a name allowlist (the AAD host), and zero
+  area alone (a real `WS_VISIBLE` owned 0x0 window with a disabled owner).
 - Dismissal needs a **positive** claim. A dialog is only dismissed when every content element is
   recognised progress status or enumerated chrome (`benign_chrome_signature.regex`). There is **no
   length amnesty**: blind review measured `Refresh` + `Evaluating...` + *"Please enter your password"*

--- a/docs/data-source-credentials.md
+++ b/docs/data-source-credentials.md
@@ -123,11 +123,14 @@ exit 3. Two consequences worth knowing:
   geometry, class or name test decides anything any more — see the next bullet.
 - **Blocking is decided from MODALITY: a modal disables its owner.** `GetWindow(GW_OWNER)` and
   `IsWindowEnabled(owner)` are harvested, and only three things are excluded from classification: the
-  frame (identified by *ownership*, falling back to the `MainWindowHandle` convention), a window whose
-  **owner is enabled** (positive one-way proof it blocks nothing), and one that is **unowned AND
-  zero-area**. Native Win32 experiments defeated the three proxies this replaced — a class prefix (an
-  owner and its owned `FixedDialog` share the exact class), a name allowlist (the AAD host), and zero
-  area alone (a real `WS_VISIBLE` owned 0x0 window with a disabled owner).
+  frame (identified by following ownership **transitively to the unowned root**, falling back to the
+  `MainWindowHandle` convention only when nothing is owned), a window whose **owner is enabled**
+  (positive one-way proof it blocks nothing), and one that is **unowned AND zero-area**. Where frame
+  identity is ambiguous the rule **fails closed** and excludes nothing. Native Win32 experiments
+  defeated every shortcut this replaced — a class prefix (an owner and its owned `FixedDialog` share
+  the exact class), a name allowlist (the AAD host), zero area alone (a real `WS_VISIBLE` owned 0x0
+  window with a disabled owner), and "first owner" (a `tooltip → credential dialog → frame` chain made
+  the credential dialog the frame).
 - Dismissal needs a **positive** claim. A dialog is only dismissed when every content element is
   recognised progress status or enumerated chrome (`benign_chrome_signature.regex`). There is **no
   length amnesty**: blind review measured `Refresh` + `Evaluating...` + *"Please enter your password"*

--- a/docs/data-source-credentials.md
+++ b/docs/data-source-credentials.md
@@ -109,10 +109,21 @@ watches for the connector modal:
 returned `BLOCKED_BY_DIALOG` at **exit 1** for *any* visible non-main window >= 100x100 — a Power BI
 Refresh progress dialog trips that trivially, and a field report on 2026-08-28 caught it doing so under
 three concurrent refreshes against a cold Snowflake warehouse. The probe now classifies a dialog by its
-text and reports what it actually saw; the size test only decides which windows are worth reading. The
-**Python** fast check (`probe_desktop_query.py` / `refresh_pbip_model.py`) still emits
-`BLOCKED_BY_DIALOG` from a size-only rule, so treat that token — wherever it comes from — as
-"something is on screen", not as "sign-in required".
+text and reports what it actually saw; the size test only decides which windows are worth reading.
+
+✅ **The Python fast check (`probe_desktop_query.py` / `refresh_pbip_model.py`) was fixed the same way
+in issue #376, and `BLOCKED_BY_DIALOG` is retired from it.** It carried the identical size-only rule on
+a worse path — it feeds the one-row data probe, the *gate of record* — so a progress dialog produced
+`BLOCKED_BY_DIALOG` at exit 1, which this repo's own classifier maps to `NO_CREDENTIAL`. It now speaks
+the same verdicts as the arbiter, with only `CREDENTIAL_MISSING` at exit 1 and every dialog verdict at
+exit 3. Two consequences worth knowing:
+
+- The same fix closed a **silent false negative** nobody had noticed: the 100x100 filter was gating the
+  credential scan too, so a credential prompt in a *smaller* window produced **no finding at all**. It
+  now scans every window at any size, matching `Test-CredentialModal`.
+- `scripts/_verdict_lines.py` does not know the new tokens, so `probe_live_source` classifies them
+  **`ERROR`** — "the probe itself could not run". The gate stays armed; nothing asserts a sign-in wall
+  that was never observed. Verified end-to-end rather than assumed.
 
 Two gotchas learned building it: (a) use a **generous timeout (>=60s)** because a serverless warehouse
 (Databricks) can **cold-start** before the modal appears, so a short wait yields a false PRESENT; and

--- a/docs/data-source-credentials.md
+++ b/docs/data-source-credentials.md
@@ -120,10 +120,18 @@ exit 3. Two consequences worth knowing:
 
 - The same fix closed a **silent false negative** nobody had noticed: the 100x100 filter was gating the
   credential scan too, so a credential prompt in a *smaller* window produced **no finding at all**. It
-  now scans every window at any size, matching `Test-CredentialModal`.
-- `scripts/_verdict_lines.py` does not know the new tokens, so `probe_live_source` classifies them
-  **`ERROR`** — "the probe itself could not run". The gate stays armed; nothing asserts a sign-in wall
-  that was never observed. Verified end-to-end rather than assumed.
+  now scans every window at any size (the **main** window excepted — a report legitimately named
+  `Account Key` is not a prompt), and no size test decides classification either.
+- Dismissal needs a **positive** claim. A dialog is only dismissed when every content element is
+  recognised progress status or enumerated chrome (`benign_chrome_signature.regex`). There is **no
+  length amnesty**: blind review measured `Refresh` + `Evaluating...` + *"Please enter your password"*
+  classifying `benign` and being suppressed outright under the old five-word rule.
+  ⚠️ `probe_desktop_credential.ps1` still carries that rule (`$MinPromptWords = 5`) and reproduces the
+  same suppression — measured, filed as #406 rather than fixed in passing.
+- `probe_live_source` recognises the dialog tokens **structurally** and maps them to **`ERROR`** —
+  "the probe itself could not run". The gate stays armed; nothing asserts a sign-in wall that was never
+  observed. Without that structural step the transcript fell through to an unanchored keyword scan, and
+  `DIALOG_NEEDS_HUMAN` quoting `Authentication required` came back out as `NO_CREDENTIAL`.
 
 Two gotchas learned building it: (a) use a **generous timeout (>=60s)** because a serverless warehouse
 (Databricks) can **cold-start** before the modal appears, so a short wait yields a false PRESENT; and

--- a/scripts/_verdict_lines.py
+++ b/scripts/_verdict_lines.py
@@ -52,6 +52,25 @@ DESKTOP_GONE_VERDICT_RE = re.compile(r"^\s*(?:REFRESH|PREFLIGHT|PROBE):\s+DESKTO
 # be read. Also a LOCAL failure the classifier maps to ERROR - deliberately outside the credential-stop
 # family, because no human sign-in makes a window-less process produce a window.
 DESKTOP_UNREADY_VERDICT_RE = re.compile(r"^\s*(?:REFRESH|PREFLIGHT|PROBE):\s+DESKTOP_UNREADY\b")
+# Dialog family (issue #376), from `refresh_pbip_model._emit_dialog_finding` /
+# `probe_desktop_query._emit_dialog_finding`. The child looked at a visible Desktop dialog and is
+# saying, authoritatively, "this is NOT a sign-in wall and I could not probe".
+#
+# It MUST be matched structurally and BEFORE the free-text scans (#400 review, finding 2). Without
+# this, the parent fell through to `CREDENTIAL_MARKERS`, which scans the whole transcript - so
+# `DIALOG_NEEDS_HUMAN` carrying the evidence excerpt `Authentication required` was relabelled
+# `NO_CREDENTIAL` on the word "authentication", overriding the child's explicit statement to the
+# contrary and firing the "a human must sign in; terminate the run" directive. Measured in review.
+#
+# Adding the tokens to CREDENTIAL_STOP_VERDICT_RE instead would have been the other wrong answer: it
+# would assert the very credential wall the child says it did not see. These map to ERROR - "the probe
+# itself could not run" - which keeps the gate armed and claims nothing about the source.
+# `tests/test_probe_live_source_verdict.py` gates this list against the detector's own verdict table,
+# so a token added there cannot stay unknown here.
+DIALOG_VERDICT_RE = re.compile(
+    r"^\s*(?:REFRESH|PREFLIGHT|PROBE):\s+"
+    r"(?P<token>REFRESH_IN_PROGRESS|DIALOG_NEEDS_HUMAN|DIALOG_UNRECOGNIZED|DIALOG_UNREADABLE)\b"
+)
 
 
 def _has_credential_stop_verdict(text: str) -> bool:
@@ -86,6 +105,96 @@ def _has_desktop_unready_verdict(text: str) -> bool:
     verdict itself (issue #153).
     """
     return any(DESKTOP_UNREADY_VERDICT_RE.match(line) for line in text.splitlines())
+
+
+def _dialog_verdict_token(text: str) -> str | None:
+    """The dialog verdict token on a machine-readable verdict LINE, or ``None`` (issue #376).
+
+    Matched on the verdict LINE, never a substring, for the same reason as every other family here -
+    but this one is load-bearing in the opposite direction: it exists so the parent STOPS free-text
+    scanning once the child has authoritatively said "a dialog is up, and it is not a sign-in wall".
+    The child's own evidence excerpt can legitimately contain a credential keyword (the blocking
+    signature includes `Authentication required`), and the unanchored scan then contradicted the
+    verdict it was quoting.
+    """
+    for line in text.splitlines():
+        match = DIALOG_VERDICT_RE.match(line)
+        if match is not None:
+            return match.group("token")
+    return None
+
+
+def _has_dialog_verdict(text: str) -> bool:
+    """True when a line is a machine-readable dialog verdict (issue #376)."""
+    return _dialog_verdict_token(text) is not None
+
+
+# Every authoritative non-success verdict the child can emit. A run that carries ANY of them did not
+# earn a clear, whatever else its transcript says. Kept as one list so a new verdict family is wired
+# into the success gate by adding it here, not by lengthening a boolean chain someone has to read.
+NON_SUCCESS_VERDICT_CHECKS = (
+    _has_credential_stop_verdict,
+    _has_desktop_gone_verdict,
+    _has_desktop_unready_verdict,
+    _has_dialog_verdict,
+)
+
+
+def _is_earned_success(text: str, table: str, *, returncode: int) -> bool:
+    """Did this child run earn a clear for ``table``?
+
+    Both channels must agree (issue #152): a zero exit code AND a machine-readable success verdict for
+    the very table we asked about - and no authoritative non-success verdict anywhere in the
+    transcript. The child prints its reassuring no-dialog banner on failure paths too, so the text can
+    look fine while the run failed; and a non-zero exit must never read as success even beside a stale
+    OK line.
+    """
+    if returncode != 0:
+        return False
+    if any(check(text) for check in NON_SUCCESS_VERDICT_CHECKS):
+        return False
+    return _has_data_ok_verdict(text, table)
+
+
+def classify_child_verdict(text: str, raw: str) -> tuple[str, str] | None:
+    """Map an AUTHORITATIVE child verdict line to ``(verdict, detail)``, or ``None``.
+
+    These are checked before any free-text scan, because the child looked at the machine and is
+    telling us what it saw; a substring scan of the transcript can only contradict it. All three map
+    to ``ERROR`` - "the probe itself could not run" - which keeps the gate armed and claims nothing
+    about the data source.
+
+    Extracted from ``probe_live_source._classify_failure`` when the #376 dialog family pushed that
+    module past pylint's ``max-module-lines``. The seam is real rather than convenient: everything
+    here is decided by a verdict LINE, and everything left there is decided by free text.
+    """
+    if _has_desktop_gone_verdict(text):
+        return (
+            "ERROR",
+            "Power BI Desktop exited or crashed before the probe could query the source: it "
+            "enumerated no windows and its process was no longer running, so nothing was learned "
+            "about the data source. This is a LOCAL tooling failure - do not report it as "
+            "UNREACHABLE or a connection/credential problem. Re-open the model in Power BI Desktop, "
+            "confirm it is running, and re-run the probe. Raw: " + raw,
+        )
+    if _has_desktop_unready_verdict(text):
+        return (
+            "ERROR",
+            "Power BI Desktop was running without any window, so the probe could not inspect its "
+            "local state or query the source. Wait for Desktop to finish starting, or restart it if "
+            "it is wedged, then re-run the probe. Raw: " + raw,
+        )
+    token = _dialog_verdict_token(text)
+    if token is not None:
+        return (
+            "ERROR",
+            f"Power BI Desktop has a dialog up that the probe could not account for ({token}), so the "
+            "refresh never established anything about the data source. The child classified the "
+            "window and reports that it is NOT a sign-in prompt - do not send anyone to "
+            "re-authenticate on the strength of this. Look at the Desktop screen, settle whatever it "
+            "is showing, and re-run the probe. Raw: " + raw,
+        )
+    return None
 
 
 def _has_data_ok_verdict(text: str, table: str) -> bool:

--- a/scripts/probe_live_source.py
+++ b/scripts/probe_live_source.py
@@ -83,11 +83,18 @@ from _probe_pbip import (  # noqa: F401  # pylint: disable=unused-import
     _tmdl_ident,
 )
 from _gate_lift import lift_gate as _lift_gate  # noqa: F401  # pylint: disable=unused-import
-from _verdict_lines import (
+from _verdict_lines import (  # noqa: F401  # pylint: disable=unused-import
+    # Several of these are no longer CALLED from this module - `_is_earned_success` and
+    # `classify_child_verdict` own them now - but they are load-bearing RE-EXPORTS: the seam tests
+    # reach them through `probe_live_source`, and `ruff --fix` deletes them without this waiver.
+    _dialog_verdict_token,
     _has_credential_stop_verdict,
     _has_data_ok_verdict,
     _has_desktop_gone_verdict,
     _has_desktop_unready_verdict,
+    _has_dialog_verdict,
+    _is_earned_success,
+    classify_child_verdict,
 )
 from check_desktop_orphans import record_desktop_event
 from connection_target import LIVE_SOURCE, powerbi_target
@@ -339,28 +346,17 @@ def _classify_failure(text: str, network_fault_observed: bool) -> tuple[str, str
     # pylint: disable=too-many-return-statements
     low = text.lower()
     raw = _error_excerpt(text)
-    # A machine-readable DESKTOP_GONE verdict line (issue #158), checked FIRST because it is the most
-    # definitive signal: Power BI Desktop enumerated zero windows AND its process was gone, so the
-    # probe never reached the source. Like "identity unverified" this is a LOCAL failure - the data
-    # source was never contacted - so it is ERROR, never UNREACHABLE (which would send someone to fix
-    # a server that was never queried) and never NO_CREDENTIAL (no sign-in revives a dead process).
-    # Matched structurally on the verdict line; the detector's reason prose is deliberately marker-free.
-    if _has_desktop_gone_verdict(text):
-        return (
-            "ERROR",
-            "Power BI Desktop exited or crashed before the probe could query the source: it "
-            "enumerated no windows and its process was no longer running, so nothing was learned "
-            "about the data source. This is a LOCAL tooling failure - do not report it as "
-            "UNREACHABLE or a connection/credential problem. Re-open the model in Power BI Desktop, "
-            "confirm it is running, and re-run the probe. Raw: " + raw,
-        )
-    if _has_desktop_unready_verdict(text):
-        return (
-            "ERROR",
-            "Power BI Desktop was running without any window, so the probe could not inspect its "
-            "local state or query the source. Wait for Desktop to finish starting, or restart it if "
-            "it is wedged, then re-run the probe. Raw: " + raw,
-        )
+    # The AUTHORITATIVE child verdicts first (`_verdict_lines.classify_child_verdict`): DESKTOP_GONE
+    # and DESKTOP_UNREADY (issue #158) and the DIALOG family (issue #376). Each is a verdict LINE the
+    # child emitted after looking at the machine, so no free-text scan below may override it.
+    #
+    # #400 review, finding 2, is why the DIALOG family had to join them: without it the transcript fell
+    # through to CREDENTIAL_MARKERS - an unanchored substring scan - and `DIALOG_NEEDS_HUMAN` quoting
+    # its own evidence `Authentication required` was relabelled NO_CREDENTIAL, the parent contradicting
+    # the child on a single word and firing "a human must sign in; terminate the run".
+    child_verdict = classify_child_verdict(text, raw)
+    if child_verdict is not None:
+        return child_verdict
     # Deliberately "identity unverified" alone, NOT "model identity unverified". Measured
     # 2026-08-03 (gpt-5.6-sol, live happy-path run): the real producer text is
     # "model  : identity unverified (no model folder resolved for this pid)" - note the extra
@@ -743,18 +739,10 @@ def _refresh_and_classify(pid: int, table: str, timeout_sec: int, network_fault_
 
     log.info("refresh finished in %.0fs", time.monotonic() - started)
     text = (refresh.stdout + refresh.stderr).strip()
-    # Honour BOTH channels the child speaks in: a zero exit code AND a machine-readable success verdict
-    # for the very table we asked to refresh. Either alone is insufficient - the child prints its
-    # reassuring no-dialog banner on stdout even on failure paths (so the text can look OK while the run
-    # failed), and a non-zero exit must never be read as success even if a stale OK line is present
-    # (issue #152: this used to classify on stdout prose alone and ignore the exit code entirely).
-    if (
-        refresh.returncode == 0
-        and not _has_credential_stop_verdict(text)
-        and not _has_desktop_gone_verdict(text)
-        and not _has_desktop_unready_verdict(text)
-        and _has_data_ok_verdict(text, table)
-    ):
+    # Both channels must agree, and no authoritative non-success verdict may be present. The whole
+    # rule - and the list of what counts as authoritative - lives in `_verdict_lines._is_earned_success`
+    # so a new verdict family joins the gate by being added to one list (issues #152, #158, #376).
+    if _is_earned_success(text, table, returncode=refresh.returncode):
         log.info("PROBE: DATA_OK 1 row(s) from %s - the source is genuinely reachable", table)
         return 0, "DATA_OK"
     verdict, detail = _classify_failure(text, network_fault_observed=network_fault_observed)

--- a/tests/test_probe_live_source_verdict.py
+++ b/tests/test_probe_live_source_verdict.py
@@ -297,24 +297,74 @@ def test_free_text_credential_marker_without_a_verdict_line_still_stops() -> Non
     assert verdict == "NO_CREDENTIAL"
 
 
-def test_blocked_by_dialog_does_not_clear_gate(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A generic Desktop dialog is a human-blocked source, not reachable data."""
-    probe_live_source = _import_probe_live_source()
-    monkeypatch.setattr(
-        probe_live_source.subprocess,
-        "run",
-        lambda *_args, **_kwargs: subprocess.CompletedProcess(
-            args=["refresh"],
-            returncode=1,
-            stdout="REFRESH: BLOCKED_BY_DIALOG pid=111; window title='(empty title)'\n",
-            stderr="",
-        ),
-    )
+def test_a_dialog_finding_keeps_the_gate_shut_without_claiming_a_credential_wall(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#376: the child's dialog verdicts must keep the gate shut, but must NOT read as a sign-in wall.
 
-    assert probe_live_source._refresh_and_classify(123, "Orders", 1, network_fault_observed=False) == (  # noqa: SLF001
-        1,
-        "NO_CREDENTIAL",
-    )
+    Master emitted ``BLOCKED_BY_DIALOG`` at exit 1 from a SIZE-ONLY test, and this matcher maps that
+    token to ``NO_CREDENTIAL`` - whose directive is "you may NOT build; a human must sign in;
+    TERMINATE THE RUN NOW". A Power BI Refresh progress dialog trips that, so a working refresh could
+    halt a migration and send someone to a screen showing nothing of the sort.
+
+    The child line is HARVESTED from the real emitter with a real classification, never hand-written:
+    that is the #152/#153 discipline, and it is the only way this test can notice if the emitted
+    wording drifts back into the classifier's free-text credential markers.
+    """
+    probe_live_source = _import_probe_live_source()
+    refresh_pbip_model, _, credential_modal = _import_skill_modules()
+
+    for texts in ((), ("Save changes?", "Discard"), ("Refresh",), ("Refresh", "Evaluating...")):
+        finding = credential_modal.classify_dialog(
+            credential_modal.DesktopWindow("Refresh" if "Refresh" in texts else "", "Cls", 702, 355, texts)
+        )
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            refresh_pbip_model._emit_dialog_finding(111, finding)
+        stdout = buffer.getvalue()
+        monkeypatch.setattr(
+            probe_live_source.subprocess,
+            "run",
+            lambda *_args, _out=stdout, **_kwargs: subprocess.CompletedProcess(
+                args=["refresh"], returncode=3, stdout=_out, stderr=""
+            ),
+        )
+
+        rc, verdict = probe_live_source._refresh_and_classify(  # noqa: SLF001
+            123, "Orders", 1, network_fault_observed=False
+        )
+
+        assert rc == 1, f"{finding.verdict} must keep the gate shut"
+        assert verdict != "DATA_OK"
+        assert verdict != "NO_CREDENTIAL", (
+            f"{finding.verdict} asserted a credential wall we never observed; emitted line: {stdout!r}"
+        )
+        assert not probe_live_source._has_credential_stop_verdict(stdout)
+
+
+def test_every_dialog_guidance_string_is_marker_free() -> None:
+    """#376 x #153: the guidance printed under a dialog verdict must not fabricate a credential stop.
+
+    The kinds are DISCOVERED from the detector's own table rather than listed here, so a kind added
+    later is covered without anyone editing this test - the same "catches a newly-added X" discipline
+    as ``_detector_unknown_reasons``. This matters because ``_classify_failure`` scans a failing
+    child's WHOLE transcript as free text: one stray "credential"/"sign in"/"authentication" in the
+    reassuring half of the message would relabel "we could not probe" as the hard stop it exists to
+    avoid, exactly as the #153 banner did.
+    """
+    probe_live_source = _import_probe_live_source()
+    _, _, credential_modal = _import_skill_modules()
+
+    guidance = credential_modal.DIALOG_KIND_GUIDANCE
+    assert len(guidance) >= 5, f"expected the detector's full guidance table; got {sorted(guidance)}"
+
+    offenders = {
+        kind: [marker for marker in probe_live_source.CREDENTIAL_MARKERS if marker in text.lower()]
+        for kind, text in guidance.items()
+        if any(marker in text.lower() for marker in probe_live_source.CREDENTIAL_MARKERS)
+    }
+
+    assert not offenders, f"guidance prose carries free-text credential markers: {offenders}"
 
 
 def _harvest_minimized_reason(credential_modal) -> str:

--- a/tests/test_probe_live_source_verdict.py
+++ b/tests/test_probe_live_source_verdict.py
@@ -367,6 +367,96 @@ def test_every_dialog_guidance_string_is_marker_free() -> None:
     assert not offenders, f"guidance prose carries free-text credential markers: {offenders}"
 
 
+def test_a_dialog_verdict_is_recognised_structurally_and_is_not_a_credential_stop() -> None:
+    """#400 review, finding 2 (HIGH): the parent overrode the child's explicit non-credential verdict.
+
+    ``probe_live_source`` did not recognise the dialog tokens, so it fell through to
+    ``CREDENTIAL_MARKERS`` - an unanchored scan of the WHOLE transcript. ``DIALOG_NEEDS_HUMAN``
+    carrying its own evidence excerpt ``Authentication required`` (an alternative that genuinely lives
+    in ``blocking_prompt_signature.regex``) was therefore relabelled ``NO_CREDENTIAL``, firing "a human
+    must sign in; terminate the run" over a child that had just said the opposite. Measured on the
+    PR-#400 build.
+
+    Every line here is harvested from the real emitter with a real classification, so a reworded
+    verdict or a new token is caught here rather than in production.
+    """
+    probe_live_source = _import_probe_live_source()
+    refresh_pbip_model, _, credential_modal = _import_skill_modules()
+
+    windows = {
+        "DIALOG_NEEDS_HUMAN": ("Authentication required",),
+        "DIALOG_NEEDS_HUMAN/native": ("Permission is required to run this native database query",),
+        "DIALOG_UNREADABLE": (),
+        "DIALOG_UNRECOGNIZED": ("Save changes?", "Discard"),
+        "REFRESH_IN_PROGRESS": ("Refresh", "Evaluating..."),
+    }
+    for label, texts in windows.items():
+        window = credential_modal.DesktopWindow("Refresh" if "Refresh" in texts else "", "Cls", 702, 355, texts)
+        finding = credential_modal.classify_dialog(window)
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            refresh_pbip_model._emit_dialog_finding(111, finding)
+        text = buffer.getvalue()
+
+        verdict, _ = probe_live_source._classify_failure(text, network_fault_observed=False)
+
+        assert probe_live_source._has_dialog_verdict(text), f"{label}: not recognised structurally"
+        assert verdict == "ERROR", f"{label}: classified {verdict}, not the honest 'could not probe'"
+        assert verdict != "NO_CREDENTIAL", f"{label}: asserted a credential wall the child denied"
+        assert not probe_live_source._has_credential_stop_verdict(text), (
+            f"{label}: a dialog verdict must never JOIN the credential-stop family - that family's "
+            "name is consumed elsewhere, and the child has explicitly said this is not one"
+        )
+
+
+def test_the_parent_knows_every_dialog_token_the_detector_can_emit() -> None:
+    """Anti-drift: a token added to the detector must not stay unknown to the parent classifier.
+
+    Without this the two halves of finding 2's fix can separate silently - a new verdict would fall
+    straight back through to the free-text scan that caused the defect. The list is DISCOVERED from
+    the detector's own table rather than restated here.
+    """
+    probe_live_source = _import_probe_live_source()
+    _, _, credential_modal = _import_skill_modules()
+
+    tokens = {
+        verdict
+        for kind, verdict in credential_modal.DIALOG_KIND_VERDICTS.items()
+        if kind != credential_modal.DIALOG_KIND_CREDENTIAL
+    }
+    assert len(tokens) >= 4, f"expected the detector's dialog tokens; got {sorted(tokens)}"
+
+    unknown = [
+        token for token in sorted(tokens) if not probe_live_source._has_dialog_verdict(f"REFRESH: {token} pid=1; x")
+    ]
+
+    assert not unknown, f"probe_live_source does not recognise these dialog verdicts: {unknown}"
+
+
+def test_a_dialog_verdict_cannot_clear_the_live_source_gate(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Defence in depth for finding 2: a dialog verdict blocks success even on a zero exit code.
+
+    The exit code alone already blocks it, but the child's success gate lists every authoritative
+    non-success verdict explicitly, and this one belongs there with its siblings.
+    """
+    probe_live_source = _import_probe_live_source()
+    monkeypatch.setattr(
+        probe_live_source.subprocess,
+        "run",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess(
+            args=["refresh"],
+            returncode=0,
+            stdout="REFRESH: DIALOG_UNREADABLE pid=111; kind=unreadable\nREFRESH: TABLES_OK 'Orders'\n",
+            stderr="",
+        ),
+    )
+
+    rc, verdict = probe_live_source._refresh_and_classify(123, "Orders", 1, network_fault_observed=False)
+
+    assert (rc, verdict) != (0, "DATA_OK"), "a dialog verdict must veto a stale-looking success line"
+    assert verdict == "ERROR"
+
+
 def _harvest_minimized_reason(credential_modal) -> str:
     """The REAL minimized-owner ``unknown_reason``, harvested by driving the detector (not hand-written).
 


### PR DESCRIPTION
Fixes #376 — `inspect_credential_modal` decided "blocking dialog" by **size alone**, exactly as `Test-BlockingDialog` did before #367, and on the path that feeds `probe_desktop_query.py` — **the gate of record**.

## What it keyed on, before and after

Measured by driving the real detector against synthesised windows. Every one is **702x355 and non-main**, so size cannot separate them — only text can.

| window | before | after |
|---|---|---|
| `Refresh` + `Evaluating...` + `Cancel` | `BLOCKED_BY_DIALOG`, **exit 1** | `REFRESH_IN_PROGRESS`, exit 3 (and **ignored** while our own operation is in flight) |
| `Please specify how to connect` | `CREDENTIAL_MISSING`, exit 1 | unchanged |
| native-database-query approval | `BLOCKED_BY_DIALOG`, **exit 1** | `DIALOG_NEEDS_HUMAN`, exit 3 |
| progress text **beside** that prompt | `BLOCKED_BY_DIALOG`, exit 1 | `DIALOG_NEEDS_HUMAN`, exit 3 |
| progress text beside unexplained prose | `BLOCKED_BY_DIALOG`, exit 1 | `DIALOG_UNRECOGNIZED`, exit 3 |
| caption `Refresh`, no content (the WPF shape) | `BLOCKED_BY_DIALOG`, exit 1 | `DIALOG_UNREADABLE`, exit 3 |
| no text at all | `BLOCKED_BY_DIALOG`, exit 1 | `DIALOG_UNREADABLE`, exit 3 |
| `Save changes?` / `Discard` | `BLOCKED_BY_DIALOG`, exit 1 | `DIALOG_UNRECOGNIZED`, exit 3 |
| credential text in an **80x60** window | **NO FINDING AT ALL** | `CREDENTIAL_MISSING`, exit 1 |

## The half that was not in the issue

That last row is a **second instance of the same defect, in the opposite direction**. `match_credential_modal` was fed only `blocking_dialog_candidates(...)`, so the 100x100 filter gated the **hard stop** as well as the classification: a credential prompt in a smaller window produced **no finding at all** — a silent false negative on the one verdict that matters most. `Test-CredentialModal` in the arbiter has always scanned every window, any class, any size; the two now agree.

## Consumer trace (established, not assumed)

`probe_desktop_query._credential_verdict` → `refresh_pbip_model.main` / `_refresh_and_save` → the printed verdict line → `probe_live_source._classify_failure`.

`BLOCKED_BY_DIALOG` is in `_verdict_lines.CREDENTIAL_STOP_VERDICT_RE`, so **before**, any dialog ≥100x100 produced `NO_CREDENTIAL` — whose directive is *"You may NOT build. You CANNOT fix this yourself… TERMINATE THE RUN NOW."* **After**, each new token falls through to **`ERROR`** ("the probe itself could not run"): `rc != 0`, `_lift_gate` is never reached, the gate stays armed, and nothing asserts a wall we did not observe. Verified end-to-end by driving the real emitters through the real classifier.

**I deliberately did not change `scripts/_verdict_lines.py`.** Adding the new tokens to the credential-stop family would map them back to `NO_CREDENTIAL` — the exact false claim being removed; `ERROR` is the honest verdict and already fails safe. Divergence stated rather than hidden.

## Is a third state needed? Yes — and a fourth

`unreadable` (we could not read it) is kept distinct from `unrecognized` (we read it, it matched nothing), from `benign` (positively read as progress), and from `credential`. `benign-title-only` — a reassuring **caption** with no content behind it — joins the **unreadable** band, not the benign one: a caption is not content, and Win32 child-HWND enumeration sees nothing inside a WPF dialog, so a caption is frequently all there is.

## Three deliberate divergences from #390 (not cargo-culted)

Win32 child-HWND text is strictly **less** evidence than a UIA harvest, so three arbiter mechanisms are **not** ported, each for a stated reason:

| arbiter mechanism | here | why |
|---|---|---|
| prose **join** before the credential match | not ported | the join needs a control-type signal to skip an interposed `Cancel`; Win32 has none, so the only join available is the naive whole-window one #390 discarded. A join can *manufacture* a phrase (`Account` + `Key` → `Account Key`) — and that error lands on the one verdict the issue says to err **away** from. Recall lost this way routes to `unrecognized`/`unreadable` (exit 3, loud), and the arbiter is the escalation path. |
| enabled-owner **exoneration** | not ported | a *suppression* path needing owner/enabled state this module does not harvest, unverifiable without a live Desktop. Omitting it costs one more exit 3. |
| `benign-unverified` (truncated harvest) | not needed | a text read that throws already fails the **whole** enumeration → `unknown_reason`. A partial read never reaches the classifier. |

Everything the two detectors *do* share — signature files, kind names, verdict tokens, precedence — is now literally the same vocabulary.

## One asymmetry, in both directions

A proven-benign progress dialog is **reported at t=0** (`REFRESH_IN_PROGRESS` — somebody else owns this instance; stacking a second refresh is what the 2026-08-28 field report had to unpick) and **ignored once our own operation is in flight**. Nothing else is ever ignored.

Correspondingly, in the **bounded** refresh wait a dialog finding is now **latched**, not raised, so it cannot abort a refresh that may still finish — while `probe_desktop_query`'s poll still **acts** on it, because that loop has no deadline of its own and a latched dialog behind a wedged query would wait for ever.

## Mutation table — 16/16 caught

Scored on a **named `N failed`** plus non-zero exit, never a bare exit code. That guard earned itself: M14's first form produced a `SyntaxError` (pytest exit 2) and was correctly refused as a catch rather than counted — the #390 harness bug, reproduced and avoided.

| # | mutation | result | named test that failed |
|---|---|---|---|
| 1 | restore the SIZE-ONLY verdict | CAUGHT | `test_poll_loop_ignores_our_own_refresh_progress_dialog` (+13) |
| 2 | remove the credential signature check | CAUGHT | `test_classify_dialog_reads_the_window_instead_of_measuring_it[credential]` |
| 3 | collapse UNREADABLE into UNRECOGNIZED | CAUGHT | `test_unreadable_owned_dialog_reports_unreadable_not_no_modal` (+7) |
| 4 | let a benign CAPTION dismiss the window | CAUGHT | `test_classify_dialog_...[benign-title-only]` |
| 5 | re-gate the credential scan behind 100x100 | CAUGHT | `test_the_credential_scan_is_not_gated_by_the_size_filter` |
| 6 | first benign element classifies the window | CAUGHT | `test_classify_dialog_...[mixed-content]` |
| 7 | always dismiss a benign dialog | CAUGHT | `test_probe_query_does_not_stop_for_power_bi_s_own_progress_dialog` |
| 8 | never dismiss a benign dialog | CAUGHT | `test_poll_loop_ignores_our_own_refresh_progress_dialog` |
| 9 | restore raise-on-dialog mid-wait | CAUGHT | `test_poll_loop_latches_unreadable_dialog_and_raises_at_the_deadline` |
| 10 | benign outranks the unreadable band | CAUGHT | `test_a_window_we_could_not_account_for_outranks_a_progress_dialog` |
| 11 | smuggle a CREDENTIAL_MARKER into guidance | CAUGHT | `test_a_dialog_finding_keeps_the_gate_shut_without_claiming_a_credential_wall` |
| 12 | in-flight detector exists but is not the default | CAUGHT | `test_poll_loop_default_detector_is_the_in_flight_one` |
| 13 | `probe_desktop_query` returns exit 1 again | CAUGHT | `test_probe_query_stops_at_exit_3_for_a_dialog_it_could_not_read` |
| 14 | poll stops using the in-flight detector | CAUGHT | `test_probe_query_poll_ignores_a_progress_dialog_while_the_query_runs` |
| 15 | `refresh_pbip_model` returns exit 1 again | CAUGHT | `test_refresh_and_save_wires_a_dialog_finding_to_exit_3` |
| 16 | `main()` stops reporting a t=0 dialog | CAUGHT | `test_refresh_main_reports_a_t0_dialog_at_exit_3_before_any_mutation` |

## Callers checked before renaming (issue acceptance 5)

`BLOCKED_BY_DIALOG` / `BlockingDialog` / `DialogBlockedError` retired from the Python path. Every consumer verified: both entry points, `join_with_credential_poll`, `_verdict_lines.py` (unchanged — the token stays in the regex, now unemitted), `tests/test_probe_live_source_verdict.py`, `SKILL.md`, `docs/data-source-credentials.md`, `powerbi-semantic-model-gotchas/SKILL.md`. The stale hand-written `BLOCKED_BY_DIALOG` fixture in `test_probe_live_source_verdict.py` is replaced by one **harvested from the real emitter** — the #152/#153 discipline.

## Gates

`pytest -q -n auto --dist loadfile` → **3009 passed**, 9 skipped, only the 3 known `test_upstream_repro_pins.py` failures · `-m timing` 7 passed · pylint **10.00/10, exit 0** on all three roots · `ruff` clean · `check_navigation_index.py` 0 · `tests/test_skills.py` 27 passed · `sync_installed_skills.py --check` 0.

## What I could NOT verify

- **No Power BI Desktop was used.** Every window in the corpus is synthesised. The `MIN_PROMPT_WORDS = 5` backstop and `benign_dialog_signature.regex` remain **inferred** from the refresh UI, not captured from a live dialog.
- **In practice a real WPF refresh dialog will most often land on `DIALOG_UNREADABLE`, not `REFRESH_IN_PROGRESS`** — Win32 child enumeration returns nothing inside WPF, so only the caption survives, and a caption cannot dismiss. That is exit 3 either way (the false *hard stop* is gone), but it is a recall limit, not a clean win, and I am not claiming otherwise. Capturing a real dialog's Win32 text is the follow-up that would settle it.
- **The `Authentication required` alternative** in `blocking_prompt_signature.regex` carries a `CREDENTIAL_MARKER`, so its evidence excerpt re-classifies as `NO_CREDENTIAL` downstream. It fails toward "a human is needed", never toward a clear — same known limit #390 recorded.
- **`benign` is reachable only when a dialog exposes real child-HWND content** (WinForms dialogs do). Unobserved in this corpus whether Power BI's own dialog does.
- **Shadowing did not apply here:** `pbip-model-refresh` is deliberately **held back** from the published plugin (`scripts/build_plugin.py:37-47`), so no plugin copy of these scripts exists to go stale. The sync still mattered for `powerbi-semantic-model-gotchas/SKILL.md`, which does ship; that file was copied and `--check` now exits 0.
- **Pre-existing, untouched:** `scripts/README.md:60` carries a leftover merge-conflict marker `>>>>>>> d8ef6c6`. Not mine, not in scope, flagged here rather than silently fixed.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
