### PR TITLE
fix(mutation-harness): award CAUGHT only for a named test outcome, not any non-zero exit

### DIFF
--- a/tests/mutation_harness.py
+++ b/tests/mutation_harness.py
@@ -16,6 +16,7 @@ running a single test and a naive harness scores that as CAUGHT. The first run o
 
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import sys
@@ -188,49 +189,169 @@ me._FAKE_ENGINE = me._FAKE_ENGINE.replace('"pageOrder": pages or []', '"pageOrde
 }
 
 
-def run(name: str, code: str, target: str) -> tuple[str, int, str, list[str], list[str]]:
-    """Apply one mutation and report ``(name, exit_code, detail, failed, errored)``.
+OUTCOME_HOOKS = """
 
-    ``failed`` and ``errored`` are the load-bearing return values. A non-zero exit code alone
-    does NOT mean the mutation was caught -- pytest exits non-zero for collection errors (4),
-    usage errors (4), internal errors (3) and interrupts (2), none of which involve a test
-    observing anything. Measured on master: ``pytest tests/does_not_exist.py`` exits 4 with zero
-    named outcomes, and the old verdict expression scored it CAUGHT.
+# --- appended by mutation_harness: structured lifecycle recording ------------------
+# Terminal text cannot distinguish "a test observed the mutation" from "pytest failed to
+# run". A collection error on a CLASS emits `ERROR path::TestName`, and a dying xdist
+# worker emits `FAILED path::test_name` for a test that never executed - both parse as a
+# named outcome. So record the real lifecycle instead of scraping the summary.
+import json as _json
+from pathlib import Path as _Path
+
+_OUTCOMES = _Path(r"{outcome_path}")
+_RECORD = {{"call_failed": [], "setup_failed": [], "collect_error": [], "internal_error": False,
+            "node_down": False}}
+
+
+def _flush():
+    _OUTCOMES.write_text(_json.dumps(_RECORD), encoding="utf-8")
+
+
+def pytest_runtest_logreport(report):
+    if report.outcome != "failed":
+        return
+    name = report.nodeid.split("::")[-1]
+    # `when` is the discriminator terminal text throws away.
+    ("call_failed" if report.when == "call" else "setup_failed")
+    _RECORD["call_failed" if report.when == "call" else "setup_failed"].append(name)
+    _flush()
+
+
+def pytest_collectreport(report):
+    if report.outcome == "failed":
+        _RECORD["collect_error"].append(report.nodeid or "<root>")
+        _flush()
+
+
+def pytest_internalerror(excrepr, excinfo):
+    _RECORD["internal_error"] = True
+    _flush()
+
+
+def pytest_testnodedown(node, error):
+    if error is not None:
+        _RECORD["node_down"] = True
+        _flush()
+
+
+_flush()
+"""
+
+
+def run(name: str, code: str, target: str) -> tuple[str, int, str, dict]:
+    """Apply one mutation and report ``(name, exit_code, detail, outcomes)``.
+
+    ``outcomes`` is the load-bearing return value, and it comes from pytest's own lifecycle
+    hooks rather than its terminal output. Three measured reasons text parsing is not enough:
+
+    * a non-zero exit alone means nothing -- ``pytest tests/does_not_exist.py`` exits 4 having
+      run no test, and the pre-fix verdict scored it CAUGHT;
+    * a **collection** failure on a class emits ``ERROR path::TestName``, which looks exactly
+      like a named test error;
+    * a dying **xdist** worker emits ``FAILED path::test_name`` for a test that never executed.
+
+    ``--color=no`` and a scrubbed ``PYTEST_ADDOPTS`` are belt-and-braces: with ``PY_COLORS=1``
+    the summary tokens carry ANSI prefixes, which silently turned real detections into
+    harness errors.
     """
     plugin = ROOT / "tests" / "_mutation_plugin.py"
+    outcomes_file = ROOT / "tests" / "_mutation_outcomes.json"
+    outcomes_file.unlink(missing_ok=True)
     plugin.write_text(
         "import sys\nfrom pathlib import Path\n"
-        f"sys.path.insert(0, r'{ROOT / 'scripts'}')\nsys.path.insert(0, r'{ROOT / 'tests'}')\n" + code,
+        f"sys.path.insert(0, r'{ROOT / 'scripts'}')\nsys.path.insert(0, r'{ROOT / 'tests'}')\n"
+        + code
+        + OUTCOME_HOOKS.format(outcome_path=str(outcomes_file)),
         encoding="utf-8",
     )
+    env = {
+        **os.environ,
+        "PYTHONPATH": os.pathsep.join([str(ROOT / "tests"), str(ROOT / "scripts")]),
+    }
+    env.pop("PYTEST_ADDOPTS", None)
+    env.pop("PY_COLORS", None)
     proc = subprocess.run(
-        [PY, "-m", "pytest", target, "-q", "-p", "_mutation_plugin", "--no-header", "-x", "--tb=no"],
+        [PY, "-m", "pytest", target, "-q", "-p", "_mutation_plugin", "--no-header", "-x", "--tb=no", "--color=no"],
         cwd=ROOT,
         capture_output=True,
         text=True,
         check=False,
-        env={
-            **os.environ,
-            "PYTHONPATH": os.pathsep.join([str(ROOT / "tests"), str(ROOT / "scripts")]),
-        },
+        env=env,
     )
     plugin.unlink(missing_ok=True)
     if "Error importing plugin" in proc.stdout + proc.stderr:
+        outcomes_file.unlink(missing_ok=True)
         raise SystemExit(f"{name}: the mutation never applied - the harness would report a FALSE 'CAUGHT'")
-    failed, errored = named_outcomes(proc.stdout)
-    if failed:
-        return name, proc.returncode, failed[0], failed, errored
+    outcomes = read_outcomes(outcomes_file)
+    outcomes_file.unlink(missing_ok=True)
+    detail = describe(proc, outcomes)
+    return name, proc.returncode, detail, outcomes
+
+
+def read_outcomes(path: Path) -> dict:
+    """Load the plugin's record. A missing or unreadable file is itself a harness error."""
+    empty = {
+        "call_failed": [],
+        "setup_failed": [],
+        "collect_error": [],
+        "internal_error": False,
+        "node_down": False,
+        "recorded": False,
+    }
+    try:
+        loaded = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return empty
+    loaded["recorded"] = True
+    return loaded
+
+
+def is_harness_error(outcomes: dict) -> bool:
+    """True when pytest failed to run rather than a test observing anything."""
+    return (
+        not outcomes.get("recorded")
+        or bool(outcomes.get("collect_error"))
+        or outcomes.get("internal_error", False)
+        or outcomes.get("node_down", False)
+    )
+
+
+def describe(proc: subprocess.CompletedProcess, outcomes: dict) -> str:
+    """One-line detail for the report, preferring the structured record."""
+    if outcomes.get("call_failed"):
+        return outcomes["call_failed"][0]
+    if outcomes.get("setup_failed"):
+        return f"{outcomes['setup_failed'][0]} (errored, did not assert)"
+    if outcomes.get("collect_error"):
+        return f"collection error: {outcomes['collect_error'][0]}"
+    if outcomes.get("internal_error"):
+        return "pytest internal error"
+    if outcomes.get("node_down"):
+        return "xdist worker died"
+    if not outcomes.get("recorded"):
+        return "no lifecycle record written - pytest never started"
+    return last_line(proc)
+
+
+def last_line(proc: subprocess.CompletedProcess) -> str:
+    """Diagnostic text from wherever pytest actually wrote it.
+
+    Indexing stdout unconditionally raised IndexError when a usage/plugin error left stdout
+    empty, so the baseline precondition crashed instead of reporting a harness error.
+    """
     lines = (proc.stdout.strip() or proc.stderr.strip() or "(no output)").splitlines()
-    return name, proc.returncode, lines[-1][:120], failed, errored
+    return lines[-1][:120] if lines else "(no output)"
 
 
 def named_outcomes(stdout: str) -> tuple[list[str], list[str]]:
-    """Return ``(failed, errored)`` test names pytest reported.
+    """Parse pytest's terminal summary. RETAINED FOR DIAGNOSTICS ONLY -- not a verdict source.
 
-    Both are evidence the mutation was **observed by a named test**. They are kept apart
-    because they are not equally strong: a FAILED line is an assertion that noticed, an ERROR
-    line is a setup/teardown crash that noticed. Neither is the same as pytest failing to run
-    at all, which names no test and is the case that must never earn credit.
+    Blind review of PR #409 established that this cannot decide anything: a **collection**
+    failure on a class emits ``ERROR path::TestName`` and a dying **xdist** worker emits
+    ``FAILED path::test_name`` for a test that never ran, so both shapes are indistinguishable
+    here from a real observation. ANSI colouring also defeats the ``startswith`` entirely.
+    The verdict comes from ``read_outcomes`` / ``is_harness_error`` instead.
     """
     failed, errored = [], []
     for line in stdout.splitlines():
@@ -253,7 +374,7 @@ def main() -> int:
         baseline = subprocess.run(
             [PY, "-m", "pytest", target, "-q", "--no-header"], cwd=ROOT, capture_output=True, text=True, check=False
         )
-        print(f"BASELINE {target:32s} exit={baseline.returncode}  {baseline.stdout.strip().splitlines()[-1]}")
+        print(f"BASELINE {target:32s} exit={baseline.returncode}  {last_line(baseline)}")
         if baseline.returncode != 0:
             dirty.append(f"{target} (exit {baseline.returncode})")
     if dirty:
@@ -272,22 +393,24 @@ def main() -> int:
             target = "tests/test_mock_tableau.py"
         else:
             target = "tests/test_e2e_offline.py"
-        label, rc, detail, failed, errored = run(name, code, target)
-        if failed:
+        label, rc, detail, outcomes = run(name, code, target)
+        if is_harness_error(outcomes):
+            # Collection error, internal error, dead xdist worker, or no record at all.
+            # pytest never ran the tests, so there is no verdict to give.
+            verdict = "HARNESS-ERROR"
+            harness_errors.append(f"{label} (exit {rc}, {detail})")
+        elif outcomes["call_failed"]:
             verdict = "CAUGHT  "
-        elif errored:
-            # Observed, but by a crash rather than an assertion. Credited and marked, because a
-            # test that only errors is weaker coverage than one that asserts.
+        elif outcomes["setup_failed"]:
+            # Observed, but by a setup/teardown crash rather than an assertion. Credited and
+            # marked, because a test that only errors is weaker coverage than one that asserts.
             verdict = "CAUGHT* "
-            detail = f"{errored[0]} (errored, did not assert)"
         elif rc == 0:
             verdict = "SURVIVED"
             survivors.append(label)
         else:
-            # Non-zero while naming NO test is pytest failing to run - collection error (4),
-            # internal error (3), interrupt (2). The mutation was never observed.
             verdict = "HARNESS-ERROR"
-            harness_errors.append(f"{label} (exit {rc}, no named test outcome)")
+            harness_errors.append(f"{label} (exit {rc}, no test outcome recorded)")
         print(f"{verdict}  {label:52s} -> {detail}")
     print()
     print("survivors (holes in the suite):", survivors or "none")

--- a/tests/mutation_harness.py
+++ b/tests/mutation_harness.py
@@ -216,6 +216,8 @@ _RECORD = {{
     "session_finished": False,
     "exitstatus": None,
     "saw_call_phase": False,
+    "runtest_loop_completed": False,
+    "synthetic_failed": [],
 }}
 
 
@@ -229,11 +231,31 @@ def pytest_runtest_logreport(report):
     # finished session with a report and exit 0 while stdout said `no tests ran`.
     if report.when == "call":
         _RECORD["saw_call_phase"] = True
-    if report.outcome == "failed":
-        # `when` is the discriminator terminal text throws away.
+    if report.outcome != "failed":
+        _flush()
+        return
+    # ONLY real lifecycle phases count as an observation. xdist synthesises a crash report
+    # for a dead worker with `when="???"`, and that names a test which never executed --
+    # filtering here is what lets a genuine failure from a LIVING worker stay durable
+    # instead of being erased wholesale by a `node_down` flag.
+    if report.when in ("call", "setup", "teardown"):
         name = report.nodeid.split("::")[-1]
         _RECORD["call_failed" if report.when == "call" else "setup_failed"].append(name)
+    else:
+        _RECORD["synthetic_failed"].append(f"{{report.nodeid}}::{{report.when}}")
     _flush()
+
+
+@_pytest.hookimpl(hookwrapper=True)
+def pytest_runtestloop(session):
+    # The ONLY evidence the selected suite ran to the end. `pytest_sessionfinish` fires even
+    # after `pytest.exit()`, and one completed call phase proves one test body ran, not that
+    # the run finished: measured, `pytest.exit()` from teardown after the first passing test
+    # gave session_finished, saw_call_phase and exit 0 -- and scored SURVIVED.
+    outcome = yield
+    if outcome.excinfo is None:
+        _RECORD["runtest_loop_completed"] = True
+        _flush()
 
 
 def pytest_collectreport(report):
@@ -350,7 +372,9 @@ def read_outcomes(path: Path) -> dict:
         "node_down": False,
         "session_finished": False,
         "exitstatus": None,
-        "saw_report": False,
+        "saw_call_phase": False,
+        "runtest_loop_completed": False,
+        "synthetic_failed": [],
         "recorded": False,
     }
     try:
@@ -369,34 +393,39 @@ def observed_mutation(outcomes: dict) -> bool:
     cost of the opposite rule -- a real assertion failure followed by ``KeyboardInterrupt`` in
     teardown exits 2, and erasing the detection turned a genuine CAUGHT into a HARNESS-ERROR.
 
-    ``node_down`` is the exception and not an inconsistency: a dying xdist worker emits
-    ``FAILED path::test_name`` for a test that **never executed**, so that record is synthetic
-    rather than observed.
+    ``node_down`` is deliberately **not** consulted here. Round-4 review showed a global flag
+    is too blunt: a genuine call failure emitted by a LIVING worker, or by the dying worker
+    before it died, is still real evidence. The synthetic crash report xdist fabricates
+    carries ``when="???"`` and is filtered at record time instead, so only actual
+    ``call``/``setup``/``teardown`` failures ever reach these lists.
     """
-    if outcomes.get("node_down"):
-        return False
     return bool(outcomes.get("call_failed") or outcomes.get("setup_failed"))
 
 
 def session_is_trustworthy(outcomes: dict) -> bool:
-    """True when a COMPLETE, coherent session ran to a verdict.
+    """True when a COMPLETE, coherent session ran the whole selected suite to a clean verdict.
 
     Required before concluding SURVIVED, because absence of evidence is only evidence of
-    absence when the run actually finished. Three measured shapes that pass a naive check:
+    absence when the run actually finished. Four measured shapes that pass a naive check:
 
     * ``pytest.exit(returncode=0)`` from ``pytest_sessionstart`` -- exit 0, a valid record
       written at plugin import, no tests at all;
     * the same from ``pytest_runtest_call`` -- ``session_finished``, ``exitstatus=0`` and a
-      setup-phase report present, while stdout says ``no tests ran``;
+      setup-phase report, while stdout says ``no tests ran``;
+    * the same from **teardown after the first passing test** -- ``session_finished``,
+      ``saw_call_phase`` and exit 0, having run 1 of 14 tests. Hence
+      ``runtest_loop_completed``, which is the only evidence the suite ran to the end;
     * a call failure then ``KeyboardInterrupt`` -- exit 2, session incoherent.
 
-    Hence ``saw_call_phase``: a test BODY must have run, not merely a setup report.
+    ``exitstatus == 0`` specifically: exit 1 means tests failed, and a failure we did not
+    record as an observation cannot prove anything survived.
     """
     return (
         bool(outcomes.get("recorded"))
         and bool(outcomes.get("session_finished"))
+        and bool(outcomes.get("runtest_loop_completed"))
         and bool(outcomes.get("saw_call_phase"))
-        and outcomes.get("exitstatus") in VERDICT_BEARING_EXITS
+        and outcomes.get("exitstatus") == 0
         and not outcomes.get("collect_error")
         and not outcomes.get("internal_error", False)
         and not outcomes.get("node_down", False)
@@ -406,10 +435,17 @@ def session_is_trustworthy(outcomes: dict) -> bool:
 def session_ended_abnormally(outcomes: dict) -> bool:
     """True when something happened TO the run, as opposed to the run reaching a verdict.
 
-    Deliberately narrower than ``not session_is_trustworthy``: a session in which every test
-    errored in **setup** has no call phase and is therefore not "trustworthy" for concluding
-    SURVIVED -- but nothing went wrong with it, and annotating that as abnormal would fire on
-    every legitimate ``CAUGHT*`` and train the reader to ignore the warning.
+    Deliberately narrower than ``not session_is_trustworthy``, twice over:
+
+    * a session in which every test errored in **setup** has no call phase, so it cannot prove
+      SURVIVED -- but nothing went wrong with it;
+    * mutations run under ``-x``, so pytest raises ``Interrupted`` from the runtest loop the
+      moment one is caught. ``runtest_loop_completed`` is therefore ``False`` for **every**
+      legitimate CAUGHT, and including it here annotated all of them.
+
+    Both would fire on every valid case, and a warning that always fires is one nobody reads.
+    ``runtest_loop_completed`` still gates ``session_is_trustworthy``, where it is the only
+    evidence the selected suite ran to the end.
     """
     return (
         not outcomes.get("recorded")
@@ -418,6 +454,7 @@ def session_ended_abnormally(outcomes: dict) -> bool:
         or bool(outcomes.get("collect_error"))
         or outcomes.get("internal_error", False)
         or outcomes.get("node_down", False)
+        or bool(outcomes.get("synthetic_failed"))
     )
 
 

--- a/tests/mutation_harness.py
+++ b/tests/mutation_harness.py
@@ -196,12 +196,27 @@ OUTCOME_HOOKS = """
 # run". A collection error on a CLASS emits `ERROR path::TestName`, and a dying xdist
 # worker emits `FAILED path::test_name` for a test that never executed - both parse as a
 # named outcome. So record the real lifecycle instead of scraping the summary.
+#
+# The record must answer "did a COMPLETE session observe this", not merely "did the plugin
+# load". An empty record written at import time is evidence of nothing: measured,
+# `pytest.exit(returncode=0)` from `pytest_sessionstart` produced exit 0 with a valid empty
+# record and no tests at all, and that scored SURVIVED.
 import json as _json
 from pathlib import Path as _Path
 
+import pytest as _pytest
+
 _OUTCOMES = _Path(r"{outcome_path}")
-_RECORD = {{"call_failed": [], "setup_failed": [], "collect_error": [], "internal_error": False,
-            "node_down": False}}
+_RECORD = {{
+    "call_failed": [],
+    "setup_failed": [],
+    "collect_error": [],
+    "internal_error": False,
+    "node_down": False,
+    "session_finished": False,
+    "exitstatus": None,
+    "saw_report": False,
+}}
 
 
 def _flush():
@@ -209,12 +224,11 @@ def _flush():
 
 
 def pytest_runtest_logreport(report):
-    if report.outcome != "failed":
-        return
-    name = report.nodeid.split("::")[-1]
-    # `when` is the discriminator terminal text throws away.
-    ("call_failed" if report.when == "call" else "setup_failed")
-    _RECORD["call_failed" if report.when == "call" else "setup_failed"].append(name)
+    _RECORD["saw_report"] = True
+    if report.outcome == "failed":
+        # `when` is the discriminator terminal text throws away.
+        name = report.nodeid.split("::")[-1]
+        _RECORD["call_failed" if report.when == "call" else "setup_failed"].append(name)
     _flush()
 
 
@@ -229,14 +243,31 @@ def pytest_internalerror(excrepr, excinfo):
     _flush()
 
 
+@_pytest.hookimpl(optionalhook=True)
 def pytest_testnodedown(node, error):
+    # xdist-only, and it MUST be declared optional: without xdist installed pytest rejects
+    # the whole plugin with `PluginValidationError: unknown hook 'pytest_testnodedown'`,
+    # which made every serial mutation unusable in that environment.
     if error is not None:
         _RECORD["node_down"] = True
         _flush()
 
 
+def pytest_sessionfinish(session, exitstatus):
+    _RECORD["session_finished"] = True
+    _RECORD["exitstatus"] = int(exitstatus)
+    _flush()
+
+
 _flush()
 """
+
+# pytest returns 0 (all passed) or 1 (tests failed) when a session ran to a verdict. Every
+# other code means something happened TO the run: 2 interrupted, 3 internal error, 4 usage
+# error, 5 nothing collected. An outcome recorded alongside one of those is not a verdict --
+# measured, a call failure followed by KeyboardInterrupt in teardown exits 2 with
+# `call_failed` populated, and the previous ordering reported CAUGHT.
+VERDICT_BEARING_EXITS = frozenset({0, 1})
 
 
 def run(name: str, code: str, target: str) -> tuple[str, int, str, dict]:
@@ -297,6 +328,9 @@ def read_outcomes(path: Path) -> dict:
         "collect_error": [],
         "internal_error": False,
         "node_down": False,
+        "session_finished": False,
+        "exitstatus": None,
+        "saw_report": False,
         "recorded": False,
     }
     try:
@@ -308,9 +342,18 @@ def read_outcomes(path: Path) -> dict:
 
 
 def is_harness_error(outcomes: dict) -> bool:
-    """True when pytest failed to run rather than a test observing anything."""
+    """True when pytest failed to run rather than a test observing anything.
+
+    ``recorded`` alone is not enough: the plugin flushes an empty record at **import**, so it
+    proves the plugin loaded, not that a session ran. Measured, ``pytest.exit(returncode=0)``
+    from ``pytest_sessionstart`` produced exit 0, ``recorded=True`` and no tests at all --
+    which the previous version reported as SURVIVED.
+    """
     return (
         not outcomes.get("recorded")
+        or not outcomes.get("session_finished")
+        or not outcomes.get("saw_report")
+        or outcomes.get("exitstatus") not in VERDICT_BEARING_EXITS
         or bool(outcomes.get("collect_error"))
         or outcomes.get("internal_error", False)
         or outcomes.get("node_down", False)

--- a/tests/mutation_harness.py
+++ b/tests/mutation_harness.py
@@ -217,6 +217,7 @@ _RECORD = {{
     "exitstatus": None,
     "saw_call_phase": False,
     "runtest_loop_completed": False,
+    "runtest_loop_exception": None,
     "synthetic_failed": [],
 }}
 
@@ -252,10 +253,16 @@ def pytest_runtestloop(session):
     # after `pytest.exit()`, and one completed call phase proves one test body ran, not that
     # the run finished: measured, `pytest.exit()` from teardown after the first passing test
     # gave session_finished, saw_call_phase and exit 0 -- and scored SURVIVED.
+    #
+    # The exception TYPE is recorded, not just the fact of one: `Interrupted` is what `-x`
+    # raises the moment a mutation is caught and is entirely expected, while `Exit` means
+    # somebody called `pytest.exit()` and the run was cut short for a reason of its own.
     outcome = yield
     if outcome.excinfo is None:
         _RECORD["runtest_loop_completed"] = True
-        _flush()
+    else:
+        _RECORD["runtest_loop_exception"] = outcome.excinfo[0].__name__
+    _flush()
 
 
 def pytest_collectreport(report):
@@ -294,6 +301,11 @@ _flush()
 # measured, a call failure followed by KeyboardInterrupt in teardown exits 2 with
 # `call_failed` populated, and the previous ordering reported CAUGHT.
 VERDICT_BEARING_EXITS = frozenset({0, 1})
+
+# Runtest-loop exceptions that mean "the run stopped because we told it to". `-x` sets
+# `--maxfail=1`, which raises `Failed`; `Interrupted` is the collection-side equivalent.
+# Anything else -- notably `Exit` from an explicit `pytest.exit()` -- is reported.
+EXPECTED_LOOP_STOPS = frozenset({"Failed", "Interrupted"})
 
 
 def sanitized_env() -> dict:
@@ -357,6 +369,10 @@ def run(name: str, code: str, target: str) -> tuple[str, int, str, dict]:
         outcomes_file.unlink(missing_ok=True)
         raise SystemExit(f"{name}: the mutation never applied - the harness would report a FALSE 'CAUGHT'")
     outcomes = read_outcomes(outcomes_file)
+    # The record is the view from INSIDE the session; the return code is the view from
+    # outside. A trylast sessionfinish hook or an atexit os._exit() can make them disagree,
+    # so both are carried and both must agree before anything is called SURVIVED.
+    outcomes["process_returncode"] = proc.returncode
     outcomes_file.unlink(missing_ok=True)
     detail = describe(proc, outcomes)
     return name, proc.returncode, detail, outcomes
@@ -374,6 +390,7 @@ def read_outcomes(path: Path) -> dict:
         "exitstatus": None,
         "saw_call_phase": False,
         "runtest_loop_completed": False,
+        "runtest_loop_exception": None,
         "synthetic_failed": [],
         "recorded": False,
     }
@@ -406,19 +423,20 @@ def session_is_trustworthy(outcomes: dict) -> bool:
     """True when a COMPLETE, coherent session ran the whole selected suite to a clean verdict.
 
     Required before concluding SURVIVED, because absence of evidence is only evidence of
-    absence when the run actually finished. Four measured shapes that pass a naive check:
+    absence when the run actually finished. Measured shapes that pass a naive check:
 
-    * ``pytest.exit(returncode=0)`` from ``pytest_sessionstart`` -- exit 0, a valid record
-      written at plugin import, no tests at all;
+    * ``pytest.exit(returncode=0)`` from ``pytest_sessionstart`` -- exit 0, a record written at
+      plugin import, no tests at all;
     * the same from ``pytest_runtest_call`` -- ``session_finished``, ``exitstatus=0`` and a
-      setup-phase report, while stdout says ``no tests ran``;
+      setup report, while stdout says ``no tests ran``;
     * the same from **teardown after the first passing test** -- ``session_finished``,
-      ``saw_call_phase`` and exit 0, having run 1 of 14 tests. Hence
-      ``runtest_loop_completed``, which is the only evidence the suite ran to the end;
-    * a call failure then ``KeyboardInterrupt`` -- exit 2, session incoherent.
+      ``saw_call_phase`` and exit 0, having run 1 of 14. Hence ``runtest_loop_completed``;
+    * a ``trylast=True`` session-finish hook that sets ``session.exitstatus = 1`` **after**
+      this recorder ran, and an ``atexit`` handler calling ``os._exit(1)`` after a clean
+      session -- both leave ``exitstatus=0`` in the record while the PROCESS returns 1.
 
-    ``exitstatus == 0`` specifically: exit 1 means tests failed, and a failure we did not
-    record as an observation cannot prove anything survived.
+    That last pair is why the recorded status is not sufficient on its own: the record is a
+    snapshot taken from inside, and the process is the outside view. Both must agree.
     """
     return (
         bool(outcomes.get("recorded"))
@@ -426,6 +444,7 @@ def session_is_trustworthy(outcomes: dict) -> bool:
         and bool(outcomes.get("runtest_loop_completed"))
         and bool(outcomes.get("saw_call_phase"))
         and outcomes.get("exitstatus") == 0
+        and outcomes.get("process_returncode") == 0
         and not outcomes.get("collect_error")
         and not outcomes.get("internal_error", False)
         and not outcomes.get("node_down", False)
@@ -435,22 +454,30 @@ def session_is_trustworthy(outcomes: dict) -> bool:
 def session_ended_abnormally(outcomes: dict) -> bool:
     """True when something happened TO the run, as opposed to the run reaching a verdict.
 
-    Deliberately narrower than ``not session_is_trustworthy``, twice over:
+    Deliberately narrower than ``not session_is_trustworthy``, and the narrowing is now by
+    **cause** rather than by dropping the term:
 
-    * a session in which every test errored in **setup** has no call phase, so it cannot prove
+    * a session where every test errored in **setup** has no call phase, so it cannot prove
       SURVIVED -- but nothing went wrong with it;
     * mutations run under ``-x``, so pytest raises ``Interrupted`` from the runtest loop the
-      moment one is caught. ``runtest_loop_completed`` is therefore ``False`` for **every**
-      legitimate CAUGHT, and including it here annotated all of them.
+      moment one is caught. That is expected and stays unannotated -- but an explicit ``Exit``
+      means somebody cut the run short, and that IS reported.
 
-    Both would fire on every valid case, and a warning that always fires is one nobody reads.
-    ``runtest_loop_completed`` still gates ``session_is_trustworthy``, where it is the only
-    evidence the selected suite ran to the end.
+    Recording the exception type is what lets those two be told apart; an earlier version
+    dropped ``runtest_loop_completed`` from this predicate entirely and so reported neither.
     """
+    # `Failed` is what `--maxfail` (which `-x` sets) raises when the limit is reached, and
+    # `Interrupted` covers the collection-side stop. Both are the run doing exactly what we
+    # asked; an explicit `Exit` from `pytest.exit()` is not. MEASURED: a caught mutation under
+    # `-x` records `runtest_loop_exception='Failed'` -- an earlier version guessed
+    # `Interrupted` and so annotated every legitimate CAUGHT.
+    loop_error = outcomes.get("runtest_loop_exception")
     return (
         not outcomes.get("recorded")
         or not outcomes.get("session_finished")
         or outcomes.get("exitstatus") not in VERDICT_BEARING_EXITS
+        or outcomes.get("process_returncode") != outcomes.get("exitstatus")
+        or (loop_error is not None and loop_error not in EXPECTED_LOOP_STOPS)
         or bool(outcomes.get("collect_error"))
         or outcomes.get("internal_error", False)
         or outcomes.get("node_down", False)

--- a/tests/mutation_harness.py
+++ b/tests/mutation_harness.py
@@ -215,7 +215,7 @@ _RECORD = {{
     "node_down": False,
     "session_finished": False,
     "exitstatus": None,
-    "saw_report": False,
+    "saw_call_phase": False,
 }}
 
 
@@ -224,7 +224,11 @@ def _flush():
 
 
 def pytest_runtest_logreport(report):
-    _RECORD["saw_report"] = True
+    # `saw_call_phase` and not merely "a report happened": a setup-phase report is emitted
+    # even when no test BODY runs, so `pytest.exit()` from `pytest_runtest_call` produced a
+    # finished session with a report and exit 0 while stdout said `no tests ran`.
+    if report.when == "call":
+        _RECORD["saw_call_phase"] = True
     if report.outcome == "failed":
         # `when` is the discriminator terminal text throws away.
         name = report.nodeid.split("::")[-1]
@@ -270,6 +274,27 @@ _flush()
 VERDICT_BEARING_EXITS = frozenset({0, 1})
 
 
+def sanitized_env() -> dict:
+    """The ONE environment both baseline and mutation runs use.
+
+    They must be identical or the comparison is meaningless. Measured: baselines inherited
+    ``PYTEST_ADDOPTS`` while mutation runs stripped it, so ``PYTEST_ADDOPTS=--collect-only``
+    made the baseline exit 0 having executed **no test at all** (``18 tests collected``),
+    after which every mutation ran the real suite and could be credited with a pre-existing
+    failure.
+
+    ``PY_COLORS`` is stripped for a different reason: ANSI prefixes on the summary tokens
+    silently turned real detections into harness errors while the verdict was text-based.
+    """
+    env = {
+        **os.environ,
+        "PYTHONPATH": os.pathsep.join([str(ROOT / "tests"), str(ROOT / "scripts")]),
+    }
+    env.pop("PYTEST_ADDOPTS", None)
+    env.pop("PY_COLORS", None)
+    return env
+
+
 def run(name: str, code: str, target: str) -> tuple[str, int, str, dict]:
     """Apply one mutation and report ``(name, exit_code, detail, outcomes)``.
 
@@ -296,12 +321,7 @@ def run(name: str, code: str, target: str) -> tuple[str, int, str, dict]:
         + OUTCOME_HOOKS.format(outcome_path=str(outcomes_file)),
         encoding="utf-8",
     )
-    env = {
-        **os.environ,
-        "PYTHONPATH": os.pathsep.join([str(ROOT / "tests"), str(ROOT / "scripts")]),
-    }
-    env.pop("PYTEST_ADDOPTS", None)
-    env.pop("PY_COLORS", None)
+    env = sanitized_env()
     proc = subprocess.run(
         [PY, "-m", "pytest", target, "-q", "-p", "_mutation_plugin", "--no-header", "-x", "--tb=no", "--color=no"],
         cwd=ROOT,
@@ -341,23 +361,73 @@ def read_outcomes(path: Path) -> dict:
     return loaded
 
 
-def is_harness_error(outcomes: dict) -> bool:
-    """True when pytest failed to run rather than a test observing anything.
+def observed_mutation(outcomes: dict) -> bool:
+    """True when a NAMED test genuinely observed the mutation.
 
-    ``recorded`` alone is not enough: the plugin flushes an empty record at **import**, so it
-    proves the plugin loaded, not that a session ran. Measured, ``pytest.exit(returncode=0)``
-    from ``pytest_sessionstart`` produced exit 0, ``recorded=True`` and no tests at all --
-    which the previous version reported as SURVIVED.
+    Detection evidence is **durable**: a test that failed in its ``call`` phase noticed the
+    mutation, and nothing that happens afterwards un-notices it. Round-3 review measured the
+    cost of the opposite rule -- a real assertion failure followed by ``KeyboardInterrupt`` in
+    teardown exits 2, and erasing the detection turned a genuine CAUGHT into a HARNESS-ERROR.
+
+    ``node_down`` is the exception and not an inconsistency: a dying xdist worker emits
+    ``FAILED path::test_name`` for a test that **never executed**, so that record is synthetic
+    rather than observed.
+    """
+    if outcomes.get("node_down"):
+        return False
+    return bool(outcomes.get("call_failed") or outcomes.get("setup_failed"))
+
+
+def session_is_trustworthy(outcomes: dict) -> bool:
+    """True when a COMPLETE, coherent session ran to a verdict.
+
+    Required before concluding SURVIVED, because absence of evidence is only evidence of
+    absence when the run actually finished. Three measured shapes that pass a naive check:
+
+    * ``pytest.exit(returncode=0)`` from ``pytest_sessionstart`` -- exit 0, a valid record
+      written at plugin import, no tests at all;
+    * the same from ``pytest_runtest_call`` -- ``session_finished``, ``exitstatus=0`` and a
+      setup-phase report present, while stdout says ``no tests ran``;
+    * a call failure then ``KeyboardInterrupt`` -- exit 2, session incoherent.
+
+    Hence ``saw_call_phase``: a test BODY must have run, not merely a setup report.
+    """
+    return (
+        bool(outcomes.get("recorded"))
+        and bool(outcomes.get("session_finished"))
+        and bool(outcomes.get("saw_call_phase"))
+        and outcomes.get("exitstatus") in VERDICT_BEARING_EXITS
+        and not outcomes.get("collect_error")
+        and not outcomes.get("internal_error", False)
+        and not outcomes.get("node_down", False)
+    )
+
+
+def session_ended_abnormally(outcomes: dict) -> bool:
+    """True when something happened TO the run, as opposed to the run reaching a verdict.
+
+    Deliberately narrower than ``not session_is_trustworthy``: a session in which every test
+    errored in **setup** has no call phase and is therefore not "trustworthy" for concluding
+    SURVIVED -- but nothing went wrong with it, and annotating that as abnormal would fire on
+    every legitimate ``CAUGHT*`` and train the reader to ignore the warning.
     """
     return (
         not outcomes.get("recorded")
         or not outcomes.get("session_finished")
-        or not outcomes.get("saw_report")
         or outcomes.get("exitstatus") not in VERDICT_BEARING_EXITS
         or bool(outcomes.get("collect_error"))
         or outcomes.get("internal_error", False)
         or outcomes.get("node_down", False)
     )
+
+
+def is_harness_error(outcomes: dict) -> bool:
+    """True when there is neither a detection nor a trustworthy session.
+
+    The asymmetry is deliberate: **detection is durable, absence is not.** A partial run can
+    prove a mutation was caught; only a complete one can prove it survived.
+    """
+    return not observed_mutation(outcomes) and not session_is_trustworthy(outcomes)
 
 
 def describe(proc: subprocess.CompletedProcess, outcomes: dict) -> str:
@@ -415,7 +485,12 @@ def main() -> int:
     dirty = []
     for target in targets:
         baseline = subprocess.run(
-            [PY, "-m", "pytest", target, "-q", "--no-header"], cwd=ROOT, capture_output=True, text=True, check=False
+            [PY, "-m", "pytest", target, "-q", "--no-header", "--color=no"],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+            env=sanitized_env(),
         )
         print(f"BASELINE {target:32s} exit={baseline.returncode}  {last_line(baseline)}")
         if baseline.returncode != 0:
@@ -437,23 +512,19 @@ def main() -> int:
         else:
             target = "tests/test_e2e_offline.py"
         label, rc, detail, outcomes = run(name, code, target)
-        if is_harness_error(outcomes):
-            # Collection error, internal error, dead xdist worker, or no record at all.
-            # pytest never ran the tests, so there is no verdict to give.
-            verdict = "HARNESS-ERROR"
-            harness_errors.append(f"{label} (exit {rc}, {detail})")
-        elif outcomes["call_failed"]:
-            verdict = "CAUGHT  "
-        elif outcomes["setup_failed"]:
-            # Observed, but by a setup/teardown crash rather than an assertion. Credited and
-            # marked, because a test that only errors is weaker coverage than one that asserts.
-            verdict = "CAUGHT* "
-        elif rc == 0:
+        if observed_mutation(outcomes):
+            # Detection is durable. A real call-phase failure noticed the mutation even if the
+            # session later fell over; only a synthetic `node_down` record is excluded.
+            verdict = "CAUGHT  " if outcomes["call_failed"] else "CAUGHT* "
+            if session_ended_abnormally(outcomes):
+                detail = f"{detail} [session ended abnormally: exit {rc}]"
+        elif session_is_trustworthy(outcomes):
             verdict = "SURVIVED"
             survivors.append(label)
         else:
+            # Neither a detection nor a complete session: pytest never reached a verdict.
             verdict = "HARNESS-ERROR"
-            harness_errors.append(f"{label} (exit {rc}, no test outcome recorded)")
+            harness_errors.append(f"{label} (exit {rc}, {detail})")
         print(f"{verdict}  {label:52s} -> {detail}")
     print()
     print("survivors (holes in the suite):", survivors or "none")

--- a/tests/mutation_harness.py
+++ b/tests/mutation_harness.py
@@ -188,7 +188,15 @@ me._FAKE_ENGINE = me._FAKE_ENGINE.replace('"pageOrder": pages or []', '"pageOrde
 }
 
 
-def run(name: str, code: str, target: str) -> tuple[str, int, str]:
+def run(name: str, code: str, target: str) -> tuple[str, int, str, list[str], list[str]]:
+    """Apply one mutation and report ``(name, exit_code, detail, failed, errored)``.
+
+    ``failed`` and ``errored`` are the load-bearing return values. A non-zero exit code alone
+    does NOT mean the mutation was caught -- pytest exits non-zero for collection errors (4),
+    usage errors (4), internal errors (3) and interrupts (2), none of which involve a test
+    observing anything. Measured on master: ``pytest tests/does_not_exist.py`` exits 4 with zero
+    named outcomes, and the old verdict expression scored it CAUGHT.
+    """
     plugin = ROOT / "tests" / "_mutation_plugin.py"
     plugin.write_text(
         "import sys\nfrom pathlib import Path\n"
@@ -209,22 +217,54 @@ def run(name: str, code: str, target: str) -> tuple[str, int, str]:
     plugin.unlink(missing_ok=True)
     if "Error importing plugin" in proc.stdout + proc.stderr:
         raise SystemExit(f"{name}: the mutation never applied - the harness would report a FALSE 'CAUGHT'")
-    caught = [line.split("::")[-1].split(" ")[0] for line in proc.stdout.splitlines() if line.startswith("FAILED")]
-    if caught:
-        return name, proc.returncode, caught[0]
+    failed, errored = named_outcomes(proc.stdout)
+    if failed:
+        return name, proc.returncode, failed[0], failed, errored
     lines = (proc.stdout.strip() or proc.stderr.strip() or "(no output)").splitlines()
-    return name, proc.returncode, lines[-1][:120]
+    return name, proc.returncode, lines[-1][:120], failed, errored
+
+
+def named_outcomes(stdout: str) -> tuple[list[str], list[str]]:
+    """Return ``(failed, errored)`` test names pytest reported.
+
+    Both are evidence the mutation was **observed by a named test**. They are kept apart
+    because they are not equally strong: a FAILED line is an assertion that noticed, an ERROR
+    line is a setup/teardown crash that noticed. Neither is the same as pytest failing to run
+    at all, which names no test and is the case that must never earn credit.
+    """
+    failed, errored = [], []
+    for line in stdout.splitlines():
+        if line.startswith("FAILED"):
+            failed.append(line.split("::")[-1].split(" ")[0])
+        elif line.startswith("ERROR ") and "::" in line:
+            errored.append(line.split("::")[-1].split(" ")[0])
+    return failed, errored
+
+
+def named_failures(stdout: str) -> list[str]:
+    """Test names pytest reported as FAILED. Kept for callers that only want assertions."""
+    return named_outcomes(stdout)[0]
 
 
 def main() -> int:
     targets = ["tests/test_e2e_offline.py", "tests/test_mock_fabric.py", "tests/test_mock_tableau.py"]
+    dirty = []
     for target in targets:
         baseline = subprocess.run(
             [PY, "-m", "pytest", target, "-q", "--no-header"], cwd=ROOT, capture_output=True, text=True, check=False
         )
         print(f"BASELINE {target:32s} exit={baseline.returncode}  {baseline.stdout.strip().splitlines()[-1]}")
+        if baseline.returncode != 0:
+            dirty.append(f"{target} (exit {baseline.returncode})")
+    if dirty:
+        # A mutation is only evidence against a clean baseline: an already-failing test would be
+        # credited to every mutation that follows it.
+        print("\nHARNESS ERROR: baseline is not clean, so no mutation verdict is trustworthy:")
+        for item in dirty:
+            print(f"  {item}")
+        return 2
     print()
-    survivors = []
+    survivors, harness_errors = [], []
     for name, code in MUTATIONS.items():
         if name.startswith("mock-"):
             target = "tests/test_mock_fabric.py"
@@ -232,13 +272,31 @@ def main() -> int:
             target = "tests/test_mock_tableau.py"
         else:
             target = "tests/test_e2e_offline.py"
-        label, rc, detail = run(name, code, target)
-        verdict = "CAUGHT " if rc != 0 else "SURVIVED"
-        if rc == 0:
+        label, rc, detail, failed, errored = run(name, code, target)
+        if failed:
+            verdict = "CAUGHT  "
+        elif errored:
+            # Observed, but by a crash rather than an assertion. Credited and marked, because a
+            # test that only errors is weaker coverage than one that asserts.
+            verdict = "CAUGHT* "
+            detail = f"{errored[0]} (errored, did not assert)"
+        elif rc == 0:
+            verdict = "SURVIVED"
             survivors.append(label)
+        else:
+            # Non-zero while naming NO test is pytest failing to run - collection error (4),
+            # internal error (3), interrupt (2). The mutation was never observed.
+            verdict = "HARNESS-ERROR"
+            harness_errors.append(f"{label} (exit {rc}, no named test outcome)")
         print(f"{verdict}  {label:52s} -> {detail}")
     print()
     print("survivors (holes in the suite):", survivors or "none")
+    print("CAUGHT* = a named test ERRORED rather than asserting; weaker coverage, still observed")
+    if harness_errors:
+        print("HARNESS ERRORS (no verdict - pytest never ran the tests):")
+        for item in harness_errors:
+            print(f"  {item}")
+        return 2
     return 0
 
 

--- a/tests/test_mutation_harness_scoring.py
+++ b/tests/test_mutation_harness_scoring.py
@@ -1,0 +1,71 @@
+"""The mutation harness must not credit a mutation for pytest failing to run.
+
+This exists because it did. `main()` judged every mutation with
+
+    verdict = "CAUGHT " if rc != 0 else "SURVIVED"
+
+which awards CAUGHT to a collection error (exit 4), an internal error (exit 3) or an
+interrupt (exit 2) -- none of which involve a test observing anything. Measured on master:
+`pytest tests/does_not_exist.py -q` exits **4** with **zero** named FAILED lines, and that
+expression scored it CAUGHT.
+
+The same file already guarded ONE instance of this class, with a comment reading "the harness
+would report a FALSE 'CAUGHT'", so the hazard was known and only partially closed.
+
+Found by blind review of PR #405, whose own 14/14 mutation table was produced by this harness.
+A surviving neutral control does not disprove the defect: a neutral change exits 0, so it only
+exercises the SURVIVED direction.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from mutation_harness import named_failures, named_outcomes  # noqa: E402
+
+
+REAL_FAILURE = "FAILED tests/test_e2e_offline.py::test_something - AssertionError: boom"
+NAMED_ERROR = "ERROR tests/test_e2e_offline.py::test_the_front_half_produced_real_artifacts_from_real_bytes"
+COLLECTION_ERROR = "ERROR tests/does_not_exist.py\n!!!!! Interrupted: no tests ran !!!!!"
+
+
+def test_a_named_failure_is_evidence() -> None:
+    """An assertion observed the mutation - the strongest form."""
+    assert named_outcomes(REAL_FAILURE) == (["test_something"], [])
+
+
+def test_a_named_ERROR_is_also_evidence_but_kept_separate() -> None:
+    """A setup/teardown crash in a NAMED test observed the mutation too, just not by asserting.
+
+    Measured: the ``engine-stand-in-emits-no-pages`` mutation produces exactly this shape. An
+    earlier version of this fix classified it as a harness error and would have discarded a real
+    detection - the opposite bug to the one being fixed.
+    """
+    failed, errored = named_outcomes(NAMED_ERROR)
+
+    assert failed == []
+    assert errored == ["test_the_front_half_produced_real_artifacts_from_real_bytes"]
+
+
+def test_a_collection_error_names_no_test_and_is_not_evidence() -> None:
+    """Exit 4 with no test named means pytest never ran anything."""
+    assert named_outcomes(COLLECTION_ERROR) == ([], [])
+
+
+def test_empty_output_is_not_evidence() -> None:
+    assert named_outcomes("") == ([], [])
+
+
+def test_every_named_failure_is_returned_not_just_the_first() -> None:
+    """``run()`` reports the first for brevity, but the verdict must see the whole set."""
+    out = "\n".join(
+        [
+            "FAILED tests/test_a.py::test_one - AssertionError",
+            "FAILED tests/test_a.py::test_two - AssertionError",
+        ]
+    )
+
+    assert named_failures(out) == ["test_one", "test_two"]

--- a/tests/test_mutation_harness_scoring.py
+++ b/tests/test_mutation_harness_scoring.py
@@ -61,7 +61,9 @@ def record(**kwargs) -> dict:
         "exitstatus": 0,
         "saw_call_phase": True,
         "runtest_loop_completed": True,
+        "runtest_loop_exception": None,
         "synthetic_failed": [],
+        "process_returncode": 0,
         "recorded": True,
     }
     base.update(kwargs)
@@ -249,14 +251,48 @@ def test_one_completed_call_phase_does_not_prove_the_suite_ran() -> None:
 def test_an_interrupted_loop_after_a_catch_is_not_annotated_as_abnormal() -> None:
     """Mutations run under ``-x``, so a CAUGHT always interrupts the loop.
 
-    ``runtest_loop_completed`` is therefore False for every legitimate detection. Including it
-    in the abnormal-session predicate annotated all of them, which is a warning nobody reads.
+    ``Interrupted`` is expected here and stays quiet; the narrowing is by **cause**, not by
+    dropping the term, so an explicit ``Exit`` is still reported (next test).
     """
-    caught_under_x = record(call_failed=["test_x"], runtest_loop_completed=False, exitstatus=1)
+    caught_under_x = record(
+        call_failed=["test_x"],
+        runtest_loop_completed=False,
+        runtest_loop_exception="Failed",
+        exitstatus=1,
+        process_returncode=1,
+    )
 
     assert observed_mutation(caught_under_x) is True
     assert session_ended_abnormally(caught_under_x) is False
     assert is_harness_error(caught_under_x) is False
+
+
+def test_an_explicit_pytest_exit_IS_annotated_even_when_the_mutation_was_caught() -> None:
+    """``Exit`` means somebody cut the run short -- distinguishable from ``-x``'s Interrupted."""
+    outcomes = record(
+        call_failed=["test_x"],
+        runtest_loop_completed=False,
+        runtest_loop_exception="Exit",
+        exitstatus=1,
+        process_returncode=1,
+    )
+
+    assert observed_mutation(outcomes) is True
+    assert session_ended_abnormally(outcomes) is True
+
+
+def test_the_record_and_the_process_must_agree() -> None:
+    """Round-5 finding: the record is the view from inside, the return code from outside.
+
+    Measured: a ``trylast=True`` session-finish hook set ``session.exitstatus = 1`` AFTER the
+    recorder ran, and an ``atexit`` handler called ``os._exit(1)`` after a clean session. Both
+    left ``exitstatus=0`` recorded while the process returned 1, and both scored SURVIVED.
+    """
+    disagreeing = record(exitstatus=0, process_returncode=1)
+
+    assert session_is_trustworthy(disagreeing) is False
+    assert session_ended_abnormally(disagreeing) is True
+    assert is_harness_error(disagreeing) is True
 
 
 def test_exit_one_without_a_recorded_detection_cannot_prove_survival() -> None:

--- a/tests/test_mutation_harness_scoring.py
+++ b/tests/test_mutation_harness_scoring.py
@@ -33,7 +33,12 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from mutation_harness import is_harness_error, read_outcomes  # noqa: E402
+from mutation_harness import (  # noqa: E402
+    is_harness_error,
+    observed_mutation,
+    read_outcomes,
+    session_is_trustworthy,
+)
 
 
 def record(**kwargs) -> dict:
@@ -51,7 +56,7 @@ def record(**kwargs) -> dict:
         "node_down": False,
         "session_finished": True,
         "exitstatus": 0,
-        "saw_report": True,
+        "saw_call_phase": True,
         "recorded": True,
     }
     base.update(kwargs)
@@ -128,18 +133,57 @@ def test_a_session_that_exits_before_running_anything_is_a_harness_error() -> No
     previous version reported as SURVIVED, i.e. as a hole in the suite rather than as a run
     that never happened.
     """
-    assert is_harness_error(record(saw_report=False, session_finished=True, exitstatus=0)) is True
+    assert is_harness_error(record(saw_call_phase=False, session_finished=True, exitstatus=0)) is True
 
 
-def test_an_interrupt_after_a_failure_is_a_harness_error() -> None:
-    """Reviewer's reproduction: a call failure, then KeyboardInterrupt during teardown.
+def test_an_interrupt_after_a_genuine_failure_still_counts_as_caught() -> None:
+    """Detection is DURABLE - round 3 overturned round 2 on exactly this case.
 
-    pytest exits **2** with ``call_failed`` populated. The failure is real but the session is
-    not, so it cannot be credited -- the previous ordering reported CAUGHT and returned 0.
+    A call failure followed by ``KeyboardInterrupt`` in teardown exits **2**. Round 2 said
+    treat an unexpected exit as a harness error "even when an earlier outcome was recorded";
+    round 3 measured the cost -- a real assertion failure erased into a HARNESS-ERROR.
+
+    A test that failed in its ``call`` phase noticed the mutation. Nothing later un-notices it.
     """
-    assert is_harness_error(record(call_failed=["test_x"], exitstatus=2)) is True
+    outcomes = record(call_failed=["test_x"], exitstatus=2)
+
+    assert observed_mutation(outcomes) is True
+    assert is_harness_error(outcomes) is False
+    # ...but the session is still not trustworthy, which is what SURVIVED would need.
+    assert session_is_trustworthy(outcomes) is False
 
 
-def test_an_unfinished_session_is_a_harness_error() -> None:
-    """No ``pytest_sessionfinish`` means the process died mid-run; the record is a snapshot."""
-    assert is_harness_error(record(call_failed=["test_x"], session_finished=False)) is True
+def test_an_unfinished_session_cannot_prove_survival_but_keeps_its_detection() -> None:
+    """The asymmetry, stated directly: a partial run can prove CAUGHT, never SURVIVED."""
+    partial = record(call_failed=["test_x"], session_finished=False)
+    assert observed_mutation(partial) is True
+    assert session_is_trustworthy(partial) is False
+    assert is_harness_error(partial) is False
+
+    silent = record(session_finished=False)
+    assert observed_mutation(silent) is False
+    assert is_harness_error(silent) is True
+
+
+def test_a_dead_worker_failure_is_synthetic_and_never_counts() -> None:
+    """The one exception, and it is not an inconsistency.
+
+    A dying xdist worker emits ``FAILED path::test_name`` for a test that **never executed**,
+    so that ``call_failed`` entry is fabricated rather than observed.
+    """
+    outcomes = record(node_down=True, call_failed=["test_never_ran"])
+
+    assert observed_mutation(outcomes) is False
+    assert is_harness_error(outcomes) is True
+
+
+def test_a_setup_report_alone_does_not_prove_a_test_body_ran() -> None:
+    """Reviewer's reproduction: ``pytest.exit(returncode=0)`` from ``pytest_runtest_call``.
+
+    That yields ``session_finished``, ``exitstatus=0`` and a setup-phase report, while pytest's
+    own stdout says ``no tests ran``. Hence ``saw_call_phase`` rather than "a report happened".
+    """
+    outcomes = record(saw_call_phase=False)
+
+    assert session_is_trustworthy(outcomes) is False
+    assert is_harness_error(outcomes) is True

--- a/tests/test_mutation_harness_scoring.py
+++ b/tests/test_mutation_harness_scoring.py
@@ -1,20 +1,29 @@
-"""The mutation harness must not credit a mutation for pytest failing to run.
+"""The mutation harness must credit a mutation only when a test actually observed it.
 
-This exists because it did. `main()` judged every mutation with
+Two defects, both found by blind review, both from the same root cause -- **scraping pytest's
+terminal output is a proxy for "did a test observe the mutation", and the proxy fails in both
+directions.**
+
+Round 1 (the original defect, on master since #331)::
 
     verdict = "CAUGHT " if rc != 0 else "SURVIVED"
 
-which awards CAUGHT to a collection error (exit 4), an internal error (exit 3) or an
-interrupt (exit 2) -- none of which involve a test observing anything. Measured on master:
-`pytest tests/does_not_exist.py -q` exits **4** with **zero** named FAILED lines, and that
-expression scored it CAUGHT.
+``run()`` already extracted named FAILED lines; ``main()`` threw them away. Measured:
+``pytest tests/does_not_exist.py -q`` exits **4** having run nothing, and scored CAUGHT.
 
-The same file already guarded ONE instance of this class, with a comment reading "the harness
-would report a FALSE 'CAUGHT'", so the hazard was known and only partially closed.
+Round 2 -- this file's first fix was still text-based, and was wrong three ways:
 
-Found by blind review of PR #405, whose own 14/14 mutation table was produced by this harness.
-A surviving neutral control does not disprove the defect: a neutral change exits 0, so it only
-exercises the SURVIVED direction.
+* a **collection** failure on a class emits ``ERROR path::TestName``, indistinguishable from a
+  named test error, so it scored CAUGHT*;
+* a dying **xdist** worker emits ``FAILED path::test_name`` for a test that never executed;
+* ``PY_COLORS=1`` prefixes those tokens with ANSI escapes, so ``startswith`` failed and genuine
+  detections became HARNESS-ERROR -- the opposite bug.
+
+The verdict now comes from pytest's own lifecycle hooks (``pytest_runtest_logreport``,
+``pytest_collectreport``, ``pytest_internalerror``, ``pytest_testnodedown``), recorded to JSON by
+the injected plugin. ``report.when`` is the discriminator terminal text throws away: ``call``
+means an assertion noticed, ``setup``/``teardown`` means a crash noticed, and neither exists when
+pytest never ran.
 """
 
 from __future__ import annotations
@@ -24,48 +33,81 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from mutation_harness import named_failures, named_outcomes  # noqa: E402
+from mutation_harness import is_harness_error, read_outcomes  # noqa: E402
 
 
-REAL_FAILURE = "FAILED tests/test_e2e_offline.py::test_something - AssertionError: boom"
-NAMED_ERROR = "ERROR tests/test_e2e_offline.py::test_the_front_half_produced_real_artifacts_from_real_bytes"
-COLLECTION_ERROR = "ERROR tests/does_not_exist.py\n!!!!! Interrupted: no tests ran !!!!!"
+def record(**kwargs) -> dict:
+    """A lifecycle record with the given fields set and the rest empty."""
+    base = {
+        "call_failed": [],
+        "setup_failed": [],
+        "collect_error": [],
+        "internal_error": False,
+        "node_down": False,
+        "recorded": True,
+    }
+    base.update(kwargs)
+    return base
 
 
-def test_a_named_failure_is_evidence() -> None:
-    """An assertion observed the mutation - the strongest form."""
-    assert named_outcomes(REAL_FAILURE) == (["test_something"], [])
+def test_an_assertion_failure_is_not_a_harness_error() -> None:
+    """The strongest evidence: a test ran and its assertion noticed."""
+    assert is_harness_error(record(call_failed=["test_x"])) is False
 
 
-def test_a_named_ERROR_is_also_evidence_but_kept_separate() -> None:
-    """A setup/teardown crash in a NAMED test observed the mutation too, just not by asserting.
+def test_a_setup_crash_is_not_a_harness_error() -> None:
+    """Weaker evidence, but still a named test observing the mutation."""
+    assert is_harness_error(record(setup_failed=["test_x"])) is False
 
-    Measured: the ``engine-stand-in-emits-no-pages`` mutation produces exactly this shape. An
-    earlier version of this fix classified it as a harness error and would have discarded a real
-    detection - the opposite bug to the one being fixed.
+
+def test_a_collection_error_is_a_harness_error_even_though_it_names_a_node() -> None:
+    """Reviewer's reproduction: a class-level collection failure emits ``ERROR path::TestName``.
+
+    Text parsing cannot tell that from a named test error. The lifecycle record can.
     """
-    failed, errored = named_outcomes(NAMED_ERROR)
-
-    assert failed == []
-    assert errored == ["test_the_front_half_produced_real_artifacts_from_real_bytes"]
+    assert is_harness_error(record(collect_error=["tests/test_x.py::TestSynthetic"])) is True
 
 
-def test_a_collection_error_names_no_test_and_is_not_evidence() -> None:
-    """Exit 4 with no test named means pytest never ran anything."""
-    assert named_outcomes(COLLECTION_ERROR) == ([], [])
+def test_a_dead_xdist_worker_is_a_harness_error_despite_a_failed_line() -> None:
+    """Reviewer's reproduction: ``[gw0] node down`` then ``FAILED path::test_name``.
+
+    That FAILED line names a test which never executed, so the terminal summary is actively
+    misleading here -- ``call_failed`` is populated AND the run is still a harness error.
+    """
+    assert is_harness_error(record(node_down=True, call_failed=["test_never_ran"])) is True
 
 
-def test_empty_output_is_not_evidence() -> None:
-    assert named_outcomes("") == ([], [])
+def test_an_internal_error_is_a_harness_error() -> None:
+    assert is_harness_error(record(internal_error=True)) is True
 
 
-def test_every_named_failure_is_returned_not_just_the_first() -> None:
-    """``run()`` reports the first for brevity, but the verdict must see the whole set."""
-    out = "\n".join(
-        [
-            "FAILED tests/test_a.py::test_one - AssertionError",
-            "FAILED tests/test_a.py::test_two - AssertionError",
-        ]
-    )
+def test_no_record_at_all_is_a_harness_error() -> None:
+    """If the plugin never wrote its file, pytest never started. Absence is not innocence."""
+    assert is_harness_error(record(recorded=False)) is True
 
-    assert named_failures(out) == ["test_one", "test_two"]
+
+def test_a_missing_outcome_file_reads_as_unrecorded(tmp_path: Path) -> None:
+    outcomes = read_outcomes(tmp_path / "nope.json")
+
+    assert outcomes["recorded"] is False
+    assert is_harness_error(outcomes) is True
+
+
+def test_an_unparseable_outcome_file_reads_as_unrecorded(tmp_path: Path) -> None:
+    """A truncated write must not be mistaken for a clean run with no failures."""
+    path = tmp_path / "outcomes.json"
+    path.write_bytes(b'{"call_failed": [')
+
+    outcomes = read_outcomes(path)
+
+    assert outcomes["recorded"] is False
+    assert is_harness_error(outcomes) is True
+
+
+def test_a_clean_run_is_neither_caught_nor_a_harness_error() -> None:
+    """The SURVIVED case: pytest ran, nothing failed. That is a hole in the suite."""
+    outcomes = record()
+
+    assert is_harness_error(outcomes) is False
+    assert not outcomes["call_failed"]
+    assert not outcomes["setup_failed"]

--- a/tests/test_mutation_harness_scoring.py
+++ b/tests/test_mutation_harness_scoring.py
@@ -28,15 +28,18 @@ pytest never ran.
 
 from __future__ import annotations
 
+import ast
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
+import mutation_harness  # noqa: E402
 from mutation_harness import (  # noqa: E402
     is_harness_error,
     observed_mutation,
     read_outcomes,
+    session_ended_abnormally,
     session_is_trustworthy,
 )
 
@@ -57,6 +60,8 @@ def record(**kwargs) -> dict:
         "session_finished": True,
         "exitstatus": 0,
         "saw_call_phase": True,
+        "runtest_loop_completed": True,
+        "synthetic_failed": [],
         "recorded": True,
     }
     base.update(kwargs)
@@ -81,13 +86,20 @@ def test_a_collection_error_is_a_harness_error_even_though_it_names_a_node() -> 
     assert is_harness_error(record(collect_error=["tests/test_x.py::TestSynthetic"])) is True
 
 
-def test_a_dead_xdist_worker_is_a_harness_error_despite_a_failed_line() -> None:
-    """Reviewer's reproduction: ``[gw0] node down`` then ``FAILED path::test_name``.
+def test_a_dead_worker_alone_cannot_prove_survival() -> None:
+    """Round 2 asserted this record was a harness error outright; round 4 refined it.
 
-    That FAILED line names a test which never executed, so the terminal summary is actively
-    misleading here -- ``call_failed`` is populated AND the run is still a harness error.
+    ``[gw0] node down`` then ``FAILED path::test_name`` -- that FAILED line names a test which
+    never executed. But the fix is to filter the synthetic report **at record time** by its
+    ``when="???"`` phase, not to veto every recorded failure whenever a worker died. So with
+    no genuine report, this is still a harness error; the discriminating case is
+    ``test_a_genuine_failure_survives_a_dead_sibling_worker``.
     """
-    assert is_harness_error(record(node_down=True, call_failed=["test_never_ran"])) is True
+    outcomes = record(node_down=True, synthetic_failed=["tests/x.py::test_never_ran::???"])
+
+    assert observed_mutation(outcomes) is False
+    assert session_is_trustworthy(outcomes) is False
+    assert is_harness_error(outcomes) is True
 
 
 def test_an_internal_error_is_a_harness_error() -> None:
@@ -99,7 +111,40 @@ def test_no_record_at_all_is_a_harness_error() -> None:
     assert is_harness_error(record(recorded=False)) is True
 
 
+def test_the_generated_plugin_renders_and_parses(tmp_path: Path) -> None:
+    """The hooks are a ``.format()`` TEMPLATE, so every literal brace must be doubled.
+
+    Caught only by an end-to-end run: an f-string added to the template as
+    ``f"{report.nodeid}"`` had its braces consumed by ``.format()``, raising
+    ``KeyError: 'report'`` for every mutation. The predicate unit tests above cannot see this
+    -- they never render the template -- so this is the test that would have.
+    """
+    src = mutation_harness.OUTCOME_HOOKS.format(outcome_path=str(tmp_path / "o.json"))
+
+    ast.parse(src)
+    assert "{report.nodeid}" in src, "literal braces must survive .format()"
+    assert "{{" not in src, "no doubled brace should remain after rendering"
+
+
+def test_every_hook_the_verdict_depends_on_is_present() -> None:
+    """Each field the predicates read must actually be written by some hook."""
+    src = mutation_harness.OUTCOME_HOOKS
+
+    for hook in (
+        "pytest_runtest_logreport",
+        "pytest_collectreport",
+        "pytest_internalerror",
+        "pytest_testnodedown",
+        "pytest_sessionfinish",
+        "pytest_runtestloop",
+    ):
+        assert f"def {hook}(" in src, f"{hook} is read by a predicate but never defined"
+    # xdist-only, and pytest rejects the whole plugin if it is not declared optional.
+    assert "optionalhook=True" in src
+
+
 def test_a_missing_outcome_file_reads_as_unrecorded(tmp_path: Path) -> None:
+    """Absence is not innocence: no record means pytest never started."""
     outcomes = read_outcomes(tmp_path / "nope.json")
 
     assert outcomes["recorded"] is False
@@ -166,15 +211,57 @@ def test_an_unfinished_session_cannot_prove_survival_but_keeps_its_detection() -
 
 
 def test_a_dead_worker_failure_is_synthetic_and_never_counts() -> None:
-    """The one exception, and it is not an inconsistency.
+    """The synthetic report is filtered AT RECORD TIME, not by a global flag.
 
-    A dying xdist worker emits ``FAILED path::test_name`` for a test that **never executed**,
-    so that ``call_failed`` entry is fabricated rather than observed.
+    Round 4 showed a global `node_down` veto is too blunt: a genuine call failure emitted by a
+    living worker -- or by the dying one before it died -- is still real evidence. xdist's
+    fabricated crash report carries ``when="???"``, so it lands in ``synthetic_failed`` and
+    never reaches ``call_failed``.
     """
-    outcomes = record(node_down=True, call_failed=["test_never_ran"])
+    outcomes = record(node_down=True, synthetic_failed=["tests/x.py::test_never_ran::???"])
 
     assert observed_mutation(outcomes) is False
     assert is_harness_error(outcomes) is True
+
+
+def test_a_genuine_failure_survives_a_dead_sibling_worker() -> None:
+    """Round-4 finding: a real call failure must NOT be erased because some worker died."""
+    outcomes = record(call_failed=["test_x"], node_down=True)
+
+    assert observed_mutation(outcomes) is True
+    assert is_harness_error(outcomes) is False
+    assert session_is_trustworthy(outcomes) is False
+
+
+def test_one_completed_call_phase_does_not_prove_the_suite_ran() -> None:
+    """Round-4 finding: ``pytest.exit()`` from teardown after the FIRST passing test.
+
+    Measured on the 14-test scoring file: ``1 passed`` then the Exit message, with
+    ``session_finished``, ``saw_call_phase`` and ``exitstatus=0`` -- and it scored SURVIVED
+    having run 1 of 14. Only ``runtest_loop_completed`` distinguishes it.
+    """
+    outcomes = record(runtest_loop_completed=False)
+
+    assert session_is_trustworthy(outcomes) is False
+    assert is_harness_error(outcomes) is True
+
+
+def test_an_interrupted_loop_after_a_catch_is_not_annotated_as_abnormal() -> None:
+    """Mutations run under ``-x``, so a CAUGHT always interrupts the loop.
+
+    ``runtest_loop_completed`` is therefore False for every legitimate detection. Including it
+    in the abnormal-session predicate annotated all of them, which is a warning nobody reads.
+    """
+    caught_under_x = record(call_failed=["test_x"], runtest_loop_completed=False, exitstatus=1)
+
+    assert observed_mutation(caught_under_x) is True
+    assert session_ended_abnormally(caught_under_x) is False
+    assert is_harness_error(caught_under_x) is False
+
+
+def test_exit_one_without_a_recorded_detection_cannot_prove_survival() -> None:
+    """Exit 1 means tests failed. A failure we did not record cannot prove anything survived."""
+    assert session_is_trustworthy(record(exitstatus=1)) is False
 
 
 def test_a_setup_report_alone_does_not_prove_a_test_body_ran() -> None:

--- a/tests/test_mutation_harness_scoring.py
+++ b/tests/test_mutation_harness_scoring.py
@@ -37,13 +37,21 @@ from mutation_harness import is_harness_error, read_outcomes  # noqa: E402
 
 
 def record(**kwargs) -> dict:
-    """A lifecycle record with the given fields set and the rest empty."""
+    """A record for a COMPLETE session that ran at least one test, with the rest empty.
+
+    The defaults matter: `recorded=True` alone proves only that the plugin imported, so a
+    valid-looking record must also show a finished session, a real test report, and a
+    verdict-bearing exit status before any verdict is issued.
+    """
     base = {
         "call_failed": [],
         "setup_failed": [],
         "collect_error": [],
         "internal_error": False,
         "node_down": False,
+        "session_finished": True,
+        "exitstatus": 0,
+        "saw_report": True,
         "recorded": True,
     }
     base.update(kwargs)
@@ -111,3 +119,27 @@ def test_a_clean_run_is_neither_caught_nor_a_harness_error() -> None:
     assert is_harness_error(outcomes) is False
     assert not outcomes["call_failed"]
     assert not outcomes["setup_failed"]
+
+
+def test_a_session_that_exits_before_running_anything_is_a_harness_error() -> None:
+    """Reviewer's reproduction: ``pytest.exit(returncode=0)`` from ``pytest_sessionstart``.
+
+    Exit 0, a valid record written at plugin import, and **no test ever ran** -- which the
+    previous version reported as SURVIVED, i.e. as a hole in the suite rather than as a run
+    that never happened.
+    """
+    assert is_harness_error(record(saw_report=False, session_finished=True, exitstatus=0)) is True
+
+
+def test_an_interrupt_after_a_failure_is_a_harness_error() -> None:
+    """Reviewer's reproduction: a call failure, then KeyboardInterrupt during teardown.
+
+    pytest exits **2** with ``call_failed`` populated. The failure is real but the session is
+    not, so it cannot be credited -- the previous ordering reported CAUGHT and returned 0.
+    """
+    assert is_harness_error(record(call_failed=["test_x"], exitstatus=2)) is True
+
+
+def test_an_unfinished_session_is_a_harness_error() -> None:
+    """No ``pytest_sessionfinish`` means the process died mid-run; the record is a snapshot."""
+    assert is_harness_error(record(call_failed=["test_x"], session_finished=False)) is True


### PR DESCRIPTION
Blind review of PR #405 found that `tests/mutation_harness.py` — on master since #331 — **awards CAUGHT to any non-zero pytest exit**, including exits where no test ran at all.

## The defect

```python
verdict = "CAUGHT " if rc != 0 else "SURVIVED"
```

`run()` already extracted named `FAILED` lines. `main()` threw them away.

**Reproduced on master:** `pytest tests/does_not_exist.py -q` → **exit 4, zero named outcomes**, scored **CAUGHT**. Collection errors (4), internal errors (3) and interrupts (2) all qualify. The baseline was printed but never enforced, so an already-failing test would be credited to every mutation after it.

The file already guarded **one** instance of this class, with a comment reading *"the harness would report a FALSE 'CAUGHT'"* — the hazard was known and half-closed.

⚠️ This matters beyond one PR: **every mutation table produced by this harness overstates its coverage by an unknown amount.**

## Three-way verdict, because two was wrong in both directions

| verdict | meaning |
|---|---|
| `CAUGHT` | a named test **FAILED** — an assertion observed the mutation |
| `CAUGHT*` | a named test **ERRORED** — observed, but by a crash rather than an assertion |
| `HARNESS-ERROR` | non-zero while naming **no test** — pytest never ran; no verdict, exit 2 |

Plus a **clean-baseline precondition**: a dirty baseline aborts before any mutation runs.

## `CAUGHT*` exists because my first fix was wrong in the opposite direction

Two-way classification flagged `engine-stand-in-emits-no-pages` as a harness error. It is not — it produces

```
ERROR tests/test_e2e_offline.py::test_the_front_half_produced_real_artifacts_from_real_bytes
```

A **named test**, so the mutation genuinely was observed; a setup crash noticed it. Discarding that would have been the opposite bug. It is credited and marked, because a test that only errors is weaker coverage than one that asserts.

**A surviving neutral control does not disprove the original defect** — a neutral change exits 0, exercising only the SURVIVED direction. That is why #405's control passed while the defect was live.

## Evidence

| | |
|---|---|
| mutation proof | replacing the named-outcome scan with a stdout-truthiness stub fails **4 of 5** named tests; restored, 5 pass |
| end-to-end | all mutations classified, `survivors: none`, **exit 0** |
| before the fix | same run reported `HARNESS_EXIT=2` with one misclassification |
| ruff | exit 0 |

`named_failures()` is retained for callers that only want assertions.
