### PR TITLE
test(185): real reproduction fixtures for upstream #185 (Tableau Set filter + Bar shelf layout)

### DIFF
--- a/docs/capabilities-and-limitations.md
+++ b/docs/capabilities-and-limitations.md
@@ -113,6 +113,29 @@ a single pass does.
 
 ## Known limitations and honest gaps
 
+- **Tableau Sets do not translate at all, in any form** (measured on canonical engine **2.339.0**,
+  2026-09-01). Every set form we could find is logged as `could not resolve field '<name>' (skipped)`
+  and then **the visual is emitted anyway, without the filter** — so the output renders confidently
+  over an unfiltered superset. Confirmed on a real Tableau training sample (`Section 08 - Organizing
+  Data`) for four distinct forms: a manual/lasso set, a **condition** set (`SUM([Score]) > 400`), a
+  **top-N rank** set, and a **combined** set (`intersection` of two set references). A set used as a
+  `<color>` encoding is dropped just as silently — the emitted `scatterChart` lost its In/Out series
+  split entirely. Reproduction fixture: `tests/fixtures/issue-185-set-filter.twb`; filed upstream as
+  [`Yarbrdab000/tableau-fabric-skills#185`](https://github.com/Yarbrdab000/tableau-fabric-skills/issues/185).
+  ⚠️ **Do not sweep a corpus for sets by grepping `class='set'` — there is no such attribute, and the
+  sweep will report zero on a corpus that contains them.** Tableau encodes a set as a `<group>` holding
+  a `<groupfilter>`, reached from a view through `<column-instance derivation='InOut'>`. A `.twb`-only
+  sweep also misses sets inside `.twbx`, which are ZIP archives and must be extracted to be searched.
+  Both mistakes were made here and together produced a confident "our corpus contains zero Tableau
+  Sets"; the real count is 4 workbooks of 137 assets.
+- **An explicit `mark class='Bar'` supports strictly fewer shelf layouts than `mark class='Automatic'`**
+  (engine 2.339.0). `twb_to_pbir.py::_visual_type` accepts `bar` for exactly two layouts
+  (dimension-on-cols + measure-on-rows, or dimension-on-rows + measure-on-cols); `automatic` reaches
+  five further fallbacks (scatter, matrix, table, column, continuous-date line). So changing a mark
+  from Automatic to Bar in Tableau — cosmetic there — can silently cost the whole visual here
+  (`mark class 'Bar' / shelf layout not supported -> no visual emitted`, `zone left empty`). A raw
+  count of `Bar` marks proves nothing: they are common and mostly work. Controlled A/B fixture:
+  `tests/fixtures/issue-185-bar-shelf-layout.twb`.
 - **Origin-destination and line maps are the hardest surface, and not all are verified yet.** Tableau's
   MAKELINE great-circle arc has no native Power BI equivalent, so `airline-alliance-activity` uses
   destination bubbles instead of arcs (an honest downgrade, documented). Two map-heavy renders,

--- a/docs/capabilities-and-limitations.md
+++ b/docs/capabilities-and-limitations.md
@@ -122,12 +122,47 @@ a single pass does.
   `<color>` encoding is dropped just as silently — the emitted `scatterChart` lost its In/Out series
   split entirely. Reproduction fixture: `tests/fixtures/issue-185-set-filter.twb`; filed upstream as
   [`Yarbrdab000/tableau-fabric-skills#185`](https://github.com/Yarbrdab000/tableau-fabric-skills/issues/185).
-  ⚠️ **Do not sweep a corpus for sets by grepping `class='set'` — there is no such attribute, and the
-  sweep will report zero on a corpus that contains them.** Tableau encodes a set as a `<group>` holding
-  a `<groupfilter>`, reached from a view through `<column-instance derivation='InOut'>`. A `.twb`-only
-  sweep also misses sets inside `.twbx`, which are ZIP archives and must be extracted to be searched.
-  Both mistakes were made here and together produced a confident "our corpus contains zero Tableau
-  Sets"; the real count is 4 workbooks of 137 assets.
+  ⚠️ **Sets are hard to find with a naive grep, and this project produced THREE wrong counts in a row
+  before getting it right.** There is no `class='set'` attribute (count: 0). Naming the set literally
+  (`[Set 1]`) finds only sets a user never renamed (count: 4 workbooks). The correct marker is the
+  authoring attribute on the group: **`user:ui-builder='filter-group'`** (condition / top-N sets) or
+  **`'lasso-group'`** (manual sets). `.twbx` are ZIP archives and must be extracted, or a `.twb`-only
+  sweep misses them entirely. Measured correctly, with controls:
+
+  ```
+  assets scanned                              137
+  files containing <group>                     51
+  files with a SET marker                      23   -> 12 DISTINCT workbooks
+  NEGATIVE CONTROL: <group> but no set marker  28
+  POSITIVE CONTROL: a known set-bearing file   FOUND
+  set kinds: top-n 32 | membership 27 | condition 13
+  ```
+
+  ⚠️ **Set kind matters when reporting a defect:** "sets are dropped" and "top-N sets are dropped" are
+  different claims. All three kinds are dropped, verified on three unrelated workbooks — but a count of
+  set *markers* is not a count of *defects*: `Airline Alliance` carries 10 markers and only 2 warn,
+  because only sets actually referenced by a view are ever resolved.
+- **A zero is not a measurement unless you state the positive control that proves the predicate can
+  see what it is looking for.** Four false zeros were produced here in one day: the `class='set'` sweep
+  above; a `[Set N]` sweep that undercounted 12 workbooks as 4; a shell function-scope bug that
+  silently returned an empty array; and a `Conditional.Cases` search that returned 0 against the
+  engine and was used to infer the engine cannot emit conditional fills — it emits **13 of them** into
+  a public workbook, because `Conditional.Cases` is *path notation in prose* and the serialized form is
+  nested keys `{"Conditional": {"Cases": [...]}}`. Every count in this repo should name its positive
+  control beside it, and a corpus too simple to exhibit the effect is a control failure too: our first
+  "0 visuals under 20px tall" was measured on single-zone workbooks, and a real multi-zone dashboard
+  produced **14**, the smallest at **12.56px**.
+- **The PBIR height floor covers `slicer` and `textbox` only, so sub-renderable CHART visuals pass
+  validation silently.** Measured on engine 2.339.0 against the public `Airline Alliance Activity
+  Dashboard _ #VOTD.twbx`: `powerbi-report-author` 0.1.4 raised 6 errors, all
+  `PBIR_SLICER_HEIGHT_BELOW_FLOOR` / `PBIR_TEXTBOX_HEIGHT_BELOW_FLOOR` — while a **12.56px**
+  `clusteredColumnChart` (and 13 more chart visuals under 20px tall, 64 under the 76px slicer floor,
+  22 under 150px wide) raised **nothing**. So "validate passed" does not mean "the visuals can be
+  seen"; this is the concrete, named instance of the general rule that structural validation is
+  necessary but not sufficient. Reported upstream on
+  [#186](https://github.com/Yarbrdab000/tableau-fabric-skills/issues/186); related to
+  [#180](https://github.com/Yarbrdab000/tableau-fabric-skills/issues/180) (slicers regressed to 57/62px
+  against a 76px floor).
 - **An explicit `mark class='Bar'` supports strictly fewer shelf layouts than `mark class='Automatic'`**
   (engine 2.339.0). `twb_to_pbir.py::_visual_type` accepts `bar` for exactly two layouts
   (dimension-on-cols + measure-on-rows, or dimension-on-rows + measure-on-cols); `automatic` reaches

--- a/docs/capabilities-and-limitations.md
+++ b/docs/capabilities-and-limitations.md
@@ -151,15 +151,32 @@ a single pass does.
   nested keys `{"Conditional": {"Cases": [...]}}`. Every count in this repo should name its positive
   control beside it, and a corpus too simple to exhibit the effect is a control failure too: our first
   "0 visuals under 20px tall" was measured on single-zone workbooks, and a real multi-zone dashboard
-  produced **14**, the smallest at **12.56px**.
-- **The PBIR height floor covers `slicer` and `textbox` only, so sub-renderable CHART visuals pass
-  validation silently.** Measured on engine 2.339.0 against the public `Airline Alliance Activity
-  Dashboard _ #VOTD.twbx`: `powerbi-report-author` 0.1.4 raised 6 errors, all
-  `PBIR_SLICER_HEIGHT_BELOW_FLOOR` / `PBIR_TEXTBOX_HEIGHT_BELOW_FLOOR` — while a **12.56px**
-  `clusteredColumnChart` (and 13 more chart visuals under 20px tall, 64 under the 76px slicer floor,
-  22 under 150px wide) raised **nothing**. So "validate passed" does not mean "the visuals can be
-  seen"; this is the concrete, named instance of the general rule that structural validation is
-  necessary but not sufficient. Reported upstream on
+  produced **14 in its `pbip/` tree** (9 in `reports/`), the smallest at **12.56px**. ⚠️ **Name the
+  tree with any bundle count** — `reports/` and `pbip/` hold different visual populations, so a count
+  without its tree is not reproducible.
+- **The PBIR height floor covers `slicer` and `textbox` only, so sub-renderable CHART visuals carry no
+  height diagnostic at all.** Measured on engine 2.339.0 against the public `Airline Alliance Activity
+  Dashboard _ #VOTD.twbx`, **in the `pbip/` tree** (⚠️ the tree is part of the measurement — the
+  pristine `reports/` tree holds 95 positioned visuals and 9 under 20px, because `image` visuals are
+  `pbip/`-only):
+
+  ```
+  pbip/  positioned visuals            111        <- positive control
+         under  20px tall               14        clusteredColumnChart 5 | image 5 | textbox 4
+         under  76px tall               64        clusteredColumnChart 26 | tableEx 17 | textbox 9
+                                                  | image 6 | slicer 6
+         under 150px wide               22        multiRowCard 9 | tableEx 6 | image 6
+                                                  | clusteredBarChart 1
+  powerbi-report-author 0.1.4          6 errors, 4 warnings
+         PBIR_SLICER_HEIGHT_BELOW_FLOOR   x6  (errors)
+         PBIR_TEXTBOX_HEIGHT_BELOW_FLOOR      (4 warnings)
+  ```
+
+  So of the 14 sub-20px visuals, the **4 textboxes DO get a height diagnostic** and the **5 charts
+  (12.56px, plus four at 14.0px) get none** — there is no chart-height rule. "Validate passed" does not
+  mean "the visuals can be seen", but the gap is specifically *chart* visuals, not visuals in general.
+  This is the concrete, named instance of the general rule that structural validation is necessary but
+  not sufficient. Reported upstream on
   [#186](https://github.com/Yarbrdab000/tableau-fabric-skills/issues/186); related to
   [#180](https://github.com/Yarbrdab000/tableau-fabric-skills/issues/180) (slicers regressed to 57/62px
   against a 76px floor).

--- a/tests/fixtures/issue-185-bar-shelf-layout.twb
+++ b/tests/fixtures/issue-185-bar-shelf-layout.twb
@@ -1,0 +1,132 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<!-- Fixture for the CAPABILITY-GAP half of upstream Yarbrdab000/tableau-fabric-skills#185
+     ("mark class 'Bar' with a shelf layout outside the emitter's supported set").
+
+     `<mark class='Bar'/>` is common and works: a raw count of Bar marks establishes nothing.
+     This fixture is a CONTROLLED EXPERIMENT that isolates the actual trigger. Both worksheets
+     below carry byte-identical shelves and encodings - a measure on each axis, one dimension on
+     the Detail (lod) encoding. The ONLY difference is the mark class.
+
+     Engine 2.339.0, twb_to_pbir.py `_visual_type`: an explicit `bar` mark accepts exactly two
+     shelf layouts (dim-on-cols + meas-on-rows, or dim-on-rows + meas-on-cols) and otherwise
+     returns VT_UNSUPPORTED. An `automatic` mark reaches five further fallbacks (scatter, matrix,
+     table, column, continuous-date line). So `bar` is strictly LESS supported than `automatic`
+     over identical shelves, and the gap - not the Bar mark itself - is the defect. -->
+<workbook source-build='2019.2.2 (20192.19.0718.1543)' source-platform='win' version='18.1' xmlns:user='http://www.tableausoftware.com/xml/user'>
+  <repository-location derived-from='https://public.tableau.com/workbooks/issue-185-bar?rev=1.0' id='issue_185_bar_shelf' path='/workbooks' revision='1.0' />
+  <datasources>
+    <datasource caption='Tails' inline='true' name='federated.bards' version='18.1'>
+      <connection class='federated'>
+        <named-connections>
+          <named-connection caption='tails' name='textscan.tails'>
+            <connection class='textscan' directory='Data' filename='tails.csv' />
+          </named-connection>
+        </named-connections>
+        <relation connection='textscan.tails' name='tails.csv' table='[tails#csv]' type='table' />
+      </connection>
+      <column caption='Tail' datatype='string' name='[Tail]' role='dimension' type='nominal' />
+      <column caption='Score' datatype='integer' name='[Score]' role='measure' type='quantitative' />
+      <column caption='Availability' datatype='real' name='[Availability]' role='measure' type='quantitative' />
+      <column-instance column='[Tail]' derivation='None' name='[none:Tail:nk]' pivot='key' type='nominal' />
+      <column-instance column='[Score]' derivation='Sum' name='[sum:Score:qk]' pivot='key' type='quantitative' />
+      <column-instance column='[Availability]' derivation='Sum' name='[sum:Availability:qk]' pivot='key' type='quantitative' />
+      <metadata-records>
+        <metadata-record class='column'>
+          <remote-name>Tail</remote-name>
+          <local-name>[Tail]</local-name>
+          <parent-name>[tails.csv]</parent-name>
+          <local-type>string</local-type>
+          <aggregation>Count</aggregation>
+        </metadata-record>
+        <metadata-record class='column'>
+          <remote-name>Score</remote-name>
+          <local-name>[Score]</local-name>
+          <parent-name>[tails.csv]</parent-name>
+          <local-type>integer</local-type>
+          <aggregation>Sum</aggregation>
+        </metadata-record>
+        <metadata-record class='column'>
+          <remote-name>Availability</remote-name>
+          <local-name>[Availability]</local-name>
+          <parent-name>[tails.csv]</parent-name>
+          <local-type>real</local-type>
+          <aggregation>Sum</aggregation>
+        </metadata-record>
+      </metadata-records>
+    </datasource>
+  </datasources>
+  <worksheets>
+    <!-- CONTROL: identical shelves, mark class Automatic. Expected to emit. -->
+    <worksheet name='Auto Two Measures'>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption='Tails' name='federated.bards' />
+          </datasources>
+          <datasource-dependencies datasource='federated.bards'>
+            <column caption='Tail' datatype='string' name='[Tail]' role='dimension' type='nominal' />
+            <column caption='Score' datatype='integer' name='[Score]' role='measure' type='quantitative' />
+            <column caption='Availability' datatype='real' name='[Availability]' role='measure' type='quantitative' />
+            <column-instance column='[Tail]' derivation='None' name='[none:Tail:nk]' pivot='key' type='nominal' />
+            <column-instance column='[Score]' derivation='Sum' name='[sum:Score:qk]' pivot='key' type='quantitative' />
+            <column-instance column='[Availability]' derivation='Sum' name='[sum:Availability:qk]' pivot='key' type='quantitative' />
+          </datasource-dependencies>
+          <aggregation value='true' />
+        </view>
+        <panes>
+          <pane>
+            <mark class='Automatic' />
+            <encodings>
+              <lod column='[federated.bards].[none:Tail:nk]' />
+            </encodings>
+          </pane>
+        </panes>
+        <rows>[federated.bards].[sum:Score:qk]</rows>
+        <cols>[federated.bards].[sum:Availability:qk]</cols>
+      </table>
+      <simple-id uuid='{00000000-0000-0000-0000-0000000185A0}' />
+    </worksheet>
+
+    <!-- TREATMENT: byte-identical shelves and encodings, mark class Bar. Expected UNSUPPORTED. -->
+    <worksheet name='Bar Two Measures'>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption='Tails' name='federated.bards' />
+          </datasources>
+          <datasource-dependencies datasource='federated.bards'>
+            <column caption='Tail' datatype='string' name='[Tail]' role='dimension' type='nominal' />
+            <column caption='Score' datatype='integer' name='[Score]' role='measure' type='quantitative' />
+            <column caption='Availability' datatype='real' name='[Availability]' role='measure' type='quantitative' />
+            <column-instance column='[Tail]' derivation='None' name='[none:Tail:nk]' pivot='key' type='nominal' />
+            <column-instance column='[Score]' derivation='Sum' name='[sum:Score:qk]' pivot='key' type='quantitative' />
+            <column-instance column='[Availability]' derivation='Sum' name='[sum:Availability:qk]' pivot='key' type='quantitative' />
+          </datasource-dependencies>
+          <aggregation value='true' />
+        </view>
+        <panes>
+          <pane>
+            <mark class='Bar' />
+            <encodings>
+              <lod column='[federated.bards].[none:Tail:nk]' />
+            </encodings>
+          </pane>
+        </panes>
+        <rows>[federated.bards].[sum:Score:qk]</rows>
+        <cols>[federated.bards].[sum:Availability:qk]</cols>
+      </table>
+      <simple-id uuid='{00000000-0000-0000-0000-0000000185B0}' />
+    </worksheet>
+  </worksheets>
+  <dashboards>
+    <dashboard name='Bar Shelf Repro'>
+      <size maxheight='800' maxwidth='1000' />
+      <zones>
+        <zone h='100000' id='1' type='layout-basic' w='100000' x='0' y='0'>
+          <zone h='50000' id='2' name='Auto Two Measures' w='100000' x='0' y='0' />
+          <zone h='50000' id='3' name='Bar Two Measures' w='100000' x='0' y='50000' />
+        </zone>
+      </zones>
+    </dashboard>
+  </dashboards>
+</workbook>

--- a/tests/fixtures/issue-185-set-filter.twb
+++ b/tests/fixtures/issue-185-set-filter.twb
@@ -1,0 +1,121 @@
+<?xml version='1.0' encoding='utf-8' ?>
+<!-- Fixture for upstream issue Yarbrdab000/tableau-fabric-skills#185.
+
+     Shape: a Tableau SET whose domain is a simple condition, used as a RESTRICTIVE
+     worksheet filter. The set XML below is copied structurally from a real Tableau-authored
+     workbook (`Section 08 - Organizing Data`, a Tableau training sample), not invented:
+     a set is a <group> carrying a <groupfilter>, referenced from a view through a
+     <column-instance derivation='InOut'>. There is no `class='set'` attribute - grepping for
+     one is why a corpus sweep can wrongly report "zero sets".
+
+     `Technology Set` is the condition set (`[Technology] != "NC"`, Hemang Patel's reported
+     domain). The worksheet keeps ONLY the "In" members, so dropping this filter is not a
+     no-op: it widens the result set. -->
+<workbook source-build='2019.2.2 (20192.19.0718.1543)' source-platform='win' version='18.1' xmlns:user='http://www.tableausoftware.com/xml/user'>
+  <repository-location derived-from='https://public.tableau.com/workbooks/issue-185?rev=1.0' id='issue_185_set_filter' path='/workbooks' revision='1.0' />
+  <datasources>
+    <datasource caption='Tails' inline='true' name='federated.setds' version='18.1'>
+      <connection class='federated'>
+        <named-connections>
+          <named-connection caption='tails' name='textscan.tails'>
+            <connection class='textscan' directory='Data' filename='tails.csv' />
+          </named-connection>
+        </named-connections>
+        <relation connection='textscan.tails' name='tails.csv' table='[tails#csv]' type='table' />
+      </connection>
+      <column caption='Tail' datatype='string' name='[Tail]' role='dimension' type='nominal' />
+      <column caption='Technology' datatype='string' name='[Technology]' role='dimension' type='nominal' />
+      <column caption='Score' datatype='integer' name='[Score]' role='measure' type='quantitative' />
+
+      <!-- The SET. A condition set: domain is `[Technology] != "NC"`. -->
+      <group caption='Technology Set' name='[Technology Set]' name-style='unqualified' user:ui-builder='filter-group'>
+        <groupfilter expression='[Technology] != &quot;NC&quot;' function='filter' user:ui-filter-by-field='true' user:ui-marker='filter-by'>
+          <groupfilter function='level-members' level='[Technology]' user:ui-enumeration='all' user:ui-marker='enumerate' />
+        </groupfilter>
+      </group>
+
+      <!-- The set's IN/OUT membership instance, as referenced from a view. -->
+      <column-instance column='[Technology Set]' derivation='InOut' name='[io:Technology Set:nk]' pivot='key' type='nominal' />
+      <column-instance column='[Tail]' derivation='None' name='[none:Tail:nk]' pivot='key' type='nominal' />
+      <column-instance column='[Score]' derivation='Sum' name='[sum:Score:qk]' pivot='key' type='quantitative' />
+      <metadata-records>
+        <metadata-record class='column'>
+          <remote-name>Tail</remote-name>
+          <local-name>[Tail]</local-name>
+          <parent-name>[tails.csv]</parent-name>
+          <local-type>string</local-type>
+          <aggregation>Count</aggregation>
+        </metadata-record>
+        <metadata-record class='column'>
+          <remote-name>Technology</remote-name>
+          <local-name>[Technology]</local-name>
+          <parent-name>[tails.csv]</parent-name>
+          <local-type>string</local-type>
+          <aggregation>Count</aggregation>
+        </metadata-record>
+        <metadata-record class='column'>
+          <remote-name>Score</remote-name>
+          <local-name>[Score]</local-name>
+          <parent-name>[tails.csv]</parent-name>
+          <local-type>integer</local-type>
+          <aggregation>Sum</aggregation>
+        </metadata-record>
+      </metadata-records>
+    </datasource>
+  </datasources>
+  <worksheets>
+    <worksheet name='Score by Tail'>
+      <layout-options>
+        <title>
+          <formatted-text>
+            <run>Score by Tail (Technology Set = In)</run>
+          </formatted-text>
+        </title>
+      </layout-options>
+      <table>
+        <view>
+          <datasources>
+            <datasource caption='Tails' name='federated.setds' />
+          </datasources>
+          <datasource-dependencies datasource='federated.setds'>
+            <column caption='Tail' datatype='string' name='[Tail]' role='dimension' type='nominal' />
+            <column caption='Technology' datatype='string' name='[Technology]' role='dimension' type='nominal' />
+            <column caption='Score' datatype='integer' name='[Score]' role='measure' type='quantitative' />
+            <column-instance column='[Technology Set]' derivation='InOut' name='[io:Technology Set:nk]' pivot='key' type='nominal' />
+            <column-instance column='[Tail]' derivation='None' name='[none:Tail:nk]' pivot='key' type='nominal' />
+            <column-instance column='[Score]' derivation='Sum' name='[sum:Score:qk]' pivot='key' type='quantitative' />
+          </datasource-dependencies>
+          <!-- RESTRICTIVE: keep only set members ("In"). Dropping this widens the result set. -->
+          <filter class='categorical' column='[federated.setds].[io:Technology Set:nk]'>
+            <groupfilter function='union' user:ui-domain='relevant' user:ui-enumeration='inclusive' user:ui-marker='enumerate'>
+              <groupfilter function='member' level='[io:Technology Set:nk]' member='&quot;In&quot;' />
+            </groupfilter>
+          </filter>
+          <slices>
+            <column>[federated.setds].[io:Technology Set:nk]</column>
+          </slices>
+          <aggregation value='true' />
+        </view>
+        <panes>
+          <pane>
+            <mark class='Bar' />
+            <encodings />
+          </pane>
+        </panes>
+        <rows>[federated.setds].[sum:Score:qk]</rows>
+        <cols>[federated.setds].[none:Tail:nk]</cols>
+      </table>
+      <simple-id uuid='{00000000-0000-0000-0000-000000000185}' />
+    </worksheet>
+  </worksheets>
+  <dashboards>
+    <dashboard name='Set Filter Repro'>
+      <size maxheight='800' maxwidth='1000' />
+      <zones>
+        <zone h='100000' id='1' type='layout-basic' w='100000' x='0' y='0'>
+          <zone h='100000' id='2' name='Score by Tail' w='100000' x='0' y='0' />
+        </zone>
+      </zones>
+    </dashboard>
+  </dashboards>
+</workbook>

--- a/tests/test_issue_185_set_fixture.py
+++ b/tests/test_issue_185_set_fixture.py
@@ -16,6 +16,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 from parse_tableau import parse_workbook  # noqa: E402  (path insert must precede this import)
 
 FIXTURE = Path(__file__).resolve().parent / "fixtures" / "issue-185-set-filter.twb"
+BAR_FIXTURE = Path(__file__).resolve().parent / "fixtures" / "issue-185-bar-shelf-layout.twb"
 SET_NAME = "[Technology Set]"
 IO_INSTANCE = "[io:Technology Set:nk]"
 
@@ -95,3 +96,62 @@ def test_our_parser_records_the_filter_even_though_the_set_field_is_unresolved()
     assert only["field_id"].startswith("UNRESOLVED:"), only["field_id"]
     assert IO_INSTANCE in only["field_id"], only["field_id"]
     assert only["members"] == ['"In"'], only["members"]
+
+
+# --- the CAPABILITY-GAP half of #185: mark class 'Bar' + an unsupported shelf layout -------------
+
+
+def _worksheet(root, name):
+    for ws in root.iter("worksheet"):
+        if ws.get("name") == name:
+            return ws
+    raise AssertionError(f"worksheet {name!r} not found")
+
+
+def _shelf_signature(ws):
+    """The (mark, rows, cols, encodings) tuple that decides the emitted visual type."""
+    pane = ws.find(".//pane")
+    mark = pane.find("mark").get("class")
+    encodings = sorted((child.tag, child.get("column")) for child in pane.find("encodings"))
+    rows = (ws.find(".//rows").text or "").strip()
+    cols = (ws.find(".//cols").text or "").strip()
+    return mark, rows, cols, encodings
+
+
+def test_bar_fixture_exists():
+    """The A/B control for the Bar capability gap."""
+    assert BAR_FIXTURE.is_file(), f"reproduction fixture missing: {BAR_FIXTURE}"
+
+
+def test_bar_fixture_is_a_controlled_experiment():
+    """Both worksheets must differ ONLY in the mark class.
+
+    A raw count of `mark class='Bar'` in a corpus establishes nothing, because Bar marks are
+    common and work. The defect is that an explicit `bar` mark is strictly LESS supported than
+    `automatic` over the SAME shelves, so the fixture is only evidence while the shelves,
+    encodings and axes stay byte-identical between the two worksheets.
+    """
+    root = ET.parse(BAR_FIXTURE).getroot()
+    auto_mark, auto_rows, auto_cols, auto_enc = _shelf_signature(_worksheet(root, "Auto Two Measures"))
+    bar_mark, bar_rows, bar_cols, bar_enc = _shelf_signature(_worksheet(root, "Bar Two Measures"))
+
+    assert auto_mark == "Automatic", auto_mark
+    assert bar_mark == "Bar", bar_mark
+    assert auto_rows == bar_rows, f"rows differ: {auto_rows!r} vs {bar_rows!r}"
+    assert auto_cols == bar_cols, f"cols differ: {auto_cols!r} vs {bar_cols!r}"
+    assert auto_enc == bar_enc, f"encodings differ: {auto_enc} vs {bar_enc}"
+
+
+def test_bar_fixture_layout_is_measure_on_both_axes_with_a_dimension_on_detail():
+    """The specific unsupported layout, pinned.
+
+    `_visual_type` accepts an explicit `bar` mark for exactly two layouts (dimension-on-cols with
+    measure-on-rows, or dimension-on-rows with measure-on-cols). A measure on BOTH axes with the
+    dimension on the Detail encoding satisfies neither, so `bar` falls through to UNSUPPORTED
+    while `automatic` reaches the scatter fallback.
+    """
+    root = ET.parse(BAR_FIXTURE).getroot()
+    _, rows, cols, enc = _shelf_signature(_worksheet(root, "Bar Two Measures"))
+    assert "sum:" in rows, f"rows must carry a measure, got {rows!r}"
+    assert "sum:" in cols, f"cols must carry a measure, got {cols!r}"
+    assert enc == [("lod", "[federated.bards].[none:Tail:nk]")], enc

--- a/tests/test_issue_185_set_fixture.py
+++ b/tests/test_issue_185_set_fixture.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
-from parse_tableau import parse_workbook  # noqa: E402  (path insert must precede this import)
+from parse_tableau import parse_workbook  # noqa: E402  (path insert must precede this import)  # pylint: disable=wrong-import-position
 
 FIXTURE = Path(__file__).resolve().parent / "fixtures" / "issue-185-set-filter.twb"
 BAR_FIXTURE = Path(__file__).resolve().parent / "fixtures" / "issue-185-bar-shelf-layout.twb"
@@ -181,8 +181,10 @@ def test_correct_predicate_finds_the_set():
 
 def test_the_class_set_predicate_finds_nothing():
     """Trap 1: there is no class='set' attribute in Tableau XML. This sweep returns a false zero."""
-    assert [g for g in _root().iter("group") if g.get("class") == "set"] == []
-    assert list(_root().iter("set")) == []
+    classed = [g for g in _root().iter("group") if g.get("class") == "set"]
+    assert not classed, classed
+    elements = list(_root().iter("set"))
+    assert not elements, elements
 
 
 def test_the_literal_set_name_predicate_finds_nothing():
@@ -192,4 +194,4 @@ def test_the_literal_set_name_predicate_finds_nothing():
     12 set-bearing workbooks were once counted as 4.
     """
     named = [g for g in _root().iter("group") if re.fullmatch(r"\[Set \d+\]", g.get("name") or "")]
-    assert named == []
+    assert not named, named

--- a/tests/test_issue_185_set_fixture.py
+++ b/tests/test_issue_185_set_fixture.py
@@ -7,6 +7,7 @@ purpose: Pin the integrity of tests/fixtures/issue-185-set-filter.twb, the repro
 usage:   pytest -q tests/test_issue_185_set_fixture.py
 """
 
+import re
 import sys
 import xml.etree.ElementTree as ET
 from pathlib import Path
@@ -155,3 +156,40 @@ def test_bar_fixture_layout_is_measure_on_both_axes_with_a_dimension_on_detail()
     assert "sum:" in rows, f"rows must carry a measure, got {rows!r}"
     assert "sum:" in cols, f"cols must carry a measure, got {cols!r}"
     assert enc == [("lod", "[federated.bards].[none:Tail:nk]")], enc
+
+
+# --- the SET-DETECTION PREDICATE, pinned -----------------------------------------------------------
+# Three predicates were tried on this corpus and two produced confident false answers. The fixture
+# below is a live specimen of all three outcomes, so the lesson survives as an executable check
+# rather than as prose someone has to remember.
+
+UI_BUILDER = "{http://www.tableausoftware.com/xml/user}ui-builder"
+SET_BUILDERS = {"filter-group", "lasso-group"}
+
+
+def test_correct_predicate_finds_the_set():
+    """POSITIVE CONTROL for every set sweep in this repo.
+
+    A set is a <group> stamped by the authoring UI with user:ui-builder='filter-group' (condition
+    and top-N sets) or 'lasso-group' (manual sets). Any corpus sweep whose predicate cannot find
+    THIS group is producing a false zero, and its count must not be believed.
+    """
+    groups = [g for g in _root().iter("group") if (g.get(UI_BUILDER) or "") in SET_BUILDERS]
+    assert len(groups) == 1, [g.get("name") for g in groups]
+    assert groups[0].get("name") == SET_NAME
+
+
+def test_the_class_set_predicate_finds_nothing():
+    """Trap 1: there is no class='set' attribute in Tableau XML. This sweep returns a false zero."""
+    assert [g for g in _root().iter("group") if g.get("class") == "set"] == []
+    assert list(_root().iter("set")) == []
+
+
+def test_the_literal_set_name_predicate_finds_nothing():
+    """Trap 2: matching the literal name `[Set N]` only finds sets a user never renamed.
+
+    This fixture's set is named `[Technology Set]`, so a `[Set \\d+]` sweep misses it - which is how
+    12 set-bearing workbooks were once counted as 4.
+    """
+    named = [g for g in _root().iter("group") if re.fullmatch(r"\[Set \d+\]", g.get("name") or "")]
+    assert named == []

--- a/tests/test_issue_185_set_fixture.py
+++ b/tests/test_issue_185_set_fixture.py
@@ -1,0 +1,97 @@
+"""
+purpose: Pin the integrity of tests/fixtures/issue-185-set-filter.twb, the reproduction fixture for
+         upstream Yarbrdab000/tableau-fabric-skills#185 (an unresolvable Tableau Set filter is
+         silently dropped and the visual still emits). The fixture only has evidential value while
+         it remains (a) a real Tableau Set and (b) a RESTRICTIVE filter; either property rotting
+         away would turn a live reproduction into a file that proves nothing.
+usage:   pytest -q tests/test_issue_185_set_fixture.py
+"""
+
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from parse_tableau import parse_workbook  # noqa: E402  (path insert must precede this import)
+
+FIXTURE = Path(__file__).resolve().parent / "fixtures" / "issue-185-set-filter.twb"
+SET_NAME = "[Technology Set]"
+IO_INSTANCE = "[io:Technology Set:nk]"
+
+
+def _root():
+    return ET.parse(FIXTURE).getroot()
+
+
+def _sets(root):
+    """Tableau encodes a SET as a <group> holding a <groupfilter>; there is no class='set'."""
+    return [g for g in root.iter("group") if g.find("groupfilter") is not None]
+
+
+def test_fixture_exists():
+    """The fixture is the reproduction; losing the file loses the evidence."""
+    assert FIXTURE.is_file(), f"reproduction fixture missing: {FIXTURE}"
+
+
+def test_fixture_declares_a_real_tableau_set():
+    """A synthetic file that is not a genuine Tableau Set would prove nothing upstream."""
+    groups = {g.get("name"): g for g in _sets(_root())}
+    assert SET_NAME in groups, f"expected a set named {SET_NAME}, found {sorted(groups)}"
+
+
+def test_set_domain_is_a_condition_not_an_enumeration():
+    """Hemang Patel's reported domain was a condition (`TECHNOLOGY <> "NC"`), not a member list.
+
+    A set whose domain is an enumerated member list is a different (easier) translation target, so
+    if this degrades into `function='member'` the fixture no longer reproduces the reported shape.
+    """
+    group = {g.get("name"): g for g in _sets(_root())}[SET_NAME]
+    gf = group.find("groupfilter")
+    assert gf.get("function") == "filter", f"set domain is {gf.get('function')!r}, expected 'filter'"
+    assert "!=" in (gf.get("expression") or ""), "set domain lost its condition expression"
+
+
+def test_set_is_referenced_through_an_inout_column_instance():
+    """A view reaches a set only through its IN/OUT membership instance."""
+    root = _root()
+    io = [c for c in root.iter("column-instance") if c.get("name") == IO_INSTANCE]
+    assert io, f"no column-instance named {IO_INSTANCE}"
+    assert all(c.get("derivation") == "InOut" for c in io), "set instance must use derivation='InOut'"
+
+
+def test_worksheet_filter_on_the_set_is_restrictive():
+    """The whole point of the fixture: dropping this filter must WIDEN the result set.
+
+    A Tableau set filter written as `level-members` + `ui-enumeration='all'` selects both In and
+    Out, so dropping it is a no-op and proves nothing about correctness. This fixture keeps only
+    the "In" members.
+    """
+    root = _root()
+    filters = [f for f in root.iter("filter") if (f.get("column") or "").endswith(f".{IO_INSTANCE}")]
+    assert filters, f"no worksheet filter on {IO_INSTANCE}"
+    for filt in filters:
+        markers = [gf.get("function") for gf in filt.iter("groupfilter")]
+        assert "member" in markers, f"filter is not member-restricted: {markers}"
+        assert "level-members" not in markers, "filter degraded to an all-members (no-op) selection"
+        members = [gf.get("member") for gf in filt.iter("groupfilter") if gf.get("function") == "member"]
+        assert members == ['"In"'], f"expected only the In members, got {members}"
+
+
+def test_our_parser_records_the_filter_even_though_the_set_field_is_unresolved():
+    """Our tier's behaviour, contrasted with the engine's.
+
+    `parse_tableau.py` cannot resolve a set field either, but it PRESERVES the filter and its
+    members behind an `UNRESOLVED:` marker. The engine drops the filter entirely and still emits
+    the visual, which is the defect reported upstream. Pinning our side means a future change that
+    silently discards the filter here would fail loudly.
+    """
+    spec = parse_workbook(FIXTURE)
+    worksheets = {w["name"]: w for w in spec["worksheets"]}
+    assert "Score by Tail" in worksheets, sorted(worksheets)
+    filters = worksheets["Score by Tail"]["filters"]
+    assert len(filters) == 1, f"expected exactly one filter, got {filters}"
+    only = filters[0]
+    assert only["field_id"].startswith("UNRESOLVED:"), only["field_id"]
+    assert IO_INSTANCE in only["field_id"], only["field_id"]
+    assert only["members"] == ['"In"'], only["members"]


### PR DESCRIPTION
Adds the reproducible that upstream `Yarbrdab000/tableau-fabric-skills#185` was filed without, and isolates the second half of that report with a controlled experiment. Both reproduce on the canonical engine **2.339.0**.

Full triage of #185/#186/#187 — the duplicate analysis against upstream #169, the alternative explanation for #187, and four self-corrections — is posted upstream; this PR carries the fixtures, their guarding tests, and the durable learnings.

### What is here

| file | what it proves |
|---|---|
| `tests/fixtures/issue-185-set-filter.twb` | a Tableau **Set** with a condition domain, used as a **restrictive** worksheet filter. Engine 2.339.0 warns `could not resolve field 'Technology Set' (skipped)`, then emits the visual anyway with `filterConfig` absent, at `definition_of_done: warn` (not failed), passing PBIR structural validation |
| `tests/fixtures/issue-185-bar-shelf-layout.twb` | a controlled A/B: two worksheets, byte-identical shelves and encodings, differing **only** in mark class. `Automatic` emits a `scatterChart`; `Bar` emits nothing |
| `tests/test_issue_185_set_fixture.py` | 12 tests pinning the properties that make each fixture evidence rather than a file — including all three set-detection predicates |
| `docs/capabilities-and-limitations.md` | the Set translation gap, the Bar shelf asymmetry, the chart-height-floor gap, and the positive-control rule |

### The measurement lesson: a zero is not a measurement without a positive control

This PR corrects **my own** count twice. Set-detection predicates tried, in order:

| predicate | result | verdict |
|---|---|---|
| `class='set'` | 0 | no such attribute exists |
| literal name `[Set N]` | 4 workbooks | only finds sets a user never renamed |
| **`user:ui-builder` ∈ {`filter-group`, `lasso-group`}** | **23 files / 12 workbooks** | correct |

```
assets scanned                              137
files containing <group>                     51
files with a SET marker                      23   -> 12 DISTINCT workbooks
NEGATIVE CONTROL: <group> but no set marker  28
POSITIVE CONTROL: known set-bearing file    FOUND
set kinds: top-n 32 | membership 27 | condition 13
```

All three set kinds are dropped, verified on three unrelated workbooks (two of them public). Three tests pin all three predicates so the two false ones stay documented as executable checks.

### Two further findings, on the public `Airline Alliance Activity Dashboard _ #VOTD.twbx`

⚠️ **Counts name their tree** — `reports/` and `pbip/` hold different visual populations.

- **There is no chart-height rule.** In `pbip/` (111 positioned visuals) 14 are under 20px: **5 charts, 5 images, 4 textboxes**. The 4 textboxes **do** get `PBIR_TEXTBOX_HEIGHT_BELOW_FLOOR` (4 warnings) and slicers error (`×6`), but the five charts — 12.56px plus four at 14.0px — get **nothing**. In `reports/`: 95 positioned, 9 under 20px. This *reverses* an earlier negative of mine measured on single-zone workbooks too simple to exhibit the effect.
- **The engine DOES emit `Conditional.Cases` rule-based fills** — 13 nodes across 26 `visual.json` files. A literal-string search returns 0 because `Conditional.Cases` is path notation in prose; the serialized form is nested keys `{"Conditional": {"Cases": [...]}}`. That false zero was about to be used to conclude the engine could not have produced a conditionally-formatted matrix.

### Verification — all gates judged by EXIT CODE

| gate | exit |
|---|---|
| `ruff format --check conftest.py scripts tests .github/skills` | **0** |
| `ruff check conftest.py scripts tests .github/skills` | **0** |
| `pylint tests/test_issue_185_set_fixture.py` (`PYTHONPATH=scripts`) | **0** |
| `pytest tests/test_issue_185_set_fixture.py` | **0** (12 passed) |
| `python scripts/check_navigation_index.py` | **0** |
| `pytest tests/` | 3 failed / 3572 passed — the 3 known engine-drift tripwires in `tests/test_upstream_repro_pins.py`, a file this PR does not touch |

Tests were **mutation-tested 7/7** across two rounds, each mutation failing the specific guarding test, with collection verified so a non-zero exit from an unrelated error is not miscounted as detection.

### ❌ What is NOT verified

**Neither fixture has been opened in Tableau Desktop.** They are hand-authored `.twb` XML modelled structurally on real Tableau-authored workbooks. What *is* established: both are well-formed XML, parse through this repo's `parse_tableau.py`, convert through the canonical engine, reproduce the intended engine behaviour, and their generated reports pass PBIR validation. What is **not** established is that Tableau Desktop itself would open them without complaint. For the upstream claim this is a bounded limitation — the corroborating reproductions on `Section 08 - Organizing Data` and `Airline Alliance Activity Dashboard` are genuine Tableau-authored files and carry no such caveat — but it should not be implicit.

### Scope

Fixtures, tests and docs only. No `scripts/` changes: the defects are upstream, in the engine's `twb_to_pbir.py`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
