### PR TITLE
Fixes #447: gate the window-spawning tests behind an opt-in marker

### DIFF
--- a/.github/skills/pbip-model-refresh/tests/conftest.py
+++ b/.github/skills/pbip-model-refresh/tests/conftest.py
@@ -7,9 +7,12 @@ absolute path, or a walk up to a repo root, would silently re-bind the tests to 
 `scripts/` folder and prove nothing about the copy.
 
 It also pins the DEFAULT Desktop-inspection state every test runs against - see
-:func:`healthy_desktop_state` for why that has to be explicit rather than inherited from the host OS.
+:func:`healthy_desktop_state` for why that has to be explicit rather than inherited from the host OS,
+and it owns the **`gui` exclusion** for exactly the same portability reason - see
+:func:`pytest_collection_modifyitems`.
 """
 
+import os
 import sys
 from pathlib import Path
 
@@ -20,9 +23,16 @@ SKILL_SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
 if str(SKILL_SCRIPTS) not in sys.path:
     sys.path.insert(0, str(SKILL_SCRIPTS))
 
+# Kept in step with the host repo's root `conftest.py` BY DUPLICATION, on purpose: this folder is
+# copied out of the repo and run with the repo unimportable, so it cannot import a shared helper.
+GUI_MARKER = "gui"
+RUN_GUI = "--run-gui"
+RUN_GUI_ENV = "T2P_RUN_GUI"
+TRUTHY = {"1", "true", "yes", "on"}
+
 
 def pytest_configure(config: pytest.Config) -> None:
-    """Register `timing` and `serial` HERE so the markers travel with the bundle.
+    """Register `timing`, `serial` and `gui` HERE so the markers travel with the bundle.
 
     **`timing`** - a handful of tests in this folder assert a sub-second wall-clock budget on an
     operation that takes ~0.03s. Measured (issue #387) under 22 concurrent pytest-xdist workers, one
@@ -38,6 +48,12 @@ def pytest_configure(config: pytest.Config) -> None:
     the probe degrading safely, and the test's stricter assertion correctly refusing it. Not one of
     them failed in seven runs that were not concurrently paired, so this needs the pairing.
 
+    **`gui`** - ten tests here spawn a real top-level window (seven a WPF app, three native
+    `CreateWindowExW` windows), which steals focus from whoever is at the keyboard; issue #447 is an
+    operator watching that happen for two days mid-demo. Registering it here is not cosmetic:
+    measured before this existed, the copied-out run emitted seven `PytestUnknownMarkWarning`s, and
+    an unregistered marker is one `--strict-markers` away from being an error in someone else's repo.
+
     Registering them in this conftest rather than a host `pyproject.toml` is the whole point: copy
     this folder into another repo and `-m "not (serial or timing)"` still works, with no
     unregistered-marker warning.
@@ -50,6 +66,48 @@ def pytest_configure(config: pytest.Config) -> None:
         "markers",
         "serial: contends for a singleton external resource; must not run beside another such test",
     )
+    config.addinivalue_line(
+        "markers",
+        "gui: spawns a real top-level window; needed for UI-Automation coverage, opt-in only",
+    )
+
+
+def _gui_is_opted_in(config: pytest.Config) -> bool:
+    """Whether this run explicitly asked for the window-spawning tests.
+
+    `config.getoption(..., default=False)` rather than a bare lookup, because `--run-gui` is
+    registered by the HOST repo's root `conftest.py` and that file does not travel with this folder.
+    In the host repo the flag answers; in a copied-out bundle only the environment variable does.
+    """
+    if os.environ.get(RUN_GUI_ENV, "").strip().lower() in TRUTHY:
+        return True
+    return bool(config.getoption(RUN_GUI, default=False))
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    """Deselect the window-spawning tests unless this run asked for them. Travels with the bundle.
+
+    ⚠️ **The host repo's copy of this rule provably does not reach here.** `tests/test_skills.py`
+    copies this folder to a temp directory and runs it as a subprocess with `cwd` outside the repo
+    and `PYTEST_ADDOPTS` cleared, precisely so the copy proves its own portability - so the root
+    `conftest.py` and `pyproject.toml` are both absent by construction. Measured with every spawn
+    site instrumented to raise: that nested run reached **all ten** of them (`10 failed, 279 passed`),
+    while the outer suite's own summary reported **zero** deselections. Invisible, which is worse
+    than loud.
+
+    A hook rather than a marker expression, for the same reason as in the host repo: a command-line
+    `-m` REPLACES an ini expression instead of composing with it, so a `-m "not slow"` anywhere
+    upstream would put every window back. A hook runs after pytest has applied the caller's `-m`.
+
+    Opt in with `T2P_RUN_GUI=1` (portable), or `--run-gui` inside the host repo.
+    """
+    if _gui_is_opted_in(config):
+        return
+    kept = [item for item in items if item.get_closest_marker(GUI_MARKER) is None]
+    dropped = [item for item in items if item.get_closest_marker(GUI_MARKER) is not None]
+    if dropped:
+        items[:] = kept
+        config.hook.pytest_deselected(items=dropped)
 
 
 # The path above must be in place before the skill's own modules import, hence the E402 waiver.

--- a/.github/skills/pbip-model-refresh/tests/test_credential_modal_detection.py
+++ b/.github/skills/pbip-model-refresh/tests/test_credential_modal_detection.py
@@ -2926,6 +2926,7 @@ $script:form.Add_Shown({ Set-Content -LiteralPath $ReadyFile -Value 'ready' -Enc
 """
 
 
+@pytest.mark.gui
 @pytest.mark.serial
 def test_an_owned_wpf_credential_modal_titled_refresh_is_a_hard_stop(tmp_path: Path) -> None:
     """Live regression for the review defect: the whole script, against a real owned WPF modal.
@@ -3382,6 +3383,7 @@ def _run_probe_against_wpf_modal(tmp_path: Path, modal_body: str, extra_args: li
         app.wait(timeout=30)
 
 
+@pytest.mark.gui
 @pytest.mark.serial
 def test_credential_text_reachable_only_through_textpattern_is_a_hard_stop(tmp_path: Path) -> None:
     """Exploit 1. `Name` + `ValuePattern` alone miss a read-only RichTextBox's content entirely."""
@@ -3391,6 +3393,7 @@ def test_credential_text_reachable_only_through_textpattern_is_a_hard_stop(tmp_p
     assert done.returncode == 1
 
 
+@pytest.mark.gui
 @pytest.mark.serial
 def test_credential_text_beyond_the_element_cap_never_reads_as_clean(tmp_path: Path) -> None:
     """Exploit 2. Truncation must not be indistinguishable from a complete, clean read.
@@ -3404,6 +3407,7 @@ def test_credential_text_beyond_the_element_cap_never_reads_as_clean(tmp_path: P
     assert "CREDENTIAL_PRESENT" not in done.stdout
 
 
+@pytest.mark.gui
 @pytest.mark.serial
 def test_credential_text_beyond_the_element_cap_convicts_when_the_cap_allows_it(tmp_path: Path) -> None:
     """The same window with the shipped cap: read in full, and convicted."""
@@ -3413,6 +3417,7 @@ def test_credential_text_beyond_the_element_cap_convicts_when_the_cap_allows_it(
     assert done.returncode == 1
 
 
+@pytest.mark.gui
 @pytest.mark.serial
 def test_a_signature_split_by_an_interposed_button_is_a_hard_stop(tmp_path: Path) -> None:
     """Exploit 3. The prose join must skip interactive elements, or `Cancel` breaks the sentence."""
@@ -3422,6 +3427,7 @@ def test_a_signature_split_by_an_interposed_button_is_a_hard_stop(tmp_path: Path
     assert done.returncode == 1
 
 
+@pytest.mark.gui
 @pytest.mark.serial
 def test_a_wedged_uia_provider_still_produces_a_verdict(tmp_path: Path) -> None:
     """The MEDIUM finding: an uncapped UIA walk let a 1s probe run 15s+ and emit nothing at all.
@@ -3675,6 +3681,7 @@ $script:timer.Add_Tick({
 """
 
 
+@pytest.mark.gui
 @pytest.mark.serial
 def test_a_native_query_prompt_beside_progress_text_is_live_reported(tmp_path: Path) -> None:
     """Round 3's High, end to end: a fully-harvested mixed window must not clear.

--- a/.github/skills/pbip-model-refresh/tests/test_credential_modal_detection.py
+++ b/.github/skills/pbip-model-refresh/tests/test_credential_modal_detection.py
@@ -1915,6 +1915,7 @@ def test_an_unresolvable_owner_chain_fails_closed() -> None:
     assert _credential_modal.main_frame([left, right]) is None, "a cycle leaves the root unknown"
 
 
+@pytest.mark.gui
 @pytest.mark.skipif(sys.platform != "win32", reason="creates real Win32 windows")
 def test_the_win32_harvest_reads_real_ownership_and_owner_enabled_state() -> None:
     """The modality facts must come from Win32, not from a dataclass default (#400 review round 3).
@@ -2142,6 +2143,7 @@ def _dotnet_main_window_handle(pid: int) -> int:
     return int((proc.stdout or "0").strip() or 0)
 
 
+@pytest.mark.gui
 @pytest.mark.skipif(sys.platform != "win32", reason="creates real Win32 windows")
 def test_a_native_unowned_credential_host_owning_a_tooltip_is_not_the_application() -> None:
     """Round 5's reproduction, built natively - the fourth topology to defeat frame identity.
@@ -2186,6 +2188,7 @@ def test_a_native_unowned_credential_host_owning_a_tooltip_is_not_the_applicatio
         probe.close()
 
 
+@pytest.mark.gui
 @pytest.mark.skipif(sys.platform != "win32", reason="creates real Win32 windows and shells out to PowerShell")
 def test_the_process_main_window_handle_is_a_z_order_answer_not_an_identity() -> None:
     """MEASURED, because "ask the authority" was the obvious fix and it does not work (#400 round 5).

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -130,3 +130,11 @@ jobs:
 
       - name: Tests (pbip-model-refresh bundle, on the platform it actually runs on)
         run: uv run pytest -q .github/skills/pbip-model-refresh/tests/
+
+      # `addopts = "-m 'not gui'"` deselects the window-spawning tests everywhere, so an operator's
+      # desktop is never hijacked (issue #447). That protection is worthless if NOBODY runs them:
+      # issue #435 is this repo's own record of 15 engine tests skipping silently in CI, where a
+      # skip was being read as a pass. A hosted Windows runner has no one to interrupt, so this is
+      # where they belong - and `-m gui` here OVERRIDES the default, it does not add to it.
+      - name: Tests (GUI, opt-in - the real UI-Automation path the credential probe depends on)
+        run: uv run pytest -q -m gui .github/skills/pbip-model-refresh/tests/

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -131,10 +131,23 @@ jobs:
       - name: Tests (pbip-model-refresh bundle, on the platform it actually runs on)
         run: uv run pytest -q .github/skills/pbip-model-refresh/tests/
 
-      # `addopts = "-m 'not gui'"` deselects the window-spawning tests everywhere, so an operator's
-      # desktop is never hijacked (issue #447). That protection is worthless if NOBODY runs them:
-      # issue #435 is this repo's own record of 15 engine tests skipping silently in CI, where a
-      # skip was being read as a pass. A hosted Windows runner has no one to interrupt, so this is
-      # where they belong - and `-m gui` here OVERRIDES the default, it does not add to it.
+      # The root `conftest.py` deselects `gui` (window-spawning) tests in every tier, so an
+      # operator's desktop is never hijacked (issue #447). That protection is worthless if NOBODY
+      # runs them: issue #435 is this repo's own record of 15 engine tests skipping silently in CI,
+      # where a skip was being read as a pass. A hosted Windows runner has no one to interrupt, so
+      # this is where they belong.
+      #
+      # ⚠️ TWO things about this command are load-bearing, and dropping either re-opens the hole:
+      #
+      #   `--run-gui` is the OPT-IN. `-m gui` alone selects them and the hook then deselects them
+      #   again, so the step would report "no tests ran" and stay green. The flag composes with the
+      #   marker expression instead of replacing it, which is the whole reason the exclusion moved
+      #   out of `addopts` (a caller's `-m` REPLACED that, and `-m "not slow"` re-ran every window).
+      #
+      #   NO PATH ARGUMENT. `testpaths` then applies, so this covers `tests/` AND `.github/skills/`
+      #   - the entire repository's gui surface. The previous version named the bundle directory, so
+      #   a gui test added anywhere else would have been excluded by default and run by nothing.
+      #   `tests/test_gui_marker_gate.py` enforces that by collecting the repo's gui tests and
+      #   checking every one of them is reachable from this command.
       - name: Tests (GUI, opt-in - the real UI-Automation path the credential probe depends on)
-        run: uv run pytest -q -m gui .github/skills/pbip-model-refresh/tests/
+        run: uv run pytest -q --run-gui -m gui

--- a/conftest.py
+++ b/conftest.py
@@ -21,6 +21,12 @@ is precisely the run that needs gating.
 The companion half is the `serial` and `timing` markers registered in `pyproject.toml`; the tests
 that carry `timing` declare it themselves, in their own source, so it survives being copied out of
 this repo. See `docs/parallel-test-loop.md` for the two-tier loop that uses them.
+
+This file also owns the **`gui`** exclusion (issue #447): a `gui` test spawns a real top-level window
+and steals focus, so it is deselected in every tier unless `--run-gui` / `T2P_RUN_GUI=1` asks for it.
+That lives here, in a collection hook, rather than in `addopts = "-m 'not gui'"` - because a
+command-line `-m` REPLACES an ini marker expression instead of composing with it, so
+`pytest -m "not slow"` (a command this repo's own docs recommend) put all of them back.
 """
 
 from __future__ import annotations
@@ -37,6 +43,14 @@ REQUIRED_DIST = "loadfile"
 CONTENDED_MARKERS = ("serial", "timing")
 
 INCLUDE_CONTENDED = "--include-contended"
+
+# A `gui` test spawns a REAL top-level window and steals focus on whatever machine runs it. Unlike
+# `serial`/`timing` this is excluded from EVERY tier, not just the parallel one, so the exclusion
+# below is unconditional and the opt-in has to be explicit.
+GUI_MARKER = "gui"
+RUN_GUI = "--run-gui"
+RUN_GUI_ENV = "T2P_RUN_GUI"
+TRUTHY = {"1", "true", "yes", "on"}
 
 WRONG_DIST_MESSAGE = (
     "pytest-xdist is active with --dist {dist!r}. This suite is only measured safe under "
@@ -60,6 +74,30 @@ def pytest_addoption(parser: pytest.Parser) -> None:
             "this exists for deliberately stress-testing that, not for normal use."
         ),
     )
+    parser.addoption(
+        RUN_GUI,
+        action="store_true",
+        default=False,
+        help=(
+            "Run `gui` tests, which spawn a real top-level window and steal focus. CI opts in with "
+            f"this; so does anyone deliberately working on the credential probe. `{RUN_GUI_ENV}=1` "
+            "does the same thing for a nested pytest that cannot be given a flag."
+        ),
+    )
+
+
+def gui_is_opted_in(config: pytest.Config) -> bool:
+    """Whether this run was explicitly asked for the window-spawning tests.
+
+    Two spellings, and both are load-bearing. The FLAG is what a human or a CI step types. The ENV
+    VAR is for a **nested** pytest that nobody can hand a flag to - `tests/test_skills.py` copies the
+    `pbip-model-refresh` bundle to a temp directory and runs it as a subprocess there, outside this
+    repo, where neither this file nor `pyproject.toml` exists (measured: the copied run reached all
+    ten spawn sites while the outer summary reported zero deselections).
+    """
+    if os.environ.get(RUN_GUI_ENV, "").strip().lower() in TRUTHY:
+        return True
+    return bool(config.getoption(RUN_GUI, default=False))
 
 
 def _xdist_is_active(config: pytest.Config) -> bool:
@@ -97,29 +135,41 @@ def pytest_configure(config: pytest.Config) -> None:
 
 
 def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
-    """Deselect every contended test whenever xdist is active. This is the MECHANISM.
+    """Deselect the tests that must not run in this configuration. This is the MECHANISM.
 
-    The markers alone are a convention: they only protect anything if the caller remembers
-    `-m "not (serial or timing)"`. Drop half of that - `-m "not timing"` - and all seven live
-    WPF/UI-Automation tests are collected under xdist again, which is precisely the configuration
-    measured to fail 3 times in 8 concurrent-pair runs (`harvest=INCOMPLETE`, 30.6s against 8.08s
-    serially). A guard that validates only `--dist loadfile` cannot see that, and a documented
-    command is not a mechanism.
+    Two independent exclusions, deliberately in one pass so the summary reports one honest count.
 
-    So the exclusion no longer depends on being asked for. `--include-contended` is the deliberate
-    opt-out, for stress-testing this very behaviour; it is not for normal use.
+    **`serial`/`timing`, whenever xdist is active.** The markers alone are a convention: they only
+    protect anything if the caller remembers `-m "not (serial or timing)"`. Drop half of that -
+    `-m "not timing"` - and all seven live WPF/UI-Automation tests are collected under xdist again,
+    which is precisely the configuration measured to fail 3 times in 8 concurrent-pair runs
+    (`harvest=INCOMPLETE`, 30.6s against 8.08s serially). A guard that validates only
+    `--dist loadfile` cannot see that, and a documented command is not a mechanism.
+    `--include-contended` is the deliberate opt-out, for stress-testing this very behaviour.
+
+    **`gui`, always, unless opted in.** ⚠️ This used to be `addopts = "-m 'not gui'"` in
+    `pyproject.toml`, and that was FAIL-OPEN: a command-line `-m` **replaces** the ini expression
+    rather than composing with it. Measured on the bundle's 309 tests - default `302/309`,
+    `-m gui` `7/309`, and `-m "not slow"` **`309/309`, every window-spawning test back**. Our own
+    `docs/offline-mock-harness.md` documents `pytest -q -m "not slow"`, so following the repo's
+    documentation re-opened the windows. A collection hook COMPOSES with `-m` instead: pytest applies
+    the caller's expression first, and whatever survives it still passes through here.
 
     Deselection - rather than skipping - keeps the count visible in the summary line
     (``N passed, 14 deselected``) and keeps every worker's collection identical, since each applies
     the same rule to the same items.
     """
-    if not _xdist_is_active(config) or config.getoption("include_contended"):
+    drop_gui = not gui_is_opted_in(config)
+    drop_contended = _xdist_is_active(config) and not config.getoption("include_contended")
+    if not (drop_gui or drop_contended):
         return
     kept: list[pytest.Item] = []
     dropped: list[pytest.Item] = []
     for item in items:
-        target = dropped if any(item.get_closest_marker(name) for name in CONTENDED_MARKERS) else kept
-        target.append(item)
+        unwanted = (drop_gui and item.get_closest_marker(GUI_MARKER) is not None) or (
+            drop_contended and any(item.get_closest_marker(name) for name in CONTENDED_MARKERS)
+        )
+        (dropped if unwanted else kept).append(item)
     if dropped:
         items[:] = kept
         config.hook.pytest_deselected(items=dropped)

--- a/docs/offline-mock-harness.md
+++ b/docs/offline-mock-harness.md
@@ -294,3 +294,10 @@ python -m pytest tests/test_e2e_offline.py -q
 
 The whole thing is ~8 seconds. `tests/test_e2e_offline.py` is marked `slow` (registered in
 `pyproject.toml`) because it binds a loopback socket and spawns a subprocess; nothing else does.
+
+⚠️ `-m "not slow"` above is safe **because the window-spawning tests are excluded by a collection
+hook, not by a marker expression** (issue #447). It was not always: while the exclusion lived in
+`addopts = "-m 'not gui'"`, a command-line `-m` REPLACED it rather than composing with it, and this
+exact documented command collected **309/309** of the `pbip-model-refresh` bundle's tests - every
+one that opens a real top-level window and steals focus. Nothing here needs `--run-gui`; see
+`docs/parallel-test-loop.md` for the tier that does.

--- a/docs/parallel-test-loop.md
+++ b/docs/parallel-test-loop.md
@@ -156,8 +156,13 @@ the boundary rather than remove it - they share one mechanism and one singleton 
 deliberately, on their own:
 
 ```bash
-uv run pytest -q -m serial
+uv run pytest -q --run-gui -m serial
 ```
+
+⚠️ `--run-gui` is not optional here, and `-m serial` alone will report *fewer* tests than you expect.
+All seven also carry **`gui`** (issue #447: they open a real top-level window and steal focus), and
+the root `conftest.py` deselects `gui` in every tier unless asked. Leave the flag off and you get the
+`serial` tests that are not `gui` - a green run that ran none of the live UI regressions.
 
 ⚠️ `--dist loadfile` is what keeps them from racing *inside* one run (all seven live in one file, so
 one worker owns them). It cannot help *across* runs, and neither can any scheduler flag. The marker
@@ -271,12 +276,16 @@ them the live WPF/UIA regressions measured above. Run them deliberately, on thei
 touched the credential probe:
 
 ```bash
-uv run pytest -q -m serial
+uv run pytest -q --run-gui -m serial
 ```
 
 That is not part of either tier. Tier 1 excludes them because two agents running tier 1 at once
-raced them; tier 2 includes them, because a serial whole-suite run is the one condition in which they
-were never observed to fail.
+raced them; **tier 2 no longer includes them either.** All seven also carry `gui` (issue #447), and
+the root `conftest.py` deselects `gui` unless `--run-gui` / `T2P_RUN_GUI=1` asks for it - so a plain
+`pytest -q` never opens a window on the machine you are working on, and the command above (or CI's
+Windows leg) is now the only thing that runs them. That is a deliberate trade: the live regressions
+were never observed to fail in a serial whole-suite run, but a serial whole-suite run is also what an
+agent types twenty times a day beside a human who is using the desktop.
 
 ⚠️ **Absence of failure in a short campaign proves nothing here.** Seven runs - including two
 concurrent pairs - found none of it. It took eight concurrent pairs to see three failures. The
@@ -307,3 +316,44 @@ The exclusion no longer depends on anyone typing the right filter - the root `co
 If CI time does become the complaint, the change is one line per job plus a measurement on the
 runners themselves - and the root-`conftest.py` guard already makes it impossible to add `-n` there
 without `--dist loadfile`.
+
+## The `gui` marker — a THIRD exclusion, and it is not part of either tier
+
+`serial` and `timing` are about the **parallel** tier: they are excluded from tier 1 and were
+restored by tier 2. `gui` is different in kind, so it is a different marker and a different
+mechanism. A `gui` test spawns a **real top-level window**, which steals focus on whatever machine
+runs it. Issue #447 is an operator watching the `Fake Desktop` WinForms app "opening and closing for
+the last 2 days" mid-demo, because `testpaths` includes `.github/skills` and a bare `pytest`
+collected it.
+
+Ten tests carry it: the seven live WPF/UIA regressions above, plus three that create native
+`WS_VISIBLE` windows with `CreateWindowExW`. They must keep opening a window - UI Automation cannot
+be exercised against a mock - so the fix is opt-in, not weaker tests:
+
+```bash
+uv run pytest -q --run-gui -m gui     # or T2P_RUN_GUI=1, which a nested pytest can inherit
+```
+
+⚠️ **It is a collection hook, NOT `addopts = "-m 'not gui'"`, and the difference is measured.** A
+command-line `-m` **replaces** an ini marker expression instead of composing with it. Under `addopts`,
+on the bundle's 309 tests:
+
+| command | selected |
+|---|---|
+| default | 302/309 |
+| `-m gui` | 7/309 |
+| `-m "not slow"` | **309/309 — every window back** |
+| `-m "not something_else"` | **309/309** |
+
+`-m "not slow"` is documented in `docs/offline-mock-harness.md`, so following the repo's own
+instructions re-opened the windows. `pytest_collection_modifyitems` runs *after* pytest has applied
+the caller's `-m`, so nothing a caller types can re-enable them; only the opt-in can.
+
+The same hook is duplicated in `.github/skills/pbip-model-refresh/tests/conftest.py`, because
+`tests/test_skills.py` copies that bundle out of the repo and runs a nested pytest where neither the
+root `conftest.py` nor `pyproject.toml` exists. Measured with every spawn site instrumented to raise:
+that nested run reached **all ten** of them, and the outer summary reported **zero** deselections.
+
+CI's `windows-latest` leg runs `uv run pytest -q --run-gui -m gui` with **no path argument**, so
+`testpaths` applies and it covers the whole repository. `tests/test_gui_marker_gate.py` executes that
+very command under `--collect-only` and fails if it does not reach every `gui` test in the repo.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,20 @@ markers = [
     # barrier in test_check_migration_progress.py did. Tests carry the marker in their own source
     # (and the pbip-model-refresh bundle registers it in its own conftest) so it survives a copy.
     "timing: asserts a wall-clock budget, so a saturated box fails it",
+    # A `gui` test SPAWNS A REAL TOP-LEVEL WINDOW, which steals focus on whatever machine runs it.
+    # Reported from the field while the operator was presenting a live demo: the "Fake Desktop"
+    # WinForms app had been "opening and closing for the last 2 days" (issue #447). It must keep
+    # spawning one - UI Automation cannot be exercised against a mock - so the fix is to make it
+    # OPT-IN, not to weaken it. `serial` is not a substitute: that only takes effect under
+    # `-n auto --dist loadfile`, and a plain `pytest` (what an agent runs) executes them anyway.
+    "gui: spawns a real top-level window; needed for UI-Automation coverage, opt-in only",
 ]
+
+# Deselect `gui` by default so an ordinary run never steals focus. ⚠️ CI MUST run `-m gui`
+# explicitly (see `.github/workflows/checks.yml`), or this trades a focus-stealing window for
+# silently-lost coverage of a fail-open credential guard - which is issue #435's failure exactly
+# ("CI runs none of the 15 engine-dependent tests - they SKIP silently, and a skip is not a pass").
+addopts = "-m 'not gui'"
 
 [tool.ruff]
 exclude = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,14 +71,15 @@ markers = [
     # spawning one - UI Automation cannot be exercised against a mock - so the fix is to make it
     # OPT-IN, not to weaken it. `serial` is not a substitute: that only takes effect under
     # `-n auto --dist loadfile`, and a plain `pytest` (what an agent runs) executes them anyway.
+    #
+    # ⚠️ The EXCLUSION is not here. It lives in the root `conftest.py`'s `pytest_collection_modifyitems`
+    # and in the bundle's own `tests/conftest.py`, because `addopts = "-m 'not gui'"` was measured
+    # FAIL-OPEN: a command-line `-m` replaces an ini marker expression rather than composing with it,
+    # so `pytest -m "not slow"` - documented in `docs/offline-mock-harness.md` - collected 309/309 of
+    # the bundle's tests, every window-spawning one included. Opt in with `--run-gui` (or
+    # `T2P_RUN_GUI=1` for a nested run that cannot be handed a flag).
     "gui: spawns a real top-level window; needed for UI-Automation coverage, opt-in only",
 ]
-
-# Deselect `gui` by default so an ordinary run never steals focus. ⚠️ CI MUST run `-m gui`
-# explicitly (see `.github/workflows/checks.yml`), or this trades a focus-stealing window for
-# silently-lost coverage of a fail-open credential guard - which is issue #435's failure exactly
-# ("CI runs none of the 15 engine-dependent tests - they SKIP silently, and a skip is not a pass").
-addopts = "-m 'not gui'"
 
 [tool.ruff]
 exclude = [

--- a/tests/test_gui_marker_gate.py
+++ b/tests/test_gui_marker_gate.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 import ast
 import contextlib
 import functools
+import importlib.util
 import os
 import re
 import shlex
@@ -375,6 +376,27 @@ def test_the_root_hook_deselects_a_gui_test_that_is_in_no_bundle() -> None:
         f"is not deselecting it: {sorted(default)}"
     )
     assert opted_in, "the same test could not be selected with the opt-in either, so it is orphaned"
+
+
+def test_the_nested_portability_run_does_not_inherit_an_ambient_gui_opt_in(monkeypatch) -> None:
+    """Kills: `T2P_RUN_GUI=1` left in a shell turning a PORTABILITY check into ten real windows.
+
+    `tests/test_skills.py` copies each bundle out and runs its whole suite. The copied bundle's own
+    conftest honours the portable opt-in - it has to, since no flag survives the copy - so an
+    inherited variable would make an unrelated check hijack the desktop, which is issue #447 by
+    another route. Driven behaviourally, by calling that module's own env builder with the variable
+    set: an assertion on the source text would be satisfied by the comment explaining it.
+    """
+    monkeypatch.setenv(RUN_GUI_ENV, "1")
+    spec = importlib.util.spec_from_file_location("t2p_test_skills_gui_probe", REPO_ROOT / "tests" / "test_skills.py")
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    child = module._repo_free_env()  # noqa: SLF001  # pylint: disable=protected-access
+    assert RUN_GUI_ENV not in child, (
+        f"the nested bundle run inherits {RUN_GUI_ENV}, so a portability check spawns real windows "
+        "whenever an operator has the opt-in exported"
+    )
 
 
 def test_the_opt_in_flag_selects_exactly_the_gui_tests() -> None:

--- a/tests/test_gui_marker_gate.py
+++ b/tests/test_gui_marker_gate.py
@@ -1,4 +1,4 @@
-"""Prove the `gui` marker hides the window-spawning tests from an ordinary run WITHOUT losing them.
+"""Prove the window-spawning tests are hidden from every ordinary run WITHOUT being lost.
 
 Issue #447. Some tests must spawn a real top-level window - UI Automation cannot be exercised
 against a mock - and one of them was stealing focus on an operator's machine mid-demo, because
@@ -9,95 +9,474 @@ WHY THIS FILE EXISTS AT ALL
 A marker that hides a test is how coverage dies silently, and this repo has already done it once:
 issue #435, "CI runs none of the 15 engine-dependent tests - they SKIP silently, and a skip is not
 a pass". So asserting "the suite is green" would be worthless here - a suite is equally green when
-the tests passed and when they vanished. Each test below asserts a COUNT, in the direction that
-would catch its own failure mode:
+the tests passed and when they vanished.
 
-* the negative control asserts the DESELECTED count is exactly the number of marked tests
-* the positive control asserts `-m gui` SELECTS that same non-zero number
-* the CI control asserts the workflow invokes `-m gui` explicitly, since the default now excludes it
+WHAT THE FIRST VERSION OF THIS FILE GOT WRONG, AND WHY EACH CONTROL BELOW IS SHAPED AS IT IS
+--------------------------------------------------------------------------------------------
+The first version hardcoded ONE bundle path and ONE marked file, and every one of its assertions
+was about that file. An independent review then measured four ways round it, all reproduced here
+before this rewrite:
 
-Collection is done in a subprocess with `--collect-only`, so nothing is executed and no window is
-ever spawned by this file.
+* `pytest tests/` runs `test_skills.py`, which copies the bundle OUT of the repo and runs a nested
+  pytest there. `pyproject.toml` does not travel with the copy, so `addopts` never applied. With
+  every spawn site instrumented to raise, that nested run reached **all ten** of them - and the
+  outer summary reported **zero** deselections, so it was invisible;
+* three tests spawn native `CreateWindowExW` windows and carried no marker at all;
+* an explicit `-m` REPLACES an ini `addopts` marker expression rather than composing with it, so
+  `-m "not slow"` - which `docs/offline-mock-harness.md` recommends - collected **309/309** of the
+  bundle's tests, every window included;
+* the controls covered one file, so a gui test added anywhere else was gated by nothing.
+
+Hence: nothing below names a test file. The gui set is enumerated **by collection** over the roots
+`pyproject.toml` declares, the window-spawning set is derived **from the AST** of every test file
+under those roots, and the CI command is read from the workflow and **executed** rather than
+pattern-matched. Collection only - `--collect-only` never runs a test, so this file never opens a
+window.
 """
 
 from __future__ import annotations
 
+import ast
+import functools
+import os
 import re
+import shlex
+import shutil
 import subprocess
 import sys
+import tomllib
 from pathlib import Path
 
+from _pytest.mark.expression import Expression
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
-BUNDLE_TESTS = REPO_ROOT / ".github" / "skills" / "pbip-model-refresh" / "tests"
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "checks.yml"
-MARKED_FILE = BUNDLE_TESTS / "test_credential_modal_detection.py"
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+
+GUI_MARKER = "gui"
+RUN_GUI_FLAG = "--run-gui"
+RUN_GUI_ENV = "T2P_RUN_GUI"
+
+# A test SPAWNS A WINDOW if it reaches one of these, directly or through a helper in its own module.
+# Both are call-context only, which is the difference between detecting a spawn and detecting a
+# mention: `tests/test_parallel_test_loop.py` contains the literal "-ReadyFile" inside its own AST
+# scanner, and matching bare constants flagged three of its meta-tests as window-spawners.
+WINDOW_SPAWN_CALLS = {"CreateWindowExW"}
+WINDOW_SPAWN_ARGV = {"-ReadyFile"}
+PROCESS_LAUNCHERS = {"Popen", "run", "call", "check_call", "check_output"}
 
 
-def _collect(*extra: str) -> str:
-    """`--collect-only -q` over the bundle tests; never executes a test, so never opens a window."""
-    proc = subprocess.run(
-        [sys.executable, "-m", "pytest", "--collect-only", "-q", str(BUNDLE_TESTS), *extra],
+def _testpath_roots() -> list[str]:
+    """The collection roots, read from `pyproject.toml` rather than restated here."""
+    with PYPROJECT.open("rb") as handle:
+        return tomllib.load(handle)["tool"]["pytest"]["ini_options"]["testpaths"]
+
+
+VERBOSITY_ONLY = re.compile(r"^(-q+|-v+|--quiet|--verbose|--verbosity(=.*)?)$")
+
+
+def _without_verbosity_flags(argv: list[str]) -> list[str]:
+    """Drop presentation-only flags from a caller's argv.
+
+    ⚠️ Not cosmetic, and found by this file's own CI check failing. `--collect-only` prints node ids
+    at `-q` and **`path: count`** at `-qq` (`TerminalReporter._printcollecteditems` branches on
+    `verbose < -1`), so appending our `-q` to a workflow command that already carries one silently
+    changed the output format and every node id vanished - which read as "CI reaches none of them".
+    Verbosity cannot affect SELECTION, which is the only thing these checks measure, so normalising
+    it keeps the command's meaning while making its transcript parseable.
+    """
+    kept: list[str] = []
+    skip_next = False
+    for token in argv:
+        if skip_next:
+            skip_next = False
+            continue
+        if VERBOSITY_ONLY.match(token):
+            skip_next = token == "--verbosity"
+            continue
+        kept.append(token)
+    return kept
+
+
+def _collect(argv: list[str], *, cwd: Path | None = None, env: dict[str, str] | None = None):
+    """`--collect-only -q` with `argv`; never executes a test, so never opens a window."""
+    return subprocess.run(
+        [sys.executable, "-m", "pytest", "--collect-only", "-q", *_without_verbosity_flags(argv)],
         capture_output=True,
         text=True,
-        cwd=REPO_ROOT,
+        cwd=cwd or REPO_ROOT,
+        env=env,
         check=False,
     )
-    return proc.stdout + proc.stderr
 
 
-def _marked_test_count() -> int:
-    """How many tests carry the marker, read from the source rather than from pytest."""
-    return len(re.findall(r"^@pytest\.mark\.gui$", MARKED_FILE.read_text(encoding="utf-8"), re.MULTILINE))
+def _node_ids(output: str) -> set[str]:
+    """Every node id in a `--collect-only -q` transcript."""
+    return {line.strip() for line in output.splitlines() if "::" in line and not line.startswith(("E ", "ERROR"))}
 
 
-def test_the_marker_is_applied_to_at_least_one_test() -> None:
-    """Kills: the marker existing in config while no test carries it, making both controls vacuous."""
-    assert _marked_test_count() > 0, (
-        "no test carries @pytest.mark.gui, so the deselect/select controls below would both pass "
-        "trivially and prove nothing"
-    )
+def _collected_node_ids(argv: list[str], **kwargs) -> set[str]:
+    """The node ids a given pytest invocation would actually run."""
+    return _node_ids(_collect(argv, **kwargs).stdout)
 
 
-def test_a_default_run_deselects_every_gui_test() -> None:
-    """Kills: dropping `addopts`, or a caller's `-m` silently replacing it -> windows return."""
-    output = _collect()
-    match = re.search(r"(\d+) deselected", output)
-    assert match, f"expected a 'deselected' count in a default collection; got:\n{output[-1500:]}"
-    assert int(match.group(1)) == _marked_test_count(), (
-        f"default run deselected {match.group(1)} test(s) but {_marked_test_count()} carry the "
-        "marker - the default filter and the marked set disagree"
-    )
+@functools.lru_cache(maxsize=1)
+def _gui_node_ids() -> frozenset[str]:
+    """Every `gui`-marked test in the repository, BY COLLECTION, over the declared testpaths.
+
+    Enumerated from `pyproject.toml`'s roots and never from the CI command, so that the CI coverage
+    check below compares two independently-derived things. Deriving both from the workflow would
+    make that check a tautology that passes however narrow the command becomes.
+    """
+    found: set[str] = set()
+    for root in _testpath_roots():
+        found |= _collected_node_ids([RUN_GUI_FLAG, "-m", GUI_MARKER, root])
+    return frozenset(found)
 
 
-def test_opting_in_selects_exactly_the_marked_tests() -> None:
-    """Kills: orphaning the tests - marked, deselected by default, and selectable by nothing."""
-    output = _collect("-m", "gui")
-    # ⚠️ Try the `selected/total` form FIRST. pytest prints "7/309 tests collected (302 deselected)"
-    # when a filter applies, and a bare `(\d+) tests? collected` matches the TOTAL inside that
-    # string - which scored this control 309 against 7 and read as a product defect rather than a
-    # regex defect.
-    match = re.search(r"(\d+)/\d+ tests? collected", output) or re.search(r"(\d+) tests? collected", output)
-    assert match, f"expected a collected count under `-m gui`; got:\n{output[-1500:]}"
-    assert int(match.group(1)) == _marked_test_count(), (
-        f"`-m gui` collected {match.group(1)} test(s) but {_marked_test_count()} carry the marker"
-    )
+def _spawn_evidence(node: ast.AST) -> str | None:
+    """Why this AST subtree opens a window, or None. Call context only - see WINDOW_SPAWN_CALLS."""
+    for child in ast.walk(node):
+        if not isinstance(child, ast.Call):
+            continue
+        called = child.func.attr if isinstance(child.func, ast.Attribute) else getattr(child.func, "id", "")
+        if called in WINDOW_SPAWN_CALLS:
+            return called
+        if called in PROCESS_LAUNCHERS:
+            for argument in ast.walk(child):
+                if isinstance(argument, ast.Constant) and argument.value in WINDOW_SPAWN_ARGV:
+                    return f"subprocess argv {argument.value}"
+    return None
 
 
-def test_ci_runs_the_gui_tests_explicitly() -> None:
-    """Kills: issue #435 in a new place - a marker that hides tests from CI as well as from a desktop."""
-    # ⚠️ Assert on the `run:` COMMAND, never on the file text. A first version asserted
-    # `"-m gui" in workflow`, and the mutation that deleted the opt-in from the run line SURVIVED -
-    # because the phrase still appeared in the explanatory comment beside it. A guard satisfied by
-    # prose rather than by the thing it checks is exactly the vacuity this repo keeps finding.
-    commands = [
+def _module_definitions(tree: ast.Module) -> dict[str, ast.AST]:
+    """Every name in a module that a test could call into, mapped to its definition."""
+    return {
+        node.name: node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef))
+    }
+
+
+def _reaches_a_spawn(node: ast.AST, definitions: dict[str, ast.AST], seen: set[str]) -> str | None:
+    """Whether `node` opens a window directly or through anything it calls in the same module.
+
+    Transitive on purpose. Seven of the ten go through `_run_probe_against_wpf_modal` and two through
+    `_NativeWindowProbe`, so a body-only scan sees three of them and calls the job done - which is
+    the shape of the defect this control exists to catch.
+    """
+    direct = _spawn_evidence(node)
+    if direct:
+        return direct
+    for child in ast.walk(node):
+        name = child.id if isinstance(child, ast.Name) else None
+        if name in definitions and name not in seen:
+            seen.add(name)
+            deeper = _reaches_a_spawn(definitions[name], definitions, seen)
+            if deeper:
+                return f"{name} -> {deeper}"
+    return None
+
+
+def _window_spawning_tests() -> dict[str, str]:
+    """Every test that opens a real window, by node id, mapped to the evidence that says so."""
+    found: dict[str, str] = {}
+    for root in _testpath_roots():
+        for path in sorted((REPO_ROOT / root).rglob("test_*.py")):
+            try:
+                tree = ast.parse(path.read_text(encoding="utf-8"))
+            except SyntaxError:  # deliberately malformed fixture files exist in this repo
+                continue
+            definitions = _module_definitions(tree)
+            relative = path.relative_to(REPO_ROOT).as_posix()
+            for func in tree.body:
+                if not isinstance(func, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    continue
+                if not func.name.startswith("test_"):
+                    continue
+                why = _reaches_a_spawn(func, definitions, {func.name})
+                if why:
+                    found[f"{relative}::{func.name}"] = why
+    return found
+
+
+def _run_commands() -> list[str]:
+    """Every `run:` command in the CI workflow, one per line."""
+    return [
         line.split("run:", 1)[1].strip()
         for line in WORKFLOW.read_text(encoding="utf-8").splitlines()
         if re.match(r"\s*run:", line)
     ]
-    opted_in = [cmd for cmd in commands if "pytest" in cmd and re.search(r"-m\s+'?gui'?\b", cmd)]
-    assert opted_in, (
-        "no CI `run:` command invokes pytest with `-m gui`. The default `addopts` now deselects "
-        "these tests everywhere, so without an explicit opt-in step they run NOWHERE - trading a "
-        "focus-stealing window for silently-lost coverage of a fail-open credential guard "
-        f"(issue #435). pytest commands found: {[c for c in commands if 'pytest' in c]}"
+
+
+def _selects_gui(command: str) -> bool:
+    """Whether a command's `-m` expression SELECTS `gui`, judged by pytest's own semantics.
+
+    Never by substring. The first version of this file asserted `"-m gui" in workflow`, and the
+    mutation that deleted the opt-in from the run line SURVIVED, because the phrase still appeared
+    in the explanatory comment beside it.
+    """
+    tokens = shlex.split(command)
+    if "pytest" not in tokens or "-m" not in tokens:
+        return False
+    expression = tokens[tokens.index("-m") + 1]
+    try:
+        compiled = Expression.compile(expression)
+    except Exception:  # pylint: disable=broad-except
+        return False
+    return bool(compiled.evaluate(lambda name: name == GUI_MARKER))
+
+
+def _ci_gui_invocations() -> list[list[str]]:
+    """The CI commands that opt into the gui tests, as argv we can run locally.
+
+    `uv run` is stripped and `pytest` replaced by this interpreter's; everything else is kept
+    VERBATIM, including `--run-gui` and any path arguments. That is the point: the check below runs
+    the real command rather than reasoning about its text, so deleting the opt-in flag or narrowing
+    the paths changes what gets collected and is caught.
+    """
+    invocations: list[list[str]] = []
+    for command in _run_commands():
+        if not _selects_gui(command):
+            continue
+        tokens = shlex.split(command)
+        invocations.append(tokens[tokens.index("pytest") + 1 :])
+    return invocations
+
+
+def _gui_tests_missed_by(argv: list[str]) -> set[str]:
+    """Which of the repository's gui tests a given pytest argv would NOT run.
+
+    THE predicate. Both the CI check and its own inverse-completeness proof call this, so the proof
+    cannot drift away from the thing it is proving.
+    """
+    return set(_gui_node_ids()) - _collected_node_ids(argv)
+
+
+def _repo_free_env() -> dict[str, str]:
+    """A child environment with nothing of this repo - or this run's opt-in - leaking into it."""
+    env = dict(os.environ)
+    for name in ("PYTHONPATH", "PYTEST_CURRENT_TEST", "PYTEST_ADDOPTS", RUN_GUI_ENV):
+        env.pop(name, None)
+    return env
+
+
+# ---------------------------------------------------------------------------------------------
+# The marked set, and its agreement with the set that actually opens windows
+# ---------------------------------------------------------------------------------------------
+
+
+def test_the_repository_has_gui_marked_tests_at_all() -> None:
+    """Kills: the whole mechanism selecting nothing, which makes every check below vacuous."""
+    assert len(_gui_node_ids()) >= 10, (
+        "expected at least the ten known window-spawning tests to be collectable under "
+        f"`{RUN_GUI_FLAG} -m {GUI_MARKER}`, got {sorted(_gui_node_ids())}"
+    )
+
+
+def test_every_window_spawning_test_declares_itself_gui() -> None:
+    """Kills the defect the first version could not see: a test that opens a window and is unmarked.
+
+    Derived from the suite's own AST, transitively, so it is not a list anyone has to remember to
+    update. Measured before this control existed: three tests created real `WS_VISIBLE` top-level
+    windows through `CreateWindowExW` and carried no marker, and replacing each spawn site with a
+    raising sentinel showed all three reached on the DEFAULT selection.
+    """
+    spawners = _window_spawning_tests()
+    assert len(spawners) >= 10, f"the AST scan found only {sorted(spawners)} - it can no longer see the spawn sites"
+    unmarked = sorted(node for node in spawners if node not in _gui_node_ids())
+    assert not unmarked, (
+        "these tests open a real top-level window but are not collected under "
+        f"`{RUN_GUI_FLAG} -m {GUI_MARKER}`, so an ordinary run hijacks the operator's desktop: "
+        + ", ".join(f"{node} [{spawners[node]}]" for node in unmarked)
+    )
+
+
+def test_no_gui_marker_outlives_the_window_it_was_added_for() -> None:
+    """The other direction: a marker left behind hides a test from every tier for no reason."""
+    stale = sorted(set(_gui_node_ids()) - set(_window_spawning_tests()))
+    assert not stale, (
+        "these tests carry @pytest.mark.gui but no longer open a window, so they are excluded from "
+        f"every run - and only CI runs them - for nothing: {stale}"
+    )
+
+
+# ---------------------------------------------------------------------------------------------
+# The exclusion itself: it must COMPOSE with whatever the caller typed
+# ---------------------------------------------------------------------------------------------
+
+
+def test_a_default_run_selects_no_gui_test() -> None:
+    """Kills: deleting the collection hook - an ordinary `pytest` opens windows again."""
+    leaked = sorted(_gui_node_ids() & _collected_node_ids([]))
+    assert not leaked, f"a default run collected window-spawning tests: {leaked}"
+
+
+def test_no_marker_expression_a_caller_can_type_re_enables_the_gui_tests() -> None:
+    """Kills the fail-open `addopts` this replaced. An explicit `-m` REPLACES an ini expression.
+
+    Measured against `addopts = "-m 'not gui'"` on the bundle's 309 tests:
+
+        default                  302/309
+        -m gui                     7/309
+        -m "not slow"            309/309   <- every window-spawning test back
+        -m "not something_else"  309/309
+
+    `not slow` is not a hypothetical: `docs/offline-mock-harness.md` documents it. A collection hook
+    runs AFTER pytest has applied the caller's `-m`, so it composes instead of being replaced.
+    """
+    leaked: dict[str, list[str]] = {}
+    for expression in ("not slow", "not something_else", "not (serial or timing)", GUI_MARKER, "serial"):
+        collected = _gui_node_ids() & _collected_node_ids(["-m", expression])
+        if collected:
+            leaked[expression] = sorted(collected)
+    assert not leaked, f"these marker expressions re-enabled the window-spawning tests: {leaked}"
+
+
+def test_the_opt_in_flag_selects_exactly_the_gui_tests() -> None:
+    """Kills: orphaning them - marked, deselected everywhere, and selectable by nothing."""
+    collected = _collected_node_ids([RUN_GUI_FLAG, "-m", GUI_MARKER])
+    assert collected == set(_gui_node_ids()), (
+        f"`{RUN_GUI_FLAG} -m {GUI_MARKER}` collected {sorted(collected)}, expected {sorted(_gui_node_ids())}"
+    )
+
+
+def test_the_portable_env_var_opts_in_too() -> None:
+    """Kills: the copied-out bundle becoming unrunnable - a nested pytest cannot be handed a flag.
+
+    `tests/test_skills.py` launches the bundle as a subprocess outside this repo, so `--run-gui` is
+    not registered there. The environment variable is the only opt-in that survives the copy, which
+    is why it is a mechanism and not a convenience.
+    """
+    env = _repo_free_env()
+    env[RUN_GUI_ENV] = "1"
+    collected = _collected_node_ids(["-m", GUI_MARKER], env=env)
+    assert collected == set(_gui_node_ids()), (
+        f"`{RUN_GUI_ENV}=1 -m {GUI_MARKER}` collected {sorted(collected)}, expected {sorted(_gui_node_ids())}"
+    )
+
+
+# ---------------------------------------------------------------------------------------------
+# The copy that leaves the repository behind
+# ---------------------------------------------------------------------------------------------
+
+
+def _bundles_with_gui_tests() -> list[Path]:
+    """Every bundled skill that ships a window-spawning test, derived from the gui node ids."""
+    bundles = set()
+    for node in _gui_node_ids():
+        path = REPO_ROOT / node.split("::", 1)[0]
+        if ".github/skills/" in path.as_posix():
+            bundles.add(path.parents[1])
+    return sorted(bundles)
+
+
+def _gui_test_names_in(bundle: Path) -> set[str]:
+    """The bare test names a bundle's gui tests carry, which survive being copied elsewhere."""
+    prefix = bundle.relative_to(REPO_ROOT).as_posix() + "/"
+    return {node.split("::", 1)[1] for node in _gui_node_ids() if node.startswith(prefix)}
+
+
+def _copy_bundle(bundle: Path, destination: Path) -> Path:
+    """Copy a skill folder exactly as its README tells a reader to."""
+    return Path(
+        shutil.copytree(
+            bundle, destination / bundle.name, ignore=shutil.ignore_patterns("__pycache__", ".pytest_cache")
+        )
+    )
+
+
+def test_a_bundle_copied_out_of_this_repo_still_deselects_its_gui_tests(tmp_path: Path) -> None:
+    """Kills the invisible one. `pyproject.toml` provably does not travel with a copied bundle.
+
+    `tests/test_skills.py` copies the bundle to a temp directory and runs a nested pytest there with
+    `cwd` outside the repo and `PYTHONPATH`/`PYTEST_ADDOPTS` cleared, so the root `conftest.py` and
+    `pyproject.toml` are both absent by construction. Measured with every spawn site instrumented to
+    raise, before the bundle carried its own hook: `10 failed, 279 passed` inside that nested run,
+    while the OUTER summary reported zero deselections. This reproduces the same copy.
+    """
+    bundles = _bundles_with_gui_tests()
+    assert bundles, "no bundled skill ships a gui test - this control would pass vacuously"
+    for bundle in bundles:
+        copied = _copy_bundle(bundle, tmp_path)
+        names = _gui_test_names_in(bundle)
+        assert names, f"{bundle.name} was selected as a gui-bearing bundle but yielded no test names"
+        result = _collect([str(copied / "tests")], cwd=tmp_path, env=_repo_free_env())
+        leaked = sorted(node for node in _node_ids(result.stdout) if node.split("::", 1)[-1] in names)
+        assert not leaked, (
+            f"{bundle.name} copied out of the repo still collects its window-spawning tests, so the "
+            f"nested run in tests/test_skills.py opens windows:\n{leaked}"
+        )
+        assert re.search(r"\b(\d+) deselected", result.stdout), (
+            f"{bundle.name} copied out of the repo deselected nothing at all, so its own conftest "
+            f"hook is not running:\n{result.stdout[-1500:]}"
+        )
+
+
+def test_a_copied_out_bundle_registers_the_gui_marker_itself(tmp_path: Path) -> None:
+    """Kills: `PytestUnknownMarkWarning` in someone else's repo - one `--strict-markers` from an error.
+
+    Judged by running the copy under `--strict-markers`, which turns an unregistered mark into a
+    collection error and therefore a non-zero exit, rather than by grepping for a warning string.
+    Measured before the bundle registered it: the nested run emitted seven of those warnings.
+    """
+    for bundle in _bundles_with_gui_tests():
+        copied = _copy_bundle(bundle, tmp_path)
+        result = _collect([str(copied / "tests"), "--strict-markers"], cwd=tmp_path, env=_repo_free_env())
+        assert result.returncode == 0, (
+            f"{bundle.name} does not register every marker it uses in its own conftest, so it warns "
+            f"(and under --strict-markers fails) wherever it is copied:\n{result.stdout[-2000:]}"
+        )
+
+
+# ---------------------------------------------------------------------------------------------
+# CI still runs them - and runs ALL of them
+# ---------------------------------------------------------------------------------------------
+
+
+def test_ci_opts_into_the_gui_tests_explicitly() -> None:
+    """Kills issue #435 in a new place - a marker that hides tests from CI as well as from a desktop."""
+    assert _ci_gui_invocations(), (
+        "no CI `run:` command selects the `gui` marker. The collection hook deselects these tests "
+        "everywhere, so without an explicit opt-in step they run NOWHERE - trading a focus-stealing "
+        "window for silently-lost coverage of a fail-open credential guard (issue #435). pytest "
+        f"commands found: {[c for c in _run_commands() if 'pytest' in c]}"
+    )
+
+
+def test_the_ci_command_reaches_every_gui_test_in_the_repository() -> None:
+    """The inverse-completeness half, and the one the first version of this file did not have.
+
+    It asserted that some `run:` line contained `pytest -m gui` - which is satisfied by a command
+    scoped to ONE directory, so a gui test added anywhere else was deselected by default and run by
+    nobody. This instead EXECUTES the workflow's own command (with `--collect-only`) and compares
+    what it collects against the gui tests found across `testpaths`. Two independently-derived sets:
+    narrowing the command's paths, or dropping its `--run-gui`, moves only one of them.
+    """
+    for argv in _ci_gui_invocations():
+        missed = sorted(_gui_tests_missed_by(argv))
+        assert not missed, (
+            f"the CI opt-in command `pytest {' '.join(argv)}` does not reach these window-spawning "
+            f"tests, so nothing runs them anywhere: {missed}"
+        )
+
+
+def test_the_ci_coverage_check_notices_a_gui_test_the_command_cannot_reach() -> None:
+    """Proves the check above CAN fail, using the same predicate rather than a re-implementation.
+
+    An inverse-completeness control that is itself vacuous is worse than none: the reviewer's own
+    mutation - add a brand-new top-level `@pytest.mark.gui` test - left all four of the previous
+    controls passing. So this runs `_gui_tests_missed_by` against a deliberately narrowed argv and
+    requires it to report the misses.
+    """
+    roots = _testpath_roots()
+    barren = [root for root in roots if not _collected_node_ids([RUN_GUI_FLAG, "-m", GUI_MARKER, root])]
+    assert barren, (
+        "every declared testpath root contains a gui test, so no root can stand in for a command "
+        f"that misses one; roots={roots}"
+    )
+    missed = _gui_tests_missed_by([RUN_GUI_FLAG, "-m", GUI_MARKER, barren[0]])
+    assert missed == set(_gui_node_ids()), (
+        f"a command scoped to {barren[0]!r} reaches no gui test at all, yet the coverage predicate "
+        f"reported only {sorted(missed)} missing - it cannot detect an unreachable gui test"
     )

--- a/tests/test_gui_marker_gate.py
+++ b/tests/test_gui_marker_gate.py
@@ -1,0 +1,103 @@
+"""Prove the `gui` marker hides the window-spawning tests from an ordinary run WITHOUT losing them.
+
+Issue #447. Some tests must spawn a real top-level window - UI Automation cannot be exercised
+against a mock - and one of them was stealing focus on an operator's machine mid-demo, because
+`testpaths` includes `.github/skills` so a bare `pytest` collects them.
+
+WHY THIS FILE EXISTS AT ALL
+---------------------------
+A marker that hides a test is how coverage dies silently, and this repo has already done it once:
+issue #435, "CI runs none of the 15 engine-dependent tests - they SKIP silently, and a skip is not
+a pass". So asserting "the suite is green" would be worthless here - a suite is equally green when
+the tests passed and when they vanished. Each test below asserts a COUNT, in the direction that
+would catch its own failure mode:
+
+* the negative control asserts the DESELECTED count is exactly the number of marked tests
+* the positive control asserts `-m gui` SELECTS that same non-zero number
+* the CI control asserts the workflow invokes `-m gui` explicitly, since the default now excludes it
+
+Collection is done in a subprocess with `--collect-only`, so nothing is executed and no window is
+ever spawned by this file.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BUNDLE_TESTS = REPO_ROOT / ".github" / "skills" / "pbip-model-refresh" / "tests"
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "checks.yml"
+MARKED_FILE = BUNDLE_TESTS / "test_credential_modal_detection.py"
+
+
+def _collect(*extra: str) -> str:
+    """`--collect-only -q` over the bundle tests; never executes a test, so never opens a window."""
+    proc = subprocess.run(
+        [sys.executable, "-m", "pytest", "--collect-only", "-q", str(BUNDLE_TESTS), *extra],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+        check=False,
+    )
+    return proc.stdout + proc.stderr
+
+
+def _marked_test_count() -> int:
+    """How many tests carry the marker, read from the source rather than from pytest."""
+    return len(re.findall(r"^@pytest\.mark\.gui$", MARKED_FILE.read_text(encoding="utf-8"), re.MULTILINE))
+
+
+def test_the_marker_is_applied_to_at_least_one_test() -> None:
+    """Kills: the marker existing in config while no test carries it, making both controls vacuous."""
+    assert _marked_test_count() > 0, (
+        "no test carries @pytest.mark.gui, so the deselect/select controls below would both pass "
+        "trivially and prove nothing"
+    )
+
+
+def test_a_default_run_deselects_every_gui_test() -> None:
+    """Kills: dropping `addopts`, or a caller's `-m` silently replacing it -> windows return."""
+    output = _collect()
+    match = re.search(r"(\d+) deselected", output)
+    assert match, f"expected a 'deselected' count in a default collection; got:\n{output[-1500:]}"
+    assert int(match.group(1)) == _marked_test_count(), (
+        f"default run deselected {match.group(1)} test(s) but {_marked_test_count()} carry the "
+        "marker - the default filter and the marked set disagree"
+    )
+
+
+def test_opting_in_selects_exactly_the_marked_tests() -> None:
+    """Kills: orphaning the tests - marked, deselected by default, and selectable by nothing."""
+    output = _collect("-m", "gui")
+    # ⚠️ Try the `selected/total` form FIRST. pytest prints "7/309 tests collected (302 deselected)"
+    # when a filter applies, and a bare `(\d+) tests? collected` matches the TOTAL inside that
+    # string - which scored this control 309 against 7 and read as a product defect rather than a
+    # regex defect.
+    match = re.search(r"(\d+)/\d+ tests? collected", output) or re.search(r"(\d+) tests? collected", output)
+    assert match, f"expected a collected count under `-m gui`; got:\n{output[-1500:]}"
+    assert int(match.group(1)) == _marked_test_count(), (
+        f"`-m gui` collected {match.group(1)} test(s) but {_marked_test_count()} carry the marker"
+    )
+
+
+def test_ci_runs_the_gui_tests_explicitly() -> None:
+    """Kills: issue #435 in a new place - a marker that hides tests from CI as well as from a desktop."""
+    # ⚠️ Assert on the `run:` COMMAND, never on the file text. A first version asserted
+    # `"-m gui" in workflow`, and the mutation that deleted the opt-in from the run line SURVIVED -
+    # because the phrase still appeared in the explanatory comment beside it. A guard satisfied by
+    # prose rather than by the thing it checks is exactly the vacuity this repo keeps finding.
+    commands = [
+        line.split("run:", 1)[1].strip()
+        for line in WORKFLOW.read_text(encoding="utf-8").splitlines()
+        if re.match(r"\s*run:", line)
+    ]
+    opted_in = [cmd for cmd in commands if "pytest" in cmd and re.search(r"-m\s+'?gui'?\b", cmd)]
+    assert opted_in, (
+        "no CI `run:` command invokes pytest with `-m gui`. The default `addopts` now deselects "
+        "these tests everywhere, so without an explicit opt-in step they run NOWHERE - trading a "
+        "focus-stealing window for silently-lost coverage of a fail-open credential guard "
+        f"(issue #435). pytest commands found: {[c for c in commands if 'pytest' in c]}"
+    )

--- a/tests/test_gui_marker_gate.py
+++ b/tests/test_gui_marker_gate.py
@@ -336,6 +336,13 @@ def test_no_marker_expression_a_caller_can_type_re_enables_the_gui_tests() -> No
 def test_the_opt_in_flag_selects_exactly_the_gui_tests() -> None:
     """Kills: orphaning them - marked, deselected everywhere, and selectable by nothing."""
     collected = _collected_node_ids([RUN_GUI_FLAG, "-m", GUI_MARKER])
+    # ⚠️ The non-vacuity assert comes FIRST and is not decoration. Both sides of the equality below
+    # are collected with `--run-gui`, so a mutation that breaks the opt-in outright empties BOTH and
+    # the equality holds - a differential assertion whose arms move together proves nothing.
+    assert collected, (
+        f"`{RUN_GUI_FLAG} -m {GUI_MARKER}` collected NOTHING, so the opt-in no longer works and the "
+        "window-spawning tests are orphaned: excluded from every tier and selectable by nobody"
+    )
     assert collected == set(_gui_node_ids()), (
         f"`{RUN_GUI_FLAG} -m {GUI_MARKER}` collected {sorted(collected)}, expected {sorted(_gui_node_ids())}"
     )
@@ -351,6 +358,7 @@ def test_the_portable_env_var_opts_in_too() -> None:
     env = _repo_free_env()
     env[RUN_GUI_ENV] = "1"
     collected = _collected_node_ids(["-m", GUI_MARKER], env=env)
+    assert collected, f"`{RUN_GUI_ENV}=1` selected nothing, so the copied-out bundle cannot be run at all"
     assert collected == set(_gui_node_ids()), (
         f"`{RUN_GUI_ENV}=1 -m {GUI_MARKER}` collected {sorted(collected)}, expected {sorted(_gui_node_ids())}"
     )
@@ -454,6 +462,12 @@ def test_the_ci_command_reaches_every_gui_test_in_the_repository() -> None:
     narrowing the command's paths, or dropping its `--run-gui`, moves only one of them.
     """
     for argv in _ci_gui_invocations():
+        collected = _collected_node_ids(argv)
+        assert collected, (
+            f"the CI opt-in command `pytest {' '.join(argv)}` collects NOTHING. `-m gui` alone "
+            f"selects the marked tests and the collection hook then deselects them again, so the "
+            f"step reports 'no tests ran' and stays green - it needs `{RUN_GUI_FLAG}` as well"
+        )
         missed = sorted(_gui_tests_missed_by(argv))
         assert not missed, (
             f"the CI opt-in command `pytest {' '.join(argv)}` does not reach these window-spawning "

--- a/tests/test_gui_marker_gate.py
+++ b/tests/test_gui_marker_gate.py
@@ -37,6 +37,7 @@ window.
 from __future__ import annotations
 
 import ast
+import contextlib
 import functools
 import os
 import re
@@ -331,6 +332,49 @@ def test_no_marker_expression_a_caller_can_type_re_enables_the_gui_tests() -> No
         if collected:
             leaked[expression] = sorted(collected)
     assert not leaked, f"these marker expressions re-enabled the window-spawning tests: {leaked}"
+
+
+@contextlib.contextmanager
+def _gui_test_outside_every_bundle():
+    """A synthetic `gui` test placed INSIDE the repo but outside every bundle, then removed.
+
+    It has to be inside the repo: pytest only loads a `conftest.py` for paths beneath it, so a file
+    in the OS temp directory is judged by neither hook and proves nothing about either. The `_`
+    prefix is what keeps it out of git (`.gitignore` has `/_*`) and out of `testpaths`, so no other
+    run can collect it.
+    """
+    folder = REPO_ROOT / f"_gui_gate_probe_{os.getpid()}"
+    folder.mkdir(exist_ok=True)
+    probe = folder / "test_root_hook_probe.py"
+    probe.write_text(
+        "import pytest\n\n\n@pytest.mark.gui\ndef test_root_hook_probe() -> None:\n"
+        '    raise AssertionError("this synthetic test must never be executed")\n',
+        encoding="utf-8",
+    )
+    try:
+        yield probe
+    finally:
+        shutil.rmtree(folder, ignore_errors=True)
+
+
+def test_the_root_hook_deselects_a_gui_test_that_is_in_no_bundle() -> None:
+    """Kills: deleting the ROOT hook's gui branch - which nothing else here can see.
+
+    Measured, and it is the reason this control exists: every gui test in the repository today lives
+    in ONE bundle, and that bundle's own `conftest.py` deselects them as well. So disabling the root
+    hook's gui branch left the bundle collecting 299/309 exactly as before and every other control
+    passed - a guard with no observable failure mode. A gui test added anywhere else would have run,
+    with windows, and nothing would have said so. This puts one there, transiently, and requires the
+    root hook to deselect it by default and the opt-in to bring it back.
+    """
+    with _gui_test_outside_every_bundle() as probe:
+        default = _collected_node_ids([str(probe)])
+        opted_in = _collected_node_ids([RUN_GUI_FLAG, str(probe)])
+    assert not default, (
+        "a gui test outside every bundle was collected by a default run, so the root conftest hook "
+        f"is not deselecting it: {sorted(default)}"
+    )
+    assert opted_in, "the same test could not be selected with the opt-in either, so it is orphaned"
 
 
 def test_the_opt_in_flag_selects_exactly_the_gui_tests() -> None:

--- a/tests/test_parallel_test_loop.py
+++ b/tests/test_parallel_test_loop.py
@@ -521,14 +521,38 @@ def test_the_opt_out_flag_puts_the_contended_tests_back() -> None:
     )
     output = result.stdout + result.stderr
     assert result.returncode == 0, output
-    assert "deselected" not in output, f"--include-contended did not restore them:\n{output[-1500:]}"
-    for node in sorted(node for node in _contended_nodes() if node.startswith(BUNDLE_TESTS + "::")):
+    # ⚠️ This used to assert `"deselected" not in output`, which was a PROXY for "the contended tests
+    # came back" and became wrong the moment a second, orthogonal deselection existed: `gui` tests
+    # spawn a real top-level window and are deselected by default on purpose (issue #447), and
+    # `--include-contended` is about `serial`/`timing`, not about hijacking someone's desktop. The
+    # per-node loop below is the real check; keep the count assertion so this stays falsifiable
+    # rather than merely relaxed - a NEW unexplained deselection must still fail here.
+    gui_nodes = {node for node in _gui_nodes() if node.startswith(BUNDLE_TESTS + "::")}
+    deselected = re.search(r"\((\d+) deselected\)", output)
+    remaining = int(deselected.group(1)) if deselected else 0
+    assert remaining == len(gui_nodes), (
+        f"--include-contended left {remaining} test(s) deselected but {len(gui_nodes)} carry "
+        f"@pytest.mark.gui; an unexplained deselection means the opt-out no longer restores "
+        f"everything it claims to:\n{output[-1500:]}"
+    )
+    for node in sorted(node for node in _contended_nodes() - gui_nodes if node.startswith(BUNDLE_TESTS + "::")):
         assert node in output, f"{node} missing even with --include-contended"
 
 
 def _contended_nodes() -> set[str]:
     """Every node id that carries a marker the parallel tier excludes."""
     return _marked_tests("serial") | _marked_tests("timing")
+
+
+def _gui_nodes() -> set[str]:
+    """Every node id that spawns a real top-level window, so is deselected by default (issue #447).
+
+    Deliberately NOT folded into `_contended_nodes()`. `serial`/`timing` are excluded from the
+    PARALLEL tier and restored by `--include-contended` for deliberate stress-testing; `gui` is
+    excluded from EVERY tier because it hijacks the operator's desktop, and `--include-contended`
+    must not put it back. Two reasons, two sets.
+    """
+    return _marked_tests("gui")
 
 
 def test_the_loop_doc_documents_both_tiers() -> None:

--- a/tests/test_parallel_test_loop.py
+++ b/tests/test_parallel_test_loop.py
@@ -300,7 +300,11 @@ def test_the_markers_actually_deselect_those_tests() -> None:
     assert excluded, "nothing derived - this test would pass vacuously"
     target = sorted(excluded)[0].split("::")[0]
     in_target = sorted(node for node in excluded if node.startswith(target + "::"))
-    result = _run_pytest(REPO_ROOT, ["-q", "--collect-only", "-m", "not (serial or timing)", target])
+    # `--run-gui` ISOLATES the mechanism this test names. The root conftest also deselects `gui`
+    # unconditionally (issue #447), and three of those tests carry no contended marker, so without
+    # the opt-in the count here measures two mechanisms at once and drifts whenever either changes.
+    # Opting in leaves `-m "not (serial or timing)"` as the only filter, which is the claim.
+    result = _run_pytest(REPO_ROOT, ["-q", "--collect-only", "--run-gui", "-m", "not (serial or timing)", target])
     output = result.stdout + result.stderr
     assert result.returncode == 0, output
     assert f"{len(in_target)} deselected" in output, (
@@ -476,8 +480,12 @@ def test_xdist_deselects_contended_tests_without_being_asked() -> None:
     """
     contended = {node for node in _contended_nodes() if node.startswith(BUNDLE_TESTS + "::")}
     assert len(contended) >= 13, f"expected the bundle's contended tests to be found, got {sorted(contended)}"
+    # `--run-gui` for the same reason as in `test_the_markers_actually_deselect_those_tests`: the
+    # `gui` exclusion is orthogonal and always on, and three gui tests carry no contended marker, so
+    # leaving it engaged would fold two mechanisms into one count. This test is about the xdist one.
     result = _run_pytest(
-        REPO_ROOT, ["-q", "--collect-only", "-n", "2", "--dist", "loadfile", "-m", "not timing", BUNDLE_TESTS]
+        REPO_ROOT,
+        ["-q", "--collect-only", "--run-gui", "-n", "2", "--dist", "loadfile", "-m", "not timing", BUNDLE_TESTS],
     )
     output = result.stdout + result.stderr
     assert result.returncode == 0, output

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -99,6 +99,12 @@ def _repo_free_env() -> dict[str, str]:
     env.pop("PYTHONPATH", None)
     env.pop("PYTEST_CURRENT_TEST", None)
     env.pop("PYTEST_ADDOPTS", None)
+    # `T2P_RUN_GUI` is the PORTABLE opt-in the copied bundle's own conftest reads (issue #447), and
+    # inheriting it here would make a PORTABILITY check spawn ten real top-level windows as a side
+    # effect. Whoever exported it asked to run the gui tests, not to have a `test_skills.py` run
+    # hijack their desktop; CI's `--run-gui -m gui` leg is where those tests are actually executed.
+    # Dropping it also makes this nested run deterministic rather than ambient-environment-dependent.
+    env.pop("T2P_RUN_GUI", None)
     return env
 
 


### PR DESCRIPTION
A bare `pytest` collects `.github/skills` (`testpaths`), so it launches a real WinForms window titled **Fake Desktop**. Reported from the field, mid-demo: it had been *"opening and closing for the last 2 days"*.

⚠️ **The tests are good and must keep spawning a real window** — UI Automation cannot be exercised against a mock, and their own comments record why each choice was measured (the WPF-button-in-an-`ElementHost` exists because a plain WinForms `Button` surfaces to UIA as `ControlType.Pane` with no patterns). They protect `probe_desktop_credential.ps1`, which can report `ContentRead: true` having never read the credential text (#406, #417). So this makes them **opt-in, not weaker**.

## Invariant and direction

An ordinary run must spawn **no window**; the tests must still run **somewhere**. Failing open here means a window steals focus on an operator's machine. Failing closed means the coverage silently disappears — which is **#435** exactly (*"CI runs none of the 15 engine-dependent tests — they SKIP silently, and a skip is not a pass"*). Both are guarded.

## Closed surface — every pytest invocation, N = 4

| invocation | runs `gui`? |
|---|---|
| `checks.yml` line 67, `uv run pytest -q` (ubuntu) | no — correct, WinForms/UIA is Windows-only |
| `checks.yml`, bundle job on `windows-latest` | no |
| `checks.yml`, **new** `-m gui` step on `windows-latest` | **yes** |
| any local/agent `pytest` | no |

`serial` was not a substitute: it only takes effect under `-n auto --dist loadfile`, and a plain `pytest` runs them anyway.

## Controls, each mutation-proven

| mutation | result |
|---|---|
| remove `addopts` | **CAUGHT** — `test_a_default_run_deselects_every_gui_test` |
| drop `-m gui` from CI | **CAUGHT** — `test_ci_runs_the_gui_tests_explicitly` |
| strip the markers | **CAUGHT** — 3 controls fail |

⚠️ Every mutation was verified to **apply** before being scored — one earlier attempt "survived" only because a PowerShell regex never matched the line.

## Two defects of my own that the mutations caught

- The first marking script marked **9** tests, not 7: it sliced each body to the next `def test_`, swallowing module-level constants between tests. Bounded by indentation -> **7**, all of which already carry `serial`.
- The CI control first asserted `'-m gui' in workflow` and the deletion mutation **SURVIVED**, because the phrase remained in the comment beside it. It now parses `run:` commands only.

## Also narrows one over-broad assertion

`test_parallel_test_loop.py` asserted `'deselected' not in output` as a **proxy** for "the contended tests came back". That held only while `serial`/`timing` were the sole deselection. `--include-contended` is about the parallel tier, not about hijacking a desktop, so `gui` stays deselected — and the assertion now pins the remaining count to the gui-marked set, so a **new** unexplained deselection still fails.

## Answering the three questions

- **Can each test reach the production path?** Yes — all three mutations above fail their named guard.
- **Does the guard cover the whole surface it names?** The N=4 table is the enumeration.
- **Does the evidence prove the verdict?** Counts, not greenness: the deselect control asserts the deselected count equals the marked count; a suite green because tests vanished would fail it.

## Gates, by exit code

`pytest tests/test_parallel_test_loop.py tests/test_gui_marker_gate.py` **0** (24 passed) · `ruff format --check` **0** · `ruff check` **0** · `pylint` **0**.

Full `pytest tests/` before this fix: 4 failed / 4036 passed — 3 known engine-drift pins plus the parallel-loop test corrected here. ⚠️ It takes **4h40m** serially; CI is the authoritative run.

Independent corroboration: the PR #431 reviewer's run hit `DIALOG_UNREADABLE` *"because an unaccounted GUI window was open"*.