### PR TITLE
fix(gates): join evidence to a workbook by LUID, once, for both gates (#450)

### DIFF
--- a/scripts/bundle_corpus.py
+++ b/scripts/bundle_corpus.py
@@ -11,6 +11,34 @@ from __future__ import annotations
 
 from pathlib import Path
 
+#: A self-contained handover package writes this beside the unit (`scripts/package_unit.py`, #446).
+PACKAGE_MARKER = "package-manifest.json"
+
+
+def is_self_contained(target: Path) -> bool:
+    """Whether ``target`` declares that it carries its own evidence and must inherit none.
+
+    ⚠️ **This is what stops an evidence walk-up, in BOTH gates, and it has to be one rule.** Every
+    gate here looks for `reference/`/`oracle/` beside the target AND beside its ancestors, and
+    **unions** the hits - which is right for an un-packaged unit under `<bundle>/pbip/<Unit>/`, whose
+    capture lives further up. `package_unit.py` writes a unit-scoped `oracle/oracle-manifest.json`
+    holding THIS unit's views with rewritten paths, so a package assembled INSIDE a run directory
+    matches every view twice and both gates then refuse the pair as an ambiguity:
+
+    * `check_reference_readiness` reports *"2 records share this name once normalized"* and takes
+      every page from ready to **unverifiable** (issue #451);
+    * `check_unit` reports *"2 producer records are named X"* and reports **0 visual coverage** -
+      measured on a synthetic package, the same defect one gate along.
+
+    Both are silent, and both make packaging strictly WORSE than not packaging. The marker is the
+    package's own declaration that it is complete, so it is taken at its word.
+
+    ⚠️ Deliberately NOT "stop when the target has its own copy of this directory": a package that
+    OMITTED a render because it could not attribute it would then pick that render up from the
+    ancestor, undoing a fail-closed packaging decision at the consumer.
+    """
+    return (target / PACKAGE_MARKER).is_file()
+
 
 def shipping_reports(root: Path) -> list[Path]:
     """Return `.Report` folders that ship under ``root``.

--- a/scripts/bundle_corpus.py
+++ b/scripts/bundle_corpus.py
@@ -9,6 +9,7 @@ separate copies of the same filesystem-discovery rules. This module is the singl
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from pathlib import Path
 
 #: A self-contained handover package writes this beside the unit (`scripts/package_unit.py`, #446).
@@ -73,3 +74,52 @@ def shipping_models(root: Path, *, include_standalone: bool = False) -> list[Pat
         if standalone.is_dir():
             models.update(path.resolve() for path in standalone.rglob("*.SemanticModel") if path.is_dir())
     return sorted(models, key=str)
+
+
+#: How far above a target an evidence directory may live.
+#:
+#: THREE, from the canonical layout rather than from taste: a capture is written to
+#: ``_runs/<NNN>-<slug>/oracle/`` while an un-packaged unit sits at
+#: ``_runs/<NNN>-<slug>/bundle/pbip/<Unit>/`` - exactly three ancestors below it. Round-1 review of
+#: PR #454 measured the exit gate stopping at ONE, so that unit could not see the run's capture at
+#: all; stopping at two still misses it for the ordinary engine-bundle shape.
+#:
+#: Widening discovery is safe in the direction that matters: every record found this way still has to
+#: pass the identity join, so a foreign capture pulled in from a shared ancestor is refused and
+#: counted, and two indistinguishable records make the page UNVERIFIABLE. Discovery adds candidates;
+#: it never admits one.
+ANCESTOR_LEVELS = 3
+
+
+def evidence_dirs(target: Path, names: Sequence[str], *, also: Sequence[Path] = ()) -> list[Path]:
+    """Existing evidence directories for ``target``: beside it, then up to two ancestors.
+
+    WARNING: **The whole walk lives here, not just where it stops.** Round-1 review of PR #454:
+    centralising only the *stop* condition left the two gates disagreeing about the *search* -
+    `check_reference_readiness` looked two levels up while `check_unit` looked one, so a non-packaged
+    unit at `<bundle>/pbip/<Unit>/` could not inherit the run's flat capture at all in the exit gate.
+    A shared rule that covers half the behaviour is two rules wearing one name.
+
+    The ancestor portion is skipped for a self-contained package (:func:`is_self_contained`); the
+    target itself, and any ``also`` root a caller adds, are always searched. Results keep discovery
+    order, are de-duplicated by resolved path, and are returned unresolved so a caller still sees the
+    spelling it passed in.
+    """
+    roots = [target, *also]
+    if not is_self_contained(target):
+        ancestor = target
+        for _ in range(ANCESTOR_LEVELS):
+            ancestor = ancestor.parent
+            roots.append(ancestor)
+    found: list[Path] = []
+    seen: set[Path] = set()
+    for root in roots:
+        for name in names:
+            candidate = root / name
+            if not candidate.is_dir():
+                continue
+            resolved = candidate.resolve()
+            if resolved not in seen:
+                seen.add(resolved)
+                found.append(candidate)
+    return found

--- a/scripts/check_reference_readiness.py
+++ b/scripts/check_reference_readiness.py
@@ -169,6 +169,11 @@ class UnitResult:
     report_dir: str | None = None
     source: str | None = None
     pages: list[dict[str, Any]] = field(default_factory=list)
+    #: How every candidate render was attributed to (or refused for) this unit, keyed by
+    #: `object_identity`'s route vocabulary. A refusal that is not counted is indistinguishable from
+    #: a render that was never captured, which is exactly how issue #450 stayed invisible: a fix that
+    #: only makes `pages_ready` go up cannot be told apart from one that deleted the guard.
+    attribution: dict[str, int] = field(default_factory=dict)
 
 
 def engine_page_id(text: str) -> str:
@@ -488,32 +493,49 @@ def _handover(root: Path, unit: str) -> dict[str, Any] | None:
     return json_object(root / "handover" / f"{unit}.json")
 
 
-def _provenance_luid(root: Path, source_sha: str) -> str | None:
-    """The published workbook LUID for this source - ONLY when provenance is byte-confirmed.
+#: Provenance ``origin`` shapes that ESTABLISH which published workbook a local file is. See
+#: :func:`_provenance_luid` - deliberately distinct from ``origin.match``, which answers a revision
+#: question and was read as if it were this one (issue #450).
+IDENTITY_MATCHED_BY = frozenset({"luid"})
 
-    Round-2 finding 3: this returned a LUID without consulting `origin.match`.
-    `stamp_tableau_provenance.py:191-192` records `"sha256"` when local and server bytes agree and
-    `"name_only"` when they DIFFER, and its own docstring says figures will not reproduce in that
-    case - yet that LUID was making server oracle evidence ready. The repo's provenance is 26
-    `sha256` / 15 `name_only` / 6 unmatched, so trusting it blindly is the common case.
 
-    Both halves are required: the stamped input hash must be THIS file, and the server comparison
-    must have agreed. Anything else leaves the name as the only usable identity, which `is_for`
-    falls back to.
+def _provenance_luid(root: Path, source_sha: str, source: Path | None = None) -> str | None:
+    """The published workbook LUID for this source, from every offline route that ESTABLISHES one.
+
+    Two routes, and they must agree:
+
+    * ``source-provenance.json``'s ``origin.workbook_luid`` for the entry whose stamped input hash is
+      THIS file - trusted when ``matched_by == "luid"`` (the harvested filename's LUID was found on
+      the site, so it is provably that item) **or** when ``match == "sha256"`` (the bytes are
+      identical to the site copy, which confirms identity by content). A ``matched_by`` of ``name``
+      or ``sanitized_name`` with differing bytes is a name collision, not an identity.
+    * the asset filename's own ``<luid>_`` prefix, which is `harvest_estate_assets.py`'s record of
+      what it downloaded.
+
+    ⚠️ This used to require ``origin.match == "sha256"`` and nothing else, which read the REVISION
+    axis as if it were the IDENTITY axis. ``stamp_tableau_provenance.find_origin`` documents them as
+    "two independent axes"; on the reference estate 48 of 78 inputs are ``name_only`` while matched
+    ``by luid``, so the common case discarded a proven LUID and fell back to comparing the artifact
+    stem ``HR_Dashboard`` against the published name ``HR Dashboard``. That fallback is weaker on
+    identity AND carries no revision guarantee, so the trade bought nothing.
+
+    Disagreement between the two routes returns None: two identities that contradict each other are
+    less evidence than none, and the name axis then has to carry it.
     """
+    stamped = oid.harvest_luid(source.stem if source is not None else None)
     payload = json_object(root / "source-provenance.json")
     for record in (payload or {}).get("inputs") or []:
         if not isinstance(record, dict):
             continue
-        stamped = record.get("input") if isinstance(record.get("input"), dict) else {}
+        stamped_input = record.get("input") if isinstance(record.get("input"), dict) else {}
         origin = record.get("origin") if isinstance(record.get("origin"), dict) else {}
-        if stamped.get("sha256") != source_sha:
+        if stamped_input.get("sha256") != source_sha:
             continue
-        if origin.get("match") != "sha256":
-            return None
+        if origin.get("matched_by") not in IDENTITY_MATCHED_BY and origin.get("match") != "sha256":
+            return oid.agreed_luid(stamped)
         luid = origin.get("workbook_luid")
-        return str(luid) if isinstance(luid, str) and luid else None
-    return None
+        return oid.agreed_luid(stamped, luid if isinstance(luid, str) else None)
+    return oid.agreed_luid(stamped)
 
 
 def resolve_source(root: Path, unit: str, handover: dict[str, Any] | None, explicit: Path | None) -> Path | None:
@@ -550,10 +572,29 @@ def resolve_source(root: Path, unit: str, handover: dict[str, Any] | None, expli
     return None
 
 
+#: A self-contained handover package writes this beside the unit (`scripts/package_unit.py`, #446).
+#: Its presence is the marker that a target owns its evidence and must not inherit an ancestor's.
+PACKAGE_MARKER = "package-manifest.json"
+
+
 def _default_dirs(root: Path, name: str) -> list[Path]:
-    """Conventional evidence locations, mirroring `check_unit.py:830-839`."""
+    """Conventional evidence locations, mirroring `check_unit.py:830-839`.
+
+    The walk-up is a UNION, not a fallback, and that is deliberate: an un-packaged unit under
+    `<bundle>/pbip/<Unit>/` finds the run's flat capture two levels up, which is the ordinary case and
+    must keep working.
+
+    ⚠️ **A self-contained package stops the walk.** `package_unit.py` writes a unit-scoped
+    `oracle/oracle-manifest.json` holding THIS unit's views with rewritten paths; a package assembled
+    INSIDE a run directory therefore sees its own copy AND the run's flat capture two levels up, and
+    every view matches twice. The gate then refuses the pair as "2 records share this name once
+    normalized" and every page goes ready -> unverifiable - strictly worse than not packaging, and
+    silent. A `package-manifest.json` beside the target is that package's own declaration that it is
+    complete, so it is taken at its word and no ancestor is consulted.
+    """
+    bases = [root] if (root / PACKAGE_MARKER).is_file() else [root, root.parent, root.parent.parent]
     seen: list[Path] = []
-    for candidate in (root / name, root.parent / name, root.parent.parent / name):
+    for candidate in (base / name for base in bases):
         if candidate.is_dir() and candidate.resolve() not in {path.resolve() for path in seen}:
             seen.append(candidate)
     return seen
@@ -576,7 +617,7 @@ def _identify(root: Path, unit: str, source: Path) -> UnitIdentity | None:
     if digest is None:
         return None
     return UnitIdentity(
-        name=unit, source_path=source, source_sha256=digest, workbook_luid=_provenance_luid(root, digest)
+        name=unit, source_path=source, source_sha256=digest, workbook_luid=_provenance_luid(root, digest, source)
     )
 
 
@@ -665,7 +706,9 @@ def _datasource_only(unit: str, report_dir: Path, engine_report: dict[str, Any] 
     )
 
 
-def _readiness_result(unit: str, report_dir: Path, source: Path, rows: list[dict[str, Any]]) -> UnitResult:
+def _readiness_result(
+    unit: str, report_dir: Path, source: Path, rows: list[dict[str, Any]], attribution: dict[str, int]
+) -> UnitResult:
     """Fold per-page rows into the unit verdict."""
     findings = [row for row in rows if row["readiness"] != READY]
     return UnitResult(
@@ -675,6 +718,7 @@ def _readiness_result(unit: str, report_dir: Path, source: Path, rows: list[dict
         report_dir=str(report_dir),
         source=str(source),
         pages=rows,
+        attribution=attribution,
     )
 
 
@@ -725,9 +769,39 @@ def assess_unit(  # pylint: disable=too-many-arguments,too-many-positional-argum
     if isinstance(emitted, UnitResult):
         return emitted
 
-    scoped = [item for item in evidence if item.is_for(identity)]
-    rows = _page_rows(objects, emitted, drop_explanations(handover), scoped, require_validation_grade)
-    return _readiness_result(unit, report_dir, source, rows)
+    scoped = _scope_evidence(evidence, identity)
+    rows = _page_rows(objects, emitted, drop_explanations(handover), scoped.admitted, require_validation_grade)
+    return _readiness_result(unit, report_dir, source, rows, scoped.census)
+
+
+@dataclass(frozen=True)
+class ScopedEvidence:
+    """One unit's share of the candidate renders, WITH the census of what was refused.
+
+    The two travel together on purpose. A refusal that is dropped instead of counted is
+    indistinguishable from a render nobody ever captured, and that ambiguity is exactly how issue
+    #450's inert guard read as a working one for six review rounds.
+    """
+
+    admitted: list[Evidence]
+    census: dict[str, int]
+
+
+def _scope_evidence(evidence: list[Evidence], identity: UnitIdentity) -> ScopedEvidence:
+    """Attribute every candidate render to ``identity``, keeping the ones it may certify.
+
+    Every render is attributed, admitted or not, and the census records which axis decided - so the
+    negative control ("a different workbook's render is refused, AND counted") is assertable and a
+    change here cannot pass as a fix while actually deleting the guard.
+    """
+    census = dict.fromkeys((*oid.WB_ROUTES, oid.WB_FOREIGN, oid.WB_UNKNOWN), 0)
+    admitted = []
+    for item in evidence:
+        verdict = item.attribution(identity)
+        census[verdict.route] = census.get(verdict.route, 0) + 1
+        if verdict.admitted:
+            admitted.append(item)
+    return ScopedEvidence(admitted=admitted, census=census)
 
 
 def _units_without_reports(engine_report: dict[str, Any] | None, reports: list[Path]) -> list[UnitResult]:
@@ -858,6 +932,10 @@ def _merge(
         "evidence_records": len(evidence),
         "evidence_untyped": sum(1 for item in evidence if item.kind == KIND_UNKNOWN),
         "evidence_untyped_names": sorted({item.name for item in evidence if item.kind == KIND_UNKNOWN}),
+        # The route census, summed over units. Admissions are per-route so "admitted because a LUID
+        # matched" is never confused with "admitted because two display names happened to agree", and
+        # refusals are counted so a foreign render is visibly refused rather than silently absent.
+        "evidence_attributed": _census(units),
         "evidence_rejected": [
             {"name": item.name, "origin": item.origin, "path": item.path, "reason": item.reason} for item in rejected
         ],
@@ -873,10 +951,20 @@ def _merge(
                 "report": unit.report_dir,
                 "source": unit.source,
                 "pages": unit.pages,
+                "attribution": unit.attribution,
             }
             for unit in units
         ],
     }
+
+
+def _census(units: list[UnitResult]) -> dict[str, int]:
+    """Every unit's attribution census, summed. Keys are always present, so a zero is visible."""
+    total = dict.fromkeys((*oid.WB_ROUTES, oid.WB_FOREIGN, oid.WB_UNKNOWN), 0)
+    for unit in units:
+        for route, count in unit.attribution.items():
+            total[route] = total.get(route, 0) + count
+    return total
 
 
 GRADE_CEILING_NOTE = (
@@ -915,6 +1003,7 @@ def render(report: dict[str, Any], *, verbose: bool = False) -> str:
             f"  [UNTYPED EVIDENCE] {report['evidence_untyped']} render(s) carry no object type "
             f"({', '.join(report['evidence_untyped_names'][:4])}) - {MANUAL_KIND_HINT}"
         )
+    lines.extend(_render_attribution(report))
     if report["status"] == STATUS_CANNOT_ESTABLISH:
         lines.append(
             "  CANNOT_ESTABLISH is NOT a pass: this gate formed no opinion, so an agent starting "
@@ -925,6 +1014,24 @@ def render(report: dict[str, Any], *, verbose: bool = False) -> str:
     if not verbose and report["pages_ready"]:
         lines.append("  Run with --verbose to list the pages that ARE ready and their grades.")
     return "\n".join(lines)
+
+
+def _render_attribution(report: dict[str, Any]) -> list[str]:
+    """Say how evidence was attributed, INCLUDING the refusals.
+
+    Reported unconditionally when any candidate render was seen: a silent refusal is
+    indistinguishable from a render that was never captured, and that ambiguity is what let issue
+    #450's inert guard look like a working one for six review rounds.
+    """
+    census = report.get("evidence_attributed") or {}
+    if not sum(census.values()):
+        return []
+    admitted = ", ".join(f"{route}={census.get(route, 0)}" for route in oid.WB_ROUTES)
+    return [
+        f"  [ATTRIBUTION] admitted by {admitted}; refused {census.get(oid.WB_FOREIGN, 0)} as another "
+        f"workbook's and {census.get(oid.WB_UNKNOWN, 0)} with no shared identity axis "
+        "(counts are per unit-and-record, so one shared capture is weighed against every unit)."
+    ]
 
 
 def _render_page(page: dict[str, Any]) -> str:

--- a/scripts/check_reference_readiness.py
+++ b/scripts/check_reference_readiness.py
@@ -459,11 +459,12 @@ def _page_row(  # pylint: disable=too-many-arguments,too-many-positional-argumen
             }
         )
         return row
-    stale = _stale_note(obj, scoped)
-    if stale is not None:
-        # ⚠️ No `render_key`: a stale render certifies nothing, so it must not contest a legitimate
+    refusal = _refusal_note(obj, scoped)
+    if refusal is not None:
+        # ⚠️ No `render_key`: a refused render certifies nothing, so it must not contest a legitimate
         # render of the same bytes in another unit and drag that page down with it.
-        row.update({"evidence": "unverifiable", "matched_by": stale, "readiness": UNVERIFIABLE})
+        row.update({"evidence": "unverifiable", "matched_by": refusal[1], "readiness": UNVERIFIABLE})
+        row["revision"] = REVISION_UNCONFIRMED if refusal[0] == oid.WB_UNCONFIRMED else row.get("revision")
         return row
     if name_only:
         scopes = sorted({item.kind for item in name_only})
@@ -479,23 +480,49 @@ def _page_row(  # pylint: disable=too-many-arguments,too-many-positional-argumen
     return row
 
 
-def _stale_note(obj: SourceObject, scoped: ScopedEvidence) -> str | None:
-    """Why a render of this object exists but is of a DIFFERENT build of this workbook, or None.
+#: What to say when a refused render is the only one this page has, per route. Ordered strongest
+#: statement first: a record we could compare and reject says more than one we could not compare.
+REFUSAL_NOTES = {
+    oid.WB_FOREIGN: "a render of ANOTHER workbook carries this name - refused, not credited",
+    oid.WB_STALE: (
+        "STALE: the render is of the same workbook at a DIFFERENT build - the local source bytes "
+        "differ from a reproducible content digest of the site copy, so it cannot certify the "
+        "migrated revision"
+    ),
+    oid.WB_UNCONFIRMED: (
+        "REVISION NOT ESTABLISHED: the render is tied to this workbook by LUID, which says WHICH "
+        "workbook a picture is of and never WHICH BUILD, and this unit's provenance carries no "
+        "comparable revision key - re-stamp with scripts/stamp_tableau_provenance.py"
+    ),
+    oid.WB_NAME: (
+        "NAME ONLY: the render declares no machine identity at all, and a display name is not unique "
+        "across projects - it may inform discovery, never certification"
+    ),
+    oid.WB_UNKNOWN: "the render declares an identity this unit cannot answer - refused, not credited",
+}
 
-    Kept distinct from BLIND on purpose: "nobody captured this page" and "the capture is of another
-    revision" call for different operator actions - capture it, versus re-harvest or re-capture
-    against the migrated build.
+
+def _refusal_note(obj: SourceObject, scoped: ScopedEvidence) -> tuple[str, str] | None:
+    """``(route, note)`` when a refused render of THIS unit's workbook matches this object, else None.
+
+    ⚠️ Only :data:`WB_STALE` and :data:`WB_UNCONFIRMED` are consulted, and the restriction is
+    load-bearing. Those two are records whose LUID matched this unit - unambiguously a render of this
+    page, of this workbook, at a build we cannot vouch for - so reporting UNVERIFIABLE rather than
+    BLIND tells the operator something true and actionable.
+
+    A ``foreign``, ``name``-only or ``unknown`` record is NOT known to be a render of this page.
+    Letting one turn a page from BLIND to UNVERIFIABLE would credit another workbook's capture with
+    partial coverage here, which is the cross-workbook leak this whole change exists to close, and it
+    would quietly erode the blind count that the estate's 46-render floor is measured against.
     """
-    if not scoped.stale:
-        return None
-    match, _ = match_evidence(obj, scoped.stale)
-    if not isinstance(match, Evidence):
-        return None
-    return (
-        f"STALE: {match.origin}:{match.provider or 'unknown'} render is of the same workbook at a "
-        "DIFFERENT build - the local source bytes differ from a REPRODUCIBLE download of the site "
-        "copy, so this cannot certify the migrated revision"
-    )
+    for route in (oid.WB_STALE, oid.WB_UNCONFIRMED):
+        candidates = scoped.refused.get(route) or []
+        if not candidates:
+            continue
+        match, _ = match_evidence(obj, candidates)
+        if isinstance(match, Evidence):
+            return route, REFUSAL_NOTES[route]
+    return None
 
 
 def _engine_report(root: Path) -> dict[str, Any] | None:
@@ -747,16 +774,16 @@ def assess_unit(  # pylint: disable=too-many-arguments,too-many-positional-argum
 class ScopedEvidence:
     """One unit's share of the candidate renders, WITH what was refused and why.
 
-    ``admitted`` may certify a page; ``stale`` is the right workbook at a build this gate can prove
-    is different, and may only make a page UNVERIFIABLE - it is never in the list `match_evidence`
-    searches, so it cannot reach READY by any path. ``census`` counts every verdict, including the
-    refusals, because a refusal that is dropped instead of counted is indistinguishable from a render
-    nobody ever captured. ``identity`` travels with them so a row can report what the admitted render
-    establishes about the REVISION as well as the workbook.
+    ``admitted`` may certify a page. ``refused`` holds every record this unit could not certify with,
+    keyed by route, so a page that has a render but cannot use it reports UNVERIFIABLE with the
+    reason rather than BLIND - "nobody captured this" and "the capture cannot certify this" call for
+    different operator actions. Nothing in ``refused`` is ever searched for a match that could reach
+    READY. ``census`` counts every verdict, because a refusal that is dropped instead of counted is
+    indistinguishable from a render nobody ever captured.
     """
 
     admitted: list[Evidence]
-    stale: list[Evidence]
+    refused: dict[str, list[Evidence]]
     census: dict[str, int]
     identity: UnitIdentity
 
@@ -765,20 +792,20 @@ def _scope_evidence(evidence: list[Evidence], identity: UnitIdentity) -> ScopedE
     """Attribute every candidate render to ``identity``, keeping the ones it may certify.
 
     Every render is attributed, admitted or not, and the census records which axis decided - so the
-    negative controls ("a foreign or unestablished record is refused, AND counted") are assertable
-    and a change here cannot pass as a fix while actually deleting the guard.
+    negative controls ("a foreign, name-only or unconfirmed record is refused, AND counted") are
+    assertable and a change here cannot pass as a fix while actually deleting the guard.
     """
     census = dict.fromkeys((*oid.WB_ROUTES, *oid.WB_REFUSALS), 0)
     admitted: list[Evidence] = []
-    stale: list[Evidence] = []
+    refused: dict[str, list[Evidence]] = {route: [] for route in oid.WB_REFUSALS}
     for item in evidence:
         verdict = item.attribution(identity)
         census[verdict.route] = census.get(verdict.route, 0) + 1
         if verdict.admitted:
             admitted.append(item)
-        elif verdict.route == oid.WB_STALE:
-            stale.append(item)
-    return ScopedEvidence(admitted=admitted, stale=stale, census=census, identity=identity)
+        else:
+            refused[verdict.route].append(item)
+    return ScopedEvidence(admitted=admitted, refused=refused, census=census, identity=identity)
 
 
 def _units_without_reports(engine_report: dict[str, Any] | None, reports: list[Path]) -> list[UnitResult]:
@@ -906,12 +933,12 @@ def _merge(
         "pages_emitted": sum(1 for page in pages if page["page_status"] == PAGE_EMITTED),
         "pages_dropped_explained": sum(1 for page in pages if page["page_status"] == PAGE_DROPPED_EXPLAINED),
         "pages_dropped_unexplained": sum(1 for page in pages if page["page_status"] == PAGE_DROPPED_UNEXPLAINED),
-        # Pages certified by a render whose REVISION this gate could not establish. Not a refusal -
-        # the evidence is real and attributed - but never a silent claim either: the gate's contract
-        # is "THIS workbook, at THIS revision", and this is the count of pages where only the first
-        # half was proven (round-1 review of PR #454, blocker 2).
+        # Pages that HAVE a render and cannot use it because its revision was never established.
+        # ⚠️ Counted from the rows that end UNVERIFIABLE for that reason, not from every row carrying
+        # a `revision` field: the earlier version counted four pages that exclusivity had already
+        # turned unverifiable, so a counter describing one population reported another.
         "pages_revision_unconfirmed": sum(
-            1 for page in pages if page.get("revision") and page["revision"] != REVISION_CONFIRMED
+            1 for page in pages if page["readiness"] == UNVERIFIABLE and page.get("revision") == REVISION_UNCONFIRMED
         ),
         "evidence_records": len(evidence),
         "evidence_untyped": sum(1 for item in evidence if item.kind == KIND_UNKNOWN),
@@ -1094,34 +1121,26 @@ def main(argv: list[str] | None = None) -> int:
 
 
 def _merge_scans(reports: list[dict[str, Any]]) -> dict[str, Any]:
-    """Combine several bundle scans, preserving the per-unit rows and the status precedence."""
+    """Combine several bundle scans, preserving the per-unit rows and the status precedence.
+
+    ⚠️ **Every integer counter is summed BY CONSTRUCTION.** This is the third instance of one class in
+    this PR - `evidence_attributed` zeroed on merge (round-1 MEDIUM 2), then
+    `pages_revision_unconfirmed` did the same because it was added after the hand-written key list
+    (round-3 B-C). Patching a third key by name would guarantee a fourth, so the list is gone: any
+    ``int`` value in a single-scan report is summed, which means a counter added tomorrow is summed
+    tomorrow. ``bool`` is excluded explicitly because it is an ``int`` subclass and
+    ``all_evidence_validation_grade`` must stay a conjunction, not a tally.
+    """
     merged = dict(reports[0])
     merged["target"] = ", ".join(report["target"] for report in reports)
     merged["units"] = [unit for report in reports for unit in report["units"]]
     merged["evidence_rejected"] = [item for report in reports for item in report["evidence_rejected"]]
     merged["evidence_untyped_names"] = sorted({n for r in reports for n in r["evidence_untyped_names"]})
-    for key in (
-        "units_scanned",
-        "units_ready",
-        "units_not_applicable",
-        "units_cannot_establish",
-        "pages_expected",
-        "pages_ready",
-        "pages_blind",
-        "pages_unverifiable",
-        "pages_insufficient_grade",
-        "pages_emitted",
-        "pages_dropped_explained",
-        "pages_dropped_unexplained",
-        "evidence_records",
-        "evidence_untyped",
-    ):
-        merged[key] = sum(report[key] for report in reports)
+    for key, value in reports[0].items():
+        if isinstance(value, bool) or not isinstance(value, int):
+            continue
+        merged[key] = sum(report.get(key, 0) for report in reports)
     merged["grades_present"] = sorted({grade for report in reports for grade in report["grades_present"]})
-    # ⚠️ `merged = dict(reports[0])` inherits the FIRST report's census verbatim, so without this the
-    # refusals of every later path vanish - measured `foreign=7` merged down to `foreign=0`. A
-    # refusal counter that silently zeroes is worse than none, because it reads as "nothing was
-    # refused" exactly where the guard did the most work.
     merged["evidence_attributed"] = {
         route: sum((report.get("evidence_attributed") or {}).get(route, 0) for report in reports)
         for route in (*oid.WB_ROUTES, *oid.WB_REFUSALS)

--- a/scripts/check_reference_readiness.py
+++ b/scripts/check_reference_readiness.py
@@ -67,7 +67,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 from xml.etree import ElementTree
-from bundle_corpus import is_self_contained, shipping_reports
+from bundle_corpus import evidence_dirs, shipping_reports
 import object_identity as oid
 from object_identity import AMBIGUOUS
 from reference_evidence import (
@@ -81,11 +81,15 @@ from reference_evidence import (
     KIND_WORKSHEET,
     MIN_RENDER_EDGE,
     PROVIDER_CEILING,
+    REVISION_CONFIRMED,
+    REVISION_MISMATCH,
+    REVISION_UNCONFIRMED,
     Evidence,
     RejectedEvidence,
     UnitIdentity,
     json_object,
     oracle_evidence,
+    provenance_origin,
     reference_evidence,
     sha256_of,
 )
@@ -104,6 +108,9 @@ __all__ = [
     "KIND_WORKSHEET",
     "MIN_RENDER_EDGE",
     "PROVIDER_CEILING",
+    "REVISION_CONFIRMED",
+    "REVISION_MISMATCH",
+    "REVISION_UNCONFIRMED",
     "Evidence",
     "RejectedEvidence",
     "UnitIdentity",
@@ -399,7 +406,7 @@ def _enforce_exclusivity(rows: list[dict[str, Any]]) -> None:
 def _page_row(  # pylint: disable=too-many-arguments,too-many-positional-arguments
     obj: SourceObject,
     page_status: str,
-    evidence: list[Evidence],
+    scoped: ScopedEvidence,
     reason: str | None,
     require_validation_grade: bool,
 ) -> dict[str, Any]:
@@ -420,7 +427,7 @@ def _page_row(  # pylint: disable=too-many-arguments,too-many-positional-argumen
         # for; an unexplained one is the conversion gap the agent must know about before starting.
         row["readiness"] = READY if page_status == PAGE_DROPPED_EXPLAINED else BLIND
         return row
-    match, name_only = match_evidence(obj, evidence)
+    match, name_only = match_evidence(obj, scoped.admitted)
     if match is AMBIGUOUS:
         row.update(
             {
@@ -443,9 +450,20 @@ def _page_row(  # pylint: disable=too-many-arguments,too-many-positional-argumen
                 "matched_by": f"{match.origin}:{match.provider or 'unknown'} (scope={match.kind})",
                 "evidence_path": match.path,
                 "render_key": _render_key(match),
+                # ⚠️ Round-1 review of PR #454, blocker 2: a page certified through a LUID or name
+                # join says WHICH workbook, never WHICH BUILD of it, and used to read as a clean
+                # READY with nothing disclosing that. Never silently claimed - stated, counted
+                # (`pages_revision_unconfirmed`) and rendered.
+                "revision": match.revision_for(scoped.identity),
                 "readiness": INSUFFICIENT_GRADE if insufficient else READY,
             }
         )
+        return row
+    stale = _stale_note(obj, scoped)
+    if stale is not None:
+        # ⚠️ No `render_key`: a stale render certifies nothing, so it must not contest a legitimate
+        # render of the same bytes in another unit and drag that page down with it.
+        row.update({"evidence": "unverifiable", "matched_by": stale, "readiness": UNVERIFIABLE})
         return row
     if name_only:
         scopes = sorted({item.kind for item in name_only})
@@ -459,6 +477,25 @@ def _page_row(  # pylint: disable=too-many-arguments,too-many-positional-argumen
         return row
     row["readiness"] = BLIND
     return row
+
+
+def _stale_note(obj: SourceObject, scoped: ScopedEvidence) -> str | None:
+    """Why a render of this object exists but is of a DIFFERENT build of this workbook, or None.
+
+    Kept distinct from BLIND on purpose: "nobody captured this page" and "the capture is of another
+    revision" call for different operator actions - capture it, versus re-harvest or re-capture
+    against the migrated build.
+    """
+    if not scoped.stale:
+        return None
+    match, _ = match_evidence(obj, scoped.stale)
+    if not isinstance(match, Evidence):
+        return None
+    return (
+        f"STALE: {match.origin}:{match.provider or 'unknown'} render is of the same workbook at a "
+        "DIFFERENT build - the local source bytes differ from a REPRODUCIBLE download of the site "
+        "copy, so this cannot certify the migrated revision"
+    )
 
 
 def _engine_report(root: Path) -> dict[str, Any] | None:
@@ -491,51 +528,6 @@ def _unit_names(engine_report: dict[str, Any] | None) -> tuple[list[str], list[s
 
 def _handover(root: Path, unit: str) -> dict[str, Any] | None:
     return json_object(root / "handover" / f"{unit}.json")
-
-
-#: Provenance ``origin`` shapes that ESTABLISH which published workbook a local file is. See
-#: :func:`_provenance_luid` - deliberately distinct from ``origin.match``, which answers a revision
-#: question and was read as if it were this one (issue #450).
-IDENTITY_MATCHED_BY = frozenset({"luid"})
-
-
-def _provenance_luid(root: Path, source_sha: str, source: Path | None = None) -> str | None:
-    """The published workbook LUID for this source, from every offline route that ESTABLISHES one.
-
-    Two routes, and they must agree:
-
-    * ``source-provenance.json``'s ``origin.workbook_luid`` for the entry whose stamped input hash is
-      THIS file - trusted when ``matched_by == "luid"`` (the harvested filename's LUID was found on
-      the site, so it is provably that item) **or** when ``match == "sha256"`` (the bytes are
-      identical to the site copy, which confirms identity by content). A ``matched_by`` of ``name``
-      or ``sanitized_name`` with differing bytes is a name collision, not an identity.
-    * the asset filename's own ``<luid>_`` prefix, which is `harvest_estate_assets.py`'s record of
-      what it downloaded.
-
-    ⚠️ This used to require ``origin.match == "sha256"`` and nothing else, which read the REVISION
-    axis as if it were the IDENTITY axis. ``stamp_tableau_provenance.find_origin`` documents them as
-    "two independent axes"; on the reference estate 48 of 78 inputs are ``name_only`` while matched
-    ``by luid``, so the common case discarded a proven LUID and fell back to comparing the artifact
-    stem ``HR_Dashboard`` against the published name ``HR Dashboard``. That fallback is weaker on
-    identity AND carries no revision guarantee, so the trade bought nothing.
-
-    Disagreement between the two routes returns None: two identities that contradict each other are
-    less evidence than none, and the name axis then has to carry it.
-    """
-    stamped = oid.harvest_luid(source.stem if source is not None else None)
-    payload = json_object(root / "source-provenance.json")
-    for record in (payload or {}).get("inputs") or []:
-        if not isinstance(record, dict):
-            continue
-        stamped_input = record.get("input") if isinstance(record.get("input"), dict) else {}
-        origin = record.get("origin") if isinstance(record.get("origin"), dict) else {}
-        if stamped_input.get("sha256") != source_sha:
-            continue
-        if origin.get("matched_by") not in IDENTITY_MATCHED_BY and origin.get("match") != "sha256":
-            return oid.agreed_luid(stamped)
-        luid = origin.get("workbook_luid")
-        return oid.agreed_luid(stamped, luid if isinstance(luid, str) else None)
-    return oid.agreed_luid(stamped)
 
 
 def resolve_source(root: Path, unit: str, handover: dict[str, Any] | None, explicit: Path | None) -> Path | None:
@@ -573,20 +565,9 @@ def resolve_source(root: Path, unit: str, handover: dict[str, Any] | None, expli
 
 
 def _default_dirs(root: Path, name: str) -> list[Path]:
-    """Conventional evidence locations, mirroring `check_unit._oracle_dirs`.
-
-    The walk-up is a UNION, not a fallback, and that is deliberate: an un-packaged unit under
-    `<bundle>/pbip/<Unit>/` finds the run's flat capture that way, which is the ordinary case.
-
-    A self-contained package stops the walk - rationale, and why both gates share the one rule:
-    `bundle_corpus.is_self_contained`.
-    """
-    bases = [root] if is_self_contained(root) else [root, root.parent, root.parent.parent]
-    seen: list[Path] = []
-    for candidate in (base / name for base in bases):
-        if candidate.is_dir() and candidate.resolve() not in {path.resolve() for path in seen}:
-            seen.append(candidate)
-    return seen
+    """Conventional evidence locations. The whole rule - walk and stop - is
+    :func:`bundle_corpus.evidence_dirs`, shared with `check_unit._oracle_dirs`."""
+    return evidence_dirs(root, [name])
 
 
 def _cannot(unit: str, detail: str, report_dir: Path | None = None, source: Path | None = None) -> UnitResult:
@@ -605,16 +586,15 @@ def _identify(root: Path, unit: str, source: Path) -> UnitIdentity | None:
     digest = sha256_of(source)
     if digest is None:
         return None
-    return UnitIdentity(
-        name=unit, source_path=source, source_sha256=digest, workbook_luid=_provenance_luid(root, digest, source)
-    )
+    luid, revision = provenance_origin(root, digest, source)
+    return UnitIdentity(name=unit, source_path=source, source_sha256=digest, workbook_luid=luid, revision=revision)
 
 
 def _page_rows(
     objects: list[SourceObject],
     emitted: dict[str, str],
     explained: dict[tuple[str, str], str],
-    scoped: list[Evidence],
+    scoped: ScopedEvidence,
     require_validation_grade: bool,
 ) -> list[dict[str, Any]]:
     """One readiness row per expected page, splitting explained from unexplained drops."""
@@ -759,38 +739,46 @@ def assess_unit(  # pylint: disable=too-many-arguments,too-many-positional-argum
         return emitted
 
     scoped = _scope_evidence(evidence, identity)
-    rows = _page_rows(objects, emitted, drop_explanations(handover), scoped.admitted, require_validation_grade)
+    rows = _page_rows(objects, emitted, drop_explanations(handover), scoped, require_validation_grade)
     return _readiness_result(unit, report_dir, source, rows, scoped.census)
 
 
 @dataclass(frozen=True)
 class ScopedEvidence:
-    """One unit's share of the candidate renders, WITH the census of what was refused.
+    """One unit's share of the candidate renders, WITH what was refused and why.
 
-    The two travel together on purpose. A refusal that is dropped instead of counted is
-    indistinguishable from a render nobody ever captured, and that ambiguity is exactly how issue
-    #450's inert guard read as a working one for six review rounds.
+    ``admitted`` may certify a page; ``stale`` is the right workbook at a build this gate can prove
+    is different, and may only make a page UNVERIFIABLE - it is never in the list `match_evidence`
+    searches, so it cannot reach READY by any path. ``census`` counts every verdict, including the
+    refusals, because a refusal that is dropped instead of counted is indistinguishable from a render
+    nobody ever captured. ``identity`` travels with them so a row can report what the admitted render
+    establishes about the REVISION as well as the workbook.
     """
 
     admitted: list[Evidence]
+    stale: list[Evidence]
     census: dict[str, int]
+    identity: UnitIdentity
 
 
 def _scope_evidence(evidence: list[Evidence], identity: UnitIdentity) -> ScopedEvidence:
     """Attribute every candidate render to ``identity``, keeping the ones it may certify.
 
     Every render is attributed, admitted or not, and the census records which axis decided - so the
-    negative control ("a different workbook's render is refused, AND counted") is assertable and a
-    change here cannot pass as a fix while actually deleting the guard.
+    negative controls ("a foreign or unestablished record is refused, AND counted") are assertable
+    and a change here cannot pass as a fix while actually deleting the guard.
     """
-    census = dict.fromkeys((*oid.WB_ROUTES, oid.WB_FOREIGN, oid.WB_UNKNOWN), 0)
-    admitted = []
+    census = dict.fromkeys((*oid.WB_ROUTES, *oid.WB_REFUSALS), 0)
+    admitted: list[Evidence] = []
+    stale: list[Evidence] = []
     for item in evidence:
         verdict = item.attribution(identity)
         census[verdict.route] = census.get(verdict.route, 0) + 1
         if verdict.admitted:
             admitted.append(item)
-    return ScopedEvidence(admitted=admitted, census=census)
+        elif verdict.route == oid.WB_STALE:
+            stale.append(item)
+    return ScopedEvidence(admitted=admitted, stale=stale, census=census, identity=identity)
 
 
 def _units_without_reports(engine_report: dict[str, Any] | None, reports: list[Path]) -> list[UnitResult]:
@@ -918,6 +906,13 @@ def _merge(
         "pages_emitted": sum(1 for page in pages if page["page_status"] == PAGE_EMITTED),
         "pages_dropped_explained": sum(1 for page in pages if page["page_status"] == PAGE_DROPPED_EXPLAINED),
         "pages_dropped_unexplained": sum(1 for page in pages if page["page_status"] == PAGE_DROPPED_UNEXPLAINED),
+        # Pages certified by a render whose REVISION this gate could not establish. Not a refusal -
+        # the evidence is real and attributed - but never a silent claim either: the gate's contract
+        # is "THIS workbook, at THIS revision", and this is the count of pages where only the first
+        # half was proven (round-1 review of PR #454, blocker 2).
+        "pages_revision_unconfirmed": sum(
+            1 for page in pages if page.get("revision") and page["revision"] != REVISION_CONFIRMED
+        ),
         "evidence_records": len(evidence),
         "evidence_untyped": sum(1 for item in evidence if item.kind == KIND_UNKNOWN),
         "evidence_untyped_names": sorted({item.name for item in evidence if item.kind == KIND_UNKNOWN}),
@@ -1013,14 +1008,24 @@ def _render_attribution(report: dict[str, Any]) -> list[str]:
     #450's inert guard look like a working one for six review rounds.
     """
     census = report.get("evidence_attributed") or {}
-    if not sum(census.values()):
-        return []
-    admitted = ", ".join(f"{route}={census.get(route, 0)}" for route in oid.WB_ROUTES)
-    return [
-        f"  [ATTRIBUTION] admitted by {admitted}; refused {census.get(oid.WB_FOREIGN, 0)} as another "
-        f"workbook's and {census.get(oid.WB_UNKNOWN, 0)} with no shared identity axis "
-        "(counts are per unit-and-record, so one shared capture is weighed against every unit)."
-    ]
+    lines: list[str] = []
+    if sum(census.values()):
+        admitted = ", ".join(f"{route}={census.get(route, 0)}" for route in oid.WB_ROUTES)
+        lines.append(
+            f"  [ATTRIBUTION] admitted by {admitted}; refused {census.get(oid.WB_FOREIGN, 0)} as another "
+            f"workbook's, {census.get(oid.WB_STALE, 0)} as a different build and "
+            f"{census.get(oid.WB_UNKNOWN, 0)} with no identity this unit can answer "
+            "(counts are per unit-and-record, so one shared capture is weighed against every unit)."
+        )
+    unconfirmed = report.get("pages_revision_unconfirmed") or 0
+    if unconfirmed:
+        lines.append(
+            f"  [REVISION NOT ESTABLISHED] {unconfirmed} ready page(s) rest on a render tied to this "
+            "workbook by LUID or name, which says WHICH workbook a picture is of and never WHICH "
+            'BUILD. Only a source-sha match, or `source-provenance.json` reporting `match: "sha256"`, '
+            "proves the capture depicts the revision you are migrating."
+        )
+    return lines
 
 
 def _render_page(page: dict[str, Any]) -> str:
@@ -1113,6 +1118,14 @@ def _merge_scans(reports: list[dict[str, Any]]) -> dict[str, Any]:
     ):
         merged[key] = sum(report[key] for report in reports)
     merged["grades_present"] = sorted({grade for report in reports for grade in report["grades_present"]})
+    # ⚠️ `merged = dict(reports[0])` inherits the FIRST report's census verbatim, so without this the
+    # refusals of every later path vanish - measured `foreign=7` merged down to `foreign=0`. A
+    # refusal counter that silently zeroes is worse than none, because it reads as "nothing was
+    # refused" exactly where the guard did the most work.
+    merged["evidence_attributed"] = {
+        route: sum((report.get("evidence_attributed") or {}).get(route, 0) for report in reports)
+        for route in (*oid.WB_ROUTES, *oid.WB_REFUSALS)
+    }
     merged["all_evidence_validation_grade"] = all(report["all_evidence_validation_grade"] for report in reports)
     statuses = {report["status"] for report in reports}
     if STATUS_FINDINGS in statuses:

--- a/scripts/check_reference_readiness.py
+++ b/scripts/check_reference_readiness.py
@@ -484,6 +484,11 @@ def _page_row(  # pylint: disable=too-many-arguments,too-many-positional-argumen
 #: statement first: a record we could compare and reject says more than one we could not compare.
 REFUSAL_NOTES = {
     oid.WB_FOREIGN: "a render of ANOTHER workbook carries this name - refused, not credited",
+    oid.WB_CONFLICT: (
+        "CONTRADICTORY IDENTITY: the render's own metadata disagrees with itself about which "
+        "workbook it is of - one machine axis matches this unit and another names a different "
+        "workbook, so neither claim may be believed"
+    ),
     oid.WB_STALE: (
         "STALE: the render is of the same workbook at a DIFFERENT build - the local source bytes "
         "differ from a reproducible content digest of the site copy, so it cannot certify the "
@@ -608,12 +613,20 @@ def _cannot(unit: str, detail: str, report_dir: Path | None = None, source: Path
     )
 
 
-def _identify(root: Path, unit: str, source: Path) -> UnitIdentity | None:
-    """Unit identity, or None when the source cannot be hashed (so evidence cannot be attributed)."""
+def _identify(root: Path, unit: str, source: Path) -> UnitIdentity | str | None:
+    """Unit identity, the refusal REASON when provenance is ambiguous, or None when unhashable.
+
+    Three outcomes rather than two, because "I could not read the bytes" and "the bytes are stamped
+    twice, for two different workbooks" are different operator actions - re-run the harvest, versus
+    re-stamp provenance. Both are ``CANNOT_ESTABLISH``; neither is a pass.
+    """
     digest = sha256_of(source)
     if digest is None:
         return None
-    luid, revision = provenance_origin(root, digest, source)
+    try:
+        luid, revision = provenance_origin(root, digest, source)
+    except oid.AmbiguousIdentity as ambiguous:
+        return str(ambiguous)
     return UnitIdentity(name=unit, source_path=source, source_sha256=digest, workbook_luid=luid, revision=revision)
 
 
@@ -757,6 +770,8 @@ def assess_unit(  # pylint: disable=too-many-arguments,too-many-positional-argum
     identity = _identify(root, unit, source)
     if identity is None:
         return _cannot(unit, f"source workbook could not be hashed, so evidence cannot be attributed: {source}")
+    if isinstance(identity, str):
+        return _cannot(unit, f"this unit's workbook identity is ambiguous: {identity}", report_dir, source)
 
     objects = _expectation(unit, report_dir, source)
     if isinstance(objects, UnitResult):
@@ -971,7 +986,7 @@ def _merge(
 
 def _census(units: list[UnitResult]) -> dict[str, int]:
     """Every unit's attribution census, summed. Keys are always present, so a zero is visible."""
-    total = dict.fromkeys((*oid.WB_ROUTES, oid.WB_FOREIGN, oid.WB_UNKNOWN), 0)
+    total = dict.fromkeys((*oid.WB_ROUTES, oid.WB_CONFLICT, oid.WB_FOREIGN, oid.WB_UNKNOWN), 0)
     for unit in units:
         for route, count in unit.attribution.items():
             total[route] = total.get(route, 0) + count
@@ -1040,7 +1055,8 @@ def _render_attribution(report: dict[str, Any]) -> list[str]:
         admitted = ", ".join(f"{route}={census.get(route, 0)}" for route in oid.WB_ROUTES)
         lines.append(
             f"  [ATTRIBUTION] admitted by {admitted}; refused {census.get(oid.WB_FOREIGN, 0)} as another "
-            f"workbook's, {census.get(oid.WB_STALE, 0)} as a different build and "
+            f"workbook's, {census.get(oid.WB_CONFLICT, 0)} whose own machine identities contradict each "
+            f"other, {census.get(oid.WB_STALE, 0)} as a different build and "
             f"{census.get(oid.WB_UNKNOWN, 0)} with no identity this unit can answer "
             "(counts are per unit-and-record, so one shared capture is weighed against every unit)."
         )

--- a/scripts/check_reference_readiness.py
+++ b/scripts/check_reference_readiness.py
@@ -67,7 +67,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 from xml.etree import ElementTree
-from bundle_corpus import shipping_reports
+from bundle_corpus import is_self_contained, shipping_reports
 import object_identity as oid
 from object_identity import AMBIGUOUS
 from reference_evidence import (
@@ -572,27 +572,16 @@ def resolve_source(root: Path, unit: str, handover: dict[str, Any] | None, expli
     return None
 
 
-#: A self-contained handover package writes this beside the unit (`scripts/package_unit.py`, #446).
-#: Its presence is the marker that a target owns its evidence and must not inherit an ancestor's.
-PACKAGE_MARKER = "package-manifest.json"
-
-
 def _default_dirs(root: Path, name: str) -> list[Path]:
-    """Conventional evidence locations, mirroring `check_unit.py:830-839`.
+    """Conventional evidence locations, mirroring `check_unit._oracle_dirs`.
 
     The walk-up is a UNION, not a fallback, and that is deliberate: an un-packaged unit under
-    `<bundle>/pbip/<Unit>/` finds the run's flat capture two levels up, which is the ordinary case and
-    must keep working.
+    `<bundle>/pbip/<Unit>/` finds the run's flat capture that way, which is the ordinary case.
 
-    ⚠️ **A self-contained package stops the walk.** `package_unit.py` writes a unit-scoped
-    `oracle/oracle-manifest.json` holding THIS unit's views with rewritten paths; a package assembled
-    INSIDE a run directory therefore sees its own copy AND the run's flat capture two levels up, and
-    every view matches twice. The gate then refuses the pair as "2 records share this name once
-    normalized" and every page goes ready -> unverifiable - strictly worse than not packaging, and
-    silent. A `package-manifest.json` beside the target is that package's own declaration that it is
-    complete, so it is taken at its word and no ancestor is consulted.
+    A self-contained package stops the walk - rationale, and why both gates share the one rule:
+    `bundle_corpus.is_self_contained`.
     """
-    bases = [root] if (root / PACKAGE_MARKER).is_file() else [root, root.parent, root.parent.parent]
+    bases = [root] if is_self_contained(root) else [root, root.parent, root.parent.parent]
     seen: list[Path] = []
     for candidate in (base / name for base in bases):
         if candidate.is_dir() and candidate.resolve() not in {path.resolve() for path in seen}:

--- a/scripts/check_unit.py
+++ b/scripts/check_unit.py
@@ -30,6 +30,7 @@ import re
 import shutil
 import subprocess
 import sys
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Generic, TypeVar
@@ -1913,13 +1914,15 @@ def _reference_oracles(target: Path, reference_dir: Path | None) -> tuple[list[O
         for dashboard in payload.get("dashboards", []) if isinstance(payload, dict) else []:
             if not isinstance(dashboard, dict):
                 continue
-            visual, numeric, caps = _reference_states(directory, dashboard)
+            visual, numeric, caps, state_luids = _reference_states(directory, dashboard)
             grades |= caps
             records.append(
                 OracleRecord(
                     name=str(dashboard.get("name") or ""),
                     kind="dashboard",
-                    workbook=_declared_workbook(dashboard, payload, sha256=payload.get("source_workbook_sha256")),
+                    workbook=_declared_workbook(
+                        dashboard, payload, sha256=payload.get("source_workbook_sha256"), extra_luids=state_luids
+                    ),
                     visual=visual,
                     numeric=numeric,
                 )
@@ -1927,10 +1930,19 @@ def _reference_oracles(target: Path, reference_dir: Path | None) -> tuple[list[O
     return records, grades
 
 
-def _reference_states(directory: Path, dashboard: dict[str, Any]) -> tuple[bool, bool, set[str]]:
-    """``(visual, numeric, grades)`` across one dashboard entry's captured states."""
+def _reference_states(directory: Path, dashboard: dict[str, Any]) -> tuple[bool, bool, set[str], list[Any]]:
+    """``(visual, numeric, grades, per-state LUID claims)`` across one dashboard entry's states.
+
+    The LUID claims are returned rather than resolved here because this gate collapses every state
+    of an entry into ONE record, so they are claims about that record and must agree with the entry's
+    and the manifest's (:func:`_declared_workbook`). The entry gate reads the state scope
+    (`reference_evidence._reference_workbook_luid`); a scope one gate reads and the other ignores is
+    a hole by construction - measured on this branch, a state declaring another workbook's LUID
+    reached ``PASS route=sha256 admitted=1`` here.
+    """
     visual = numeric = False
     grades: set[str] = set()
+    luids: list[Any] = []
     for state in dashboard.get("states", []):
         if not isinstance(state, dict):
             continue
@@ -1940,7 +1952,8 @@ def _reference_states(directory: Path, dashboard: dict[str, Any]) -> tuple[bool,
         visual = visual or _existing_relative(directory, state.get("image"))
         oracle = state.get("numeric_oracle")
         numeric = numeric or (isinstance(oracle, str) and _existing_relative(directory, oracle))
-    return visual, numeric, grades
+        luids.append(state.get("workbook_luid"))
+    return visual, numeric, grades, luids
 
 
 def _is_within(directory: Path, base: Path) -> bool:
@@ -1951,7 +1964,9 @@ def _is_within(directory: Path, base: Path) -> bool:
         return False
 
 
-def _declared_workbook(payload: Any, container: Any = None, *, sha256: Any = None) -> oid.WorkbookIdentity:
+def _declared_workbook(
+    payload: Any, container: Any = None, *, sha256: Any = None, extra_luids: Iterable[Any] = ()
+) -> oid.WorkbookIdentity:
     """The producing workbook a manifest entry declares, on whichever axes it wrote.
 
     ⚠️ **Issue #450 was exactly this function reading a key nobody writes.** It read ``workbook``;
@@ -1960,11 +1975,21 @@ def _declared_workbook(payload: Any, container: Any = None, *, sha256: Any = Non
     real 360-view capture, every single record therefore arrived ownerless, and the foreign-workbook
     guard that this gate advertises had never once fired. ``workbook`` is still read, first, because
     it is the documented override a hand-written manifest may carry.
+
+    ⚠️ **The LUID is no longer SELECTED by scope.** ``entry.get(...) or outer.get(...)`` took the
+    entry's claim and dropped the manifest's, so an entry-level LUID matching this unit silently
+    superseded a manifest-level one naming another workbook - measured by round-2 review as
+    ``PASS visual=1 numeric=1 admitted=1``, with the contradiction gone before
+    :meth:`object_identity.WorkbookIdentity.attribute` could see it. Every non-blank claim must AGREE
+    (:func:`object_identity.agreed_luid`), which is the same one rule the entry gate's
+    `reference_evidence._reference_workbook_luid` applies. The NAME axis keeps its precedence
+    deliberately: since round-3 B-B a display name never admits, so no ordering of names can fail
+    open, and a name that DIFFERS from the unit's is already ``foreign``.
     """
     entry = payload if isinstance(payload, dict) else {}
     outer = container if isinstance(container, dict) else {}
     return oid.WorkbookIdentity.of(
-        luid=entry.get("workbook_luid") or outer.get("workbook_luid"),
+        luid=oid.agreed_luid(entry.get("workbook_luid"), outer.get("workbook_luid"), *extra_luids),
         name=entry.get("workbook") or outer.get("workbook") or entry.get("workbook_name") or outer.get("workbook_name"),
         sha256=sha256,
     )

--- a/scripts/check_unit.py
+++ b/scripts/check_unit.py
@@ -1849,13 +1849,25 @@ class OracleRecord:
     ORDINARY case rather than an edge one (``scripts/tableau_view_types.py``). Measured before this:
     a record explicitly carrying ``view_type: "worksheet"`` gave a full oracle PASS to the DASHBOARD
     of the same name - the kind was present in the manifest and thrown away here.
+
+    ``workbook`` is an :class:`object_identity.WorkbookIdentity`, shared with
+    ``check_reference_readiness`` - see issue #450, where this gate read a ``workbook`` key that no
+    producer writes while the sibling gate read a LUID it then distrusted, and one disagreement about
+    "what identifies a workbook" produced a fail-open defect here and a fail-closed one there.
+
+    ``unit_local`` records a LOCATION fact, not an identity one: a ``reference/manifest.json`` found
+    INSIDE the unit was captured for that unit by construction (``_reference_dirs`` never walks up,
+    and ``capture_tableau_reference.py`` writes per-unit), and it declares no workbook at all - only
+    the source workbook's sha256. Marking it is what lets an *oracle* record with no establishable
+    identity be refused without also refusing every locally-captured reference render.
     """
 
     name: str
     kind: str | None
-    workbook: str | None
+    workbook: oid.WorkbookIdentity
     visual: bool
     numeric: bool
+    unit_local: bool = False
 
 
 def _declared_kind(record: Any) -> str | None:
@@ -1878,9 +1890,17 @@ def _reference_oracles(target: Path, reference_dir: Path | None) -> tuple[list[O
     Every entry is a DASHBOARD by construction: ``capture_tableau_reference.py`` builds this array
     from the migration spec's ``dashboards`` (``_dashboard_names``), so the kind is structurally known
     here and does not depend on #402 landing.
+
+    A `reference/manifest.json` declares no producing workbook - it records ``source_workbook_sha256``
+    and nothing else - and :func:`_reference_dirs` only ever looks INSIDE the unit, so such a record
+    is this unit's by LOCATION. That is stated as ``unit_local`` rather than left to look like an
+    unattributed record, because issue #450's fix refuses unattributed ORACLE records and the two
+    cases must not be confused: one is "found in this unit's own folder", the other is "found in a
+    shared capture with nothing saying whose it is".
     """
     records: list[OracleRecord] = []
     grades: set[str] = set()
+    unit = _unit_dir(target)
     for directory in _reference_dirs(target, reference_dir):
         manifest = directory / "manifest.json"
         if not manifest.is_file():
@@ -1889,37 +1909,66 @@ def _reference_oracles(target: Path, reference_dir: Path | None) -> tuple[list[O
             payload = _read_json(manifest)
         except (OSError, json.JSONDecodeError):
             continue
+        local = _is_within(directory, unit) or _is_within(directory, target)
         for dashboard in payload.get("dashboards", []) if isinstance(payload, dict) else []:
             if not isinstance(dashboard, dict):
                 continue
-            visual = numeric = False
-            for state in dashboard.get("states", []):
-                if not isinstance(state, dict):
-                    continue
-                caps = {str(cap) for cap in state.get("capabilities", []) if isinstance(cap, str)}
-                if caps:
-                    grades.add("validation-grade" if "validation_grade" in caps else "/".join(sorted(caps)))
-                visual = visual or _existing_relative(directory, state.get("image"))
-                oracle = state.get("numeric_oracle")
-                numeric = numeric or (isinstance(oracle, str) and _existing_relative(directory, oracle))
+            visual, numeric, caps = _reference_states(directory, dashboard)
+            grades |= caps
             records.append(
                 OracleRecord(
                     name=str(dashboard.get("name") or ""),
                     kind="dashboard",
-                    workbook=_declared_workbook(dashboard) or _declared_workbook(payload),
+                    workbook=_declared_workbook(dashboard, payload, sha256=payload.get("source_workbook_sha256")),
                     visual=visual,
                     numeric=numeric,
+                    unit_local=local,
                 )
             )
     return records, grades
 
 
-def _declared_workbook(payload: Any) -> str | None:
-    """The producing workbook a manifest entry declares, or None when it declares none."""
-    if not isinstance(payload, dict):
-        return None
-    value = payload.get("workbook")
-    return value.strip() if isinstance(value, str) and value.strip() else None
+def _reference_states(directory: Path, dashboard: dict[str, Any]) -> tuple[bool, bool, set[str]]:
+    """``(visual, numeric, grades)`` across one dashboard entry's captured states."""
+    visual = numeric = False
+    grades: set[str] = set()
+    for state in dashboard.get("states", []):
+        if not isinstance(state, dict):
+            continue
+        caps = {str(cap) for cap in state.get("capabilities", []) if isinstance(cap, str)}
+        if caps:
+            grades.add("validation-grade" if "validation_grade" in caps else "/".join(sorted(caps)))
+        visual = visual or _existing_relative(directory, state.get("image"))
+        oracle = state.get("numeric_oracle")
+        numeric = numeric or (isinstance(oracle, str) and _existing_relative(directory, oracle))
+    return visual, numeric, grades
+
+
+def _is_within(directory: Path, base: Path) -> bool:
+    """Whether ``directory`` sits inside ``base``. Both are already resolved by their finders."""
+    try:
+        return directory.resolve().is_relative_to(base.resolve())
+    except (OSError, ValueError):
+        return False
+
+
+def _declared_workbook(payload: Any, container: Any = None, *, sha256: Any = None) -> oid.WorkbookIdentity:
+    """The producing workbook a manifest entry declares, on whichever axes it wrote.
+
+    ⚠️ **Issue #450 was exactly this function reading a key nobody writes.** It read ``workbook``;
+    ``capture_tableau_oracle.py`` writes ``workbook_luid`` and ``workbook_name`` per view, and
+    ``capture_tableau_reference.py`` writes ``source_workbook_sha256`` on the manifest. Measured on a
+    real 360-view capture, every single record therefore arrived ownerless, and the foreign-workbook
+    guard that this gate advertises had never once fired. ``workbook`` is still read, first, because
+    it is the documented override a hand-written manifest may carry.
+    """
+    entry = payload if isinstance(payload, dict) else {}
+    outer = container if isinstance(container, dict) else {}
+    return oid.WorkbookIdentity.of(
+        luid=entry.get("workbook_luid") or outer.get("workbook_luid"),
+        name=entry.get("workbook") or outer.get("workbook") or entry.get("workbook_name") or outer.get("workbook_name"),
+        sha256=sha256,
+    )
 
 
 def _oracle_capture_oracles(target: Path, oracle_dir: Path | None) -> tuple[list[OracleRecord], set[str]]:
@@ -1954,7 +2003,7 @@ def _oracle_capture_oracles(target: Path, oracle_dir: Path | None) -> tuple[list
                 OracleRecord(
                     name=str(record.get("view_name") or record.get("view_url_name") or ""),
                     kind=_declared_kind(record),
-                    workbook=_declared_workbook(record) or _declared_workbook(payload),
+                    workbook=_declared_workbook(record, payload),
                     visual=bool(visual),
                     numeric=bool(numeric),
                 )
@@ -1968,14 +2017,12 @@ class OracleEvidence:
 
     Four guards, one per measured defect:
 
-    * **Workbook.** A record that DECLARES a producing workbook must declare one this unit ships. The
-      unit side is a filesystem-sanitised artifact stem, so a lossy fallback is legitimate here - but
-      only when the key resolves uniquely on **BOTH** sides. Measured before this: records declaring
-      ``Bo ok`` and ``Bo-ok`` were both admitted to unit workbook ``Book``, because uniqueness was
-      checked among unit workbooks only. Uniqueness of a lossy key on one side is not identity.
-      A record declaring no workbook is admissible but counted in ``unattributed`` and surfaced in
-      the grade: "I cannot tell whose picture this is" is weaker evidence and the reader should see
-      that rather than infer it.
+    * **Workbook.** A record must be tied to THIS unit's workbook by identity - LUID first, exact
+      display name second, and a lossy name only when the key resolves uniquely on **BOTH** sides.
+      Measured before that last guard: records declaring ``Bo ok`` and ``Bo-ok`` were both admitted to
+      unit workbook ``Book``, because uniqueness was checked among unit workbooks only. A record
+      whose workbook CANNOT be established certifies nothing and is counted in ``unattributed`` -
+      see :func:`_admissible_oracle_records`, where issue #450 lived.
     * **Kind.** A record may only satisfy a page of the SAME kind, and a record whose kind cannot be
       established satisfies nothing. See :class:`OracleRecord`.
     * **Exact spelling.** A view name and a page name are BOTH source-owned - they come from the same
@@ -1987,12 +2034,14 @@ class OracleEvidence:
 
     ⚠️ **The KIND half of issue #438 is CLOSED here**, so the runtime caveat that disclosed it while
     it was open is gone with it - a disclosure that outlives its gap manufactures doubt exactly as
-    falsely as a missing one manufactures confidence. What remains is
-    [#450](https://github.com/Guust-Franssens/tableau-to-powerbi-migration/issues/450): a real
-    manifest names its producer ``workbook_name`` while :func:`_declared_workbook` reads ``workbook``,
-    so on a live capture every record is ownerless (measured 360 of 360) and the two-sided guard
-    above never engages. ``loosely_attributed`` and :func:`_oracle_caveats` therefore stay, re-aimed
-    at #450.
+    falsely as a missing one manufactures confidence.
+    [#450](https://github.com/Guust-Franssens/tableau-to-powerbi-migration/issues/450) is closed too:
+    :func:`_declared_workbook` read a ``workbook`` key no producer writes, so on a live capture every
+    record arrived ownerless (measured 360 of 360) and was **admitted anyway**. It now reads the
+    fields the producers do write - ``workbook_luid``/``workbook_name`` for an oracle capture,
+    ``source_workbook_sha256`` for a reference one - and an unestablished workbook is a refusal.
+    ``loosely_attributed`` and :func:`_oracle_caveats` remain, because the lossy NAME route is still
+    reachable for a unit whose LUID cannot be established.
     """
 
     by_exact: dict[tuple[str, str], list[OracleRecord]]
@@ -2013,15 +2062,58 @@ class OracleEvidence:
         return None, None
 
 
+def _unit_workbook_identities(target: Path) -> list[oid.WorkbookIdentity]:
+    """This unit's workbook, once per artifact stem, each carrying the unit's LUID when known.
+
+    The LUID comes from the handover slice's ``workbook.source_id``, whose basename is
+    ``harvest_estate_assets.py``'s ``<luid>_<sanitized-name>`` - this repo's own record of which
+    published workbook it downloaded, exact and needing neither server nor credentials. Every claim
+    must agree (:func:`object_identity.agreed_luid`): a unit whose slices name two different source
+    workbooks has no single workbook identity, and picking the first would be the #438 coin toss.
+
+    One identity PER STEM rather than one identity with several names, so the LUID axis is consulted
+    first for each of them. That ordering is the guard: a record whose LUID disagrees is foreign
+    against every stem, and cannot be re-admitted by a stem whose display name happens to match.
+    """
+    stems, _ = _unit_workbook_keys(target)
+    workbooks, _ = _handover_workbooks(target)
+    luid = oid.agreed_luid(
+        *(
+            oid.harvest_luid(Path(str(payload.get("source_id"))).stem)
+            for _path, _name, payload in workbooks
+            if isinstance(payload, dict) and payload.get("source_id")
+        )
+    )
+    return [oid.WorkbookIdentity(luid=luid, name=stem) for stem in sorted(stems)] or [oid.WorkbookIdentity(luid=luid)]
+
+
+def _attribute_record(unit_ids: list[oid.WorkbookIdentity], record: OracleRecord) -> oid.Attribution:
+    """How ``record`` ties to this unit: the first admission, else the strongest refusal.
+
+    A unit may ship artifacts under several stems, so every candidate identity is tried. Ordering the
+    result - admission, then ``foreign``, then ``unknown`` - matters because ``unknown`` against one
+    stem must never mask a ``foreign`` verdict reached against another: a record we could compare and
+    reject is a stronger statement than one we could not compare at all.
+    """
+    verdicts = [identity.attribute(record.workbook) for identity in unit_ids]
+    if not verdicts:
+        verdicts = [oid.WorkbookIdentity().attribute(record.workbook)]
+    return next(
+        (verdict for verdict in verdicts if verdict.admitted),
+        next((verdict for verdict in verdicts if verdict.route == oid.WB_FOREIGN), verdicts[0]),
+    )
+
+
 def _admissible_oracle_records(
-    records: list[OracleRecord], unit_workbooks: set[str]
+    records: list[OracleRecord], unit_ids: list[oid.WorkbookIdentity]
 ) -> tuple[list[OracleRecord], list[str], int, int, list[str]]:
     """``(admissible, foreign, unattributed, kindless, loosely_attributed)`` after both guards."""
     unit_index: NormalizedIndex[str] = NormalizedIndex()
-    for name in sorted(unit_workbooks):
-        unit_index.add(name, name)
+    for identity in unit_ids:
+        if identity.name:
+            unit_index.add(identity.name, identity.name)
     producer_index: NormalizedIndex[str] = NormalizedIndex()
-    for declared in sorted({record.workbook for record in records if record.workbook is not None}):
+    for declared in sorted({record.workbook.name for record in records if record.workbook.name}):
         producer_index.add(declared, declared)
 
     admissible: list[OracleRecord] = []
@@ -2029,20 +2121,21 @@ def _admissible_oracle_records(
     loosely_attributed: list[str] = []
     unattributed = kindless = 0
     for record in records:
-        if record.workbook is None:
-            unattributed += 1
-        elif record.workbook not in unit_workbooks:
-            two_sided = unit_index.unique(record.workbook) is not None and (
-                producer_index.unique(record.workbook) is not None
-            )
-            if not two_sided:
-                foreign.append(record.workbook)
+        verdict = _attribute_record(unit_ids, record)
+        if not record.unit_local and not verdict.admitted:
+            if verdict.route == oid.WB_UNKNOWN:
+                # ⚠️ Issue #450: this used to `unattributed += 1` and then FALL THROUGH to
+                # `admissible`, so a record whose producing workbook could not be established was
+                # admitted anyway - and because the field this gate read was one no producer writes,
+                # that was every record on a real capture (360 of 360). Refusing is the fix; the
+                # count stays, because a refusal nobody can see is not a guard.
+                unattributed += 1
                 continue
-            # Admitted on a LOSSY workbook key rather than an exact one. Both sides are now checked,
-            # so this is no longer the #438 coin toss - but it is still a weaker join than an exact
-            # match, and #450 makes it unreachable on real captures anyway (the manifest declares
-            # `workbook_name`, not `workbook`), so it stays disclosed rather than assumed sound.
-            loosely_attributed.append(record.workbook)
+            rescued = _lossy_workbook_rescue(verdict, record, unit_index, producer_index)
+            if rescued is None:
+                foreign.append(record.workbook.describe())
+                continue
+            loosely_attributed.append(rescued)
         if record.kind is None:
             kindless += 1
             continue
@@ -2050,12 +2143,39 @@ def _admissible_oracle_records(
     return admissible, foreign, unattributed, kindless, loosely_attributed
 
 
+def _lossy_workbook_rescue(
+    verdict: oid.Attribution,
+    record: OracleRecord,
+    unit_index: NormalizedIndex[str],
+    producer_index: NormalizedIndex[str],
+) -> str | None:
+    """The declared name a LOSSY workbook key may still admit, or None to refuse.
+
+    The unit side is a filesystem-sanitised artifact stem, so a lossy fallback is legitimate on the
+    NAME axis - but only when the key resolves uniquely on **BOTH** sides. Measured before that:
+    records declaring ``Bo ok`` and ``Bo-ok`` were both admitted to unit workbook ``Book``, because
+    uniqueness was checked among unit workbooks only. Uniqueness of a lossy key on one side is not
+    identity.
+
+    ⚠️ **Only a NAME disagreement is rescuable.** If the LUIDs or the source hashes were compared and
+    disagreed, this returns None unconditionally: a stronger axis that has already answered must not
+    be overridden by a weaker one, which is the identity-loss join
+    (:meth:`object_identity.WorkbookIdentity.attribute`) that both halves of #450 grew out of.
+    """
+    name = record.workbook.name
+    if verdict.axis != oid.WB_NAME or not name:
+        return None
+    if unit_index.unique(name) is None or producer_index.unique(name) is None:
+        return None
+    return name
+
+
 def _resolve_oracle_evidence(
-    records: list[OracleRecord], candidates: list[dict[str, Any]], unit_workbooks: set[str]
+    records: list[OracleRecord], candidates: list[dict[str, Any]], unit_ids: list[oid.WorkbookIdentity]
 ) -> OracleEvidence:
     """Index producer records against the expected pages without losing a collision."""
     _ = candidates
-    admissible, foreign, unattributed, kindless, loosely = _admissible_oracle_records(records, unit_workbooks)
+    admissible, foreign, unattributed, kindless, loosely = _admissible_oracle_records(records, unit_ids)
     by_exact: dict[tuple[str, str], list[OracleRecord]] = {}
     for record in admissible:
         by_exact.setdefault((str(record.kind), record.name), []).append(record)
@@ -2104,7 +2224,7 @@ def check_oracle_coverage(target: Path, reference_dir: Path | None, oracle_dir: 
             "no output, so there is no page left to hold against a reference",
             excluded=accepted,
         )
-    evidence = _resolve_oracle_evidence(reference + oracle, pages, _unit_workbook_keys(target)[0])
+    evidence = _resolve_oracle_evidence(reference + oracle, pages, _unit_workbook_identities(target))
     rows = [_oracle_row(page, expectation["index"], evidence) for page in pages]
     visual_missing = [row["page"] for row in rows if not row["visual"]]
     numeric_missing = [row["page"] for row in rows if not row["numeric"]]
@@ -2148,12 +2268,11 @@ def _oracle_caveats(rows: list[dict[str, Any]], evidence: OracleEvidence) -> lis
     exactly as falsely as omitting it once manufactured confidence. A disclosure is only honest while
     its gap is open; retiring it is part of the fix, not a separate cleanup.
 
-    What remains is [#450](https://github.com/Guust-Franssens/tableau-to-powerbi-migration/issues/450):
-    a record admitted through the LOSSY workbook key is a weaker join than an exact match. Both sides
-    of that key are now checked for uniqueness, so this is no longer the coin toss #438 described -
-    but it is still worth naming, and on a live capture it is unreachable for a different reason
-    worth knowing: the manifest declares ``workbook_name`` while :func:`_declared_workbook` reads
-    ``workbook``, so every record arrives ownerless (measured 360 of 360).
+    What remains is [#450](https://github.com/Guust-Franssens/tableau-to-powerbi-migration/issues/450)'s
+    residual: a record admitted through the LOSSY workbook name is a weaker join than an exact match
+    or a LUID. Both sides of that key are checked for uniqueness, so it is not the coin toss #438
+    described - but it is the route a unit takes whenever its own workbook LUID cannot be
+    established, and a reader deciding which PASS to distrust should be told which ones rest on it.
     """
     certified = [row["page"]["name"] for row in rows if row["visual"] or row["numeric"]]
     caveats: list[str] = []
@@ -2161,8 +2280,9 @@ def _oracle_caveats(rows: list[dict[str, Any]], evidence: OracleEvidence) -> lis
         workbooks = ", ".join(repr(name) for name in sorted(set(evidence.loosely_attributed)))
         caveats.append(
             f"⚠️ #450 WORKBOOK MATCHED LOOSELY: {len(evidence.loosely_attributed)} record(s) were "
-            f"admitted on a normalized workbook name rather than an exact one, so {len(certified)} "
-            f"certified page(s) rest on a lossier join than an exact workbook match: {workbooks}"
+            f"admitted on a normalized workbook name rather than a LUID or an exact name, so "
+            f"{len(certified)} certified page(s) rest on a lossier join than an exact workbook "
+            f"match: {workbooks}"
         )
     return caveats
 
@@ -2176,7 +2296,10 @@ def _oracle_grade(grades: set[str], evidence: OracleEvidence) -> str:
     """
     grade = ", ".join(sorted(grades)) or "not checked (no oracle manifest found)"
     if evidence.unattributed:
-        grade += f" (⚠️ {evidence.unattributed} record(s) declare no producing workbook)"
+        grade += (
+            f" (⚠️ {evidence.unattributed} record(s) establish no producing workbook and certify "
+            "nothing; a capture must carry workbook_luid, or the manifest a source_workbook_sha256)"
+        )
     if evidence.kindless:
         grade += (
             f" (⚠️ {evidence.kindless} record(s) establish no dashboard/worksheet kind and "

--- a/scripts/check_unit.py
+++ b/scripts/check_unit.py
@@ -37,7 +37,7 @@ from typing import Any, Generic, TypeVar
 import check_desktop_orphans as check_desktop_orphans_module
 import object_identity as oid
 import read_handover
-from bundle_corpus import is_self_contained, shipping_models, shipping_reports
+from bundle_corpus import evidence_dirs, shipping_models, shipping_reports
 from check_field_bindings import model_for_report
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -1819,19 +1819,15 @@ def _oracle_dirs(target: Path, explicit: Path | None) -> list[Path]:
     a bundle at ``_runs/<NNN>-<slug>/bundle`` was invisible and oracle-coverage reported "no oracle
     manifest found" for evidence that existed.
 
-    ⚠️ A self-contained package stops the walk up to ``target.parent``. Measured: a package at
-    ``_runs/<run>/<unit>/`` beside the run's flat capture read BOTH manifests, every view matched
-    twice, and this gate refused each page as *"2 producer records are named X"* - 0 visual coverage,
-    silently. That is issue #451's defect one gate along, so the rule lives once, in
-    :func:`bundle_corpus.is_self_contained`, rather than being fixed here a second time.
+    ⚠️ The walk itself - how far up, and where it stops - is :func:`bundle_corpus.evidence_dirs`,
+    shared with the entry gate. This function used to stop one level short of it, so a non-packaged
+    unit at ``<bundle>/pbip/<Unit>/`` could not reach the run's flat capture at all (round-1 review
+    of PR #454).
     """
     if explicit:
-        candidates: list[Path | None] = [explicit]
-    else:
-        unit = _unit_dir(target)
-        bases = (unit, target) if is_self_contained(unit) else (unit, target, target.parent)
-        candidates = [base / name for base in bases for name in ORACLE_DIR_NAMES]
-    return _resolved_unique(candidates)
+        return _resolved_unique([explicit])
+    unit = _unit_dir(target)
+    return evidence_dirs(unit, ORACLE_DIR_NAMES, also=[target])
 
 
 def _existing_relative(base: Path, rel: str | None) -> bool:
@@ -1862,11 +1858,13 @@ class OracleRecord:
     producer writes while the sibling gate read a LUID it then distrusted, and one disagreement about
     "what identifies a workbook" produced a fail-open defect here and a fail-closed one there.
 
-    ``unit_local`` records a LOCATION fact, not an identity one: a ``reference/manifest.json`` found
-    INSIDE the unit was captured for that unit by construction (``_reference_dirs`` never walks up,
-    and ``capture_tableau_reference.py`` writes per-unit), and it declares no workbook at all - only
-    the source workbook's sha256. Marking it is what lets an *oracle* record with no establishable
-    identity be refused without also refusing every locally-captured reference render.
+    ⚠️ There is deliberately **no** ``unit_local`` flag. There was: a `reference/manifest.json` found
+    inside the unit skipped the workbook guard entirely, on the argument that its location proved
+    ownership. Round-1 review of PR #454 measured what that bought - a record whose join returned
+    ``unknown`` was admitted anyway (``admitted_evidence=1``, visual AND numeric certified), and so
+    was one whose ``source_workbook_sha256`` named a **different workbook**. Location controls
+    DISCOVERY; it never substitutes for identity. The manifest's ``source_workbook_sha256`` is the
+    identity it actually carries, and it is now compared against the unit's own hashed source asset.
     """
 
     name: str
@@ -1874,7 +1872,6 @@ class OracleRecord:
     workbook: oid.WorkbookIdentity
     visual: bool
     numeric: bool
-    unit_local: bool = False
 
 
 def _declared_kind(record: Any) -> str | None:
@@ -1898,16 +1895,13 @@ def _reference_oracles(target: Path, reference_dir: Path | None) -> tuple[list[O
     from the migration spec's ``dashboards`` (``_dashboard_names``), so the kind is structurally known
     here and does not depend on #402 landing.
 
-    A `reference/manifest.json` declares no producing workbook - it records ``source_workbook_sha256``
-    and nothing else - and :func:`_reference_dirs` only ever looks INSIDE the unit, so such a record
-    is this unit's by LOCATION. That is stated as ``unit_local`` rather than left to look like an
-    unattributed record, because issue #450's fix refuses unattributed ORACLE records and the two
-    cases must not be confused: one is "found in this unit's own folder", the other is "found in a
-    shared capture with nothing saying whose it is".
+    A `reference/manifest.json` declares no producing workbook NAME - it records
+    ``source_workbook_sha256`` (`capture_tableau_reference.py:234`), which is a machine identity and
+    is checked as one against :func:`_unit_source_sha256`. It is deliberately NOT trusted for sitting
+    inside the unit; see :class:`OracleRecord`.
     """
     records: list[OracleRecord] = []
     grades: set[str] = set()
-    unit = _unit_dir(target)
     for directory in _reference_dirs(target, reference_dir):
         manifest = directory / "manifest.json"
         if not manifest.is_file():
@@ -1916,7 +1910,6 @@ def _reference_oracles(target: Path, reference_dir: Path | None) -> tuple[list[O
             payload = _read_json(manifest)
         except (OSError, json.JSONDecodeError):
             continue
-        local = _is_within(directory, unit) or _is_within(directory, target)
         for dashboard in payload.get("dashboards", []) if isinstance(payload, dict) else []:
             if not isinstance(dashboard, dict):
                 continue
@@ -1929,7 +1922,6 @@ def _reference_oracles(target: Path, reference_dir: Path | None) -> tuple[list[O
                     workbook=_declared_workbook(dashboard, payload, sha256=payload.get("source_workbook_sha256")),
                     visual=visual,
                     numeric=numeric,
-                    unit_local=local,
                 )
             )
     return records, grades
@@ -2069,29 +2061,81 @@ class OracleEvidence:
         return None, None
 
 
+def _unit_source_claims(target: Path) -> tuple[list[str], list[str]]:
+    """``(recorded path/name claims, LUID claims)`` about the Tableau source this unit was built from.
+
+    Two independent producers record it, and both are read: the handover slice's
+    ``workbook.source_id`` (a run-root-relative path) and ``migration-spec.json``'s
+    ``source.file_name`` (a bare basename). Every LUID claim must AGREE - see
+    :func:`object_identity.agreed_luid`.
+
+    ⚠️ Both are parsed with :func:`object_identity.persisted_stem`, never ``Path(...).stem``. A real
+    slice records ``_runs\\407-...\\assets\\<luid>_HR_Dashboard.twbx``; on POSIX those backslashes are
+    ordinary characters, so ``Path`` returns the whole string, the LUID prefix is invisible and the
+    unit ends up with no machine identity - on Linux CI only. Round-1 review of PR #454 measured
+    exactly that divergence, which is the worst possible shape for a safety guard.
+    """
+    names: list[str] = []
+    for _path, _name, payload in _handover_workbooks(target)[0]:
+        if isinstance(payload, dict) and payload.get("source_id"):
+            names.append(str(payload["source_id"]))
+    spec = _migration_spec(target)
+    declared = (_json_object(spec) or {}).get("source") if spec is not None else None
+    if isinstance(declared, dict) and declared.get("file_name"):
+        names.append(str(declared["file_name"]))
+    return names, [oid.harvest_luid(oid.persisted_stem(name)) or "" for name in names]
+
+
+def _unit_source_sha256(target: Path) -> str | None:
+    """sha256 of this unit's Tableau source asset, or None when it cannot be located.
+
+    This is the machine identity a `reference/manifest.json` actually carries
+    (``source_workbook_sha256``), so without it such a record could only be admitted on something
+    weaker - which is precisely what round-1 review of PR #454 refused. Returning None is therefore
+    fail-CLOSED by design: an unlocatable source means a sha-bearing record certifies nothing, and
+    the refusal is counted in ``unattributed_evidence`` rather than dropped.
+    """
+    unit = _unit_dir(target)
+    bases = [unit, target, unit.parent, unit.parent.parent]
+    for recorded in _unit_source_claims(target)[0]:
+        basename = oid.persisted_name(recorded)
+        if not basename:
+            continue
+        candidates = [Path(recorded)]
+        candidates += [base / sub / basename for base in bases for sub in ("assets", ".")]
+        for candidate in candidates:
+            try:
+                if candidate.is_file():
+                    return hashlib.sha256(candidate.read_bytes()).hexdigest()
+            except OSError:
+                continue
+    return None
+
+
 def _unit_workbook_identities(target: Path) -> list[oid.WorkbookIdentity]:
-    """This unit's workbook, once per artifact stem, each carrying the unit's LUID when known.
+    """This unit's workbook, once per artifact stem, on every axis it can establish.
 
-    The LUID comes from the handover slice's ``workbook.source_id``, whose basename is
-    ``harvest_estate_assets.py``'s ``<luid>_<sanitized-name>`` - this repo's own record of which
-    published workbook it downloaded, exact and needing neither server nor credentials. Every claim
-    must agree (:func:`object_identity.agreed_luid`): a unit whose slices name two different source
-    workbooks has no single workbook identity, and picking the first would be the #438 coin toss.
+    The LUID comes from ``harvest_estate_assets.py``'s ``<luid>_<sanitized-name>`` filename - this
+    repo's own record of which published workbook it downloaded - as recorded by the handover slice
+    AND the migration spec. Every claim must agree (:func:`object_identity.agreed_luid`): a unit
+    whose records name two different source workbooks has no single workbook identity, and picking
+    the first would be the #438 coin toss.
 
-    One identity PER STEM rather than one identity with several names, so the LUID axis is consulted
-    first for each of them. That ordering is the guard: a record whose LUID disagrees is foreign
-    against every stem, and cannot be re-admitted by a stem whose display name happens to match.
+    The sha256 is the unit's own source bytes, so a `reference/manifest.json`'s
+    ``source_workbook_sha256`` is CHECKED rather than believed - or, when the source cannot be
+    located, refused.
+
+    One identity PER STEM rather than one identity with several names, so the machine axes are
+    consulted first for each of them. That ordering is the guard: a record whose LUID disagrees is
+    foreign against every stem, and cannot be re-admitted by a stem whose display name happens to
+    match.
     """
     stems, _ = _unit_workbook_keys(target)
-    workbooks, _ = _handover_workbooks(target)
-    luid = oid.agreed_luid(
-        *(
-            oid.harvest_luid(Path(str(payload.get("source_id"))).stem)
-            for _path, _name, payload in workbooks
-            if isinstance(payload, dict) and payload.get("source_id")
-        )
-    )
-    return [oid.WorkbookIdentity(luid=luid, name=stem) for stem in sorted(stems)] or [oid.WorkbookIdentity(luid=luid)]
+    luid = oid.agreed_luid(*_unit_source_claims(target)[1])
+    sha = _unit_source_sha256(target)
+    return [oid.WorkbookIdentity(luid=luid, name=stem, sha256=sha) for stem in sorted(stems)] or [
+        oid.WorkbookIdentity(luid=luid, sha256=sha)
+    ]
 
 
 def _attribute_record(unit_ids: list[oid.WorkbookIdentity], record: OracleRecord) -> oid.Attribution:
@@ -2129,13 +2173,16 @@ def _admissible_oracle_records(
     unattributed = kindless = 0
     for record in records:
         verdict = _attribute_record(unit_ids, record)
-        if not record.unit_local and not verdict.admitted:
+        if not verdict.admitted:
             if verdict.route == oid.WB_UNKNOWN:
                 # ⚠️ Issue #450: this used to `unattributed += 1` and then FALL THROUGH to
                 # `admissible`, so a record whose producing workbook could not be established was
                 # admitted anyway - and because the field this gate read was one no producer writes,
-                # that was every record on a real capture (360 of 360). Refusing is the fix; the
-                # count stays, because a refusal nobody can see is not a guard.
+                # that was every record on a real capture (360 of 360). Round-1 review of PR #454
+                # found the same shape once more, wearing a different hat: a `reference/` manifest
+                # inside the unit skipped this guard entirely on the strength of its LOCATION.
+                # Refusing is the fix in both cases; the count stays, because a refusal nobody can
+                # see is not a guard.
                 unattributed += 1
                 continue
             rescued = _lossy_workbook_rescue(verdict, record, unit_index, producer_index)
@@ -2164,13 +2211,14 @@ def _lossy_workbook_rescue(
     uniqueness was checked among unit workbooks only. Uniqueness of a lossy key on one side is not
     identity.
 
-    ⚠️ **Only a NAME disagreement is rescuable.** If the LUIDs or the source hashes were compared and
-    disagreed, this returns None unconditionally: a stronger axis that has already answered must not
-    be overridden by a weaker one, which is the identity-loss join
+    ⚠️ **Only a NAME disagreement is rescuable.** If a MACHINE axis - the LUID or the source hash -
+    was compared and disagreed, or was claimed by the record and unanswerable by the unit, this
+    returns None unconditionally: a stronger axis that has already answered must not be overridden by
+    a weaker one, which is the identity-loss join
     (:meth:`object_identity.WorkbookIdentity.attribute`) that both halves of #450 grew out of.
     """
     name = record.workbook.name
-    if verdict.axis != oid.WB_NAME or not name:
+    if verdict.route != oid.WB_FOREIGN or verdict.axis != oid.WB_NAME or not name:
         return None
     if unit_index.unique(name) is None or producer_index.unique(name) is None:
         return None

--- a/scripts/check_unit.py
+++ b/scripts/check_unit.py
@@ -37,7 +37,7 @@ from typing import Any, Generic, TypeVar
 import check_desktop_orphans as check_desktop_orphans_module
 import object_identity as oid
 import read_handover
-from bundle_corpus import shipping_models, shipping_reports
+from bundle_corpus import is_self_contained, shipping_models, shipping_reports
 from check_field_bindings import model_for_report
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -1818,12 +1818,19 @@ def _oracle_dirs(target: Path, explicit: Path | None) -> list[Path]:
     AGENTS.md "Canonical work layout"). Looking for only one of the two meant a real capture beside
     a bundle at ``_runs/<NNN>-<slug>/bundle`` was invisible and oracle-coverage reported "no oracle
     manifest found" for evidence that existed.
+
+    ⚠️ A self-contained package stops the walk up to ``target.parent``. Measured: a package at
+    ``_runs/<run>/<unit>/`` beside the run's flat capture read BOTH manifests, every view matched
+    twice, and this gate refused each page as *"2 producer records are named X"* - 0 visual coverage,
+    silently. That is issue #451's defect one gate along, so the rule lives once, in
+    :func:`bundle_corpus.is_self_contained`, rather than being fixed here a second time.
     """
     if explicit:
         candidates: list[Path | None] = [explicit]
     else:
         unit = _unit_dir(target)
-        candidates = [base / name for base in (unit, target, target.parent) for name in ORACLE_DIR_NAMES]
+        bases = (unit, target) if is_self_contained(unit) else (unit, target, target.parent)
+        candidates = [base / name for base in bases for name in ORACLE_DIR_NAMES]
     return _resolved_unique(candidates)
 
 

--- a/scripts/check_unit.py
+++ b/scripts/check_unit.py
@@ -2039,16 +2039,18 @@ class OracleEvidence:
     record arrived ownerless (measured 360 of 360) and was **admitted anyway**. It now reads the
     fields the producers do write - ``workbook_luid``/``workbook_name`` for an oracle capture,
     ``source_workbook_sha256`` for a reference one - and an unestablished workbook is a refusal.
-    ``loosely_attributed`` and :func:`_oracle_caveats` remain, because the lossy NAME route is still
-    reachable for a unit whose LUID cannot be established.
+    ⚠️ Round-3 review, B-B: the lossy NAME rescue is GONE, not further guarded. A display name -
+    exact or normalised - can no longer admit anything, so the rescue had nothing left to rescue.
+    ``name_only`` counts what it refuses, because that is a different operator action from
+    ``foreign``: re-capture with view typing, versus ignore another workbook's render.
     """
 
     by_exact: dict[tuple[str, str], list[OracleRecord]]
     unattributed: int
     kindless: int
     admitted: int
-    #: Records admitted on a LOSSY workbook key rather than an exact one (issue #450).
-    loosely_attributed: list[str]
+    #: Records refused because a display NAME was their only identity (round-3 review, B-B).
+    name_only: list[str]
     foreign: tuple[str, ...]
 
     def evidence_for(self, page: dict[str, Any]) -> tuple[OracleRecord | None, str | None]:
@@ -2158,18 +2160,10 @@ def _attribute_record(unit_ids: list[oid.WorkbookIdentity], record: OracleRecord
 def _admissible_oracle_records(
     records: list[OracleRecord], unit_ids: list[oid.WorkbookIdentity]
 ) -> tuple[list[OracleRecord], list[str], int, int, list[str]]:
-    """``(admissible, foreign, unattributed, kindless, loosely_attributed)`` after both guards."""
-    unit_index: NormalizedIndex[str] = NormalizedIndex()
-    for identity in unit_ids:
-        if identity.name:
-            unit_index.add(identity.name, identity.name)
-    producer_index: NormalizedIndex[str] = NormalizedIndex()
-    for declared in sorted({record.workbook.name for record in records if record.workbook.name}):
-        producer_index.add(declared, declared)
-
+    """``(admissible, foreign, unattributed, kindless, name_only)`` after both guards."""
     admissible: list[OracleRecord] = []
     foreign: list[str] = []
-    loosely_attributed: list[str] = []
+    name_only: list[str] = []
     unattributed = kindless = 0
     for record in records:
         verdict = _attribute_record(unit_ids, record)
@@ -2184,45 +2178,21 @@ def _admissible_oracle_records(
                 # Refusing is the fix in both cases; the count stays, because a refusal nobody can
                 # see is not a guard.
                 unattributed += 1
-                continue
-            rescued = _lossy_workbook_rescue(verdict, record, unit_index, producer_index)
-            if rescued is None:
+            elif verdict.route == oid.WB_NAME:
+                # ⚠️ Round-3 review, B-B. A record carrying ONLY a display name used to be admitted
+                # here, and this gate added no caveat for it - measured `PASS, visual=1, numeric=1`
+                # from a bare name that a workbook in another project is indistinguishable from. It
+                # is refused, and counted SEPARATELY from `foreign`: "a name matched, and a name is
+                # not identity" is a different operator action from "this is another workbook's".
+                name_only.append(record.workbook.describe())
+            else:
                 foreign.append(record.workbook.describe())
-                continue
-            loosely_attributed.append(rescued)
+            continue
         if record.kind is None:
             kindless += 1
             continue
         admissible.append(record)
-    return admissible, foreign, unattributed, kindless, loosely_attributed
-
-
-def _lossy_workbook_rescue(
-    verdict: oid.Attribution,
-    record: OracleRecord,
-    unit_index: NormalizedIndex[str],
-    producer_index: NormalizedIndex[str],
-) -> str | None:
-    """The declared name a LOSSY workbook key may still admit, or None to refuse.
-
-    The unit side is a filesystem-sanitised artifact stem, so a lossy fallback is legitimate on the
-    NAME axis - but only when the key resolves uniquely on **BOTH** sides. Measured before that:
-    records declaring ``Bo ok`` and ``Bo-ok`` were both admitted to unit workbook ``Book``, because
-    uniqueness was checked among unit workbooks only. Uniqueness of a lossy key on one side is not
-    identity.
-
-    ⚠️ **Only a NAME disagreement is rescuable.** If a MACHINE axis - the LUID or the source hash -
-    was compared and disagreed, or was claimed by the record and unanswerable by the unit, this
-    returns None unconditionally: a stronger axis that has already answered must not be overridden by
-    a weaker one, which is the identity-loss join
-    (:meth:`object_identity.WorkbookIdentity.attribute`) that both halves of #450 grew out of.
-    """
-    name = record.workbook.name
-    if verdict.route != oid.WB_FOREIGN or verdict.axis != oid.WB_NAME or not name:
-        return None
-    if unit_index.unique(name) is None or producer_index.unique(name) is None:
-        return None
-    return name
+    return admissible, foreign, unattributed, kindless, name_only
 
 
 def _resolve_oracle_evidence(
@@ -2230,7 +2200,7 @@ def _resolve_oracle_evidence(
 ) -> OracleEvidence:
     """Index producer records against the expected pages without losing a collision."""
     _ = candidates
-    admissible, foreign, unattributed, kindless, loosely = _admissible_oracle_records(records, unit_ids)
+    admissible, foreign, unattributed, kindless, named = _admissible_oracle_records(records, unit_ids)
     by_exact: dict[tuple[str, str], list[OracleRecord]] = {}
     for record in admissible:
         by_exact.setdefault((str(record.kind), record.name), []).append(record)
@@ -2239,7 +2209,7 @@ def _resolve_oracle_evidence(
         unattributed=unattributed,
         kindless=kindless,
         admitted=len(admissible),
-        loosely_attributed=loosely,
+        name_only=named,
         foreign=tuple(sorted(set(foreign))),
     )
 
@@ -2295,6 +2265,7 @@ def check_oracle_coverage(target: Path, reference_dir: Path | None, oracle_dir: 
         "refused_evidence": [row["refusal"] for row in rows if row["refusal"]],
         "foreign_workbook_evidence": list(evidence.foreign),
         "unattributed_evidence": evidence.unattributed,
+        "name_only_evidence": list(evidence.name_only),
         "kindless_evidence": evidence.kindless,
         # ⚠️ Reported because the kind guard is otherwise UNKILLABLE: dropping the record would also
         # be masked by the `(kind, name)` lookup key never matching a kind-less record, so a test
@@ -2331,13 +2302,17 @@ def _oracle_caveats(rows: list[dict[str, Any]], evidence: OracleEvidence) -> lis
     """
     certified = [row["page"]["name"] for row in rows if row["visual"] or row["numeric"]]
     caveats: list[str] = []
-    if evidence.loosely_attributed and certified:
-        workbooks = ", ".join(repr(name) for name in sorted(set(evidence.loosely_attributed)))
+    if evidence.name_only:
+        workbooks = ", ".join(sorted(set(evidence.name_only)))
         caveats.append(
-            f"⚠️ #450 WORKBOOK MATCHED LOOSELY: {len(evidence.loosely_attributed)} record(s) were "
-            f"admitted on a normalized workbook name rather than a LUID or an exact name, so "
-            f"{len(certified)} certified page(s) rest on a lossier join than an exact workbook "
-            f"match: {workbooks}"
+            f"⚠️ NAME-ONLY EVIDENCE REFUSED: {len(evidence.name_only)} record(s) declared a display "
+            "name and no machine identity, so they certify nothing - a workbook of the same name in "
+            f"another project is indistinguishable from them: {workbooks}"
+        )
+    if evidence.unattributed and certified:
+        caveats.append(
+            f"⚠️ {evidence.unattributed} record(s) establish no producing workbook at all and were "
+            f"refused, so {len(certified)} certified page(s) rest only on the records that did"
         )
     return caveats
 

--- a/scripts/check_unit.py
+++ b/scripts/check_unit.py
@@ -2144,16 +2144,18 @@ def _attribute_record(unit_ids: list[oid.WorkbookIdentity], record: OracleRecord
     """How ``record`` ties to this unit: the first admission, else the strongest refusal.
 
     A unit may ship artifacts under several stems, so every candidate identity is tried. Ordering the
-    result - admission, then ``foreign``, then ``unknown`` - matters because ``unknown`` against one
-    stem must never mask a ``foreign`` verdict reached against another: a record we could compare and
-    reject is a stronger statement than one we could not compare at all.
+    result - admission, then a CONTRADICTION or ``foreign``, then ``unknown`` - matters because
+    ``unknown`` against one stem must never mask the stronger verdict reached against another: a
+    record we could compare and reject says more than one we could not compare at all, and a record
+    whose own machine identities disagree says more still.
     """
     verdicts = [identity.attribute(record.workbook) for identity in unit_ids]
     if not verdicts:
         verdicts = [oid.WorkbookIdentity().attribute(record.workbook)]
+    compared = (oid.WB_CONFLICT, oid.WB_FOREIGN)
     return next(
         (verdict for verdict in verdicts if verdict.admitted),
-        next((verdict for verdict in verdicts if verdict.route == oid.WB_FOREIGN), verdicts[0]),
+        next((verdict for verdict in verdicts if verdict.route in compared), verdicts[0]),
     )
 
 

--- a/scripts/object_identity.py
+++ b/scripts/object_identity.py
@@ -42,11 +42,31 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass, field
-from typing import Generic, TypeVar
+from typing import Any, Generic, TypeVar
 
 KIND_DASHBOARD = "dashboard"
 KIND_WORKSHEET = "worksheet"
 KIND_UNKNOWN = "unknown"
+
+#: How a render was tied to a unit's workbook. The first three ADMIT; the last two REFUSE.
+WB_SHA = "sha256"
+WB_LUID = "luid"
+WB_NAME = "name"
+WB_FOREIGN = "foreign"
+WB_UNKNOWN = "unknown"
+
+#: Routes that admit. Ordered strongest-first, which is also the order :meth:`WorkbookIdentity.attribute`
+#: consults them - a stronger axis, once BOTH sides carry it, is decisive and is never re-litigated by
+#: a weaker one.
+WB_ROUTES = (WB_SHA, WB_LUID, WB_NAME)
+WB_ADMITTING = frozenset(WB_ROUTES)
+
+#: `harvest_estate_assets.py` names every download `<luid>_<sanitized-name><ext>`, which is the only
+#: offline route to a workbook LUID that needs no server. Mirrors
+#: `stamp_tableau_provenance.HARVEST_STEM_RE`, kept here so both gates share one parser.
+HARVEST_STEM_RE = re.compile(
+    r"^(?P<luid>[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})_(?P<rest>.+)$"
+)
 
 #: The only kinds an identity may carry. `KIND_UNKNOWN` is deliberately absent: an object whose kind
 #: is unknown has no identity, which is the whole point.
@@ -325,3 +345,162 @@ def collisions(identities: list[ObjectIdentity]) -> list[tuple[str, ...]]:
 def duplicates(names: list[str]) -> list[str]:
     """Names appearing more than once in an engine list, kept because a ``set()`` would hide them."""
     return sorted({name for name in names if names.count(name) > 1})
+
+
+# ------------------------------------------------------------------------------------------------
+# WORKBOOK identity - which workbook a render belongs to
+# ------------------------------------------------------------------------------------------------
+#
+# Everything above answers "which OBJECT is this a picture of". This half answers the question one
+# level up - "whose workbook is it" - and it lives here because BOTH gates ask it and, until issue
+# #450, each had invented its own key for it. Measured on the reference estate:
+#
+# * `check_reference_readiness` joined an artifact stem against a display name, and trusted a LUID
+#   ONLY when `origin.match == "sha256"` - a field that answers a revision question. So a workbook
+#   proven by LUID whose bytes had since changed lost its identity, `HR_Dashboard` fell back to exact
+#   equality against `HR Dashboard`, and 23 correctly-typed renders were discarded: 0 of 7 pages
+#   ready. **Fail-closed.**
+# * `check_unit` read `record["workbook"]`, a key NO capture producer writes, while the manifest
+#   carries `workbook_luid` and `workbook_name`. Every record arrived ownerless - 360 of 360 - and
+#   was admitted anyway, so its foreign-workbook guard had never once fired. **Fail-open.**
+#
+# One of each direction, from one cause: no shared definition of what identifies a workbook. So the
+# definition is here, once, and both gates construct their two sides through it.
+
+
+@dataclass(frozen=True)
+class Attribution:
+    """Which axis tied a render to a unit, or why it could not be tied. Never a condition.
+
+    ``__bool__`` raises for the same reason :meth:`Resolution.__bool__` does, and here the reason is
+    concrete: ``route`` is a non-empty string for ``foreign`` and ``unknown`` too, so ``if
+    identity.attribute(record):`` would admit a FOREIGN workbook's render. :attr:`admitted` is the
+    only reader that answers the question.
+
+    ``axis`` names the axis that DECIDED - the same value as ``route`` for an admission, and for a
+    refusal the axis whose two sides disagreed. It exists so a caller can tell "the LUIDs differ"
+    from "the display names differ": a lossy name fallback may legitimately widen the latter and must
+    never be allowed to override the former.
+    """
+
+    route: str
+    detail: str
+    axis: str | None = None
+
+    @property
+    def admitted(self) -> bool:
+        """Whether this render may certify a page in the unit it was attributed against."""
+        return self.route in WB_ADMITTING
+
+    def __bool__(self) -> bool:
+        raise AmbiguousIdentity(
+            f"an Attribution is not a condition - read .admitted; this one is {self.route} ({self.detail})"
+        )
+
+
+@dataclass(frozen=True)
+class WorkbookIdentity:
+    """Who a Tableau workbook is, on the three axes a producer can actually record.
+
+    * ``sha256`` - the bytes of the source workbook. Strongest: it is revision-bound as well as
+      identity-bound, which is why a stale capture cannot hide behind it.
+    * ``luid`` - the published workbook's server id. **This is the identity.** Exact, unique across
+      projects, and the one thing `capture_tableau_oracle.py` always writes.
+    * ``name`` - the display name. **Decoration.** Two projects may hold workbooks with the same
+      name, which is the ambiguity `_runs/<NNN>-<slug>/` numbering exists to avoid elsewhere.
+
+    Every axis is optional because every producer records a different subset; an identity carrying
+    none of them is *unestablished* and, by :meth:`attribute`, certifies nothing.
+    """
+
+    luid: str | None = None
+    name: str | None = None
+    sha256: str | None = None
+
+    @classmethod
+    def of(cls, *, luid: Any = None, name: Any = None, sha256: Any = None) -> WorkbookIdentity:
+        """Build from raw manifest values, keeping only non-blank strings.
+
+        A blank or non-string value is *absent*, never an empty-string identity that would compare
+        equal to another absent one.
+        """
+        return cls(luid=_text(luid), name=_text(name), sha256=_text(sha256))
+
+    @property
+    def established(self) -> bool:
+        """Whether this identity carries anything at all to compare on."""
+        return any((self.luid, self.name, self.sha256))
+
+    def describe(self) -> str:
+        """A short, reportable rendering - so a refusal can name what it compared."""
+        parts = [f"{axis}={value!r}" for axis, value in (("luid", self.luid), ("name", self.name)) if value]
+        if self.sha256:
+            parts.append(f"sha256={self.sha256[:12]}...")
+        return ", ".join(parts) or "no workbook identity"
+
+    def attribute(self, record: WorkbookIdentity) -> Attribution:
+        """Tie ``record`` to this unit, on the STRONGEST axis both sides carry.
+
+        ⚠️ **The first shared axis is decisive.** A mismatch there returns ``foreign`` and never falls
+        through to a weaker one - otherwise a foreign workbook that happens to share a display name
+        would be admitted on the name axis after its LUID had already said no. That fall-through is
+        the identity-loss join this module exists to make unrepresentable.
+
+        ⚠️ **The name axis is EXACT.** A normalized comparison would attribute one workbook's captures
+        to another whose name differs only by case or spacing. If a published display name genuinely
+        differs from the local artifact stem - `HR Dashboard` vs `HR_Dashboard` - the LUID is the
+        answer, and guessing across the difference is not.
+
+        No shared axis at all is ``unknown``: **cannot establish**, never "belongs to this unit".
+        """
+        for axis, mine, theirs in (
+            (WB_SHA, self.sha256, record.sha256),
+            (WB_LUID, self.luid, record.luid),
+            (WB_NAME, self.name, record.name),
+        ):
+            if mine is None or theirs is None:
+                continue
+            if _axis_equal(axis, mine, theirs):
+                return Attribution(axis, f"{axis} matches ({self.describe()})", axis=axis)
+            return Attribution(
+                WB_FOREIGN,
+                f"{axis} differs: unit {self.describe()} vs record {record.describe()}",
+                axis=axis,
+            )
+        return Attribution(
+            WB_UNKNOWN,
+            f"no shared identity axis: unit {self.describe()} vs record {record.describe()}",
+        )
+
+
+def _text(value: Any) -> str | None:
+    """A non-blank string, or None. Blank is absence, not an identity that compares equal."""
+    return value.strip() if isinstance(value, str) and value.strip() else None
+
+
+def _axis_equal(axis: str, mine: str, theirs: str) -> bool:
+    """Axis comparison. Machine ids are case-insensitive; a display NAME is compared exactly."""
+    return mine == theirs if axis == WB_NAME else mine.casefold() == theirs.casefold()
+
+
+def harvest_luid(stem: str | None) -> str | None:
+    """The LUID prefix of a `harvest_estate_assets.py` filename stem, or None for any other name.
+
+    ``<luid>_<sanitized-name>`` is the harvester's own convention (display names are not unique
+    across projects), so the prefix is this repo's own record of which published workbook it
+    downloaded - exact, and available with no server and no credentials. A hand-placed or renamed
+    workbook simply yields None and keeps the weaker routes, gaining nothing it did not ask for.
+    """
+    found = HARVEST_STEM_RE.match(stem or "")
+    return found.group("luid") if found else None
+
+
+def agreed_luid(*claims: str | None) -> str | None:
+    """The one LUID every non-blank claim agrees on, or None when they disagree.
+
+    Two identities that disagree are LESS evidence than none: a filename prefix that contradicts the
+    stamped provenance means one of them is about a different workbook, and picking whichever was
+    read first is exactly how a foreign render gets admitted. Disagreement therefore fails closed.
+    """
+    seen = {claim.strip().casefold() for claim in claims if isinstance(claim, str) and claim.strip()}
+    return seen.pop() if len(seen) == 1 else None

--- a/scripts/object_identity.py
+++ b/scripts/object_identity.py
@@ -72,6 +72,17 @@ WB_UNKNOWN = "unknown"
 #: that did not. Conflicting machine identities are LESS evidence than none.
 WB_CONFLICT = "conflicting-identity"
 
+#: What :func:`agreed_luid` returns when two non-blank claims DISAGREE, and what :meth:`
+#: WorkbookIdentity.attribute` reads as :data:`WB_CONFLICT` on whichever side declared it. It is a
+#: VALUE rather than an exception because the contradiction has to survive being stored on the
+#: identity: round-2 review of PR #454 measured both readers collapsing several declared LUIDs to
+#: the first one by SCOPE PRECEDENCE, so a contradicting manifest-level LUID vanished before
+#: :meth:`WorkbookIdentity.attribute` ever saw the record - entry gate `READY 1/1 exit 0`, exit gate
+#: `PASS visual=1 numeric=1`, `conflicting-identity` 0. Returning None would have re-armed exactly
+#: that, because an absent LUID is deliberately SILENT. No LUID can equal it: `<` never appears in
+#: one, and every claim is case-folded before comparison.
+LUID_CONTRADICTED = "<contradicted-luid-declarations>"
+
 #: The axes that identify a workbook to a MACHINE, and the ONLY ones that may certify a page. A
 #: record that claims one has told us how it must be checked; a unit that cannot answer it has
 #: established nothing.
@@ -529,7 +540,26 @@ class WorkbookIdentity:
         Note the asymmetry that :meth:`_contradiction` keeps: an axis the unit *cannot answer* is
         silent, an axis that *disagrees* is fatal, and collapsing the two would either re-open the
         fall-through above or refuse every record whose producer wrote fewer fields than ours.
+
+        ⚠️ **Round 2 of PR #454: a side may also contradict ITSELF, before any comparison happens.**
+        A manifest declares a LUID at several SCOPES (state, entry, manifest) and a unit at several
+        producers (handover slice, migration spec), and both readers used to take the first non-blank
+        one by scope precedence - so a contradicting claim was discarded before this method saw it.
+        :func:`agreed_luid` now folds every claim into one value and marks a disagreement with
+        :data:`LUID_CONTRADICTED`, which is read here, first, as :data:`WB_CONFLICT`. It is checked
+        before the axis walk because a self-contradicted LUID is not a claim that could match or
+        differ; there is nothing left to compare it against.
         """
+        if LUID_CONTRADICTED in (self.luid, record.luid):
+            side = "this unit" if self.luid == LUID_CONTRADICTED else "the record"
+            return Attribution(
+                WB_CONFLICT,
+                f"{side} declares two different workbook LUIDs at different scopes, so which "
+                f"workbook it is about is unanswerable: unit {self.describe()} vs record "
+                f"{record.describe()} - contradictory machine identities are less evidence than "
+                "none, and scope order is not a verdict",
+                axis=WB_LUID,
+            )
         for axis in WB_MACHINE_AXES:
             mine, theirs = getattr(self, _FIELD[axis]), getattr(record, _FIELD[axis])
             if theirs is None:
@@ -651,15 +681,25 @@ def persisted_stem(text: str | None) -> str:
     return PurePosixPath(persisted_name(text)).stem
 
 
-def agreed_luid(*claims: str | None) -> str | None:
-    """The one LUID every non-blank claim agrees on, or None when they disagree.
+def agreed_luid(*claims: Any) -> str | None:
+    """The one LUID every non-blank claim agrees on; :data:`LUID_CONTRADICTED` when two disagree.
+
+    **This is the single place any number of LUID claims become one.** Blank, whitespace and
+    non-string claims are ABSENT and stay silent; equal claims (case-insensitively, since a LUID is a
+    machine id) are one claim; two that differ are a contradiction.
 
     Two identities that disagree are LESS evidence than none: a filename prefix that contradicts the
-    stamped provenance means one of them is about a different workbook, and picking whichever was
-    read first is exactly how a foreign render gets admitted. Disagreement therefore fails closed.
+    stamped provenance, or a manifest-level LUID that contradicts the state-level one, means one of
+    them is about a different workbook, and picking whichever was read first is exactly how a foreign
+    render gets admitted. Disagreement therefore fails closed - and it does so by returning a value
+    that :meth:`WorkbookIdentity.attribute` refuses as :data:`WB_CONFLICT`, never None. Round 2 of PR
+    #454 measured why the distinction is load-bearing: an absent LUID is deliberately silent, so
+    reporting a contradiction as absence re-opens the fail-open one layer earlier.
     """
     seen = {claim.strip().casefold() for claim in claims if isinstance(claim, str) and claim.strip()}
-    return seen.pop() if len(seen) == 1 else None
+    if len(seen) > 1:
+        return LUID_CONTRADICTED
+    return seen.pop() if seen else None
 
 
 # ------------------------------------------------------------------------------------------------

--- a/scripts/object_identity.py
+++ b/scripts/object_identity.py
@@ -56,22 +56,38 @@ KIND_UNKNOWN = "unknown"
 WB_SHA = "sha256"
 WB_LUID = "luid"
 WB_NAME = "name"
+WB_UNCONFIRMED = "revision-unconfirmed"
 WB_STALE = "stale"
 WB_FOREIGN = "foreign"
 WB_UNKNOWN = "unknown"
 
-#: The axes that identify a workbook to a MACHINE. A record that claims one of these has told us how
-#: it must be checked, and a unit that cannot answer on that axis has not established anything - see
-#: :meth:`WorkbookIdentity.attribute`. ``WB_NAME`` is deliberately absent: a display name is not
-#: unique across projects.
+#: The axes that identify a workbook to a MACHINE, and the ONLY ones that may certify a page. A
+#: record that claims one has told us how it must be checked; a unit that cannot answer it has
+#: established nothing.
 WB_MACHINE_AXES = (WB_SHA, WB_LUID)
 
-#: Routes that admit, strongest first - also the order :meth:`WorkbookIdentity.attribute` consults
-#: them.
-WB_ROUTES = (WB_SHA, WB_LUID, WB_NAME)
+#: Routes that ADMIT, strongest first.
+#:
+#: ⚠️ ``WB_NAME`` is deliberately NOT here, and that is round-3's correction to the one rule. The rule
+#: as first written handled "the record claims a machine identity this unit cannot answer" and left
+#: the opposite case credited: a record claiming NO machine identity at all was admitted on an exact
+#: display name, which is the case where the name is LEAST trustworthy because nothing corroborates
+#: it. Measured by the reviewer::
+#:
+#:     unit:   luid=A, sha=AA, name=Book
+#:     record: name=Book only
+#:     -> route=name, admitted -> entry gate READY exit 0; exit gate PASS visual=1 numeric=1
+#:
+#: A workbook of the same display name in another project is indistinguishable from that record. A
+#: name is decoration - two projects may hold one, which is the ambiguity `_runs/<NNN>-<slug>/`
+#: numbering exists to avoid - so it may inform DISCOVERY and never certification. Measured cost on
+#: the 407 reference estate: ``census["name"] == 0``, i.e. nothing was being admitted this way.
+WB_ROUTES = (WB_SHA, WB_LUID)
 
-#: Every refusal, so a census can carry them all and a refusal is never silently absent.
-WB_REFUSALS = (WB_STALE, WB_FOREIGN, WB_UNKNOWN)
+#: Every refusal, so a census can carry them all and a refusal is never silently absent. ``WB_NAME``
+#: is a refusal that is REPORTED rather than discarded: "a name matched, and a name is not identity"
+#: is a different operator action from "nothing matched".
+WB_REFUSALS = (WB_NAME, WB_UNCONFIRMED, WB_STALE, WB_FOREIGN, WB_UNKNOWN)
 
 WB_ADMITTING = frozenset(WB_ROUTES)
 
@@ -481,14 +497,11 @@ class WorkbookIdentity:
         * both sides answer -> that axis is **decisive**: equal admits, unequal is ``foreign``, and
           neither is ever re-litigated by a weaker axis.
 
-        Only when the record claims **no** machine axis at all does the display name decide, and then
-        exactly: a normalized comparison would attribute one workbook's captures to another whose
-        name differs only by case or spacing.
-
-        ⚠️ The rule is deliberately one-directional, and the asymmetry is a known residual: a record
-        carrying ONLY a display name is still admitted against a unit that does have a LUID, because
-        nothing stronger is on offer from the producer. That route is the weakest one and every
-        admission through it is counted separately (``census["name"]``) so a reader can see it.
+        Only when the record claims **no** machine axis at all is the display name consulted, and
+        then it is reported as :data:`WB_NAME` - a REFUSAL that names what it saw. ⚠️ Round 3: it used
+        to be an admission, which is the moved-boundary shape. Machine-bearing records were made
+        safe while records carrying only the non-unique decoration stayed credited, and that is the
+        case where a name is least trustworthy because nothing corroborates it.
         """
         for axis in WB_MACHINE_AXES:
             mine, theirs = getattr(self, _FIELD[axis]), getattr(record, _FIELD[axis])
@@ -510,7 +523,12 @@ class WorkbookIdentity:
             )
         if self.name is not None and record.name is not None:
             if _axis_equal(WB_NAME, self.name, record.name):
-                return Attribution(WB_NAME, f"name matches ({self.describe()})", axis=WB_NAME)
+                return Attribution(
+                    WB_NAME,
+                    f"only a display NAME matches ({self.describe()}), and a name is not identity - "
+                    "another project may hold a workbook of the same name, so this certifies nothing",
+                    axis=WB_NAME,
+                )
             return Attribution(
                 WB_FOREIGN,
                 f"name differs: unit {self.describe()} vs record {record.describe()}",
@@ -592,11 +610,10 @@ def agreed_luid(*claims: str | None) -> str | None:
 # REVISION identity - which BUILD of a workbook, as opposed to which workbook
 # ------------------------------------------------------------------------------------------------
 
-#: Content-normalised digest of a Tableau archive: sha256 over the sorted
-#: ``(member name, sha256(normalised member bytes))`` pairs, so neither zip member ORDER and mtimes
-#: nor an XML build-stamp comment can change it. ``v2`` because ``v1`` normalised the zip only - see
-#: :func:`revision_key`.
-REVISION_ALGO_ARCHIVE = "twbx-content-v2"
+#: Content-normalised digest of a Tableau archive: sha256 over the sorted, LENGTH-PREFIXED
+#: ``(member name, sha256(normalised member bytes))`` pairs, read entry-by-entry from ``infolist()``.
+#: ``v3`` because the method has been corrected twice - see :func:`revision_key`.
+REVISION_ALGO_ARCHIVE = "twbx-content-v3"
 
 #: Comment-normalised digest of a flat Tableau XML payload - a `.twb`/`.tds` served whole rather than
 #: inside an archive. Same normalisation as an XML member of an archive, because it is the same file.
@@ -706,13 +723,25 @@ def revision_key(payload: bytes) -> RevisionKey | None:
 
     Three explicit SHAPES, each with its own versioned algorithm, and no silent path between them:
 
-    * an archive -> every member digested, XML members comment-normalised (``twbx-content-v2``);
+    * an archive -> every member digested, XML members comment-normalised (``twbx-content-v3``);
     * flat Tableau XML -> comment-normalised (``tableau-xml-v1``);
     * anything else -> its raw bytes, named as such (``raw-sha256-v1``).
 
-    ⚠️ None means **cannot establish**: the bytes look like an archive but will not open. That case is
-    never quietly downgraded to a raw hash, because a raw hash of a repacked archive is the unstable
-    value this whole type exists to avoid - see :class:`RevisionKey` for the measurement.
+    ⚠️ **The archive method is corrected, and the corrections are the point.** An earlier version read
+    members with ``ZipFile.read(name)``, which resolves a NAME: a zip carrying two entries with the
+    same filename would have had the first one read twice, so a change to it alone left the digest
+    identical. Entries are now read from :meth:`ZipFile.infolist` through :meth:`ZipFile.open`, which
+    addresses the entry itself. Names and digests are LENGTH-PREFIXED before hashing, so no two
+    different member lists can serialise to the same byte stream.
+
+    ⚠️ **Duplicate member names, an archive comment and member extra fields are REFUSED, not
+    ignored.** Each is a place to hide bytes that the digest would not cover, and refusing yields no
+    key at all - which reads as *cannot establish*, never as agreement. Measured on the 407 reference
+    estate: 49 of 49 archives carry none of the three, so the strict rule refuses nothing real.
+
+    ⚠️ None also means the bytes look like an archive but will not open. That case is never quietly
+    downgraded to a raw hash, because a raw hash of a repacked archive is the unstable value this
+    whole type exists to avoid - see :class:`RevisionKey` for the measurement.
     """
     if not payload:
         return None
@@ -722,17 +751,33 @@ def revision_key(payload: bytes) -> RevisionKey | None:
         return RevisionKey(algo=REVISION_ALGO_FLAT, value=hashlib.sha256(payload).hexdigest())
     try:
         with zipfile.ZipFile(io.BytesIO(payload)) as archive:
+            if archive.comment:
+                return None
+            entries = archive.infolist()
+            if len({info.filename for info in entries}) != len(entries):
+                return None
+            if any(info.extra for info in entries):
+                return None
             members = sorted(
-                (info.filename, _normalise_member(info.filename, archive.read(info.filename)))
-                for info in archive.infolist()
+                (info.filename, _normalise_member(info.filename, _read_entry(archive, info))) for info in entries
             )
     except (zipfile.BadZipFile, OSError, RuntimeError, ValueError):
         return None
     digest = hashlib.sha256()
     for name, data in members:
-        digest.update(name.encode("utf-8"))
+        encoded = name.encode("utf-8")
+        # Length-prefixed, so `("ab", X) ("c", Y)` and `("a", X') ("bc", Y')` cannot serialise alike.
+        digest.update(len(encoded).to_bytes(8, "big"))
+        digest.update(encoded)
+        digest.update(len(data).to_bytes(8, "big"))
         digest.update(hashlib.sha256(data).digest())
     return RevisionKey(algo=REVISION_ALGO_ARCHIVE, value=digest.hexdigest())
+
+
+def _read_entry(archive: zipfile.ZipFile, info: zipfile.ZipInfo) -> bytes:
+    """One member's bytes, addressed by ENTRY rather than by name. See :func:`revision_key`."""
+    with archive.open(info) as handle:
+        return handle.read()
 
 
 def _normalise_member(name: str, data: bytes) -> bytes:

--- a/scripts/object_identity.py
+++ b/scripts/object_identity.py
@@ -61,6 +61,17 @@ WB_STALE = "stale"
 WB_FOREIGN = "foreign"
 WB_UNKNOWN = "unknown"
 
+#: Two MACHINE axes both answered and CONTRADICTED each other - the record's bytes are this unit's
+#: source but its LUID names another workbook, or the reverse. Its own route, not folded into
+#: ``WB_FOREIGN``, because it is a different operator action: `foreign` says "this is someone else's
+#: capture, ignore it", `conflicting-identity` says "this record's own metadata disagrees with
+#: itself, so one of the two claims is wrong and neither can be believed". Round-N review of PR #454
+#: measured what folding it into the winning axis costs: a record whose sha256 matched and whose LUID
+#: belonged to another workbook reached `READY 1/1` at the entry gate and `PASS visual=1 numeric=1` at
+#: the exit gate, because the walk returned on the first axis that agreed and never looked at the one
+#: that did not. Conflicting machine identities are LESS evidence than none.
+WB_CONFLICT = "conflicting-identity"
+
 #: The axes that identify a workbook to a MACHINE, and the ONLY ones that may certify a page. A
 #: record that claims one has told us how it must be checked; a unit that cannot answer it has
 #: established nothing.
@@ -87,7 +98,7 @@ WB_ROUTES = (WB_SHA, WB_LUID)
 #: Every refusal, so a census can carry them all and a refusal is never silently absent. ``WB_NAME``
 #: is a refusal that is REPORTED rather than discarded: "a name matched, and a name is not identity"
 #: is a different operator action from "nothing matched".
-WB_REFUSALS = (WB_NAME, WB_UNCONFIRMED, WB_STALE, WB_FOREIGN, WB_UNKNOWN)
+WB_REFUSALS = (WB_NAME, WB_UNCONFIRMED, WB_STALE, WB_CONFLICT, WB_FOREIGN, WB_UNKNOWN)
 
 WB_ADMITTING = frozenset(WB_ROUTES)
 
@@ -476,8 +487,14 @@ class WorkbookIdentity:
             parts.append(f"sha256={self.sha256[:12]}...")
         return ", ".join(parts) or "no workbook identity"
 
-    def attribute(self, record: WorkbookIdentity) -> Attribution:
+    def attribute(self, record: WorkbookIdentity) -> Attribution:  # pylint: disable=too-many-return-statements
         """Tie ``record`` to this unit. **A machine identity the unit cannot answer is ``unknown``.**
+
+        ⚠️ ``too-many-return-statements`` is disabled deliberately, for the same reason as
+        :func:`revision_key`: all seven returns are *distinct verdicts*, each carrying the ``detail``
+        string an operator acts on, and this whole file exists so a caller can tell one refusal from
+        another. Funnelling them through shared exits would satisfy the checker by making "which
+        guard refused" unreadable in the one place this repo most needs it legible.
 
         This is the one rule, and it replaced four separate fail-open patches (round-1 review of PR
         #454). Read it as a single sentence:
@@ -502,6 +519,16 @@ class WorkbookIdentity:
         to be an admission, which is the moved-boundary shape. Machine-bearing records were made
         safe while records carrying only the non-unique decoration stayed credited, and that is the
         case where a name is least trustworthy because nothing corroborates it.
+
+        ⚠️ **Round N: an axis that agrees does not end the walk.** "Decisive" above was read as
+        "returns", so the FIRST agreeing axis won and the rest were never consulted - and a record
+        whose sha256 matched this unit while its LUID named another workbook was admitted on the
+        sha256 and reached `READY 1/1` / `PASS visual=1 numeric=1`. Every machine axis both sides can
+        answer is now compared before anything is admitted, and an active CONTRADICTION between two
+        of them is :data:`WB_CONFLICT`: a refusal in its own right, never resolved by axis priority.
+        Note the asymmetry that :meth:`_contradiction` keeps: an axis the unit *cannot answer* is
+        silent, an axis that *disagrees* is fatal, and collapsing the two would either re-open the
+        fall-through above or refuse every record whose producer wrote fewer fields than ours.
         """
         for axis in WB_MACHINE_AXES:
             mine, theirs = getattr(self, _FIELD[axis]), getattr(record, _FIELD[axis])
@@ -515,6 +542,12 @@ class WorkbookIdentity:
                     axis=axis,
                 )
             if _axis_equal(axis, mine, theirs):
+                # ⚠️ `or` is unavailable here: `Attribution.__bool__` RAISES on purpose, so a
+                # truthiness shortcut would blow up on exactly the contradictory records this guard
+                # exists to catch. Compare against None explicitly.
+                conflict = self._contradiction(record, decided=axis)
+                if conflict is not None:
+                    return conflict
                 return Attribution(axis, f"{axis} matches ({self.describe()})", axis=axis)
             return Attribution(
                 WB_FOREIGN,
@@ -538,6 +571,29 @@ class WorkbookIdentity:
             WB_UNKNOWN,
             f"no shared identity axis: unit {self.describe()} vs record {record.describe()}",
         )
+
+    def _contradiction(self, record: WorkbookIdentity, *, decided: str) -> Attribution | None:
+        """A machine axis OTHER than ``decided`` that both sides answer and that DISAGREES, or None.
+
+        Only a disagreement counts. An axis the record does not claim, or one this unit cannot
+        answer, is silent here: those are "less evidence", and the walk in :meth:`attribute` already
+        decides what they mean. This function answers only the narrower question the axis-priority
+        return used to skip - *does anything the record says contradict the axis that just agreed?*
+        """
+        for axis in WB_MACHINE_AXES:
+            if axis == decided:
+                continue
+            mine, theirs = getattr(self, _FIELD[axis]), getattr(record, _FIELD[axis])
+            if mine is None or theirs is None or _axis_equal(axis, mine, theirs):
+                continue
+            return Attribution(
+                WB_CONFLICT,
+                f"the record's {decided} matches this unit but its {axis} does not: unit "
+                f"{self.describe()} vs record {record.describe()} - contradictory machine "
+                "identities are less evidence than none, so neither claim may certify anything",
+                axis=axis,
+            )
+        return None
 
 
 #: Which field each axis reads. A mapping rather than a tuple of triples so the axis names in
@@ -718,8 +774,15 @@ def _is_xml(payload: bytes) -> bool:
     return head.startswith(XML_PREFIXES)
 
 
-def revision_key(payload: bytes) -> RevisionKey | None:
+def revision_key(payload: bytes) -> RevisionKey | None:  # pylint: disable=too-many-return-statements
     """The reproducible build digest of one Tableau asset, or None when it cannot be computed.
+
+    ⚠️ ``too-many-return-statements`` is disabled ON PURPOSE rather than refactored away. All eight
+    returns are distinct verdicts this function exists to make - three payload SHAPES and four named
+    REFUSALS, each with its own comment saying what it refuses and why - and this repo's rule is that
+    a fail-closed guard must be identifiable, not merely present. Merging them behind shared exit
+    points would satisfy the checker by making "which guard refused" unreadable, which is the wrong
+    trade in exactly the code where it matters most.
 
     Three explicit SHAPES, each with its own versioned algorithm, and no silent path between them:
 

--- a/scripts/object_identity.py
+++ b/scripts/object_identity.py
@@ -42,23 +42,34 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass, field
+from pathlib import PurePosixPath
 from typing import Any, Generic, TypeVar
 
 KIND_DASHBOARD = "dashboard"
 KIND_WORKSHEET = "worksheet"
 KIND_UNKNOWN = "unknown"
 
-#: How a render was tied to a unit's workbook. The first three ADMIT; the last two REFUSE.
+#: How a render was tied to a unit's workbook. The first three ADMIT; the rest REFUSE.
 WB_SHA = "sha256"
 WB_LUID = "luid"
 WB_NAME = "name"
+WB_STALE = "stale"
 WB_FOREIGN = "foreign"
 WB_UNKNOWN = "unknown"
 
-#: Routes that admit. Ordered strongest-first, which is also the order :meth:`WorkbookIdentity.attribute`
-#: consults them - a stronger axis, once BOTH sides carry it, is decisive and is never re-litigated by
-#: a weaker one.
+#: The axes that identify a workbook to a MACHINE. A record that claims one of these has told us how
+#: it must be checked, and a unit that cannot answer on that axis has not established anything - see
+#: :meth:`WorkbookIdentity.attribute`. ``WB_NAME`` is deliberately absent: a display name is not
+#: unique across projects.
+WB_MACHINE_AXES = (WB_SHA, WB_LUID)
+
+#: Routes that admit, strongest first - also the order :meth:`WorkbookIdentity.attribute` consults
+#: them.
 WB_ROUTES = (WB_SHA, WB_LUID, WB_NAME)
+
+#: Every refusal, so a census can carry them all and a refusal is never silently absent.
+WB_REFUSALS = (WB_STALE, WB_FOREIGN, WB_UNKNOWN)
+
 WB_ADMITTING = frozenset(WB_ROUTES)
 
 #: `harvest_estate_assets.py` names every download `<luid>_<sanitized-name><ext>`, which is the only
@@ -67,6 +78,10 @@ WB_ADMITTING = frozenset(WB_ROUTES)
 HARVEST_STEM_RE = re.compile(
     r"^(?P<luid>[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})_(?P<rest>.+)$"
 )
+
+#: Either separator, because a path RECORDED BY ANOTHER HOST is text, not a path. See
+#: :func:`persisted_name`.
+PATH_SEPARATORS = re.compile(r"[\\/]+")
 
 #: The only kinds an identity may carry. `KIND_UNKNOWN` is deliberately absent: an object whose kind
 #: is unknown has no identity, which is the whole point.
@@ -439,27 +454,46 @@ class WorkbookIdentity:
         return ", ".join(parts) or "no workbook identity"
 
     def attribute(self, record: WorkbookIdentity) -> Attribution:
-        """Tie ``record`` to this unit, on the STRONGEST axis both sides carry.
+        """Tie ``record`` to this unit. **A machine identity the unit cannot answer is ``unknown``.**
 
-        ⚠️ **The first shared axis is decisive.** A mismatch there returns ``foreign`` and never falls
-        through to a weaker one - otherwise a foreign workbook that happens to share a display name
-        would be admitted on the name axis after its LUID had already said no. That fall-through is
-        the identity-loss join this module exists to make unrepresentable.
+        This is the one rule, and it replaced four separate fail-open patches (round-1 review of PR
+        #454). Read it as a single sentence:
 
-        ⚠️ **The name axis is EXACT.** A normalized comparison would attribute one workbook's captures
-        to another whose name differs only by case or spacing. If a published display name genuinely
-        differs from the local artifact stem - `HR Dashboard` vs `HR_Dashboard` - the LUID is the
-        answer, and guessing across the difference is not.
+            *If a record carries a machine identity - a source sha256 or a workbook LUID - that this
+            unit cannot establish or compare, the result is ``unknown``. There is no fall-through to a
+            weaker axis, and location never substitutes for a failed or unestablished join.*
 
-        No shared axis at all is ``unknown``: **cannot establish**, never "belongs to this unit".
+        Concretely, walking :data:`WB_MACHINE_AXES` strongest-first:
+
+        * the record makes no claim on this axis -> try the next one;
+        * the record claims it and the unit cannot answer -> **``unknown``**, stop. ⚠️ This is the
+          half that was missing. A real oracle record carries ``workbook_luid`` AND ``workbook_name``,
+          so skipping an *unshared* LUID and admitting on an equal display name let a FOREIGN
+          workbook certify a page in both gates - measured, `READY 1/1` and `PASS visual+numeric`,
+          on a record whose LUID belonged to another workbook entirely;
+        * both sides answer -> that axis is **decisive**: equal admits, unequal is ``foreign``, and
+          neither is ever re-litigated by a weaker axis.
+
+        Only when the record claims **no** machine axis at all does the display name decide, and then
+        exactly: a normalized comparison would attribute one workbook's captures to another whose
+        name differs only by case or spacing.
+
+        ⚠️ The rule is deliberately one-directional, and the asymmetry is a known residual: a record
+        carrying ONLY a display name is still admitted against a unit that does have a LUID, because
+        nothing stronger is on offer from the producer. That route is the weakest one and every
+        admission through it is counted separately (``census["name"]``) so a reader can see it.
         """
-        for axis, mine, theirs in (
-            (WB_SHA, self.sha256, record.sha256),
-            (WB_LUID, self.luid, record.luid),
-            (WB_NAME, self.name, record.name),
-        ):
-            if mine is None or theirs is None:
+        for axis in WB_MACHINE_AXES:
+            mine, theirs = getattr(self, _FIELD[axis]), getattr(record, _FIELD[axis])
+            if theirs is None:
                 continue
+            if mine is None:
+                return Attribution(
+                    WB_UNKNOWN,
+                    f"the record is identified by {axis} ({record.describe()}) and this unit "
+                    f"establishes none, so nothing can be compared - unit {self.describe()}",
+                    axis=axis,
+                )
             if _axis_equal(axis, mine, theirs):
                 return Attribution(axis, f"{axis} matches ({self.describe()})", axis=axis)
             return Attribution(
@@ -467,10 +501,23 @@ class WorkbookIdentity:
                 f"{axis} differs: unit {self.describe()} vs record {record.describe()}",
                 axis=axis,
             )
+        if self.name is not None and record.name is not None:
+            if _axis_equal(WB_NAME, self.name, record.name):
+                return Attribution(WB_NAME, f"name matches ({self.describe()})", axis=WB_NAME)
+            return Attribution(
+                WB_FOREIGN,
+                f"name differs: unit {self.describe()} vs record {record.describe()}",
+                axis=WB_NAME,
+            )
         return Attribution(
             WB_UNKNOWN,
             f"no shared identity axis: unit {self.describe()} vs record {record.describe()}",
         )
+
+
+#: Which field each axis reads. A mapping rather than a tuple of triples so the axis names in
+#: :data:`WB_MACHINE_AXES` and the fields cannot drift apart.
+_FIELD = {WB_SHA: "sha256", WB_LUID: "luid", WB_NAME: "name"}
 
 
 def _text(value: Any) -> str | None:
@@ -490,9 +537,37 @@ def harvest_luid(stem: str | None) -> str | None:
     across projects), so the prefix is this repo's own record of which published workbook it
     downloaded - exact, and available with no server and no credentials. A hand-placed or renamed
     workbook simply yields None and keeps the weaker routes, gaining nothing it did not ask for.
+
+    ⚠️ Feed this :func:`persisted_stem`, never ``Path(...).stem``. See that function.
     """
     found = HARVEST_STEM_RE.match(stem or "")
     return found.group("luid") if found else None
+
+
+def persisted_name(text: str | None) -> str:
+    """The final segment of a path RECORDED BY ANOTHER HOST, on either host.
+
+    ⚠️ ``pathlib.Path`` is the *running* host's flavour, and that is a safety bug rather than a
+    portability nicety. A real handover slice records
+    ``_runs\\407-dryrun-gates\\assets\\<luid>_HR_Dashboard.twbx``; on POSIX those backslashes are
+    ordinary filename characters, so ``Path(...).stem`` returns the whole string, `harvest_luid` sees
+    no prefix, and the unit ends up with **no LUID** - which is exactly the state that used to let a
+    weaker axis admit a foreign record. Measured: the same input yields the LUID under
+    ``PureWindowsPath`` and ``None`` under ``PurePosixPath``, so a guard behaved differently in the
+    two places we look (a Windows workstation and a Linux CI runner).
+
+    Splitting on BOTH separators is host-independent by construction. It is safe for this data
+    because these paths are written by `harvest_estate_assets.safe_component`, which rewrites every
+    character outside ``[A-Za-z0-9-_]`` - a literal backslash can never appear inside a name.
+    """
+    raw = (text or "").strip()
+    stripped = PATH_SEPARATORS.sub("/", raw).rstrip("/")
+    return stripped.rsplit("/", 1)[-1] if stripped else ""
+
+
+def persisted_stem(text: str | None) -> str:
+    """:func:`persisted_name` without its extension - what :func:`harvest_luid` expects."""
+    return PurePosixPath(persisted_name(text)).stem
 
 
 def agreed_luid(*claims: str | None) -> str | None:

--- a/scripts/object_identity.py
+++ b/scripts/object_identity.py
@@ -40,9 +40,12 @@ a method is *missing* proves nothing - that is the ninth vacuity mode this repo 
 
 from __future__ import annotations
 
+import hashlib
+import io
 import re
+import zipfile
 from dataclasses import dataclass, field
-from pathlib import PurePosixPath
+from pathlib import Path, PurePosixPath
 from typing import Any, Generic, TypeVar
 
 KIND_DASHBOARD = "dashboard"
@@ -82,6 +85,10 @@ HARVEST_STEM_RE = re.compile(
 #: Either separator, because a path RECORDED BY ANOTHER HOST is text, not a path. See
 #: :func:`persisted_name`.
 PATH_SEPARATORS = re.compile(r"[\\/]+")
+
+#: A `.twbx`/`.tdsx` is a zip; a `.twb`/`.tds` is XML. The magic decides which revision-key algorithm
+#: applies, rather than a file extension a caller may not have.
+ZIP_MAGIC = b"PK\x03\x04"
 
 #: The only kinds an identity may carry. `KIND_UNKNOWN` is deliberately absent: an object whose kind
 #: is unknown has no identity, which is the whole point.
@@ -579,3 +586,163 @@ def agreed_luid(*claims: str | None) -> str | None:
     """
     seen = {claim.strip().casefold() for claim in claims if isinstance(claim, str) and claim.strip()}
     return seen.pop() if len(seen) == 1 else None
+
+
+# ------------------------------------------------------------------------------------------------
+# REVISION identity - which BUILD of a workbook, as opposed to which workbook
+# ------------------------------------------------------------------------------------------------
+
+#: Content-normalised digest of a Tableau archive: sha256 over the sorted
+#: ``(member name, sha256(normalised member bytes))`` pairs, so neither zip member ORDER and mtimes
+#: nor an XML build-stamp comment can change it. ``v2`` because ``v1`` normalised the zip only - see
+#: :func:`revision_key`.
+REVISION_ALGO_ARCHIVE = "twbx-content-v2"
+
+#: Comment-normalised digest of a flat Tableau XML payload - a `.twb`/`.tds` served whole rather than
+#: inside an archive. Same normalisation as an XML member of an archive, because it is the same file.
+REVISION_ALGO_XML = "tableau-xml-v1"
+
+#: Raw sha256, for a payload that is neither an archive nor XML. Kept as an explicit, named SHAPE so
+#: no payload silently falls through to it - see :func:`revision_key`.
+REVISION_ALGO_FLAT = "raw-sha256-v1"
+
+#: Members whose bytes are Tableau XML, and so carry the build-stamp comment normalised below.
+XML_MEMBER_SUFFIXES = (".twb", ".tds")
+
+#: ``<!-- build 20263.26.0824.1544 -->`` - the TABLEAU SERVER build that serialised the file, stamped
+#: into every `.twb` it hands out. It is not workbook content, and it changes when the SERVER is
+#: upgraded. See :func:`_normalise_xml`.
+XML_COMMENT_RE = re.compile(rb"<!--.*?-->", re.DOTALL)
+
+#: What a Tableau XML payload starts with, after any BOM. Cheap and exact enough to pick the shape.
+XML_PREFIXES = (b"<?xml", b"<workbook", b"<datasource")
+
+
+@dataclass(frozen=True)
+class RevisionKey:
+    """A reproducible digest of WHICH BUILD a Tableau asset is, with the algorithm that made it.
+
+    ⚠️ **Measured 2026-09-03 against the live site, 3 downloads of every item in one run.** A raw
+    ``sha256`` of a `.twbx` download is **not** reproducible: Tableau Server repacks the archive per
+    request, so the same unchanged workbook hashes differently.
+
+    | over 48 workbooks + all datasources | raw sha256 | content digest |
+    |---|---|---|
+    | DIFFERS across downloads in one run | **13 of 48** workbooks | **0** |
+
+    Every repacker had identical byte length and an identical content digest, and the population is
+    itself unstable - ``World Indicators`` differed in one sample and agreed minutes later - so a raw
+    digest does not merely fail for a fixed subset: any ``confirmed`` verdict it produces is luck.
+    That measurement is why the revision key exists rather than a bare ``sha256`` comparison, and why
+    it is **versioned**: a value computed by a different algorithm must read as *cannot compare*, not
+    as *drift*, or every pre-existing capture raises a false alarm.
+
+    ⚠️ ``REVISION_ALGO_FLAT`` is **not a fallback**, and the distinction is the whole safety property.
+    A payload that IS an archive but cannot be read yields **no key at all** (see :func:`revision_key`)
+    - silently re-hashing those bytes raw is exactly what re-opens the defect. A payload that is not
+    an archive is a different SHAPE, whose bytes are already its content: measured, every non-archive
+    item on the site returned a stable raw digest across all three downloads.
+    """
+
+    algo: str
+    value: str
+
+    def as_json(self) -> dict[str, str]:
+        """The persisted form. Both halves, always - a value without its algorithm is uncomparable."""
+        return {"algo": self.algo, "value": self.value}
+
+    @classmethod
+    def from_json(cls, payload: Any) -> RevisionKey | None:
+        """Read a persisted key, or None for anything that is not a complete one."""
+        if not isinstance(payload, dict):
+            return None
+        algo, value = _text(payload.get("algo")), _text(payload.get("value"))
+        return cls(algo=algo, value=value) if algo and value else None
+
+    def agrees_with(self, other: RevisionKey | None) -> bool | None:
+        """``True``/``False`` when the two are comparable, ``None`` when they are NOT.
+
+        ``None`` is the important return. Two keys made by different algorithms say nothing about
+        each other, so the answer is *cannot establish* - never *drift*. An old manifest carrying an
+        earlier algorithm therefore reads ``unconfirmed``, which is the whole reason the key is
+        versioned.
+        """
+        if other is None or self.algo != other.algo:
+            return None
+        return self.value.casefold() == other.value.casefold()
+
+
+def _normalise_xml(data: bytes) -> bytes:
+    """Tableau XML with the SERVER's own nonces removed.
+
+    ⚠️ Measured 2026-09-03, and it is why the archive key is ``v2`` and the flat key exists at all.
+    Normalising the zip alone was not enough: comparing the 78 harvested assets against the site,
+    **28** reported a content difference, and diffing six of them - three inside a `.twbx`, three
+    served flat - showed the ENTIRE difference was one line, every time::
+
+        -<!-- build 20263.26.0824.1544 -->
+        +<!-- build 20263.26.0828.1352 -->
+
+    That is the Tableau **server** build that serialised the file. It moved because the site was
+    upgraded between the harvest and the check, not because any workbook changed - most of those
+    files were byte-identical in length. Left in, it produces a false drift alarm for every asset
+    harvested before a server upgrade: the same false-alarm-at-scale failure the content key exists
+    to remove, one layer further in. With it removed, 28 false ``differs`` became 0.
+
+    Only XML comments are stripped: a comment is not migrated content, and everything that is -
+    marks, calculations, connections, parameters - lives in elements and attributes.
+    """
+    return XML_COMMENT_RE.sub(b"", data)
+
+
+def _is_xml(payload: bytes) -> bool:
+    """Whether a non-archive payload is Tableau XML, so the same normalisation applies."""
+    head = payload.lstrip(b"\xef\xbb\xbf").lstrip()[:16]
+    return head.startswith(XML_PREFIXES)
+
+
+def revision_key(payload: bytes) -> RevisionKey | None:
+    """The reproducible build digest of one Tableau asset, or None when it cannot be computed.
+
+    Three explicit SHAPES, each with its own versioned algorithm, and no silent path between them:
+
+    * an archive -> every member digested, XML members comment-normalised (``twbx-content-v2``);
+    * flat Tableau XML -> comment-normalised (``tableau-xml-v1``);
+    * anything else -> its raw bytes, named as such (``raw-sha256-v1``).
+
+    ⚠️ None means **cannot establish**: the bytes look like an archive but will not open. That case is
+    never quietly downgraded to a raw hash, because a raw hash of a repacked archive is the unstable
+    value this whole type exists to avoid - see :class:`RevisionKey` for the measurement.
+    """
+    if not payload:
+        return None
+    if not payload.startswith(ZIP_MAGIC):
+        if _is_xml(payload):
+            return RevisionKey(algo=REVISION_ALGO_XML, value=hashlib.sha256(_normalise_xml(payload)).hexdigest())
+        return RevisionKey(algo=REVISION_ALGO_FLAT, value=hashlib.sha256(payload).hexdigest())
+    try:
+        with zipfile.ZipFile(io.BytesIO(payload)) as archive:
+            members = sorted(
+                (info.filename, _normalise_member(info.filename, archive.read(info.filename)))
+                for info in archive.infolist()
+            )
+    except (zipfile.BadZipFile, OSError, RuntimeError, ValueError):
+        return None
+    digest = hashlib.sha256()
+    for name, data in members:
+        digest.update(name.encode("utf-8"))
+        digest.update(hashlib.sha256(data).digest())
+    return RevisionKey(algo=REVISION_ALGO_ARCHIVE, value=digest.hexdigest())
+
+
+def _normalise_member(name: str, data: bytes) -> bytes:
+    """One archive member's bytes, comment-normalised when it is Tableau XML. See :func:`_normalise_xml`."""
+    return _normalise_xml(data) if name.lower().endswith(XML_MEMBER_SUFFIXES) else data
+
+
+def revision_key_of(path: Path) -> RevisionKey | None:
+    """:func:`revision_key` for a file on disk, or None when it cannot be read."""
+    try:
+        return revision_key(path.read_bytes())
+    except OSError:
+        return None

--- a/scripts/reference_evidence.py
+++ b/scripts/reference_evidence.py
@@ -31,9 +31,9 @@ from object_identity import (
     KIND_UNKNOWN,
     KIND_WORKSHEET,
     WB_LUID,
-    WB_NAME,
     WB_SHA,
     WB_STALE,
+    WB_UNCONFIRMED,
     Attribution,
     Candidate,
     WorkbookIdentity,
@@ -388,27 +388,39 @@ class Evidence:  # pylint: disable=too-many-instance-attributes
 
         The REVISION half is here, because it is this gate's contract rather than a property of
         identity: evidence must be for "THIS workbook, at THIS revision". A sha256 join is
-        revision-bound by construction, so it passes through confirmed. A LUID or name join says
-        *which* workbook, never *which build of it*, so it inherits the unit's revision status:
+        revision-bound by construction, so it passes through confirmed. A LUID join says *which*
+        workbook, never *which build of it*, so it inherits the unit's revision status:
 
-        * :data:`REVISION_MISMATCH` - drift is SOUNDLY established, so the render is
-          :data:`object_identity.WB_STALE` and certifies nothing;
-        * :data:`REVISION_UNCONFIRMED` - the render is admitted, and the caller MUST disclose that
-          the revision was not established (:func:`check_reference_readiness._page_row` writes
-          ``row["revision"]``). Round-1 review of PR #454's blocker 2 was exactly that a page in this
-          state read as a clean `READY` with nothing saying so.
+        * :data:`REVISION_MISMATCH` -> :data:`object_identity.WB_STALE`;
+        * :data:`REVISION_UNCONFIRMED` -> :data:`object_identity.WB_UNCONFIRMED`.
+
+        ⚠️ Round 3: ``unconfirmed`` used to be ADMITTED with a note, and that was fail-open. The human
+        output's first line said `READY` and the caveat came later, which is not disclosure a
+        consumer acts on. Neither refusal certifies anything now; both are counted, and
+        :func:`check_reference_readiness._page_row` reports the page UNVERIFIABLE with the reason.
 
         ⚠️ Absence of provenance, and a byte comparison that could not be made soundly, are both
         UNCONFIRMED rather than mismatched. "I cannot tell whether the bytes moved" and "I can tell,
-        and they did" are different statements, and only the second may refuse a page.
+        and they did" are different statements, and they call for different operator actions -
+        re-stamp provenance versus re-capture against the migrated build.
         """
         verdict = unit.workbook().attribute(self.workbook())
-        if verdict.route in (WB_LUID, WB_NAME) and unit.revision == REVISION_MISMATCH:
+        if verdict.route != WB_LUID:
+            return verdict
+        if unit.revision == REVISION_MISMATCH:
             return Attribution(
                 WB_STALE,
                 "the same workbook, a DIFFERENT build: this unit's source bytes differ from a "
-                f"REPRODUCIBLE download of the site copy, and a {verdict.axis} join says which "
-                "workbook a render is of, never which revision",
+                "REPRODUCIBLE content digest of the site copy, and a luid join says which workbook a "
+                "render is of, never which revision",
+                axis=verdict.axis,
+            )
+        if unit.revision != REVISION_CONFIRMED:
+            return Attribution(
+                WB_UNCONFIRMED,
+                "the right workbook, at an UNESTABLISHED build: a luid join says which workbook a "
+                "render is of, never which revision, and this unit's provenance carries no "
+                "comparable revision key - re-stamp it with scripts/stamp_tableau_provenance.py",
                 axis=verdict.axis,
             )
         return verdict
@@ -417,7 +429,9 @@ class Evidence:  # pylint: disable=too-many-instance-attributes
         """What this render establishes about the REVISION, once it has been admitted.
 
         A sha256 join pins the bytes, so it is confirmed whatever provenance says. Anything weaker
-        inherits the unit's status, which is why an admitted render can still be UNCONFIRMED.
+        inherits the unit's status - and since round 3 an admitted render is always CONFIRMED,
+        because everything else is refused. The field stays because a reader should see the claim
+        stated rather than inferred from its absence.
         """
         return REVISION_CONFIRMED if self.attribution(unit).route == WB_SHA else unit.revision
 

--- a/scripts/reference_evidence.py
+++ b/scripts/reference_evidence.py
@@ -23,7 +23,7 @@ import struct
 import zlib
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterable
 from xml.etree import ElementTree
 
 from object_identity import (
@@ -34,6 +34,7 @@ from object_identity import (
     WB_SHA,
     WB_STALE,
     WB_UNCONFIRMED,
+    AmbiguousIdentity,
     Attribution,
     Candidate,
     WorkbookIdentity,
@@ -193,22 +194,72 @@ def provenance_origin(root: Path, source_sha: str, source: Path | None = None) -
     Anything with no comparable key - including no provenance at all - is ``unconfirmed``, which is
     admitted and DISCLOSED rather than silently claimed as current (round-1 review of PR #454,
     blocker 2).
+
+    ⚠️ **Every record matching ``source_sha`` is read, and the verdict does not depend on their
+    order.** This used to ``return`` on the first SHA hit, so two provenance records carrying the
+    same source digest and DIFFERENT ``workbook_luid`` values resolved to whichever came first in the
+    JSON. Measured by the round-N reviewer on byte-identical evidence, reversing only the array
+    order::
+
+        AMBIGUOUS_FIRST    = {"status":"READY",   "pages_ready":1, "luid":1,    "exit":0}
+        AMBIGUOUS_REVERSED = {"status":"FINDINGS","pages_ready":0, "foreign":1, "exit":1}
+
+    One of those records is about another workbook and nothing here says which, so this raises
+    :class:`object_identity.AmbiguousIdentity` - a *cannot establish*, which
+    `check_reference_readiness.assess_unit` turns into ``CANNOT_ESTABLISH`` and which is explicitly
+    never a pass. Where the records merely disagree about the REVISION they are folded to the
+    weakest claim they support, which is likewise order-free and fails closed.
     """
     stamped = harvest_luid(persisted_stem(source.name if source is not None else None))
     inputs = list((json_object(root / "source-provenance.json") or {}).get("inputs") or [])
-    for record in inputs:
-        if not isinstance(record, dict):
-            continue
-        stamped_input = record.get("input") if isinstance(record.get("input"), dict) else {}
-        origin = record.get("origin") if isinstance(record.get("origin"), dict) else {}
-        if stamped_input.get("sha256") != source_sha:
-            continue
-        revision = revision_status(origin, inputs)
-        if origin.get("matched_by") not in IDENTITY_MATCHED_BY and origin.get("match") != "sha256":
-            return agreed_luid(stamped), revision
-        luid = origin.get("workbook_luid")
-        return agreed_luid(stamped, luid if isinstance(luid, str) else None), revision
-    return agreed_luid(stamped), REVISION_UNCONFIRMED
+    origins = [origin for origin in map(_stamped_origin, inputs) if origin is not None and origin[0] == source_sha]
+    if not origins:
+        return agreed_luid(stamped), REVISION_UNCONFIRMED
+    claimed = {luid for _, luid in ((sha, _identity_claim(origin)) for sha, origin in origins) if luid}
+    if len(claimed) > 1:
+        raise AmbiguousIdentity(
+            f"source-provenance.json carries {len(origins)} record(s) for source sha256 "
+            f"{source_sha[:12]}... claiming {len(claimed)} different workbook LUIDs "
+            f"({', '.join(sorted(claimed))}). One of them is about a different workbook and nothing "
+            "here says which, so this unit has no workbook identity - re-stamp with "
+            "scripts/stamp_tableau_provenance.py rather than letting array order decide"
+        )
+    return agreed_luid(stamped, *claimed), _weakest_revision(revision_status(origin, inputs) for _, origin in origins)
+
+
+def _stamped_origin(record: Any) -> tuple[Any, dict[str, Any]] | None:
+    """``(recorded input sha256, origin)`` for one `source-provenance.json` entry, or None."""
+    if not isinstance(record, dict):
+        return None
+    stamped_input = record.get("input") if isinstance(record.get("input"), dict) else {}
+    origin = record.get("origin") if isinstance(record.get("origin"), dict) else {}
+    return stamped_input.get("sha256"), origin
+
+
+def _identity_claim(origin: dict[str, Any]) -> str | None:
+    """The workbook LUID this origin ESTABLISHES, or None when it establishes none.
+
+    ``matched_by``/``match`` decide whether the recorded LUID may be believed at all; see
+    :func:`provenance_origin`. Case-folded, so two spellings of one LUID are one claim rather than an
+    ambiguity.
+    """
+    if origin.get("matched_by") not in IDENTITY_MATCHED_BY and origin.get("match") != "sha256":
+        return None
+    luid = origin.get("workbook_luid")
+    return luid.strip().casefold() if isinstance(luid, str) and luid.strip() else None
+
+
+def _weakest_revision(claims: Iterable[str]) -> str:
+    """The least that every one of ``claims`` supports - order-free, and fails closed.
+
+    Two records for one source that disagree about the build settle nothing between them, so the
+    weakest claim stands: a single ``mismatch`` refuses, a single ``unconfirmed`` withholds, and only
+    unanimous confirmation confirms.
+    """
+    seen = set(claims)
+    if REVISION_MISMATCH in seen:
+        return REVISION_MISMATCH
+    return REVISION_CONFIRMED if seen == {REVISION_CONFIRMED} else REVISION_UNCONFIRMED
 
 
 def revision_status(origin: dict[str, Any], inputs: list[Any]) -> str:
@@ -633,9 +684,29 @@ def provider_grade(provider: str, capabilities: Any) -> str:
     return GRADE_VALIDATION if CAP_VALIDATION in caps else "/".join(sorted(caps))
 
 
-def _reference_states(directory: Path, entry: dict[str, Any], workbook_sha: Any) -> list[Evidence | RejectedEvidence]:
+def _reference_workbook_luid(entry: dict[str, Any], state: dict[str, Any], manifest: dict[str, Any]) -> str | None:
+    """The workbook LUID a `reference/manifest.json` declares, on the state, entry or manifest.
+
+    ⚠️ **This used to be thrown away**, and that is the entry-gate half of the round-N contradiction
+    finding: only ``source_workbook_sha256`` was carried into :class:`Evidence`, so a manifest whose
+    sha256 matched this unit while its ``workbook_luid`` named another workbook had nothing left to
+    contradict with by the time :meth:`WorkbookIdentity.attribute` saw it - `READY 1/1`, exit 0,
+    ``attribution.luid == 0``. Key names mirror `check_unit._declared_workbook`, so one vocabulary
+    describes a manifest at both gates.
+    """
+    for source in (state, entry, manifest):
+        luid = source.get("workbook_luid") or source.get("source_workbook_luid")
+        if isinstance(luid, str) and luid.strip():
+            return luid.strip()
+    return None
+
+
+def _reference_states(
+    directory: Path, entry: dict[str, Any], manifest: dict[str, Any]
+) -> list[Evidence | RejectedEvidence]:
     """Build every state of one `reference/manifest.json` entry."""
     name = str(entry.get("name") or "")
+    workbook_sha = manifest.get("source_workbook_sha256")
     built: list[Evidence | RejectedEvidence] = []
     for state in entry.get("states") or []:
         if not isinstance(state, dict):
@@ -660,6 +731,7 @@ def _reference_states(directory: Path, entry: dict[str, Any], workbook_sha: Any)
                     height=dims.get("h") if isinstance(dims.get("h"), int) else None,
                 ),
                 workbook_sha=str(workbook_sha) if isinstance(workbook_sha, str) and workbook_sha else None,
+                workbook_luid=_reference_workbook_luid(entry, state, manifest),
             )
         )
     return built
@@ -679,11 +751,11 @@ def reference_evidence(reference_dirs: list[Path]) -> tuple[list[Evidence], list
     """
     built: list[Evidence | RejectedEvidence] = []
     for directory in reference_dirs:
-        payload = json_object(directory / "manifest.json")
-        entries = (payload or {}).get("dashboards")
+        payload = json_object(directory / "manifest.json") or {}
+        entries = payload.get("dashboards")
         for entry in entries if isinstance(entries, list) else []:
             if isinstance(entry, dict):
-                built.extend(_reference_states(directory, entry, (payload or {}).get("source_workbook_sha256")))
+                built.extend(_reference_states(directory, entry, payload))
     return _split(built)
 
 

--- a/scripts/reference_evidence.py
+++ b/scripts/reference_evidence.py
@@ -21,9 +21,10 @@ import json
 import re
 import struct
 import zlib
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any
 from xml.etree import ElementTree
 
 from object_identity import (

--- a/scripts/reference_evidence.py
+++ b/scripts/reference_evidence.py
@@ -686,7 +686,7 @@ def provider_grade(provider: str, capabilities: Any) -> str:
 
 
 def _reference_workbook_luid(entry: dict[str, Any], state: dict[str, Any], manifest: dict[str, Any]) -> str | None:
-    """The workbook LUID a `reference/manifest.json` declares, on the state, entry or manifest.
+    """The workbook LUID a `reference/manifest.json` declares, on the state, entry AND manifest.
 
     ⚠️ **This used to be thrown away**, and that is the entry-gate half of the round-N contradiction
     finding: only ``source_workbook_sha256`` was carried into :class:`Evidence`, so a manifest whose
@@ -694,12 +694,18 @@ def _reference_workbook_luid(entry: dict[str, Any], state: dict[str, Any], manif
     contradict with by the time :meth:`WorkbookIdentity.attribute` saw it - `READY 1/1`, exit 0,
     ``attribution.luid == 0``. Key names mirror `check_unit._declared_workbook`, so one vocabulary
     describes a manifest at both gates.
+
+    ⚠️ **Round 2 then found the same fail-open one layer earlier: this SELECTED by scope.** It
+    returned the first non-blank claim - state, then entry, then manifest - so a state-level LUID
+    matching this unit silently superseded a manifest-level one naming a different workbook, and the
+    contradiction was gone before anything could compare it (`READY`, `ready`, `sha256=1`,
+    `conflicting-identity=0`, exit 0). Nothing in the manifest schema makes a narrower scope an
+    override, so every non-blank claim must AGREE: :func:`object_identity.agreed_luid` is the one
+    place that is decided, for this reader and `check_unit._declared_workbook` alike.
     """
-    for source in (state, entry, manifest):
-        luid = source.get("workbook_luid") or source.get("source_workbook_luid")
-        if isinstance(luid, str) and luid.strip():
-            return luid.strip()
-    return None
+    return agreed_luid(
+        *(source.get(key) for source in (state, entry, manifest) for key in ("workbook_luid", "source_workbook_luid"))
+    )
 
 
 def _reference_states(
@@ -799,8 +805,16 @@ def _oracle_leg(directory: Path, record: dict[str, Any]) -> tuple[Path, Recorded
     return None
 
 
-def _oracle_record(directory: Path, record: dict[str, Any]) -> Evidence | RejectedEvidence:
-    """Build one oracle view record."""
+def _oracle_record(directory: Path, record: dict[str, Any], manifest: dict[str, Any]) -> Evidence | RejectedEvidence:
+    """Build one oracle view record.
+
+    The LUID is joined across the view record AND the manifest, by the same rule as a reference
+    manifest's scopes (:func:`_reference_workbook_luid`): every non-blank claim must agree. The
+    top-level key is read because `check_unit._declared_workbook` reads it, and a scope one gate
+    honours while the other ignores it is a hole by construction - measured on this branch, an
+    oracle manifest whose top-level ``workbook_luid`` named another workbook reached
+    `READY / ready / luid=1 / conflicting-identity=0 / exit 0` here while the exit gate compared it.
+    """
     name = str(record.get("view_name") or record.get("view_url_name") or "")
     leg = _oracle_leg(directory, record)
     if leg is None:
@@ -815,7 +829,7 @@ def _oracle_record(directory: Path, record: dict[str, Any]) -> Evidence | Reject
         provider="oracle_capture",
         render_path=render_path,
         recorded=recorded,
-        workbook_luid=luid,
+        workbook_luid=agreed_luid(luid, manifest.get("workbook_luid")),
         workbook_name=workbook_name,
     )
 
@@ -831,10 +845,10 @@ def oracle_evidence(oracle_dirs: list[Path]) -> tuple[list[Evidence], list[Rejec
     """
     built: list[Evidence | RejectedEvidence] = []
     for directory in oracle_dirs:
-        payload = json_object(directory / "oracle-manifest.json")
+        payload = json_object(directory / "oracle-manifest.json") or {}
         built.extend(
-            _oracle_record(directory, record)
-            for record in (payload or {}).get("views") or []
+            _oracle_record(directory, record, payload)
+            for record in payload.get("views") or []
             if isinstance(record, dict)
         )
     return _split(built)

--- a/scripts/reference_evidence.py
+++ b/scripts/reference_evidence.py
@@ -183,18 +183,16 @@ def provenance_origin(root: Path, source_sha: str, source: Path | None = None) -
     * **revision** - THREE-valued, and that is a measured correction rather than a hedge.
 
     ⚠️ **``match: "name_only"`` is NOT by itself evidence of a changed build.** ``find_origin``
-    compares the harvested bytes against ``content_sha256(luid)``, a fresh download. On the 407
-    reference estate that identical request was issued **twice for each of 30 workbooks inside one
-    run** and returned **DIFFERENT digests for 18 of them** - the server repacks a `.twbx` per
-    request, so the comparison cannot be reproduced and ``name_only`` is structurally guaranteed.
-    Reading it as drift marked 18 of 67 units, 246 records and 125 pages unverifiable on an estate
-    where nothing had changed; a gate that refuses correct evidence at that rate gets switched off,
-    which is how a good gate dies.
+    compares the harvested bytes against a fresh download, and a `.twbx` is repacked per request:
+    measured 2026-09-03 on the live site, three downloads of every item in one run, the RAW digest
+    differed for **27 of 49 archives** while the content-normalised key differed for **0 of 67**
+    items. Reading ``name_only`` as drift marked 18 of 67 units and 125 pages unverifiable on an
+    estate where nothing had changed. The reproducible answer is ``origin.revision_match``, from
+    :class:`object_identity.RevisionKey`; see :func:`revision_status`.
 
-    So drift is claimed only when the comparison is REPRODUCIBLE: every ``remote_sha256`` recorded
-    for that LUID agrees. Measured, that flags 0 of 67 units here while still firing on a genuine
-    change. Anything else - including no provenance at all - is ``unconfirmed``, which is admitted
-    and DISCLOSED rather than silently claimed as current (round-1 review of PR #454, blocker 2).
+    Anything with no comparable key - including no provenance at all - is ``unconfirmed``, which is
+    admitted and DISCLOSED rather than silently claimed as current (round-1 review of PR #454,
+    blocker 2).
     """
     stamped = harvest_luid(persisted_stem(source.name if source is not None else None))
     inputs = list((json_object(root / "source-provenance.json") or {}).get("inputs") or [])
@@ -214,22 +212,35 @@ def provenance_origin(root: Path, source_sha: str, source: Path | None = None) -
 
 
 def revision_status(origin: dict[str, Any], inputs: list[Any]) -> str:
-    """``confirmed`` / ``mismatch`` / ``unconfirmed`` for one stamped origin. See :func:`provenance_origin`."""
-    if origin.get("match") == "sha256":
+    """``confirmed`` / ``mismatch`` / ``unconfirmed`` for one stamped origin.
+
+    Reads the REPRODUCIBLE key first. ``stamp_tableau_provenance.find_origin`` records
+    ``revision_match`` from :class:`object_identity.RevisionKey` on both sides, which normalises a
+    `.twbx`/`.tdsx` archive so zip member order and mtimes cannot change it. Measured 2026-09-03
+    against the live site, three downloads of every item in one run:
+
+    | over 48 workbooks + 19 datasources | raw sha256 differs | content key differs |
+    |---|---|---|
+    | archives (49) | **27** | **0** |
+    | non-archives (18, plain `.twb` XML) | **0** | n/a - raw IS the content |
+
+    ⚠️ ``match: "name_only"`` is therefore NOT evidence of a changed build, and round 2 of PR #454
+    was right to refuse to treat it as one - but wrong to conclude that no reproducible comparison
+    existed. It did; the wrong digest was being taken. A raw *match* still implies a content match,
+    so ``match == "sha256"`` remains a valid confirmation; a raw *difference* establishes nothing.
+
+    ⚠️ An origin carrying no comparable key is ``unconfirmed``, never ``mismatch``. That covers a
+    manifest stamped before this key existed, two different key algorithms, and an archive that would
+    not open - the last of which yields NO key at all rather than a raw one, because silently
+    re-hashing those bytes raw is precisely the defect this replaces.
+    """
+    _ = inputs
+    declared = origin.get("revision_match")
+    if declared == "same":
         return REVISION_CONFIRMED
-    if origin.get("match") != "name_only":
-        return REVISION_UNCONFIRMED
-    luid = origin.get("workbook_luid")
-    observed = {
-        (record.get("origin") or {}).get("remote_sha256")
-        for record in inputs
-        if isinstance(record, dict)
-        and isinstance(record.get("origin"), dict)
-        and record["origin"].get("workbook_luid") == luid
-    }
-    # One reproducible answer means the comparison is load-bearing; two mean the download is not
-    # deterministic and the difference is about packaging, not about the workbook.
-    return REVISION_MISMATCH if len(observed) == 1 and None not in observed else REVISION_UNCONFIRMED
+    if declared == "differs":
+        return REVISION_MISMATCH
+    return REVISION_CONFIRMED if origin.get("match") == "sha256" else REVISION_UNCONFIRMED
 
 
 @dataclass(frozen=True)

--- a/scripts/reference_evidence.py
+++ b/scripts/reference_evidence.py
@@ -30,7 +30,9 @@ from object_identity import (
     KIND_DASHBOARD,
     KIND_UNKNOWN,
     KIND_WORKSHEET,
+    Attribution,
     Candidate,
+    WorkbookIdentity,
 )
 
 
@@ -111,17 +113,36 @@ MANUAL_KIND_HINT = (
 class UnitIdentity:
     """Who a unit is, for attributing evidence to it.
 
-    ``workbook_luid`` is populated ONLY when provenance is byte-confirmed. Round-2 review measured
-    the alternative: ``stamp_tableau_provenance.py`` records ``origin.match: "name_only"`` when the
-    local and server bytes DIFFER and says outright that figures will not reproduce, yet that LUID
-    was making server oracle evidence ready. The repo's own provenance is 26 ``sha256`` / 15
-    ``name_only`` / 6 unmatched, so trusting it unconditionally is the common case, not an edge one.
+    ``workbook_luid`` is the published workbook's server id, and it is **the** identity: a display
+    name is not unique across projects, and the local artifact stem is a filesystem-sanitised
+    spelling of one (`HR_Dashboard` for `HR Dashboard`), so the name axis cannot bridge harvest.
+
+    ⚠️ Round-2 review gated this LUID on ``origin.match == "sha256"`` and issue #450's fix removed
+    that gate, because ``match`` answers a different question. ``stamp_tableau_provenance.find_origin``
+    says so itself: ``matched_by`` records *how the workbook was found* (``luid``/``name``/
+    ``sanitized_name``) and ``match`` records *how strongly the bytes were confirmed* (``sha256`` vs
+    ``name_only``), and they are "two independent axes: a LUID match with ``name_only`` means 'this is
+    provably the same item on the site, and it has changed since we harvested it'". Reading the
+    REVISION axis as if it were the IDENTITY axis discarded a proven LUID and fell back to exact-name
+    equality - a join that is weaker on identity **and** carries no revision guarantee either, so it
+    traded nothing for the 23 renders it threw away. Freshness is disclosed by the grade, which for an
+    oracle capture is already "layout/text only"; it is not an identity question.
     """
 
     name: str
     source_path: Path
     source_sha256: str
     workbook_luid: str | None = None
+
+    def workbook(self) -> WorkbookIdentity:
+        """This unit's workbook, on the axes it can establish.
+
+        The unit's ``name`` is an ARTIFACT STEM, not a published display name. It is offered on the
+        name axis anyway because that is the only axis a locally-captured `reference/` manifest and a
+        server oracle can share when no LUID is available - but it is the weakest route, and
+        :meth:`WorkbookIdentity.attribute` consults it last.
+        """
+        return WorkbookIdentity.of(luid=self.workbook_luid, name=self.name, sha256=self.source_sha256)
 
 
 @dataclass(frozen=True)
@@ -256,30 +277,30 @@ class Evidence:  # pylint: disable=too-many-instance-attributes
             names.append(self.name[len(MANUAL_NAME_PREFIX) :])
         return Candidate(names=tuple(names), kind=self.kind)
 
-    def is_for(self, unit: UnitIdentity) -> bool:
-        """Whether this render is provably evidence for ``unit``.
+    def workbook(self) -> WorkbookIdentity:
+        """The workbook this render declares it came from, on whichever axes its producer wrote."""
+        return WorkbookIdentity.of(luid=self.workbook_luid, name=self.workbook_name, sha256=self.workbook_sha)
 
-        Reference evidence is keyed by the SOURCE SHA, so a capture taken against an older revision
-        of the workbook does not silently remain valid - a stale picture is worse than a missing one
-        because it looks like evidence.
+    def attribution(self, unit: UnitIdentity) -> Attribution:
+        """Why this render does or does not belong to ``unit``, naming the axis that decided.
 
-        Oracle evidence carries BOTH a LUID and a workbook name, and both are used. Round-2 review
-        measured the previous either/or: a record carrying a LUID discarded its name, so removing the
-        (untrusted) source provenance made correctly-NAMED records return `0/3 blind`. A LUID is
-        trusted only when the unit's provenance was byte-confirmed; otherwise the name is the
-        fallback, exactly as documented.
+        The whole join is :meth:`WorkbookIdentity.attribute`, shared with ``check_unit.py`` - see
+        issue #450, where the two gates disagreed about how a workbook is identified and produced one
+        fail-closed and one fail-open defect from that single disagreement.
 
-        WARNING: the name fallback is EXACT. It was normalized, which made this a lossy join on
-        workbook identity - the same collapse defect, at a layer nobody had enumerated. Two workbook
-        names differing only by case or repeated whitespace would have attributed one workbook's
-        captures to the other. If a published workbook name genuinely differs from the unit name, the
-        LUID route is the answer; guessing across the difference is not.
+        Reference evidence carries the source SHA, so it is matched revision-first: a capture taken
+        against an older revision of the workbook does not silently remain valid, because a stale
+        picture is worse than a missing one - it looks like evidence. Oracle evidence carries a LUID
+        and a display name, and the LUID is decisive whenever the unit has one.
+
+        ⚠️ There is deliberately **no** ``is_for()`` boolean beside this. There was, as a one-line
+        delegate, and the mutation runner measured what that cost: two mutants pinning the old
+        boolean went on reporting CAUGHT while patching a method the gate no longer called. A second
+        reader of one contract is a place for two answers to diverge, which is the whole shape of
+        #450. Callers read ``.admitted``, which :class:`object_identity.Attribution` makes the only
+        legal reader.
         """
-        if self.workbook_sha is not None:
-            return self.workbook_sha.casefold() == unit.source_sha256.casefold()
-        if self.workbook_luid and unit.workbook_luid:
-            return self.workbook_luid.casefold() == unit.workbook_luid.casefold()
-        return self.workbook_name == unit.name
+        return unit.workbook().attribute(self.workbook())
 
 
 def sha256_of(path: Path) -> str | None:

--- a/scripts/reference_evidence.py
+++ b/scripts/reference_evidence.py
@@ -30,9 +30,16 @@ from object_identity import (
     KIND_DASHBOARD,
     KIND_UNKNOWN,
     KIND_WORKSHEET,
+    WB_LUID,
+    WB_NAME,
+    WB_SHA,
+    WB_STALE,
     Attribution,
     Candidate,
     WorkbookIdentity,
+    agreed_luid,
+    harvest_luid,
+    persisted_stem,
 )
 
 
@@ -109,6 +116,14 @@ MANUAL_KIND_HINT = (
 )
 
 
+#: What is known about the REVISION the evidence depicts, as distinct from which workbook it is of.
+#: Three values, because two were not enough: "I proved the bytes are the site copy", "I proved they
+#: are not", and "I could not tell" are different claims, and only the middle one may refuse a page.
+REVISION_CONFIRMED = "confirmed"
+REVISION_UNCONFIRMED = "unconfirmed"
+REVISION_MISMATCH = "mismatch"
+
+
 @dataclass(frozen=True)
 class UnitIdentity:
     """Who a unit is, for attributing evidence to it.
@@ -117,22 +132,22 @@ class UnitIdentity:
     name is not unique across projects, and the local artifact stem is a filesystem-sanitised
     spelling of one (`HR_Dashboard` for `HR Dashboard`), so the name axis cannot bridge harvest.
 
-    ⚠️ Round-2 review gated this LUID on ``origin.match == "sha256"`` and issue #450's fix removed
-    that gate, because ``match`` answers a different question. ``stamp_tableau_provenance.find_origin``
-    says so itself: ``matched_by`` records *how the workbook was found* (``luid``/``name``/
-    ``sanitized_name``) and ``match`` records *how strongly the bytes were confirmed* (``sha256`` vs
-    ``name_only``), and they are "two independent axes: a LUID match with ``name_only`` means 'this is
-    provably the same item on the site, and it has changed since we harvested it'". Reading the
-    REVISION axis as if it were the IDENTITY axis discarded a proven LUID and fell back to exact-name
-    equality - a join that is weaker on identity **and** carries no revision guarantee either, so it
-    traded nothing for the 23 renders it threw away. Freshness is disclosed by the grade, which for an
-    oracle capture is already "layout/text only"; it is not an identity question.
+    ⚠️ Round-2 review gated this LUID on ``origin.match == "sha256"``; issue #450 removed that gate
+    because ``match`` answers a different question. ``stamp_tableau_provenance.find_origin`` says so
+    itself: ``matched_by`` records *how the workbook was found* and ``match`` records *how strongly
+    the bytes were confirmed*, and they are "two independent axes".
+
+    ``revision`` is that second axis, kept and reported rather than discarded - round-1 review of PR
+    #454 found dropping it made a capture of a different BUILD read as current. It is THREE-valued
+    on measured grounds; see :func:`check_reference_readiness._provenance_origin` for why
+    ``name_only`` alone is not evidence of a changed build.
     """
 
     name: str
     source_path: Path
     source_sha256: str
     workbook_luid: str | None = None
+    revision: str = REVISION_UNCONFIRMED
 
     def workbook(self) -> WorkbookIdentity:
         """This unit's workbook, on the axes it can establish.
@@ -140,9 +155,81 @@ class UnitIdentity:
         The unit's ``name`` is an ARTIFACT STEM, not a published display name. It is offered on the
         name axis anyway because that is the only axis a locally-captured `reference/` manifest and a
         server oracle can share when no LUID is available - but it is the weakest route, and
-        :meth:`WorkbookIdentity.attribute` consults it last.
+        :meth:`WorkbookIdentity.attribute` reaches it only when the record claims no machine identity
+        at all.
         """
         return WorkbookIdentity.of(luid=self.workbook_luid, name=self.name, sha256=self.source_sha256)
+
+
+#: Provenance ``origin`` shapes that ESTABLISH which published workbook a local file is. Deliberately
+#: distinct from ``origin.match``, which answers a REVISION question and was read as if it were this
+#: one (issue #450).
+IDENTITY_MATCHED_BY = frozenset({"luid"})
+
+
+def provenance_origin(root: Path, source_sha: str, source: Path | None = None) -> tuple[str | None, str]:
+    """``(workbook LUID, revision status)`` for one source, from every offline route.
+
+    Lives beside :class:`UnitIdentity` because it builds one. Two INDEPENDENT answers -
+    `stamp_tableau_provenance.find_origin` calls them "two independent axes" - and reading either as
+    the other has now caused a defect in each direction:
+
+    * **identity** - ``origin.workbook_luid``, trusted when ``matched_by == "luid"`` (the harvested
+      filename's LUID was found on the site, so it is provably that item) **or** when
+      ``match == "sha256"``. Reading ``match`` alone discarded a proven LUID and fell back to
+      comparing the artifact stem ``HR_Dashboard`` against the published name ``HR Dashboard``
+      (issue #450). The asset filename's own ``<luid>_`` prefix is a second claim and the two must
+      agree: contradictory identities are less evidence than none.
+    * **revision** - THREE-valued, and that is a measured correction rather than a hedge.
+
+    ⚠️ **``match: "name_only"`` is NOT by itself evidence of a changed build.** ``find_origin``
+    compares the harvested bytes against ``content_sha256(luid)``, a fresh download. On the 407
+    reference estate that identical request was issued **twice for each of 30 workbooks inside one
+    run** and returned **DIFFERENT digests for 18 of them** - the server repacks a `.twbx` per
+    request, so the comparison cannot be reproduced and ``name_only`` is structurally guaranteed.
+    Reading it as drift marked 18 of 67 units, 246 records and 125 pages unverifiable on an estate
+    where nothing had changed; a gate that refuses correct evidence at that rate gets switched off,
+    which is how a good gate dies.
+
+    So drift is claimed only when the comparison is REPRODUCIBLE: every ``remote_sha256`` recorded
+    for that LUID agrees. Measured, that flags 0 of 67 units here while still firing on a genuine
+    change. Anything else - including no provenance at all - is ``unconfirmed``, which is admitted
+    and DISCLOSED rather than silently claimed as current (round-1 review of PR #454, blocker 2).
+    """
+    stamped = harvest_luid(persisted_stem(source.name if source is not None else None))
+    inputs = list((json_object(root / "source-provenance.json") or {}).get("inputs") or [])
+    for record in inputs:
+        if not isinstance(record, dict):
+            continue
+        stamped_input = record.get("input") if isinstance(record.get("input"), dict) else {}
+        origin = record.get("origin") if isinstance(record.get("origin"), dict) else {}
+        if stamped_input.get("sha256") != source_sha:
+            continue
+        revision = revision_status(origin, inputs)
+        if origin.get("matched_by") not in IDENTITY_MATCHED_BY and origin.get("match") != "sha256":
+            return agreed_luid(stamped), revision
+        luid = origin.get("workbook_luid")
+        return agreed_luid(stamped, luid if isinstance(luid, str) else None), revision
+    return agreed_luid(stamped), REVISION_UNCONFIRMED
+
+
+def revision_status(origin: dict[str, Any], inputs: list[Any]) -> str:
+    """``confirmed`` / ``mismatch`` / ``unconfirmed`` for one stamped origin. See :func:`provenance_origin`."""
+    if origin.get("match") == "sha256":
+        return REVISION_CONFIRMED
+    if origin.get("match") != "name_only":
+        return REVISION_UNCONFIRMED
+    luid = origin.get("workbook_luid")
+    observed = {
+        (record.get("origin") or {}).get("remote_sha256")
+        for record in inputs
+        if isinstance(record, dict)
+        and isinstance(record.get("origin"), dict)
+        and record["origin"].get("workbook_luid") == luid
+    }
+    # One reproducible answer means the comparison is load-bearing; two mean the download is not
+    # deterministic and the difference is about packaging, not about the workbook.
+    return REVISION_MISMATCH if len(observed) == 1 and None not in observed else REVISION_UNCONFIRMED
 
 
 @dataclass(frozen=True)
@@ -284,23 +371,44 @@ class Evidence:  # pylint: disable=too-many-instance-attributes
     def attribution(self, unit: UnitIdentity) -> Attribution:
         """Why this render does or does not belong to ``unit``, naming the axis that decided.
 
-        The whole join is :meth:`WorkbookIdentity.attribute`, shared with ``check_unit.py`` - see
+        The identity half is :meth:`WorkbookIdentity.attribute`, shared with ``check_unit.py`` - see
         issue #450, where the two gates disagreed about how a workbook is identified and produced one
         fail-closed and one fail-open defect from that single disagreement.
 
-        Reference evidence carries the source SHA, so it is matched revision-first: a capture taken
-        against an older revision of the workbook does not silently remain valid, because a stale
-        picture is worse than a missing one - it looks like evidence. Oracle evidence carries a LUID
-        and a display name, and the LUID is decisive whenever the unit has one.
+        The REVISION half is here, because it is this gate's contract rather than a property of
+        identity: evidence must be for "THIS workbook, at THIS revision". A sha256 join is
+        revision-bound by construction, so it passes through confirmed. A LUID or name join says
+        *which* workbook, never *which build of it*, so it inherits the unit's revision status:
 
-        ⚠️ There is deliberately **no** ``is_for()`` boolean beside this. There was, as a one-line
-        delegate, and the mutation runner measured what that cost: two mutants pinning the old
-        boolean went on reporting CAUGHT while patching a method the gate no longer called. A second
-        reader of one contract is a place for two answers to diverge, which is the whole shape of
-        #450. Callers read ``.admitted``, which :class:`object_identity.Attribution` makes the only
-        legal reader.
+        * :data:`REVISION_MISMATCH` - drift is SOUNDLY established, so the render is
+          :data:`object_identity.WB_STALE` and certifies nothing;
+        * :data:`REVISION_UNCONFIRMED` - the render is admitted, and the caller MUST disclose that
+          the revision was not established (:func:`check_reference_readiness._page_row` writes
+          ``row["revision"]``). Round-1 review of PR #454's blocker 2 was exactly that a page in this
+          state read as a clean `READY` with nothing saying so.
+
+        ⚠️ Absence of provenance, and a byte comparison that could not be made soundly, are both
+        UNCONFIRMED rather than mismatched. "I cannot tell whether the bytes moved" and "I can tell,
+        and they did" are different statements, and only the second may refuse a page.
         """
-        return unit.workbook().attribute(self.workbook())
+        verdict = unit.workbook().attribute(self.workbook())
+        if verdict.route in (WB_LUID, WB_NAME) and unit.revision == REVISION_MISMATCH:
+            return Attribution(
+                WB_STALE,
+                "the same workbook, a DIFFERENT build: this unit's source bytes differ from a "
+                f"REPRODUCIBLE download of the site copy, and a {verdict.axis} join says which "
+                "workbook a render is of, never which revision",
+                axis=verdict.axis,
+            )
+        return verdict
+
+    def revision_for(self, unit: UnitIdentity) -> str:
+        """What this render establishes about the REVISION, once it has been admitted.
+
+        A sha256 join pins the bytes, so it is confirmed whatever provenance says. Anything weaker
+        inherits the unit's status, which is why an admitted render can still be UNCONFIRMED.
+        """
+        return REVISION_CONFIRMED if self.attribution(unit).route == WB_SHA else unit.revision
 
 
 def sha256_of(path: Path) -> str | None:

--- a/scripts/stamp_tableau_provenance.py
+++ b/scripts/stamp_tableau_provenance.py
@@ -59,6 +59,7 @@ from pathlib import Path
 from typing import Any
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
+from object_identity import RevisionKey, revision_key  # noqa: E402  # pylint: disable=wrong-import-position
 from tableau_env import pat_secret, resolve_env  # noqa: E402  # pylint: disable=wrong-import-position
 
 LOG = logging.getLogger("provenance")
@@ -67,11 +68,16 @@ WORKBOOK_SUFFIXES = (".twb", ".twbx")
 
 
 def fingerprint(path: Path) -> dict[str, Any]:
-    """Size + sha256, plus per-member CRCs for a ``.twbx``.
+    """Size + sha256 + a reproducible REVISION KEY, plus per-member CRCs for a ``.twbx``.
 
     The members matter more than the outer hash: a ``.twbx`` is a zip, and zip metadata (timestamps,
     compression) can differ between two downloads of the same content, so two identical workbooks can
     hash differently. Member CRCs compare the content itself.
+
+    ⚠️ That warning was written here and then not acted on where it counted - the origin comparison
+    below hashed raw bytes on BOTH sides, so an unchanged workbook read as ``name_only``.
+    :func:`object_identity.revision_key` is the content-normalised digest that makes the comparison
+    reproducible, and it is recorded on both sides so a consumer never has to guess which it holds.
     """
     raw = path.read_bytes()
     record: dict[str, Any] = {
@@ -79,6 +85,9 @@ def fingerprint(path: Path) -> dict[str, Any]:
         "size_bytes": len(raw),
         "sha256": hashlib.sha256(raw).hexdigest(),
     }
+    key = revision_key(raw)
+    if key is not None:
+        record["revision_key"] = key.as_json()
     if path.suffix.lower() == ".twbx" and zipfile.is_zipfile(path):
         with zipfile.ZipFile(path) as archive:
             record["members"] = [
@@ -152,10 +161,28 @@ class TableauLookup:
 
     def content_sha256(self, workbook_id: str) -> str | None:
         """sha256 of the workbook as the server would hand it to us, or ``None`` if it cannot be read."""
+        payload = self._content(workbook_id)
+        return hashlib.sha256(payload).hexdigest() if payload is not None else None
+
+    def content_revision_key(self, workbook_id: str) -> RevisionKey | None:
+        """The REPRODUCIBLE build digest of the site copy, or None when it cannot be computed.
+
+        ⚠️ :meth:`content_sha256` above is not reproducible and never was. Measured 2026-09-03 against
+        this site, three downloads of every item inside one run: the raw digest differed across
+        downloads for **27 of 49 archives** (18 of 48 workbooks, 9 of 19 datasources) while the
+        content-normalised digest differed for **0 of 67**. Every raw-unstable item had an identical
+        byte length, and the population is itself unstable - ``World Indicators`` differed in one
+        sample and agreed minutes later - so a raw comparison does not merely fail for a fixed
+        subset: any "confirmed" verdict it produces is luck.
+        """
+        payload = self._content(workbook_id)
+        return revision_key(payload) if payload is not None else None
+
+    def _content(self, workbook_id: str) -> bytes | None:
         status, payload = self._call(
             "GET", f"/sites/{self.site_id}/workbooks/{workbook_id}/content?includeExtract=True"
         )
-        return hashlib.sha256(payload).hexdigest() if status == 200 else None
+        return payload if status == 200 else None
 
 
 HARVEST_STEM_RE = re.compile(
@@ -183,7 +210,7 @@ def _sanitized(text: str) -> str:
     return "".join(char if char.isalnum() or char in "-_" else "_" for char in text)[:60]
 
 
-def find_origin(lookup: TableauLookup, stem: str, local_sha: str) -> dict[str, Any] | None:
+def find_origin(lookup: TableauLookup, stem: str, local: dict[str, Any]) -> dict[str, Any] | None:
     """Identify a local workbook on the site by LUID or name, then CONFIRM by content hash.
 
     Returns ``None`` when no workbook matches. When one does, ``matched_by`` records *how it was
@@ -193,8 +220,17 @@ def find_origin(lookup: TableauLookup, stem: str, local_sha: str) -> dict[str, A
     site, and it has changed since we harvested it", which is a different and more useful statement
     than a name collision.
 
-    A name-only match is still worth recording: it says "a workbook of this name exists there and it
-    is NOT this build", which is precisely the ambiguity that makes a cited figure irreproducible.
+    ⚠️ ``match`` alone could never carry that second claim, and saying it did was wrong. It compares
+    RAW bytes, and a `.twbx` is repacked per download - measured 2026-09-03 on this site, three
+    downloads of every item in one run: **27 of 49 archives** returned a different raw digest for
+    identical content, **0 of 67** items returned a different content digest. ``revision_match`` is
+    therefore the load-bearing verdict; ``match`` is kept unchanged so an existing consumer is not
+    silently re-interpreted, and because a raw MATCH still implies a content match.
+
+    ``revision_match`` is ``"same"`` / ``"differs"`` / ``None``, and ``None`` means *the two keys are
+    not comparable* - a missing key on either side, or two different algorithms. It is never
+    ``"differs"`` in that case: a false drift alarm on every pre-existing capture would be worse than
+    the gap it closes.
     """
     luid, name_part = split_harvest_stem(stem)
     workbooks = lookup.workbooks()
@@ -219,6 +255,9 @@ def find_origin(lookup: TableauLookup, stem: str, local_sha: str) -> dict[str, A
 
     workbook = candidates[0]
     remote_sha = lookup.content_sha256(workbook["id"])
+    remote_key = lookup.content_revision_key(workbook["id"])
+    local_key = RevisionKey.from_json(local.get("revision_key"))
+    agreement = local_key.agrees_with(remote_key) if local_key is not None else None
     return {
         "server": lookup.base,
         "site": lookup.site,
@@ -231,7 +270,9 @@ def find_origin(lookup: TableauLookup, stem: str, local_sha: str) -> dict[str, A
         "tableau_product_version": lookup.product_version,
         "rest_api_version": lookup.version,
         "matched_by": matched_by,
-        "match": "sha256" if remote_sha == local_sha else "name_only",
+        "match": "sha256" if remote_sha == local["sha256"] else "name_only",
+        "revision_match": None if agreement is None else ("same" if agreement else "differs"),
+        "remote_revision_key": remote_key.as_json() if remote_key is not None else None,
         "remote_sha256": remote_sha,
         "same_name_count": sum(1 for wb in workbooks if wb.get("name") == workbook.get("name")),
     }
@@ -261,7 +302,7 @@ def build(target: Path, env: dict[str, str]) -> dict[str, Any]:
         record = {"input": fingerprint(path)}
         if lookup is not None:
             try:
-                origin = find_origin(lookup, path.stem, record["input"]["sha256"])
+                origin = find_origin(lookup, path.stem, record["input"])
             except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught
                 origin, record["lookup_error"] = None, f"{type(exc).__name__}: {str(exc)[:150]}"
             record["origin"] = origin

--- a/tests/mutate_check_unit.py
+++ b/tests/mutate_check_unit.py
@@ -568,7 +568,7 @@ MUTATIONS: list[tuple[str, str, str, list[str]]] = [
     ),
     (
         "ORACLE WORKBOOK: a lossy name rescues a LUID disagreement (#450, the fail-open direction)",
-        "    if verdict.axis != oid.WB_NAME or not name:",
+        "    if verdict.route != oid.WB_FOREIGN or verdict.axis != oid.WB_NAME or not name:",
         "    if not name:",
         ["test_a_foreign_luid_is_refused_even_when_the_workbook_name_matches_exactly"],
     ),
@@ -583,6 +583,32 @@ MUTATIONS: list[tuple[str, str, str, list[str]]] = [
         "    if evidence.kindless:\n        grade += (",
         "    if False:\n        grade += (",
         ["test_a_record_whose_kind_is_unestablished_certifies_nothing"],
+    ),
+    (
+        "ORACLE WORKBOOK: a unit-local reference manifest skips the guard again (round-2 blocker 3)",
+        "        if not verdict.admitted:",
+        "        if not verdict.admitted and record.workbook.established:",
+        ["test_a_unit_local_reference_manifest_is_not_certified_by_its_location"],
+    ),
+    (
+        "ORACLE WORKBOOK: the unit stops hashing its own source, so a recorded sha is unchecked",
+        "    sha = _unit_source_sha256(target)",
+        "    sha = None",
+        ["test_a_unit_local_reference_manifest_certifies_when_its_recorded_sha_is_this_source"],
+    ),
+    (
+        # ⚠️ There is deliberately NO mutant here for `Path(name).stem` vs `persisted_stem(name)`.
+        # On Windows `WindowsPath` accepts BOTH separators, so no fixture string exists that `Path`
+        # mishandles and the fix handles - the mutant is unkillable on this host BY CONSTRUCTION, and
+        # an entry that can only ever report CAUGHT on Linux is a vacuity, not a guard. The property
+        # is pinned by `test_the_recorded_path_parse_does_not_use_the_running_hosts_flavour`, which
+        # exercises PureWindowsPath and PurePosixPath explicitly on one host, and by
+        # `test_a_windows_recorded_source_id_still_yields_its_luid`, which fails on POSIX CI if the
+        # call site regresses. `mutation_reference_readiness.py` carries the matching mutant.
+        "ORACLE DISCOVERY: the ancestor walk stops one level short of the run root",
+        "    return evidence_dirs(unit, ORACLE_DIR_NAMES, also=[target])",
+        "    return _resolved_unique([base / name for base in (unit, target) for name in ORACLE_DIR_NAMES])",
+        ["test_a_non_packaged_unit_still_reads_an_ancestors_oracle_capture"],
     ),
     (
         "SLUG CENSUS: a brand-new lossy call site outside the index",

--- a/tests/mutate_check_unit.py
+++ b/tests/mutate_check_unit.py
@@ -540,36 +540,50 @@ MUTATIONS: list[tuple[str, str, str, list[str]]] = [
         ["test_two_producer_records_naming_one_page_satisfy_nothing"],
     ),
     (
-        "ORACLE WORKBOOK: the producing side of the uniqueness guard is dropped",
-        "    if unit_index.unique(name) is None or producer_index.unique(name) is None:",
-        "    if unit_index.unique(name) is None:",
+        # ⚠️ Round-3 B-B DELETED the lossy sanitised-spelling rescue this used to aim at, so the old
+        # snippet (`unit_index.unique(name) or producer_index.unique(name)`) could never apply again.
+        # Re-aimed at the property rather than the vanished code: putting a name rescue BACK must be
+        # caught. A display name is decoration, and two producers slugging alike prove it.
+        "ORACLE WORKBOOK: a lossy display name is allowed to admit again",
+        "    for record in records:\n        verdict = _attribute_record(unit_ids, record)\n        if not verdict.admitted:",
+        "    for record in records:\n        verdict = _attribute_record(unit_ids, record)\n"
+        "        if verdict.route == oid.WB_FOREIGN and verdict.axis == oid.WB_NAME:\n"
+        '            verdict = oid.Attribution(oid.WB_LUID, "lossy name rescue", axis=oid.WB_NAME)\n'
+        "        if not verdict.admitted:",
         ["test_two_producing_workbooks_slugging_alike_are_both_refused"],
     ),
     (
-        "ORACLE WORKBOOK: the unit side of the uniqueness guard is dropped",
-        "    if unit_index.unique(name) is None or producer_index.unique(name) is None:",
-        "    if producer_index.unique(name) is None:",
+        # The LUID twin of "the unit stops hashing its own source" below. A unit that establishes no
+        # LUID cannot call anything foreign - the refusal silently downgrades to `unattributed`.
+        "ORACLE WORKBOOK: the unit stops establishing its own LUID, so nothing is ever foreign",
+        "    luid = oid.agreed_luid(*_unit_source_claims(target)[1])",
+        "    luid = None",
         ["test_oracle_evidence_from_a_different_workbook_satisfies_nothing"],
-    ),
-    (
-        "ORACLE WORKBOOK: the sanitised-spelling fallback is removed entirely",
-        "    if unit_index.unique(name) is None or producer_index.unique(name) is None:",
-        "    if True:",
-        ["test_one_producing_workbook_still_binds_through_a_sanitised_spelling"],
     ),
     (
         # Issue #450: `_declared_workbook` read a `workbook` key no capture producer writes, so on a
         # real 360-view capture EVERY record arrived ownerless and was admitted anyway.
+        # ⚠️ The anchor was `test_the_workbook_name_a_real_capture_writes_is_read`, which does not
+        # exist - so this reported BROKEN (189 deselected, 0 run), not CAUGHT. Re-anchored on the
+        # test that actually asserts the field is read: without `workbook_name`, the record is
+        # ownerless and `name_only_evidence` is empty rather than naming it.
         "ORACLE WORKBOOK: the fields a real capture writes are ignored again (#450)",
         '        name=entry.get("workbook") or outer.get("workbook") or entry.get("workbook_name")'
         ' or outer.get("workbook_name"),',
         '        name=entry.get("workbook") or outer.get("workbook"),',
-        ["test_the_workbook_name_a_real_capture_writes_is_read"],
+        ["test_a_display_name_alone_never_certifies_however_real_the_capture"],
     ),
     (
+        # ⚠️ Re-aimed for the same reason as the first entry: the rescue this guarded
+        # (`verdict.route != oid.WB_FOREIGN or verdict.axis != oid.WB_NAME or not name`) is deleted,
+        # so the snippet was unappliable. The fail-open direction it defended is still worth a
+        # mutant, so the mutant now REINSTATES it - one axis up, where the LUIDs themselves disagree.
         "ORACLE WORKBOOK: a lossy name rescues a LUID disagreement (#450, the fail-open direction)",
-        "    if verdict.route != oid.WB_FOREIGN or verdict.axis != oid.WB_NAME or not name:",
-        "    if not name:",
+        "    compared = (oid.WB_CONFLICT, oid.WB_FOREIGN)\n    return next(",
+        "    compared = (oid.WB_CONFLICT, oid.WB_FOREIGN)\n"
+        "    if any(identity.name and record.workbook.name == identity.name for identity in unit_ids):\n"
+        '        return oid.Attribution(oid.WB_LUID, "lossy name rescue", axis=oid.WB_NAME)\n'
+        "    return next(",
         ["test_a_foreign_luid_is_refused_even_when_the_workbook_name_matches_exactly"],
     ),
     (
@@ -649,14 +663,12 @@ MUTATIONS: list[tuple[str, str, str, list[str]]] = [
         ["test_underscore_oracle_directory_is_still_discovered"],
     ),
     (
-        # The kind half of #438 is fixed on this branch, so the two mutations that defended its
-        # caveat are gone with the caveat. These two survive because #450 does.
-        "DISCLOSURE: loose workbook attribution is no longer tracked, so its caveat never fires",
-        "            loosely_attributed.append(rescued)",
-        "            pass",
-        ["test_a_loosely_attributed_workbook_carries_a_caveat_naming_it"],
-    ),
-    (
+        # ⚠️ The "loose workbook attribution is no longer tracked" mutant that used to sit here is
+        # DELETED, not repaired. Its target (`loosely_attributed.append(rescued)`) and its anchor
+        # (`test_a_loosely_attributed_workbook_carries_a_caveat_naming_it`) both went with round-3's
+        # removal of the lossy rescue, so it could only ever report ANCHOR-SNIPPET x0. A mutation
+        # that cannot apply is not coverage, and re-aiming it would defend a caveat whose gap is
+        # closed - the same reason the #438 KIND caveat and its two mutants were retired together.
         "DISCLOSURE: the caveats never reach the rendered output",
         '        lines.extend(f"                    {caveat}" for caveat in check.get("known_gap_caveats", []))',
         "        pass",

--- a/tests/mutate_check_unit.py
+++ b/tests/mutate_check_unit.py
@@ -541,30 +541,42 @@ MUTATIONS: list[tuple[str, str, str, list[str]]] = [
     ),
     (
         "ORACLE WORKBOOK: the producing side of the uniqueness guard is dropped",
-        "            two_sided = unit_index.unique(record.workbook) is not None and (\n"
-        "                producer_index.unique(record.workbook) is not None\n            )",
-        "            two_sided = unit_index.unique(record.workbook) is not None",
+        "    if unit_index.unique(name) is None or producer_index.unique(name) is None:",
+        "    if unit_index.unique(name) is None:",
         ["test_two_producing_workbooks_slugging_alike_are_both_refused"],
     ),
     (
         "ORACLE WORKBOOK: the unit side of the uniqueness guard is dropped",
-        "            two_sided = unit_index.unique(record.workbook) is not None and (\n"
-        "                producer_index.unique(record.workbook) is not None\n            )",
-        "            two_sided = producer_index.unique(record.workbook) is not None",
+        "    if unit_index.unique(name) is None or producer_index.unique(name) is None:",
+        "    if producer_index.unique(name) is None:",
         ["test_oracle_evidence_from_a_different_workbook_satisfies_nothing"],
     ),
     (
         "ORACLE WORKBOOK: the sanitised-spelling fallback is removed entirely",
-        "            two_sided = unit_index.unique(record.workbook) is not None and (\n"
-        "                producer_index.unique(record.workbook) is not None\n            )",
-        "            two_sided = False",
+        "    if unit_index.unique(name) is None or producer_index.unique(name) is None:",
+        "    if True:",
         ["test_one_producing_workbook_still_binds_through_a_sanitised_spelling"],
     ),
     (
+        # Issue #450: `_declared_workbook` read a `workbook` key no capture producer writes, so on a
+        # real 360-view capture EVERY record arrived ownerless and was admitted anyway.
+        "ORACLE WORKBOOK: the fields a real capture writes are ignored again (#450)",
+        '        name=entry.get("workbook") or outer.get("workbook") or entry.get("workbook_name")'
+        ' or outer.get("workbook_name"),',
+        '        name=entry.get("workbook") or outer.get("workbook"),',
+        ["test_the_workbook_name_a_real_capture_writes_is_read"],
+    ),
+    (
+        "ORACLE WORKBOOK: a lossy name rescues a LUID disagreement (#450, the fail-open direction)",
+        "    if verdict.axis != oid.WB_NAME or not name:",
+        "    if not name:",
+        ["test_a_foreign_luid_is_refused_even_when_the_workbook_name_matches_exactly"],
+    ),
+    (
         "ORACLE WORKBOOK: unattributed evidence is no longer disclosed in the grade",
-        '        grade += f" (\u26a0\ufe0f {evidence.unattributed} record(s) declare no producing workbook)"',
-        "        pass",
-        ["test_oracle_evidence_declaring_no_workbook_is_admitted_but_flagged"],
+        '        grade += (\n            f" (\u26a0\ufe0f {evidence.unattributed} record(s) establish no producing workbook and certify "',
+        '        grade += (\n            f" ("',
+        ["test_a_record_whose_workbook_cannot_be_established_certifies_nothing"],
     ),
     (
         "ORACLE KIND: kind-less evidence is discarded SILENTLY",
@@ -614,7 +626,7 @@ MUTATIONS: list[tuple[str, str, str, list[str]]] = [
         # The kind half of #438 is fixed on this branch, so the two mutations that defended its
         # caveat are gone with the caveat. These two survive because #450 does.
         "DISCLOSURE: loose workbook attribution is no longer tracked, so its caveat never fires",
-        "            loosely_attributed.append(record.workbook)",
+        "            loosely_attributed.append(rescued)",
         "            pass",
         ["test_a_loosely_attributed_workbook_carries_a_caveat_naming_it"],
     ),

--- a/tests/mutate_revision_key.py
+++ b/tests/mutate_revision_key.py
@@ -21,12 +21,8 @@ MUTATIONS: list[tuple[str, str, str, str, str, str, str]] = [
     (
         "revision_key: hash the container raw instead of its contents",
         "scripts/object_identity.py",
-        "    digest = hashlib.sha256()\n"
-        "    for name, data in members:\n"
-        '        digest.update(name.encode("utf-8"))\n'
-        "        digest.update(hashlib.sha256(data).digest())\n"
-        "    return RevisionKey(algo=REVISION_ALGO_ARCHIVE, value=digest.hexdigest())",
-        "    return RevisionKey(algo=REVISION_ALGO_ARCHIVE, value=hashlib.sha256(payload).hexdigest())",
+        '        digest.update(len(encoded).to_bytes(8, "big"))',
+        "        return RevisionKey(algo=REVISION_ALGO_ARCHIVE, value=hashlib.sha256(payload).hexdigest())  # noqa",
         # A repacked archive must now produce a DIFFERENT key - which is the defect being re-created.
         "probe_repack_now_differs",
         "tests/test_workbook_identity.py::test_a_repack_changes_the_raw_digest_and_not_the_revision_key",
@@ -35,8 +31,8 @@ MUTATIONS: list[tuple[str, str, str, str, str, str, str]] = [
     (
         "revision_key: drop the member NAME from the digest",
         "scripts/object_identity.py",
-        '        digest.update(name.encode("utf-8"))\n        digest.update(hashlib.sha256(data).digest())',
-        "        digest.update(hashlib.sha256(data).digest())",
+        "        digest.update(encoded)\n",
+        "",
         "probe_rename_now_agrees",
         "tests/test_workbook_identity.py::test_genuinely_different_content_still_differs",
         "tests/test_workbook_identity.py::test_a_repack_changes_the_raw_digest_and_not_the_revision_key",
@@ -105,6 +101,33 @@ MUTATIONS: list[tuple[str, str, str, str, str, str, str]] = [
         "tests/test_workbook_identity.py::test_a_non_archive_uses_its_own_shape_and_says_so",
         "tests/test_workbook_identity.py::test_a_repack_changes_the_raw_digest_and_not_the_revision_key",
     ),
+    (
+        "B-B: a display name admits again",
+        "scripts/object_identity.py",
+        "WB_ROUTES = (WB_SHA, WB_LUID)",
+        "WB_ROUTES = (WB_SHA, WB_LUID, WB_NAME)",
+        "probe_name_admits",
+        "tests/test_reference_evidence.py::test_a_record_claiming_no_machine_identity_at_all_is_refused_and_counted",
+        "tests/test_workbook_identity.py::test_a_matching_luid_admits_and_names_the_luid_axis",
+    ),
+    (
+        "B-A: an unconfirmed revision is admitted again",
+        "scripts/reference_evidence.py",
+        "        if unit.revision != REVISION_CONFIRMED:",
+        "        if False:",
+        "probe_unconfirmed_admits",
+        "tests/test_reference_evidence.py::test_a_manifest_stamped_before_the_key_existed_is_unconfirmed_not_drifted",
+        "tests/test_reference_evidence.py::test_a_byte_confirmed_provenance_luid_certifies_normally",
+    ),
+    (
+        "B-C: the merge goes back to a hand-written key list",
+        "scripts/check_reference_readiness.py",
+        "        if isinstance(value, bool) or not isinstance(value, int):",
+        '        if isinstance(value, bool) or not isinstance(value, int) or key == "pages_revision_unconfirmed":',
+        "probe_merge_drops_a_counter",
+        "tests/test_check_reference_readiness.py::test_every_integer_counter_survives_a_merge_by_construction",
+        "tests/test_check_reference_readiness.py::test_the_attribution_census_survives_a_multi_path_scan",
+    ),
 ]
 
 PROBES = r"""
@@ -161,6 +184,32 @@ def probe_build_stamp_now_differs():
 
 def probe_flat_xml_now_raw():
     return oid.revision_key(LOCAL).algo == oid.REVISION_ALGO_FLAT
+
+def probe_name_admits():
+    unit = oid.WorkbookIdentity(luid="a" * 8, name="Book")
+    return unit.attribute(oid.WorkbookIdentity(name="Book")).admitted is True
+
+def probe_unconfirmed_admits():
+    return oid.WB_UNCONFIRMED not in [
+        ev.Evidence.attribution.__doc__ and oid.WB_UNCONFIRMED
+    ] or _unconfirmed_now_admits()
+
+def _unconfirmed_now_admits():
+    import reference_evidence as _ev
+    from pathlib import Path as _P
+    unit = _ev.UnitIdentity(name="WB", source_path=_P("x"), source_sha256="a" * 64, workbook_luid="L", revision="unconfirmed")
+    rec = _ev.Evidence(name="v", kind="worksheet", grade="g", origin="oracle", provider="oracle_capture",
+                       path="p", width=1, height=1, workbook_sha=None, workbook_luid="L", workbook_name=None,
+                       render_digest="d")
+    return rec.attribution(unit).route == oid.WB_LUID
+
+def probe_merge_drops_a_counter():
+    import check_reference_readiness as _crr
+    base = {"target": "a", "units": [], "evidence_rejected": [], "evidence_untyped_names": [],
+            "grades_present": [], "status": "READY", "pages_revision_unconfirmed": 1, "pages_ready": 1,
+            "all_evidence_validation_grade": True, "evidence_attributed": {}}
+    merged = _crr._merge_scans([dict(base), dict(base)])
+    return merged["pages_revision_unconfirmed"] == 1 and merged["pages_ready"] == 2
 
 print("PROBE_RESULT", bool(globals()[sys.argv[1]]()))
 """

--- a/tests/mutate_revision_key.py
+++ b/tests/mutate_revision_key.py
@@ -1,0 +1,210 @@
+"""Round-3 mutation proof for the revision key.
+
+⚠️ Every mutant carries a PROBE that calls the patched object and asserts a mutation-specific result
+BEFORE the anchor test runs. This repo has a measured case of 22/22 mutations scored "caught" that
+were all false positives - an import error made the test command exit non-zero - so "the anchor
+failed" is not evidence unless the mutation demonstrably took effect.
+
+usage: uv run python tests/mutate_revision_key.py
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# (label, file, find, replace, probe expression -> must be True under the mutant, anchor, control)
+MUTATIONS: list[tuple[str, str, str, str, str, str, str]] = [
+    (
+        "revision_key: hash the container raw instead of its contents",
+        "scripts/object_identity.py",
+        "    digest = hashlib.sha256()\n"
+        "    for name, data in members:\n"
+        '        digest.update(name.encode("utf-8"))\n'
+        "        digest.update(hashlib.sha256(data).digest())\n"
+        "    return RevisionKey(algo=REVISION_ALGO_ARCHIVE, value=digest.hexdigest())",
+        "    return RevisionKey(algo=REVISION_ALGO_ARCHIVE, value=hashlib.sha256(payload).hexdigest())",
+        # A repacked archive must now produce a DIFFERENT key - which is the defect being re-created.
+        "probe_repack_now_differs",
+        "tests/test_workbook_identity.py::test_a_repack_changes_the_raw_digest_and_not_the_revision_key",
+        "tests/test_workbook_identity.py::test_a_key_never_compares_across_algorithms",
+    ),
+    (
+        "revision_key: drop the member NAME from the digest",
+        "scripts/object_identity.py",
+        '        digest.update(name.encode("utf-8"))\n        digest.update(hashlib.sha256(data).digest())',
+        "        digest.update(hashlib.sha256(data).digest())",
+        "probe_rename_now_agrees",
+        "tests/test_workbook_identity.py::test_genuinely_different_content_still_differs",
+        "tests/test_workbook_identity.py::test_a_repack_changes_the_raw_digest_and_not_the_revision_key",
+    ),
+    (
+        "revision_key: silently fall back to a raw hash for an unreadable archive",
+        "scripts/object_identity.py",
+        "    except (zipfile.BadZipFile, OSError, RuntimeError, ValueError):\n        return None",
+        "    except (zipfile.BadZipFile, OSError, RuntimeError, ValueError):\n"
+        "        return RevisionKey(algo=REVISION_ALGO_ARCHIVE, value=hashlib.sha256(payload).hexdigest())",
+        "probe_truncated_now_keyed",
+        "tests/test_workbook_identity.py::test_an_unreadable_archive_yields_no_key_rather_than_a_raw_one",
+        "tests/test_workbook_identity.py::test_a_repack_changes_the_raw_digest_and_not_the_revision_key",
+    ),
+    (
+        "RevisionKey: compare across algorithms instead of refusing",
+        "scripts/object_identity.py",
+        "        if other is None or self.algo != other.algo:\n            return None",
+        "        if other is None:\n            return None",
+        "probe_cross_algo_now_compares",
+        "tests/test_workbook_identity.py::test_a_key_never_compares_across_algorithms",
+        "tests/test_workbook_identity.py::test_a_repack_changes_the_raw_digest_and_not_the_revision_key",
+    ),
+    (
+        "revision_status: a missing revision_match is read as drift",
+        "scripts/reference_evidence.py",
+        '    return REVISION_CONFIRMED if origin.get("match") == "sha256" else REVISION_UNCONFIRMED',
+        '    return REVISION_CONFIRMED if origin.get("match") == "sha256" else REVISION_MISMATCH',
+        "probe_missing_key_now_mismatch",
+        "tests/test_reference_evidence.py::test_a_manifest_stamped_before_the_key_existed_is_unconfirmed_not_drifted",
+        "tests/test_reference_evidence.py::test_a_byte_confirmed_provenance_luid_certifies_normally",
+    ),
+    (
+        "revision_status: ignore revision_match and go back to the raw verdict",
+        "scripts/reference_evidence.py",
+        '    declared = origin.get("revision_match")',
+        "    declared = None",
+        "probe_revision_match_ignored",
+        "tests/test_reference_evidence.py::test_a_repacked_archive_is_confirmed_rather_than_merely_unconfirmed",
+        "tests/test_reference_evidence.py::test_a_byte_confirmed_provenance_luid_certifies_normally",
+    ),
+    (
+        "fingerprint: stop recording the local revision key",
+        "scripts/stamp_tableau_provenance.py",
+        '        record["revision_key"] = key.as_json()',
+        "        pass",
+        "probe_fingerprint_has_no_key",
+        "tests/test_stamp_tableau_provenance.py::test_a_repacked_site_copy_is_recorded_as_the_same_revision",
+        "tests/test_stamp_tableau_provenance.py::test_matching_bytes_are_recorded_as_a_sha256_match",
+    ),
+    (
+        "revision_key: stop normalising the server build stamp",
+        "scripts/object_identity.py",
+        '    return XML_COMMENT_RE.sub(b"", data)',
+        "    return data",
+        "probe_build_stamp_now_differs",
+        "tests/test_workbook_identity.py::test_the_server_build_stamp_does_not_count_as_a_changed_workbook",
+        "tests/test_workbook_identity.py::test_a_repack_changes_the_raw_digest_and_not_the_revision_key",
+    ),
+    (
+        "revision_key: a flat XML payload is hashed raw again",
+        "scripts/object_identity.py",
+        "        if _is_xml(payload):",
+        "        if False:",
+        "probe_flat_xml_now_raw",
+        "tests/test_workbook_identity.py::test_a_non_archive_uses_its_own_shape_and_says_so",
+        "tests/test_workbook_identity.py::test_a_repack_changes_the_raw_digest_and_not_the_revision_key",
+    ),
+]
+
+PROBES = r"""
+import hashlib, io, sys, zipfile
+sys.path.insert(0, "scripts")
+import object_identity as oid
+import reference_evidence as ev
+import stamp_tableau_provenance as prov
+from pathlib import Path
+
+M = [("Book.twb", b"<workbook/>"), ("Data/x.hyper", b"\x00extract")]
+
+def _zip(members, dt):
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as z:
+        for n, d in members:
+            z.writestr(zipfile.ZipInfo(n, date_time=dt), d)
+    return buf.getvalue()
+
+A = _zip(M, (2026, 1, 1, 0, 0, 0))
+B = _zip(list(reversed(M)), (2026, 9, 3, 11, 22, 33))
+
+def probe_repack_now_differs():
+    return oid.revision_key(A) != oid.revision_key(B)
+
+def probe_rename_now_agrees():
+    renamed = _zip([("Cook.twb", M[0][1]), M[1]], (2026, 1, 1, 0, 0, 0))
+    return oid.revision_key(A).agrees_with(oid.revision_key(renamed)) is True
+
+def probe_truncated_now_keyed():
+    return oid.revision_key(A[:64]) is not None
+
+def probe_cross_algo_now_compares():
+    a = oid.RevisionKey(algo=oid.REVISION_ALGO_ARCHIVE, value="a" * 64)
+    f = oid.RevisionKey(algo=oid.REVISION_ALGO_FLAT, value="a" * 64)
+    return a.agrees_with(f) is not None
+
+def probe_missing_key_now_mismatch():
+    return ev.revision_status({"match": "name_only"}, []) == ev.REVISION_MISMATCH
+
+def probe_revision_match_ignored():
+    return ev.revision_status({"match": "name_only", "revision_match": "same"}, []) != ev.REVISION_CONFIRMED
+
+def probe_fingerprint_has_no_key():
+    p = Path(sys.argv[2])
+    p.write_bytes(A)
+    return "revision_key" not in prov.fingerprint(p)
+
+LOCAL = b"<?xml version='1.0'?>\n<!-- build 1 -->\n<workbook><worksheets/></workbook>"
+REMOTE = b"<?xml version='1.0'?>\n<!-- build 2 -->\n<workbook><worksheets/></workbook>"
+
+def probe_build_stamp_now_differs():
+    return oid.revision_key(LOCAL) != oid.revision_key(REMOTE)
+
+def probe_flat_xml_now_raw():
+    return oid.revision_key(LOCAL).algo == oid.REVISION_ALGO_FLAT
+
+print("PROBE_RESULT", bool(globals()[sys.argv[1]]()))
+"""
+
+
+def run(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, *args], cwd=ROOT, capture_output=True, text=True, check=False, encoding="utf-8"
+    )
+
+
+def main() -> int:
+    """Apply each mutation; require the PROBE to fire, the anchor to fail and the control to pass."""
+    probe_file = ROOT / "_probes_tmp.py"
+    probe_file.write_text(PROBES, encoding="utf-8")
+    scratch_twbx = ROOT / "_probe_tmp.twbx"
+    failures = []
+    for label, relative, find, replace, probe, anchor, control in MUTATIONS:
+        path = ROOT / relative
+        original = path.read_text(encoding="utf-8")
+        if original.count(find) != 1:
+            print(f"UNAPPLIED  {label} (pattern x{original.count(find)} in {relative})")
+            failures.append(label)
+            continue
+        path.write_text(original.replace(find, replace), encoding="utf-8")
+        try:
+            probed = run(str(probe_file), probe, str(scratch_twbx))
+            fired = "PROBE_RESULT True" in probed.stdout
+            anchor_code = run("-m", "pytest", anchor, "-q", "--no-header", "-p", "no:cacheprovider").returncode
+            control_code = run("-m", "pytest", control, "-q", "--no-header", "-p", "no:cacheprovider").returncode
+        finally:
+            path.write_text(original, encoding="utf-8")
+        ok = fired and anchor_code != 0 and control_code == 0
+        verdict = "KILLED" if ok else ("PROBE DID NOT FIRE" if not fired else "SURVIVED/CONTROL BROKE")
+        print(f"{verdict:<22} {label}\n{'':<22} probe_fired={fired} anchor={anchor_code} control={control_code}")
+        if not fired and probed.stderr:
+            print(f"{'':<22} probe stderr: {probed.stderr.strip().splitlines()[-1][:120]}")
+        if not ok:
+            failures.append(label)
+    print(f"\n{len(MUTATIONS) - len(failures)}/{len(MUTATIONS)} killed with a firing probe")
+    probe_file.unlink(missing_ok=True)
+    scratch_twbx.unlink(missing_ok=True)
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/mutation_reference_readiness.py
+++ b/tests/mutation_reference_readiness.py
@@ -296,8 +296,9 @@ ev.Evidence.candidate = lambda self: oid.Candidate(names=(self.name,), kind=self
     # --- evidence must be ATTRIBUTABLE ----------------------------------------------------------
     "evidence-matches-any-workbook": Mutation(
         code="""
+import object_identity as oid
 import reference_evidence as ev
-ev.Evidence.is_for = lambda self, unit: True
+ev.Evidence.attribution = lambda self, unit: oid.Attribution(oid.WB_LUID, "mutant admits everything")
 """,
         anchor="test_evidence_for_another_workbook_does_not_satisfy_this_one",
         controls=("test_a_page_with_no_evidence_at_all_is_blind_not_unverifiable",),
@@ -318,9 +319,9 @@ ev.Evidence.build = classmethod(build)
     "a-name-only-provenance-luid-is-trusted": Mutation(
         code="""
 import check_reference_readiness as crr
-# Round-2 finding 3: origin.match was never consulted, so a LUID whose bytes DIFFER from the
-# server's - which stamp_tableau_provenance.py says will not reproduce - made evidence ready.
-def _provenance_luid(root, source_sha):
+# An origin that establishes identity by NEITHER route - no `matched_by: "luid"` and unconfirmed
+# bytes - must yield no LUID. This mutant trusts one anyway, which is the name-collision hole.
+def _provenance_luid(root, source_sha, source=None):
     payload = crr.json_object(root / "source-provenance.json")
     for record in (payload or {}).get("inputs") or []:
         origin = record.get("origin") or {}
@@ -332,6 +333,30 @@ crr._provenance_luid = _provenance_luid
 """,
         anchor="test_a_name_only_provenance_luid_is_not_trusted",
         controls=("test_a_sha256_confirmed_provenance_luid_is_trusted",),
+    ),
+    "a-luid-matched-provenance-is-discarded-when-the-bytes-differ": Mutation(
+        code="""
+import check_reference_readiness as crr
+# Issue #450, symptom A: `origin.match` answers a REVISION question and was read as if it were the
+# identity one, so a LUID-matched workbook whose bytes had since changed lost its identity entirely
+# and fell back to comparing an artifact stem against a published display name.
+_orig = crr._provenance_luid
+def _provenance_luid(root, source_sha, source=None):
+    payload = crr.json_object(root / "source-provenance.json")
+    for record in (payload or {}).get("inputs") or []:
+        stamped = record.get("input") or {}
+        origin = record.get("origin") or {}
+        if stamped.get("sha256") != source_sha:
+            continue
+        if origin.get("match") != "sha256":
+            return None
+        luid = origin.get("workbook_luid")
+        return luid if isinstance(luid, str) and luid else None
+    return None
+crr._provenance_luid = _provenance_luid
+""",
+        anchor="test_a_luid_matched_provenance_survives_a_changed_revision",
+        controls=("test_a_name_only_provenance_luid_is_not_trusted",),
     ),
     "a-luid-record-discards-its-workbook-name": Mutation(
         code="""
@@ -807,17 +832,16 @@ rule.scan_source = scan_source
     "evidence-attribution-normalizes-the-workbook-name": Mutation(
         code="""
 import object_identity as oid
-import reference_evidence as ev
-# Found by WRITING the quarantine rule, not by reasoning: `Evidence.is_for` compared workbook names
-# through the lossy function, so two workbooks differing only by whitespace would have swapped
-# captures. A layer nobody had enumerated.
-def is_for(self, unit):
-    if self.workbook_sha is not None:
-        return self.workbook_sha.casefold() == unit.source_sha256.casefold()
-    if self.workbook_luid and unit.workbook_luid:
-        return self.workbook_luid.casefold() == unit.workbook_luid.casefold()
-    return bool(self.workbook_name) and oid.normalize(self.workbook_name) == oid.normalize(unit.name)
-ev.Evidence.is_for = is_for
+# Found by WRITING the quarantine rule, not by reasoning: the workbook-name comparison ran through
+# the lossy function, so two workbooks differing only by whitespace would have swapped captures. A
+# layer nobody had enumerated - and since #450 it lives in the join BOTH gates share, so this mutant
+# aims at that one function rather than at one gate's copy of the rule.
+_orig = oid._axis_equal
+def _axis_equal(axis, mine, theirs):
+    if axis == oid.WB_NAME:
+        return oid.normalize(mine) == oid.normalize(theirs)
+    return _orig(axis, mine, theirs)
+oid._axis_equal = _axis_equal
 """,
         anchor="test_evidence_attribution_uses_the_exact_workbook_name",
         controls=("test_oracle_evidence_for_this_workbook_does_count",),

--- a/tests/mutation_reference_readiness.py
+++ b/tests/mutation_reference_readiness.py
@@ -943,9 +943,9 @@ import check_reference_readiness as crr
 # bundle-wide pass is a no-op.
 _enforce = crr._enforce_exclusivity
 _result = crr._readiness_result
-def _readiness_result(unit, report_dir, source, rows):
+def _readiness_result(unit, report_dir, source, rows, attribution):
     _enforce(rows)
-    return _result(unit, report_dir, source, rows)
+    return _result(unit, report_dir, source, rows, attribution)
 crr._readiness_result = _readiness_result
 crr._enforce_exclusivity = lambda rows: None
 """,

--- a/tests/mutation_reference_readiness.py
+++ b/tests/mutation_reference_readiness.py
@@ -447,6 +447,51 @@ oid.WB_ADMITTING = frozenset({*oid.WB_ROUTES, oid.WB_STALE})
         anchor="test_a_reproducible_byte_difference_is_the_only_thing_that_proves_drift",
         controls=("test_a_byte_confirmed_provenance_luid_certifies_normally",),
     ),
+    # --- round N of PR #454: an unassessable identity must not collapse into READY ---------------
+    "the-first-agreeing-axis-wins-again": Mutation(
+        code="""
+import object_identity as oid
+# BLOCKING FINDING B. `attribute` returned as soon as one machine axis agreed, so a record whose
+# sha256 was this unit's source and whose LUID named ANOTHER workbook was admitted on the sha256:
+# entry gate READY 1/1 exit 0, exit gate PASS visual=1 numeric=1.
+oid.WorkbookIdentity._contradiction = lambda self, record, *, decided: None
+""",
+        anchor="test_a_reference_manifest_whose_luid_contradicts_its_matching_sha_certifies_nothing",
+        controls=("test_a_reference_manifest_whose_luid_agrees_with_its_sha_still_certifies",),
+    ),
+    "the-reference-manifests-luid-is-discarded-again": Mutation(
+        code="""
+import reference_evidence as ev
+# The other half of FINDING B: the entry gate dropped the manifest's `workbook_luid` before building
+# `Evidence`, so by the time the join ran there was nothing left to contradict the matching sha.
+ev._reference_workbook_luid = lambda entry, state, manifest: None
+""",
+        anchor="test_a_reference_manifest_whose_luid_contradicts_its_matching_sha_certifies_nothing",
+        controls=("test_a_reference_manifest_whose_luid_agrees_with_its_sha_still_certifies",),
+    ),
+    "ambiguous-provenance-is-resolved-by-array-order": Mutation(
+        code="""
+import reference_evidence as ev
+# BLOCKING FINDING A. The SHA loop returned on its first hit, so two provenance records for one
+# source digest naming different workbooks resolved by JSON array order - byte-identical evidence
+# read READY/exit 0 one way round and FINDINGS/exit 1 the other.
+_orig = ev._weakest_revision
+def provenance_origin(root, source_sha, source=None):
+    stamped = ev.harvest_luid(ev.persisted_stem(source.name if source is not None else None))
+    inputs = list((ev.json_object(root / "source-provenance.json") or {}).get("inputs") or [])
+    for record in inputs:
+        found = ev._stamped_origin(record)
+        if found is None or found[0] != source_sha:
+            continue
+        return ev.agreed_luid(stamped, ev._identity_claim(found[1])), ev.revision_status(found[1], inputs)
+    return ev.agreed_luid(stamped), ev.REVISION_UNCONFIRMED
+ev.provenance_origin = provenance_origin
+import check_reference_readiness as crr
+crr.provenance_origin = provenance_origin
+""",
+        anchor="test_the_ambiguous_provenance_verdict_does_not_depend_on_the_array_order",
+        controls=("test_a_byte_confirmed_provenance_luid_certifies_normally",),
+    ),
     "a-recorded-path-is-parsed-with-the-running-hosts-flavour": Mutation(
         code="""
 import object_identity as oid

--- a/tests/mutation_reference_readiness.py
+++ b/tests/mutation_reference_readiness.py
@@ -90,6 +90,7 @@ TARGETS = (
     "tests/test_check_reference_readiness.py",
     "tests/test_reference_evidence.py",
     "tests/test_object_identity.py",
+    "tests/test_workbook_identity.py",
     "tests/test_identity_normalization.py",
 )
 #: `mutation_harness.run` passes its target as ONE argv element, so a whole-suite control names the
@@ -321,15 +322,16 @@ ev.Evidence.build = classmethod(build)
 import check_reference_readiness as crr
 # An origin that establishes identity by NEITHER route - no `matched_by: "luid"` and unconfirmed
 # bytes - must yield no LUID. This mutant trusts one anyway, which is the name-collision hole.
-def _provenance_luid(root, source_sha, source=None):
+_orig = crr.provenance_origin
+def _provenance_origin(root, source_sha, source=None):
+    _luid, revision = _orig(root, source_sha, source)
     payload = crr.json_object(root / "source-provenance.json")
     for record in (payload or {}).get("inputs") or []:
-        origin = record.get("origin") or {}
-        luid = origin.get("workbook_luid")
+        luid = (record.get("origin") or {}).get("workbook_luid")
         if isinstance(luid, str) and luid:
-            return luid
-    return None
-crr._provenance_luid = _provenance_luid
+            return luid, revision
+    return None, revision
+crr.provenance_origin = _provenance_origin
 """,
         anchor="test_a_name_only_provenance_luid_is_not_trusted",
         controls=("test_a_sha256_confirmed_provenance_luid_is_trusted",),
@@ -340,35 +342,141 @@ import check_reference_readiness as crr
 # Issue #450, symptom A: `origin.match` answers a REVISION question and was read as if it were the
 # identity one, so a LUID-matched workbook whose bytes had since changed lost its identity entirely
 # and fell back to comparing an artifact stem against a published display name.
-_orig = crr._provenance_luid
-def _provenance_luid(root, source_sha, source=None):
+_orig = crr.provenance_origin
+def _provenance_origin(root, source_sha, source=None):
+    luid, revision = _orig(root, source_sha, source)
     payload = crr.json_object(root / "source-provenance.json")
     for record in (payload or {}).get("inputs") or []:
         stamped = record.get("input") or {}
         origin = record.get("origin") or {}
-        if stamped.get("sha256") != source_sha:
-            continue
-        if origin.get("match") != "sha256":
-            return None
-        luid = origin.get("workbook_luid")
-        return luid if isinstance(luid, str) and luid else None
-    return None
-crr._provenance_luid = _provenance_luid
+        if stamped.get("sha256") == source_sha and origin.get("match") != "sha256":
+            return None, revision
+    return luid, revision
+crr.provenance_origin = _provenance_origin
 """,
-        anchor="test_a_luid_matched_provenance_survives_a_changed_revision",
+        anchor="test_a_luid_matched_provenance_still_establishes_identity_but_not_the_revision",
         controls=("test_a_name_only_provenance_luid_is_not_trusted",),
     ),
-    "a-luid-record-discards-its-workbook-name": Mutation(
+    "an-oracle-record-discards-its-workbook-name": Mutation(
         code="""
 import reference_evidence as ev
+# Round-2 finding 3 shipped as "a LUID-bearing record discarded its name". Since round-2 review of
+# PR #454 a LUID-bearing record never REACHES the name axis - an unanswerable LUID is `unknown` - so
+# that mutant became inert and is re-aimed: the name must still be read for a record that carries no
+# machine identity at all, which is the only route a hand-written or reference manifest has.
 _orig = ev._oracle_workbook_ids
 def _oracle_workbook_ids(record):
-    luid, name = _orig(record)
-    return (luid, None) if luid else (None, name)
+    luid, _name = _orig(record)
+    return luid, None
 ev._oracle_workbook_ids = _oracle_workbook_ids
 """,
-        anchor="test_a_record_carrying_both_luid_and_name_can_still_fall_back_to_the_name",
+        anchor="test_a_record_claiming_no_machine_identity_at_all_may_still_match_on_the_name",
         controls=("test_a_sha256_confirmed_provenance_luid_is_trusted",),
+    ),
+    # --- round-2 review of PR #454: one rule for an unanswerable machine identity ----------------
+    "an-unanswerable-luid-falls-through-to-the-name": Mutation(
+        code="""
+import object_identity as oid
+# BLOCKER 1. A real oracle record carries BOTH workbook_luid and workbook_name, so skipping an
+# UNSHARED luid and admitting on an equal display name let a foreign workbook certify a page.
+def attribute(self, record):
+    for axis in oid.WB_MACHINE_AXES:
+        mine, theirs = getattr(self, oid._FIELD[axis]), getattr(record, oid._FIELD[axis])
+        if mine is None or theirs is None:
+            continue
+        if oid._axis_equal(axis, mine, theirs):
+            return oid.Attribution(axis, "match", axis=axis)
+        return oid.Attribution(oid.WB_FOREIGN, "differs", axis=axis)
+    if self.name is not None and record.name is not None:
+        if oid._axis_equal(oid.WB_NAME, self.name, record.name):
+            return oid.Attribution(oid.WB_NAME, "match", axis=oid.WB_NAME)
+        return oid.Attribution(oid.WB_FOREIGN, "differs", axis=oid.WB_NAME)
+    return oid.Attribution(oid.WB_UNKNOWN, "none")
+oid.WorkbookIdentity.attribute = attribute
+""",
+        anchor="test_a_record_whose_luid_this_unit_cannot_answer_is_not_rescued_by_its_name",
+        controls=("test_a_record_claiming_no_machine_identity_at_all_may_still_match_on_the_name",),
+    ),
+    "an-unanswerable-machine-axis-is-simply-skipped": Mutation(
+        code="""
+import object_identity as oid
+_orig = oid.WorkbookIdentity.attribute
+def attribute(self, record):
+    verdict = _orig(self, record)
+    if verdict.route == oid.WB_UNKNOWN and self.name and record.name and self.name == record.name:
+        return oid.Attribution(oid.WB_NAME, "rescued", axis=oid.WB_NAME)
+    return verdict
+oid.WorkbookIdentity.attribute = attribute
+""",
+        anchor="test_a_record_whose_luid_this_unit_cannot_answer_is_not_rescued_by_its_name",
+        controls=("test_a_byte_confirmed_provenance_luid_certifies_normally",),
+    ),
+    "the-revision-axis-is-discarded-again": Mutation(
+        code="""
+import check_reference_readiness as crr
+import reference_evidence as ev
+# BLOCKER 2: separating identity from revision is right; DROPPING the revision made a capture of a
+# possibly-different build read as a clean READY with nothing saying so.
+ev.revision_status = lambda origin, inputs: crr.REVISION_CONFIRMED
+""",
+        anchor="test_a_luid_matched_provenance_still_establishes_identity_but_not_the_revision",
+        controls=("test_a_byte_confirmed_provenance_luid_certifies_normally",),
+    ),
+    "a-non-reproducible-byte-difference-is-called-drift": Mutation(
+        code="""
+import check_reference_readiness as crr
+import reference_evidence as ev
+# The other direction, and the reason the rule is measured rather than chosen: content_sha256(luid)
+# returned DIFFERENT digests for 18 of 30 workbooks inside one run, so `name_only` alone marked 125
+# pages unverifiable on an estate where nothing had changed.
+def _revision_status(origin, inputs):
+    if origin.get("match") == "sha256":
+        return crr.REVISION_CONFIRMED
+    return crr.REVISION_MISMATCH if origin.get("match") == "name_only" else crr.REVISION_UNCONFIRMED
+ev.revision_status = _revision_status
+""",
+        anchor="test_a_luid_matched_provenance_still_establishes_identity_but_not_the_revision",
+        controls=("test_a_reproducible_byte_difference_is_the_only_thing_that_proves_drift",),
+    ),
+    "a-stale-render-is-admitted-anyway": Mutation(
+        code="""
+import object_identity as oid
+oid.WB_ADMITTING = frozenset({*oid.WB_ROUTES, oid.WB_STALE})
+""",
+        anchor="test_a_reproducible_byte_difference_is_the_only_thing_that_proves_drift",
+        controls=("test_a_byte_confirmed_provenance_luid_certifies_normally",),
+    ),
+    "a-recorded-path-is-parsed-with-the-running-hosts-flavour": Mutation(
+        code="""
+import object_identity as oid
+from pathlib import PurePosixPath
+# BLOCKER 4: `Path` is the running host's flavour, so a Windows-recorded handover path loses its
+# LUID prefix on Linux CI - the guard behaved differently in the two places we look.
+oid.persisted_stem = lambda text: PurePosixPath(text or "").stem
+""",
+        anchor="test_the_recorded_path_parse_does_not_use_the_running_hosts_flavour",
+        controls=("test_agreed_luid_refuses_two_claims_that_disagree",),
+    ),
+    "the-merged-census-keeps-only-the-first-scan": Mutation(
+        code="""
+import check_reference_readiness as crr
+_orig = crr._merge_scans
+def _merge_scans(reports):
+    merged = _orig(reports)
+    merged["evidence_attributed"] = reports[0].get("evidence_attributed")
+    return merged
+crr._merge_scans = _merge_scans
+""",
+        anchor="test_the_attribution_census_survives_a_multi_path_scan",
+        controls=("test_every_refusal_is_counted_so_it_can_be_told_from_a_missing_capture",),
+    ),
+    "the-ancestor-walk-stops-one-level-short": Mutation(
+        code="""
+import bundle_corpus
+bundle_corpus.ANCESTOR_LEVELS = 2
+""",
+        anchor="test_a_unit_three_levels_below_the_run_still_inherits_the_flat_capture",
+        controls=("test_a_non_packaged_target_still_finds_an_ancestors_oracle",),
     ),
     # --- completeness needs a readable, unique mapping --------------------------------------------
     "unreadable-page-json-falls-back-to-the-directory-name": Mutation(

--- a/tests/mutation_reference_readiness.py
+++ b/tests/mutation_reference_readiness.py
@@ -360,17 +360,18 @@ crr.provenance_origin = _provenance_origin
     "an-oracle-record-discards-its-workbook-name": Mutation(
         code="""
 import reference_evidence as ev
-# Round-2 finding 3 shipped as "a LUID-bearing record discarded its name". Since round-2 review of
-# PR #454 a LUID-bearing record never REACHES the name axis - an unanswerable LUID is `unknown` - so
-# that mutant became inert and is re-aimed: the name must still be read for a record that carries no
-# machine identity at all, which is the only route a hand-written or reference manifest has.
+# Round-2 finding 3 shipped as "a LUID-bearing record discarded its name". A LUID-bearing record has
+# not reached the name axis since round 2 - an unanswerable LUID is `unknown` - and since round-3
+# B-B a name never ADMITS at all. Re-aimed a second time, at what the name still does: DISCLOSURE.
+# Dropping it turns a `name` refusal into `unknown`, and those are different operator actions -
+# "something claimed to be this workbook by its display name" vs "nothing identified it at all".
 _orig = ev._oracle_workbook_ids
 def _oracle_workbook_ids(record):
     luid, _name = _orig(record)
     return luid, None
 ev._oracle_workbook_ids = _oracle_workbook_ids
 """,
-        anchor="test_a_record_claiming_no_machine_identity_at_all_may_still_match_on_the_name",
+        anchor="test_a_record_claiming_no_machine_identity_at_all_is_refused_and_counted",
         controls=("test_a_sha256_confirmed_provenance_luid_is_trusted",),
     ),
     # --- round-2 review of PR #454: one rule for an unanswerable machine identity ----------------
@@ -395,7 +396,7 @@ def attribute(self, record):
 oid.WorkbookIdentity.attribute = attribute
 """,
         anchor="test_a_record_whose_luid_this_unit_cannot_answer_is_not_rescued_by_its_name",
-        controls=("test_a_record_claiming_no_machine_identity_at_all_may_still_match_on_the_name",),
+        controls=("test_a_record_claiming_no_machine_identity_at_all_is_refused_and_counted",),
     ),
     "an-unanswerable-machine-axis-is-simply-skipped": Mutation(
         code="""

--- a/tests/test_check_reference_readiness.py
+++ b/tests/test_check_reference_readiness.py
@@ -1150,3 +1150,78 @@ def test_one_render_cannot_satisfy_a_page_in_each_of_two_units(bundle: Path) -> 
     assert rows[("Two", "Shared")]["readiness"] != "ready"
     assert report["pages_ready"] == 0
     assert crr.main([str(bundle), "--quiet"]) == 1
+
+
+# --------------------------------------------------------------------------------------------
+# Evidence discovery: the walk-up is a UNION, and a self-contained package must stop it (#451)
+# --------------------------------------------------------------------------------------------
+
+
+def test_a_non_packaged_target_still_finds_an_ancestors_oracle(tmp_path: Path) -> None:
+    """The control that makes the package test below meaningful rather than a deletion.
+
+    `_default_dirs` looks beside the target, beside its parent AND beside its grandparent, because an
+    un-packaged unit under `<bundle>/pbip/<Unit>/` finds the run's flat capture that way. Removing
+    the walk-up would break the ordinary case, so it has to keep working IN THE SAME RUN as the
+    package that must not inherit.
+    """
+    target = tmp_path / "run" / "bundle" / "unit"
+    target.mkdir(parents=True)
+    (tmp_path / "run" / "_oracle").mkdir()
+
+    assert crr._default_dirs(target, "_oracle") == [tmp_path / "run" / "_oracle"]
+
+
+def test_a_self_contained_package_does_not_inherit_an_ancestors_oracle(tmp_path: Path) -> None:
+    """A `package-manifest.json` beside the target stops the walk (issue #451).
+
+    `package_unit.py` writes a unit-scoped `oracle/oracle-manifest.json` holding THIS unit's views
+    with rewritten paths. A package assembled INSIDE a run directory therefore saw its own copy AND
+    the run's flat capture two levels up, every view matched twice, and the gate refused the pair as
+    "2 records share this name once normalized" - taking every page from ready to unverifiable,
+    silently, so packaging was strictly worse than not packaging.
+    """
+    target = tmp_path / "run" / "packages" / "unit"
+    (target / "oracle").mkdir(parents=True)
+    (target / "package-manifest.json").write_text("{}", encoding="utf-8")
+    (tmp_path / "run" / "oracle").mkdir()
+
+    assert crr._default_dirs(target, "oracle") == [target / "oracle"]
+
+
+def test_a_package_with_no_evidence_of_its_own_still_inherits_nothing(tmp_path: Path) -> None:
+    """Kills: "stop only when the package has its own copy", which re-opens the union by accident.
+
+    A package that omitted a render because it could not attribute it must NOT then pick that render
+    up from the ancestor - that is the omission being undone by the consumer, which is how a
+    fail-closed packaging decision would turn back into a fail-open one.
+    """
+    target = tmp_path / "run" / "packages" / "unit"
+    target.mkdir(parents=True)
+    (target / "package-manifest.json").write_text("{}", encoding="utf-8")
+    (tmp_path / "run" / "oracle").mkdir()
+
+    assert crr._default_dirs(target, "oracle") == []
+
+
+def test_a_packaged_unit_reads_only_its_own_manifest_end_to_end(tmp_path: Path) -> None:
+    """The same defect at gate level: the doubled record must not reach the readiness verdict.
+
+    Both manifests describe the SAME view of the SAME workbook, which is what a package inside a run
+    directory produces; the ancestor copy is the one that must be ignored.
+    """
+    package = tmp_path / "run" / "unit"
+    package.mkdir(parents=True)
+    (tmp_path / "assets").mkdir()
+    sha = build_unit(package, "WB", worksheets=["Revenue Trend"])
+    view = {"view_name": "Revenue Trend", "view_type": "worksheet", "workbook_name": "WB"}
+    write_oracle(package, [view])
+    write_oracle(tmp_path / "run", [view])
+    assert crr.scan(package)["units"][0]["pages"][0]["readiness"] == "unverifiable"
+
+    (package / "package-manifest.json").write_text("{}", encoding="utf-8")
+
+    report = crr.scan(package)
+    assert report["units"][0]["pages"][0]["readiness"] == "ready"
+    assert report["evidence_records"] == 1
+    assert sha

--- a/tests/test_check_reference_readiness.py
+++ b/tests/test_check_reference_readiness.py
@@ -1225,3 +1225,44 @@ def test_a_packaged_unit_reads_only_its_own_manifest_end_to_end(tmp_path: Path) 
     assert report["units"][0]["pages"][0]["readiness"] == "ready"
     assert report["evidence_records"] == 1
     assert sha
+
+
+def test_a_unit_three_levels_below_the_run_still_inherits_the_flat_capture(tmp_path: Path) -> None:
+    """MEDIUM 1 from round-1 review of PR #454, at the canonical depth.
+
+    `capture_tableau_oracle.py` writes `_runs/<NNN>-<slug>/oracle/` while an un-packaged unit sits at
+    `_runs/<NNN>-<slug>/bundle/pbip/<Unit>/` - THREE ancestors below it. Stopping at one (the exit
+    gate) or two (this one) makes a real capture invisible for the ordinary engine-bundle shape, so
+    the depth is part of the shared rule rather than each gate's guess.
+    """
+    unit = tmp_path / "run" / "bundle" / "pbip" / "Unit"
+    unit.mkdir(parents=True)
+    (tmp_path / "run" / "oracle").mkdir()
+
+    assert crr._default_dirs(unit, "oracle") == [tmp_path / "run" / "oracle"]
+
+
+def test_the_attribution_census_survives_a_multi_path_scan(tmp_path: Path) -> None:
+    """MEDIUM 2: `_merge_scans` inherits `dict(reports[0])`, so later refusals used to vanish.
+
+    Measured on two bundles: the second refused 7 records as another workbook's, and the merged
+    report said `foreign=0`. A refusal counter that silently zeroes is worse than none, because it
+    reads as "nothing was refused" exactly where the guard did the most work.
+    """
+    clean, dirty = tmp_path / "clean", tmp_path / "dirty"
+    for root in (clean, dirty):
+        (root / "bundle").mkdir(parents=True)
+        (root / "assets").mkdir(parents=True)
+    build_unit(clean / "bundle", "Book", worksheets=["Revenue"])
+    write_oracle(clean / "bundle", [{"view_name": "Revenue", "view_type": "worksheet", "workbook_name": "Book"}])
+    build_unit(dirty / "bundle", "Other", worksheets=["Revenue"])
+    write_oracle(
+        dirty / "bundle",
+        [{"view_name": f"V{i}", "view_type": "worksheet", "workbook_name": "Elsewhere"} for i in range(7)],
+    )
+
+    merged = crr._merge_scans([crr.scan(clean / "bundle"), crr.scan(dirty / "bundle")])
+
+    assert merged["evidence_attributed"]["foreign"] == 7
+    assert merged["evidence_attributed"]["name"] == 1
+    assert "refused 7 as another" in crr.render(merged)

--- a/tests/test_check_reference_readiness.py
+++ b/tests/test_check_reference_readiness.py
@@ -158,6 +158,8 @@ def write_reference(  # pylint: disable=too-many-arguments,too-many-locals
     record_integrity: bool = True,
     view_type: str | None = None,
     workbook_luid: str | None = None,
+    entry_luid: str | None = None,
+    state_luid: str | None = None,
 ) -> Path:
     """A `reference/manifest.json`. Each entry is ``(name, provider, capabilities)``.
 
@@ -172,6 +174,11 @@ def write_reference(  # pylint: disable=too-many-arguments,too-many-locals
     ``workbook_luid`` writes the manifest-level LUID key `check_unit._declared_workbook` already
     reads. The producer does not write it today; a manifest carrying one is enriched or hand-edited,
     which is exactly the shape the round-N contradiction finding used.
+
+    ``entry_luid`` and ``state_luid`` write the SAME key at the two narrower scopes both gates also
+    read. They exist because round 2 of PR #454 found the readers selecting one scope's claim by
+    precedence and discarding the others - a fixture that could only write one scope cannot express
+    a multi-scope contradiction, and so could not have caught it.
     """
     reference = root / "reference"
     reference.mkdir(parents=True, exist_ok=True)
@@ -193,13 +200,18 @@ def write_reference(  # pylint: disable=too-many-arguments,too-many-locals
         }
         if view_type is not None:
             state["view_type"] = view_type
+        if state_luid is not None:
+            state["workbook_luid"] = state_luid
         if record_integrity:
             state |= {
                 "sha256": hashlib.sha256(blob).hexdigest(),
                 "bytes": len(blob),
                 "dimensions": {"w": size[0], "h": size[1], "dpr": 2},
             }
-        dashboards.append({"name": name, "states": [state]})
+        entry: dict = {"name": name, "states": [state]}
+        if entry_luid is not None:
+            entry["workbook_luid"] = entry_luid
+        dashboards.append(entry)
     payload: dict = {"source_workbook_sha256": source_sha, "dashboards": dashboards}
     if workbook_luid is not None:
         payload["workbook_luid"] = workbook_luid

--- a/tests/test_check_reference_readiness.py
+++ b/tests/test_check_reference_readiness.py
@@ -157,6 +157,7 @@ def write_reference(  # pylint: disable=too-many-arguments,too-many-locals
     render_bytes: bytes | None = None,
     record_integrity: bool = True,
     view_type: str | None = None,
+    workbook_luid: str | None = None,
 ) -> Path:
     """A `reference/manifest.json`. Each entry is ``(name, provider, capabilities)``.
 
@@ -167,6 +168,10 @@ def write_reference(  # pylint: disable=too-many-arguments,too-many-locals
 
     Note the manifest's top-level key is `dashboards`, but `capture_tableau_reference.py:199` files
     WORKSHEET thumbnails there too - which is why the key cannot be evidence of scope.
+
+    ``workbook_luid`` writes the manifest-level LUID key `check_unit._declared_workbook` already
+    reads. The producer does not write it today; a manifest carrying one is enriched or hand-edited,
+    which is exactly the shape the round-N contradiction finding used.
     """
     reference = root / "reference"
     reference.mkdir(parents=True, exist_ok=True)
@@ -195,9 +200,10 @@ def write_reference(  # pylint: disable=too-many-arguments,too-many-locals
                 "dimensions": {"w": size[0], "h": size[1], "dpr": 2},
             }
         dashboards.append({"name": name, "states": [state]})
-    (reference / "manifest.json").write_text(
-        json.dumps({"source_workbook_sha256": source_sha, "dashboards": dashboards}), encoding="utf-8"
-    )
+    payload: dict = {"source_workbook_sha256": source_sha, "dashboards": dashboards}
+    if workbook_luid is not None:
+        payload["workbook_luid"] = workbook_luid
+    (reference / "manifest.json").write_text(json.dumps(payload), encoding="utf-8")
     return reference
 
 

--- a/tests/test_check_reference_readiness.py
+++ b/tests/test_check_reference_readiness.py
@@ -201,6 +201,10 @@ def write_reference(  # pylint: disable=too-many-arguments,too-many-locals
     return reference
 
 
+UNIT_LUID = "adc431bb-aeeb-43fe-8ecb-092d4bae8bfa"
+OTHER_LUID = "007f70ac-bf40-4838-9d73-134d40f504db"
+
+
 def write_oracle(root: Path, views: list[dict], *, size: tuple[int, int] = (320, 240)) -> Path:
     """An `_oracle/oracle-manifest.json`. Each view dict may carry `view_type` (PR #422).
 
@@ -250,6 +254,7 @@ def build_unit(  # pylint: disable=too-many-arguments
     page_ids: list[str] | None = None,
     viz_fidelity: list[dict] | None = None,
     pbip_warnings: list[str] | None = None,
+    luid: str | None = UNIT_LUID,
 ) -> str:
     """Wire a complete workbook unit and return its source sha256, which evidence must carry."""
     source = write_workbook(bundle.parent / "assets" / f"{unit}.twb", worksheets=worksheets, dashboards=dashboards)
@@ -258,7 +263,28 @@ def build_unit(  # pylint: disable=too-many-arguments
     if page_ids is None:
         page_ids = [obj.page_id for obj in crr.source_objects(source) or []]
     write_report(bundle, unit, page_ids)
-    return hashlib.sha256(source.read_bytes()).hexdigest()
+    digest = hashlib.sha256(source.read_bytes()).hexdigest()
+    if luid is not None:
+        (bundle / "source-provenance.json").write_text(
+            json.dumps(
+                {
+                    "inputs": [
+                        {
+                            "input": {"file": source.name, "sha256": digest},
+                            "origin": {
+                                "workbook_luid": luid,
+                                "workbook_name": unit,
+                                "matched_by": "luid",
+                                "match": "name_only",
+                                "revision_match": "same",
+                            },
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+    return digest
 
 
 # --------------------------------------------------------------------------------------------
@@ -604,7 +630,7 @@ def test_a_worksheet_render_does_satisfy_a_worksheet_page(bundle: Path) -> None:
 def test_an_oracle_record_with_no_view_type_cannot_satisfy_a_page(bundle: Path) -> None:
     """PR #422's field absent = cannot establish, never "it could be either"."""
     build_unit(bundle, "WB", worksheets=["Revenue Trend"])
-    write_oracle(bundle, [{"view_name": "Revenue Trend", "workbook_name": "WB"}])
+    write_oracle(bundle, [{"view_name": "Revenue Trend", "workbook_luid": UNIT_LUID}])
 
     page = crr.scan(bundle)["units"][0]["pages"][0]
     assert page["readiness"] == "unverifiable"
@@ -614,7 +640,7 @@ def test_an_oracle_record_with_no_view_type_cannot_satisfy_a_page(bundle: Path) 
 def test_an_oracle_record_typed_unknown_cannot_satisfy_a_page(bundle: Path) -> None:
     """PR #422 fails closed to `unknown` when the Metadata API is disabled; so must this."""
     build_unit(bundle, "WB", worksheets=["Revenue Trend"])
-    write_oracle(bundle, [{"view_name": "Revenue Trend", "view_type": "unknown", "workbook_name": "WB"}])
+    write_oracle(bundle, [{"view_name": "Revenue Trend", "view_type": "unknown", "workbook_luid": UNIT_LUID}])
 
     assert crr.scan(bundle)["units"][0]["pages"][0]["readiness"] == "unverifiable"
 
@@ -622,7 +648,7 @@ def test_an_oracle_record_typed_unknown_cannot_satisfy_a_page(bundle: Path) -> N
 def test_an_oracle_record_typed_worksheet_still_cannot_satisfy_a_dashboard_page(bundle: Path) -> None:
     """The scope join applies to the oracle route too, not only to `reference/`."""
     build_unit(bundle, "WB", worksheets=["Ops"], dashboards={"Ops": ["Ops"]})
-    write_oracle(bundle, [{"view_name": "Ops", "view_type": "worksheet", "workbook_name": "WB"}])
+    write_oracle(bundle, [{"view_name": "Ops", "view_type": "worksheet", "workbook_luid": UNIT_LUID}])
 
     assert crr.scan(bundle)["units"][0]["pages"][0]["readiness"] == "unverifiable"
 
@@ -802,7 +828,7 @@ def test_oracle_grade_is_below_the_validation_bar(bundle: Path) -> None:
     that same mutable constant.
     """
     build_unit(bundle, "WB", worksheets=["Revenue Trend"])
-    write_oracle(bundle, [{"view_name": "Revenue Trend", "view_type": "worksheet", "workbook_name": "WB"}])
+    write_oracle(bundle, [{"view_name": "Revenue Trend", "view_type": "worksheet", "workbook_luid": UNIT_LUID}])
 
     strict = crr.scan(bundle, require_validation_grade=True)
     assert strict["pages_insufficient_grade"] == 1
@@ -1214,7 +1240,7 @@ def test_a_packaged_unit_reads_only_its_own_manifest_end_to_end(tmp_path: Path) 
     package.mkdir(parents=True)
     (tmp_path / "assets").mkdir()
     sha = build_unit(package, "WB", worksheets=["Revenue Trend"])
-    view = {"view_name": "Revenue Trend", "view_type": "worksheet", "workbook_name": "WB"}
+    view = {"view_name": "Revenue Trend", "view_type": "worksheet", "workbook_luid": UNIT_LUID}
     write_oracle(package, [view])
     write_oracle(tmp_path / "run", [view])
     assert crr.scan(package)["units"][0]["pages"][0]["readiness"] == "unverifiable"
@@ -1258,7 +1284,7 @@ def test_the_attribution_census_survives_a_multi_path_scan(tmp_path: Path) -> No
     build_unit(dirty / "bundle", "Other", worksheets=["Revenue"])
     write_oracle(
         dirty / "bundle",
-        [{"view_name": f"V{i}", "view_type": "worksheet", "workbook_name": "Elsewhere"} for i in range(7)],
+        [{"view_name": f"V{i}", "view_type": "worksheet", "workbook_luid": OTHER_LUID} for i in range(7)],
     )
 
     merged = crr._merge_scans([crr.scan(clean / "bundle"), crr.scan(dirty / "bundle")])
@@ -1266,3 +1292,38 @@ def test_the_attribution_census_survives_a_multi_path_scan(tmp_path: Path) -> No
     assert merged["evidence_attributed"]["foreign"] == 7
     assert merged["evidence_attributed"]["name"] == 1
     assert "refused 7 as another" in crr.render(merged)
+
+
+def test_every_integer_counter_survives_a_merge_by_construction(tmp_path: Path) -> None:
+    """B-C, fixed as a CLASS: the merge must not carry a hand-written list of keys to sum.
+
+    ⚠️ This is the third instance of one shape in PR #454 - `evidence_attributed` zeroed on merge
+    (round-1 MEDIUM 2), then `pages_revision_unconfirmed` did the same because it was added after the
+    list was written. Patching a third key by name would guarantee a fourth, so this asserts the
+    PROPERTY rather than any key: every integer counter in a single scan is summed, whatever it is
+    called and whenever it was added.
+    """
+    first, second = tmp_path / "one", tmp_path / "two"
+    for root, unit in ((first, "One"), (second, "Two")):
+        (root / "bundle").mkdir(parents=True)
+        (root / "assets").mkdir(parents=True)
+        build_unit(root / "bundle", unit, worksheets=["Revenue"])
+        # Strip `revision_match` so the page is REVISION-UNCONFIRMED: the counter this test exists
+        # for must be NON-ZERO, or `0 != 0 + 0` is false and the assertion proves nothing.
+        provenance = root / "bundle" / "source-provenance.json"
+        payload = json.loads(provenance.read_text(encoding="utf-8"))
+        del payload["inputs"][0]["origin"]["revision_match"]
+        provenance.write_text(json.dumps(payload), encoding="utf-8")
+        write_oracle(root / "bundle", [{"view_name": "Revenue", "view_type": "worksheet", "workbook_luid": UNIT_LUID}])
+    reports = [crr.scan(first / "bundle"), crr.scan(second / "bundle")]
+
+    merged = crr._merge_scans(reports)
+
+    counters = {key for key, value in reports[0].items() if isinstance(value, int) and not isinstance(value, bool)}
+    assert reports[0]["pages_revision_unconfirmed"] == 1, "the counter must be non-zero or the check is vacuous"
+    assert "pages_revision_unconfirmed" in counters, "the counter this was written for must be in scope"
+    assert len(counters) > 10, "sanity: the report really does carry a family of counters"
+    unsummed = {key for key in counters if merged[key] != reports[0][key] + reports[1][key]}
+    assert unsummed == set(), f"a counter silently dropped on merge: {sorted(unsummed)}"
+    # `bool` is an `int` subclass, so the conjunction must NOT have been tallied into 2.
+    assert merged["all_evidence_validation_grade"] in (True, False)

--- a/tests/test_check_unit.py
+++ b/tests/test_check_unit.py
@@ -26,6 +26,7 @@ sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
 import check_unit as cu  # noqa: E402  # pylint: disable=wrong-import-position
 import check_field_bindings  # noqa: E402  # pylint: disable=wrong-import-position
+import object_identity as oid  # noqa: E402  # pylint: disable=wrong-import-position
 import read_handover  # noqa: E402  # pylint: disable=wrong-import-position
 import run_estate  # noqa: E402  # pylint: disable=wrong-import-position
 
@@ -160,6 +161,7 @@ def _write_reference_manifest(
     numeric: bool = True,
     workbook: str | None = None,
     source_sha: str | None = "auto",
+    workbook_luid: str | None = None,
 ) -> None:
     """A `reference/manifest.json`.
 
@@ -192,6 +194,8 @@ def _write_reference_manifest(
     payload: dict[str, object] = {"dashboards": dashboards}
     if workbook is not None:
         payload["workbook"] = workbook
+    if workbook_luid is not None:
+        payload["workbook_luid"] = workbook_luid
     if source_sha is not None:
         payload["source_workbook_sha256"] = source_sha
     (unit / "reference" / "manifest.json").write_text(json.dumps(payload), encoding="utf-8")
@@ -3580,6 +3584,54 @@ def test_a_unit_local_reference_manifest_recording_another_workbooks_sha_is_refu
     assert oracle["visual_present"] == 0
     assert oracle["admitted_evidence"] == 0
     assert oracle["foreign_workbook_evidence"] == ["sha256=dededededede..."]
+
+
+def test_a_manifest_whose_luid_contradicts_its_matching_sha_certifies_nothing(tmp_path: Path) -> None:
+    """BLOCKING FINDING B at the EXIT gate. Verbatim before this fix::
+
+        CONTRADICTORY_EXIT={"status":"PASS","visual_present":1,"numeric_present":1,
+          "admitted_evidence":1,"foreign_workbook_evidence":[],"unattributed_evidence":0}
+
+    The unit's own LUID comes from its spec's `<luid>_<name>` asset filename and its sha256 from that
+    asset's bytes, so this manifest agrees with one and contradicts the other. `_attribute_record` is
+    asserted directly because it names WHICH guard refused: `visual_present == 0` alone is produced
+    by at least four other guards in this gate, and `unattributed_evidence`/`name_only_evidence` are
+    pinned to zero so an accidental downgrade to a weaker refusal fails here too.
+    """
+    _write_spec(tmp_path, ["Revenue"])
+    _write_report(tmp_path, ["Revenue"])
+    source = _write_unit_source(tmp_path, b"the workbook this unit was built from")
+    _write_reference_manifest(
+        tmp_path,
+        ["Revenue"],
+        workbook=None,
+        source_sha=_sha256(source),
+        workbook_luid="007f70ac-bf40-4838-9d73-134d40f504db",
+    )
+
+    records, _ = cu._reference_oracles(tmp_path, None)
+    verdict = cu._attribute_record(cu._unit_workbook_identities(tmp_path), records[0])
+    oracle = cu.check_oracle_coverage(tmp_path, None, None)
+
+    assert verdict.route == oid.WB_CONFLICT
+    assert verdict.admitted is False
+    assert oracle["status"] == cu.STATUS_NOT_CHECKED
+    assert (oracle["visual_present"], oracle["numeric_present"], oracle["admitted_evidence"]) == (0, 0, 0)
+    assert oracle["unattributed_evidence"] == 0 and oracle["name_only_evidence"] == []
+    assert oracle["foreign_workbook_evidence"] != [], "a refusal nobody can see is not a guard"
+
+
+def test_a_manifest_whose_luid_agrees_with_its_matching_sha_still_certifies(tmp_path: Path) -> None:
+    """The positive control: two agreeing machine axes are the STRONGEST evidence, not a conflict."""
+    _write_spec(tmp_path, ["Revenue"])
+    _write_report(tmp_path, ["Revenue"])
+    source = _write_unit_source(tmp_path, b"the workbook this unit was built from")
+    _write_reference_manifest(tmp_path, ["Revenue"], workbook=None, source_sha=_sha256(source), workbook_luid=UNIT_LUID)
+
+    oracle = cu.check_oracle_coverage(tmp_path, None, None)
+
+    assert oracle["status"] == cu.STATUS_PASS
+    assert (oracle["visual_present"], oracle["admitted_evidence"]) == (1, 1)
 
 
 def test_a_sha_bearing_record_is_refused_when_the_unit_cannot_hash_its_source(tmp_path: Path) -> None:

--- a/tests/test_check_unit.py
+++ b/tests/test_check_unit.py
@@ -3418,6 +3418,45 @@ def test_a_reference_manifest_inside_the_unit_is_attributable_by_location(tmp_pa
     assert oracle["unattributed_evidence"] == 0
 
 
+def test_a_non_packaged_unit_still_reads_an_ancestors_oracle_capture(tmp_path: Path) -> None:
+    """The control that makes the package test below meaningful rather than a deletion.
+
+    `_oracle_dirs` looks beside the unit AND beside its parent, because `capture_tableau_oracle.py`
+    writes one flat capture per run while a unit sits under it. Removing that walk-up would make a
+    real capture invisible, which is the defect the `oracle/`-name search was added to fix.
+    """
+    unit = tmp_path / "unit"
+    _write_spec(unit, ["Revenue"])
+    _write_report(unit, ["Revenue"])
+    _write_oracle_manifest(tmp_path, ["Revenue"], workbook="Book")
+
+    assert cu.check_oracle_coverage(unit, None, None)["visual_present"] == 1
+
+
+def test_a_self_contained_package_does_not_also_read_the_runs_flat_capture(tmp_path: Path) -> None:
+    """Issue #451's defect ONE GATE ALONG - found here, not in the brief, and measured before fixing.
+
+    A package at `_runs/<run>/<unit>/` beside the run's flat capture read BOTH manifests, so every
+    view matched twice and this gate refused each page as "2 producer records are named 'Revenue'":
+    0 visual coverage, silently, making packaging strictly worse than not packaging. Same class as
+    the entry gate's "2 records share this name once normalized", so the rule lives once in
+    `bundle_corpus.is_self_contained` rather than being fixed a second time here.
+    """
+    unit = tmp_path / "unit"
+    _write_spec(unit, ["Revenue"])
+    _write_report(unit, ["Revenue"])
+    _write_oracle_manifest(unit, ["Revenue"], workbook="Book")
+    _write_oracle_manifest(tmp_path, ["Revenue"], workbook="Book")
+    assert cu.check_oracle_coverage(unit, None, None)["refused_evidence"] == ["2 producer records are named 'Revenue'"]
+
+    (unit / "package-manifest.json").write_text("{}", encoding="utf-8")
+
+    oracle = cu.check_oracle_coverage(unit, None, None)
+    assert oracle["status"] == cu.STATUS_PASS
+    assert oracle["visual_present"] == 1
+    assert oracle["refused_evidence"] == []
+
+
 def test_two_reference_records_with_one_name_satisfy_nothing_and_say_why(tmp_path: Path) -> None:
     """Multiplicity is the point of keeping records: two claims about one name settle nothing."""
     _write_spec(tmp_path, ["Revenue"])

--- a/tests/test_check_unit.py
+++ b/tests/test_check_unit.py
@@ -143,7 +143,7 @@ def _write_reference_manifest(
     (unit / "reference" / "manifest.json").write_text(json.dumps(payload), encoding="utf-8")
 
 
-def _write_oracle_manifest(
+def _write_oracle_manifest(  # pylint: disable=too-many-arguments,too-many-positional-arguments
     unit: Path,
     names: list[str],
     *,
@@ -151,7 +151,18 @@ def _write_oracle_manifest(
     data: bool = True,
     workbook: str | None = "Book",
     view_type: str | None = "dashboard",
+    workbook_luid: str | None = None,
+    workbook_name: str | None = None,
 ) -> None:
+    """An oracle manifest.
+
+    ⚠️ ``workbook`` writes a TOP-LEVEL ``workbook`` key, which is a synthetic shape: the real producer
+    writes ``workbook_luid`` and ``workbook_name`` PER VIEW and no ``workbook`` anywhere. That gap is
+    issue #450 - the gate read the key the fixtures wrote instead of the ones the capture writes, so
+    every record on a live capture arrived ownerless (measured 360 of 360) and the guard never fired.
+    ``workbook_luid``/``workbook_name`` write the real shape; both are kept so the synthetic override
+    stays testable too.
+    """
     records = []
     for index, name in enumerate(names):
         image_path = f"images/{name}__{index}.png"
@@ -167,6 +178,10 @@ def _write_oracle_manifest(
         }
         if view_type is not None:
             record["view_type"] = view_type
+        if workbook_luid is not None:
+            record["workbook_luid"] = workbook_luid
+        if workbook_name is not None:
+            record["workbook_name"] = workbook_name
         records.append(record)
     (unit / "_oracle").mkdir(exist_ok=True)
     payload: dict[str, object] = {"views": records}
@@ -3250,7 +3265,7 @@ def test_oracle_evidence_from_a_different_workbook_satisfies_nothing(tmp_path: P
     assert oracle["status"] == cu.STATUS_NOT_CHECKED
     assert oracle["visual_present"] == 0
     assert oracle["numeric_present"] == 0
-    assert oracle["foreign_workbook_evidence"] == ["Different Workbook"]
+    assert oracle["foreign_workbook_evidence"] == ["name='Different Workbook'"]
 
 
 def test_oracle_evidence_from_this_workbook_still_counts(tmp_path: Path) -> None:
@@ -3265,11 +3280,25 @@ def test_oracle_evidence_from_this_workbook_still_counts(tmp_path: Path) -> None
     assert oracle["foreign_workbook_evidence"] == []
 
 
-def test_oracle_evidence_declaring_no_workbook_is_admitted_but_flagged(tmp_path: Path) -> None:
-    """'I cannot tell whose picture this is' is weaker evidence and the grade must say so.
+# --------------------------------------------------------------------------------------------
+# Issue #450: the workbook guard read a key no capture producer writes, and failed OPEN
+# --------------------------------------------------------------------------------------------
 
-    Real oracle manifests carry no workbook field, so refusing them outright would reject every
-    capture in the estate. They are admitted and counted, and the count is printed.
+
+def test_a_record_whose_workbook_cannot_be_established_certifies_nothing(tmp_path: Path) -> None:
+    """Kills issue #450's fail-open, which is what this test used to ASSERT.
+
+    ⚠️ It previously read *"declaring no workbook is admitted but flagged"*, on the premise that "real
+    oracle manifests carry no workbook field, so refusing them outright would reject every capture in
+    the estate". The premise was false in the only way that mattered: a real manifest carries
+    ``workbook_luid`` and ``workbook_name`` per view - it carries no ``workbook`` key, which is a
+    defect in the READER, not a property of the producer. Measured on a real 360-view capture, every
+    record was therefore "unattributed" and admitted anyway, so the guard advertised in
+    :class:`OracleEvidence` had never once fired and a foreign workbook's render could certify any
+    page whose name it shared.
+
+    A record that establishes no workbook at all now certifies nothing. It is still counted, because
+    a refusal nobody can see is not a guard.
     """
     _write_spec(tmp_path, ["Revenue"])
     _write_report(tmp_path, ["Revenue"])
@@ -3277,9 +3306,116 @@ def test_oracle_evidence_declaring_no_workbook_is_admitted_but_flagged(tmp_path:
 
     oracle = cu.check_oracle_coverage(tmp_path, None, None)
 
-    assert oracle["visual_present"] == 1
+    assert oracle["status"] == cu.STATUS_NOT_CHECKED
+    assert oracle["visual_present"] == 0
     assert oracle["unattributed_evidence"] == 1
-    assert "1 record(s) declare no producing workbook" in oracle["grade"]
+    assert oracle["admitted_evidence"] == 0
+    # Counted ONCE, and not as another workbook's: "I cannot tell whose this is" and "I can tell, and
+    # it is not yours" are different operator actions - re-capture with typing vs ignore it - and a
+    # record that lands in both buckets tells the reader neither. It is also the only observable
+    # difference left if the explicit refusal here is deleted, because the lossy rescue below refuses
+    # an unestablished record too; measured by mutation, that deletion is otherwise silent.
+    assert oracle["foreign_workbook_evidence"] == []
+    assert "1 record(s) establish no producing workbook" in oracle["grade"]
+
+
+def test_the_workbook_name_a_real_capture_writes_is_read(tmp_path: Path) -> None:
+    """The positive half of #450: `capture_tableau_oracle.py` writes `workbook_name` PER VIEW.
+
+    Without this the fix above is indistinguishable from "refuse everything", which would make the
+    gate report zero coverage on every real capture in the estate.
+    """
+    _write_spec(tmp_path, ["Revenue"])
+    _write_report(tmp_path, ["Revenue"])
+    _write_oracle_manifest(tmp_path, ["Revenue"], workbook=None, workbook_name="Book")
+
+    oracle = cu.check_oracle_coverage(tmp_path, None, None)
+
+    assert oracle["visual_present"] == 1
+    assert oracle["unattributed_evidence"] == 0
+    assert oracle["foreign_workbook_evidence"] == []
+
+
+def test_a_foreign_workbook_name_a_real_capture_writes_is_refused(tmp_path: Path) -> None:
+    """The discriminating twin: reading the right field must REFUSE as readily as it admits."""
+    _write_spec(tmp_path, ["Revenue"])
+    _write_report(tmp_path, ["Revenue"])
+    _write_oracle_manifest(tmp_path, ["Revenue"], workbook=None, workbook_name="Different Workbook")
+
+    oracle = cu.check_oracle_coverage(tmp_path, None, None)
+
+    assert oracle["visual_present"] == 0
+    assert oracle["foreign_workbook_evidence"] == ["name='Different Workbook'"]
+
+
+def test_a_foreign_luid_is_refused_even_when_the_workbook_name_matches_exactly(tmp_path: Path) -> None:
+    """Kills: a weaker axis rescuing a record a stronger one has already rejected.
+
+    Two projects may hold workbooks with the same display name - the ambiguity `_runs/<NNN>-<slug>/`
+    numbering exists to avoid - so a name that agrees after a LUID that does not is exactly the case
+    where the name must not be consulted. The unit's own LUID comes from its handover slice's
+    `workbook.source_id`, whose basename is `harvest_estate_assets.py`'s `<luid>_<name>`.
+    """
+    _write_spec(tmp_path, ["Revenue"])
+    _write_report(tmp_path, ["Revenue"])
+    _write_handover(tmp_path, {"name": "Book", "source_id": "assets/adc431bb-aeeb-43fe-8ecb-092d4bae8bfa_Book.twbx"})
+    _write_oracle_manifest(
+        tmp_path,
+        ["Revenue"],
+        workbook=None,
+        workbook_luid="007f70ac-bf40-4838-9d73-134d40f504db",
+        workbook_name="Book",
+    )
+
+    oracle = cu.check_oracle_coverage(tmp_path, None, None)
+
+    assert oracle["visual_present"] == 0
+    assert oracle["foreign_workbook_evidence"] == ["luid='007f70ac-bf40-4838-9d73-134d40f504db', name='Book'"]
+    assert oracle["known_gap_caveats"] == [], "a LUID disagreement is not rescuable by a lossy name"
+
+
+def test_a_matching_luid_admits_a_record_whose_display_name_the_filesystem_changed(tmp_path: Path) -> None:
+    """The positive control for the LUID route, and symptom A of #450 in this gate.
+
+    A unit ships `Book.Report` while the site publishes `Bo ok`; the stem is a sanitised spelling, not
+    the name. The LUID is what bridges them, and it is exact.
+    """
+    _write_spec(tmp_path, ["Revenue"])
+    _write_report(tmp_path, ["Revenue"])
+    _write_handover(tmp_path, {"name": "Book", "source_id": "assets/adc431bb-aeeb-43fe-8ecb-092d4bae8bfa_Book.twbx"})
+    _write_oracle_manifest(
+        tmp_path,
+        ["Revenue"],
+        workbook=None,
+        workbook_luid="ADC431BB-AEEB-43FE-8ECB-092D4BAE8BFA",
+        workbook_name="Bo ok",
+    )
+
+    oracle = cu.check_oracle_coverage(tmp_path, None, None)
+
+    assert oracle["visual_present"] == 1
+    assert oracle["foreign_workbook_evidence"] == []
+    assert oracle["known_gap_caveats"] == [], "an exact LUID match is not a loose attribution"
+
+
+def test_a_reference_manifest_inside_the_unit_is_attributable_by_location(tmp_path: Path) -> None:
+    """A real `reference/manifest.json` declares NO producing workbook, and does not need to.
+
+    `capture_tableau_reference.py:234` writes `source_workbook_sha256` and `dashboards[]` - there is
+    no workbook name anywhere - and `_reference_dirs` only ever looks inside the unit. So such a
+    record is this unit's by LOCATION, and refusing it for "no workbook identity" would delete the
+    only validation-grade capture route in the toolkit. Stated as its own test because the #450 fix
+    refuses ORACLE records on exactly that ground, and the two must not be confused.
+    """
+    _write_spec(tmp_path, ["Revenue"])
+    _write_report(tmp_path, ["Revenue"])
+    _write_reference_manifest(tmp_path, ["Revenue"], workbook=None)
+
+    oracle = cu.check_oracle_coverage(tmp_path, None, None)
+
+    assert oracle["status"] == cu.STATUS_PASS
+    assert oracle["visual_present"] == 1
+    assert oracle["unattributed_evidence"] == 0
 
 
 def test_two_reference_records_with_one_name_satisfy_nothing_and_say_why(tmp_path: Path) -> None:
@@ -3481,7 +3617,9 @@ def test_two_producing_workbooks_slugging_alike_are_both_refused(tmp_path: Path)
     oracle = cu.check_oracle_coverage(tmp_path, None, None)
 
     assert oracle["visual_present"] == 0
-    assert oracle["foreign_workbook_evidence"] == ["Bo ok", "Bo-ok"]
+    # Reported as the identity that was compared, not as a bare name: since #450 a refusal may turn
+    # on a LUID rather than a name, and a reader deciding what to re-capture needs to see which.
+    assert oracle["foreign_workbook_evidence"] == ["name='Bo ok'", "name='Bo-ok'"]
 
 
 def test_one_producing_workbook_still_binds_through_a_sanitised_spelling(tmp_path: Path) -> None:

--- a/tests/test_check_unit.py
+++ b/tests/test_check_unit.py
@@ -9,6 +9,7 @@ exit code and output shape rather than any non-zero result.
 from __future__ import annotations
 
 import importlib.util
+import hashlib
 import json
 import os
 import time
@@ -118,8 +119,41 @@ def _csv(path: Path) -> None:
     path.write_text("a\n1\n", encoding="utf-8")
 
 
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _write_unit_source(unit: Path, blob: bytes, *, name: str = "Book.twbx") -> Path:
+    """The Tableau asset this unit was built from, recorded where BOTH producers record it.
+
+    A handover slice's ``workbook.source_id`` and `migration-spec.json`'s ``source.file_name`` are
+    the two independent claims `check_unit._unit_source_claims` reads, so the fixture writes both -
+    a fixture that recorded only one could not tell a working resolver from one that happened to
+    read the other.
+    """
+    asset = unit / "assets" / name
+    asset.parent.mkdir(parents=True, exist_ok=True)
+    asset.write_bytes(blob)
+    handover = unit / "handover"
+    handover.mkdir(parents=True, exist_ok=True)
+    (handover / "Book.json").write_text(
+        json.dumps({"estate": {}, "workbook": {"name": "Book", "source_id": f"assets/{name}"}}), encoding="utf-8"
+    )
+    spec = unit / "migration-spec.json"
+    if spec.is_file():
+        payload = json.loads(spec.read_text(encoding="utf-8"))
+        payload["source"] = {"file_name": name}
+        spec.write_text(json.dumps(payload), encoding="utf-8")
+    return asset
+
+
 def _write_reference_manifest(
-    unit: Path, names: list[str], *, numeric: bool = True, workbook: str | None = "Book"
+    unit: Path,
+    names: list[str],
+    *,
+    numeric: bool = True,
+    workbook: str | None = "Book",
+    source_sha: str | None = None,
 ) -> None:
     states = []
     dashboards = []
@@ -140,6 +174,8 @@ def _write_reference_manifest(
     payload: dict[str, object] = {"dashboards": dashboards}
     if workbook is not None:
         payload["workbook"] = workbook
+    if source_sha is not None:
+        payload["source_workbook_sha256"] = source_sha
     (unit / "reference" / "manifest.json").write_text(json.dumps(payload), encoding="utf-8")
 
 
@@ -3374,6 +3410,60 @@ def test_a_foreign_luid_is_refused_even_when_the_workbook_name_matches_exactly(t
     assert oracle["known_gap_caveats"] == [], "a LUID disagreement is not rescuable by a lossy name"
 
 
+def test_a_foreign_luid_is_refused_when_this_unit_cannot_establish_a_luid_at_all(tmp_path: Path) -> None:
+    """BLOCKER 1 at the exit gate, and the case the test above structurally cannot reach.
+
+    ⚠️ The negative test beside this one gives the unit a LUID, so it only ever exercises *LUID vs
+    LUID*. Round-1 review of PR #454 measured the gap: with NO unit LUID the guard skipped the
+    record's LUID as "not shared" and admitted it on an equal display name - `PASS`, visual AND
+    numeric, from a foreign workbook. Real oracle records always carry both fields, so this was the
+    ordinary case rather than an edge one.
+    """
+    _write_spec(tmp_path, ["Revenue"])
+    _write_report(tmp_path, ["Revenue"])
+    _write_oracle_manifest(
+        tmp_path,
+        ["Revenue"],
+        workbook=None,
+        workbook_luid="007f70ac-bf40-4838-9d73-134d40f504db",
+        workbook_name="Book",
+    )
+
+    oracle = cu.check_oracle_coverage(tmp_path, None, None)
+
+    assert oracle["status"] == cu.STATUS_NOT_CHECKED
+    assert oracle["visual_present"] == 0
+    assert oracle["numeric_present"] == 0
+    assert oracle["admitted_evidence"] == 0
+    assert oracle["unattributed_evidence"] == 1
+
+
+def test_a_windows_recorded_source_id_still_yields_its_luid(tmp_path: Path) -> None:
+    """BLOCKER 4 at this gate's call site: a handover records a path from ANOTHER host.
+
+    ⚠️ This assertion is a no-op on Windows and load-bearing on Linux, and that asymmetry is the
+    defect rather than a flaw in the test. `WindowsPath` accepts both separators, so a Windows
+    workstation reports the guard working while a Linux CI runner - where those backslashes are
+    ordinary filename characters - gets no LUID at all and falls back to a weaker axis. CI runs on
+    Linux, so this test is exercised exactly where the divergence bites; the flavour-explicit proof
+    that runs anywhere is `test_workbook_identity.test_the_recorded_path_parse_does_not_use_the_running_hosts_flavour`.
+    """
+    _write_spec(tmp_path, ["Revenue"])
+    _write_report(tmp_path, ["Revenue"])
+    _write_handover(
+        tmp_path,
+        {
+            "name": "Book",
+            "source_id": "_runs\\407-dryrun-gates\\assets\\adc431bb-aeeb-43fe-8ecb-092d4bae8bfa_Book.twbx",
+        },
+    )
+
+    assert cu._unit_source_claims(tmp_path)[1] == ["adc431bb-aeeb-43fe-8ecb-092d4bae8bfa"]
+    assert [identity.luid for identity in cu._unit_workbook_identities(tmp_path)] == [
+        "adc431bb-aeeb-43fe-8ecb-092d4bae8bfa"
+    ]
+
+
 def test_a_matching_luid_admits_a_record_whose_display_name_the_filesystem_changed(tmp_path: Path) -> None:
     """The positive control for the LUID route, and symptom A of #450 in this gate.
 
@@ -3398,14 +3488,17 @@ def test_a_matching_luid_admits_a_record_whose_display_name_the_filesystem_chang
     assert oracle["known_gap_caveats"] == [], "an exact LUID match is not a loose attribution"
 
 
-def test_a_reference_manifest_inside_the_unit_is_attributable_by_location(tmp_path: Path) -> None:
-    """A real `reference/manifest.json` declares NO producing workbook, and does not need to.
+def test_a_unit_local_reference_manifest_is_not_certified_by_its_location(tmp_path: Path) -> None:
+    """BLOCKER 3 from round-1 review of PR #454. This test asserted the OPPOSITE.
 
-    `capture_tableau_reference.py:234` writes `source_workbook_sha256` and `dashboards[]` - there is
-    no workbook name anywhere - and `_reference_dirs` only ever looks inside the unit. So such a
-    record is this unit's by LOCATION, and refusing it for "no workbook identity" would delete the
-    only validation-grade capture route in the toolkit. Stated as its own test because the #450 fix
-    refuses ORACLE records on exactly that ground, and the two must not be confused.
+    ⚠️ It read *"a reference manifest inside the unit is attributable by location"*, on the argument
+    that `_reference_dirs` never walks up so such a manifest is this unit's by construction. Measured
+    consequence: the guard was SKIPPED for those records, so a manifest with no workbook identity at
+    all was admitted (`admitted_evidence=1`, visual AND numeric certified) - and so was one whose
+    `source_workbook_sha256` named a **different workbook** entirely.
+
+    Location controls DISCOVERY; it never substitutes for identity. A manifest that establishes no
+    workbook now certifies nothing, and is counted.
     """
     _write_spec(tmp_path, ["Revenue"])
     _write_report(tmp_path, ["Revenue"])
@@ -3413,9 +3506,64 @@ def test_a_reference_manifest_inside_the_unit_is_attributable_by_location(tmp_pa
 
     oracle = cu.check_oracle_coverage(tmp_path, None, None)
 
+    assert oracle["status"] == cu.STATUS_NOT_CHECKED
+    assert oracle["visual_present"] == 0
+    assert oracle["numeric_present"] == 0
+    assert oracle["admitted_evidence"] == 0
+    assert oracle["unattributed_evidence"] == 1
+
+
+def test_a_unit_local_reference_manifest_certifies_when_its_recorded_sha_is_this_source(tmp_path: Path) -> None:
+    """The positive twin: the identity a reference manifest DOES carry is `source_workbook_sha256`.
+
+    `capture_tableau_reference.py:234` writes it, so the fix for blocker 3 is to hash the unit's own
+    source asset and compare - not to refuse the whole producer. Without this twin, "refuse every
+    reference record" would pass the test above and delete the only validation-grade route in the
+    toolkit.
+    """
+    _write_spec(tmp_path, ["Revenue"])
+    _write_report(tmp_path, ["Revenue"])
+    source = _write_unit_source(tmp_path, b"the workbook this unit was built from")
+    _write_reference_manifest(tmp_path, ["Revenue"], workbook=None, source_sha=_sha256(source))
+
+    oracle = cu.check_oracle_coverage(tmp_path, None, None)
+
     assert oracle["status"] == cu.STATUS_PASS
     assert oracle["visual_present"] == 1
+    assert oracle["admitted_evidence"] == 1
     assert oracle["unattributed_evidence"] == 0
+
+
+def test_a_unit_local_reference_manifest_recording_another_workbooks_sha_is_refused(tmp_path: Path) -> None:
+    """The negative twin, and the sharper half of blocker 3: a MISMATCHING sha was admitted too."""
+    _write_spec(tmp_path, ["Revenue"])
+    _write_report(tmp_path, ["Revenue"])
+    _write_unit_source(tmp_path, b"the workbook this unit was built from")
+    _write_reference_manifest(tmp_path, ["Revenue"], workbook=None, source_sha="de" * 32)
+
+    oracle = cu.check_oracle_coverage(tmp_path, None, None)
+
+    assert oracle["visual_present"] == 0
+    assert oracle["admitted_evidence"] == 0
+    assert oracle["foreign_workbook_evidence"] == ["sha256=dededededede..."]
+
+
+def test_a_sha_bearing_record_is_refused_when_the_unit_cannot_hash_its_source(tmp_path: Path) -> None:
+    """Fail-CLOSED on unknown: no locatable source means the recorded sha cannot be checked.
+
+    This is the cost of blocker 3's fix and it is stated rather than hidden - a unit that ships no
+    resolvable Tableau asset cannot use sha-bearing evidence, and the refusal is disclosed in the
+    grade rather than silently dropped.
+    """
+    _write_spec(tmp_path, ["Revenue"])
+    _write_report(tmp_path, ["Revenue"])
+    _write_reference_manifest(tmp_path, ["Revenue"], workbook=None, source_sha="ab" * 32)
+
+    oracle = cu.check_oracle_coverage(tmp_path, None, None)
+
+    assert oracle["visual_present"] == 0
+    assert oracle["unattributed_evidence"] == 1
+    assert "establish no producing workbook" in oracle["grade"]
 
 
 def test_a_non_packaged_unit_still_reads_an_ancestors_oracle_capture(tmp_path: Path) -> None:

--- a/tests/test_check_unit.py
+++ b/tests/test_check_unit.py
@@ -59,12 +59,17 @@ def _freshen_clean_fixture_cache() -> Path:
     return fixture
 
 
+UNIT_LUID = "adc431bb-aeeb-43fe-8ecb-092d4bae8bfa"
+OTHER_LUID = "007f70ac-bf40-4838-9d73-134d40f504db"
+
+
 def _write_spec(unit: Path, names: list[str]) -> None:
     """A dashboards-only migration spec, with the schema-required empty `worksheets` array."""
     unit.mkdir(parents=True, exist_ok=True)
     (unit / "migration-spec.json").write_text(
         json.dumps(
             {
+                "source": {"file_name": f"{UNIT_LUID}_Book.twbx"},
                 "dashboards": [{"id": f"dash.{index}", "name": name} for index, name in enumerate(names)],
                 "worksheets": [],
             }
@@ -123,7 +128,7 @@ def _sha256(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
-def _write_unit_source(unit: Path, blob: bytes, *, name: str = "Book.twbx") -> Path:
+def _write_unit_source(unit: Path, blob: bytes, *, name: str = f"{UNIT_LUID}_Book.twbx", handover: bool = True) -> Path:
     """The Tableau asset this unit was built from, recorded where BOTH producers record it.
 
     A handover slice's ``workbook.source_id`` and `migration-spec.json`'s ``source.file_name`` are
@@ -134,11 +139,12 @@ def _write_unit_source(unit: Path, blob: bytes, *, name: str = "Book.twbx") -> P
     asset = unit / "assets" / name
     asset.parent.mkdir(parents=True, exist_ok=True)
     asset.write_bytes(blob)
-    handover = unit / "handover"
-    handover.mkdir(parents=True, exist_ok=True)
-    (handover / "Book.json").write_text(
-        json.dumps({"estate": {}, "workbook": {"name": "Book", "source_id": f"assets/{name}"}}), encoding="utf-8"
-    )
+    if handover:
+        slices = unit / "handover"
+        slices.mkdir(parents=True, exist_ok=True)
+        (slices / "Book.json").write_text(
+            json.dumps({"estate": {}, "workbook": {"name": "Book", "source_id": f"assets/{name}"}}), encoding="utf-8"
+        )
     spec = unit / "migration-spec.json"
     if spec.is_file():
         payload = json.loads(spec.read_text(encoding="utf-8"))
@@ -152,9 +158,21 @@ def _write_reference_manifest(
     names: list[str],
     *,
     numeric: bool = True,
-    workbook: str | None = "Book",
-    source_sha: str | None = None,
+    workbook: str | None = None,
+    source_sha: str | None = "auto",
 ) -> None:
+    """A `reference/manifest.json`.
+
+    ⚠️ ``source_sha="auto"`` writes the unit's source asset and records ITS hash, which is what
+    `capture_tableau_reference.py:234` does. Round-3 review, B-B: a display name no longer certifies
+    anything, so a fixture identifying a reference record by ``workbook`` alone stopped representing
+    any real capture - it now represents a hand-edited one, which is a different test.
+    """
+    if source_sha == "auto":
+        # No handover slice: the migration spec's `source.file_name` already establishes the
+        # asset, and writing a slice here would put an unrelated check into every test that
+        # merely wanted a reference manifest.
+        source_sha = _sha256(_write_unit_source(unit, b"the workbook this unit was built from", handover=False))
     states = []
     dashboards = []
     for name in names:
@@ -187,7 +205,7 @@ def _write_oracle_manifest(  # pylint: disable=too-many-arguments,too-many-posit
     data: bool = True,
     workbook: str | None = "Book",
     view_type: str | None = "dashboard",
-    workbook_luid: str | None = None,
+    workbook_luid: str | None = UNIT_LUID,
     workbook_name: str | None = None,
 ) -> None:
     """An oracle manifest.
@@ -343,6 +361,7 @@ def _write_full_spec(
     (unit / "migration-spec.json").write_text(
         json.dumps(
             {
+                "source": {"file_name": f"{UNIT_LUID}_Book.twbx"},
                 "dashboards": spec_dashboards,
                 "worksheets": [{"id": ws_id, "name": name} for ws_id, name in worksheets],
             }
@@ -627,7 +646,14 @@ def _complete_worksheet(ws_id: str, name: str, **overrides: object) -> dict[str,
 def _spec_with_worksheets(unit: Path, worksheets: list[dict[str, object]]) -> None:
     unit.mkdir(parents=True, exist_ok=True)
     (unit / "migration-spec.json").write_text(
-        json.dumps({"migration_spec_version": "1.0", "dashboards": [], "worksheets": worksheets}),
+        json.dumps(
+            {
+                "migration_spec_version": "1.0",
+                "source": {"file_name": f"{UNIT_LUID}_Book.twbx"},
+                "dashboards": [],
+                "worksheets": worksheets,
+            }
+        ),
         encoding="utf-8",
     )
 
@@ -3294,14 +3320,14 @@ def test_oracle_evidence_from_a_different_workbook_satisfies_nothing(tmp_path: P
     """
     _write_spec(tmp_path, ["Revenue"])
     _write_report(tmp_path, ["Revenue"])
-    _write_oracle_manifest(tmp_path, ["Revenue"], workbook="Different Workbook")
+    _write_oracle_manifest(tmp_path, ["Revenue"], workbook=None, workbook_luid=OTHER_LUID)
 
     oracle = cu.check_oracle_coverage(tmp_path, None, None)
 
     assert oracle["status"] == cu.STATUS_NOT_CHECKED
     assert oracle["visual_present"] == 0
     assert oracle["numeric_present"] == 0
-    assert oracle["foreign_workbook_evidence"] == ["name='Different Workbook'"]
+    assert oracle["foreign_workbook_evidence"] == [f"luid='{OTHER_LUID}'"]
 
 
 def test_oracle_evidence_from_this_workbook_still_counts(tmp_path: Path) -> None:
@@ -3338,7 +3364,7 @@ def test_a_record_whose_workbook_cannot_be_established_certifies_nothing(tmp_pat
     """
     _write_spec(tmp_path, ["Revenue"])
     _write_report(tmp_path, ["Revenue"])
-    _write_oracle_manifest(tmp_path, ["Revenue"], workbook=None)
+    _write_oracle_manifest(tmp_path, ["Revenue"], workbook=None, workbook_luid=None)
 
     oracle = cu.check_oracle_coverage(tmp_path, None, None)
 
@@ -3355,7 +3381,7 @@ def test_a_record_whose_workbook_cannot_be_established_certifies_nothing(tmp_pat
     assert "1 record(s) establish no producing workbook" in oracle["grade"]
 
 
-def test_the_workbook_name_a_real_capture_writes_is_read(tmp_path: Path) -> None:
+def test_a_display_name_alone_never_certifies_however_real_the_capture(tmp_path: Path) -> None:
     """The positive half of #450: `capture_tableau_oracle.py` writes `workbook_name` PER VIEW.
 
     Without this the fix above is indistinguishable from "refuse everything", which would make the
@@ -3363,25 +3389,30 @@ def test_the_workbook_name_a_real_capture_writes_is_read(tmp_path: Path) -> None
     """
     _write_spec(tmp_path, ["Revenue"])
     _write_report(tmp_path, ["Revenue"])
-    _write_oracle_manifest(tmp_path, ["Revenue"], workbook=None, workbook_name="Book")
+    _write_oracle_manifest(tmp_path, ["Revenue"], workbook=None, workbook_luid=None, workbook_name="Book")
 
     oracle = cu.check_oracle_coverage(tmp_path, None, None)
 
-    assert oracle["visual_present"] == 1
-    assert oracle["unattributed_evidence"] == 0
-    assert oracle["foreign_workbook_evidence"] == []
+    assert oracle["visual_present"] == 0, "a display name is decoration, not identity"
+    assert oracle["admitted_evidence"] == 0
+    assert oracle["name_only_evidence"] == ["name='Book'"]
+    assert any("NAME-ONLY EVIDENCE REFUSED" in caveat for caveat in oracle["known_gap_caveats"])
 
 
-def test_a_foreign_workbook_name_a_real_capture_writes_is_refused(tmp_path: Path) -> None:
+def test_a_foreign_display_name_is_refused_too_and_counted_separately(tmp_path: Path) -> None:
     """The discriminating twin: reading the right field must REFUSE as readily as it admits."""
     _write_spec(tmp_path, ["Revenue"])
     _write_report(tmp_path, ["Revenue"])
-    _write_oracle_manifest(tmp_path, ["Revenue"], workbook=None, workbook_name="Different Workbook")
+    _write_oracle_manifest(tmp_path, ["Revenue"], workbook=None, workbook_luid=None, workbook_name="Different Workbook")
 
     oracle = cu.check_oracle_coverage(tmp_path, None, None)
 
     assert oracle["visual_present"] == 0
+    # A name that DIFFERS was compared and disagreed, so it is `foreign`; a name that MATCHES is
+    # `name_only`, because agreement on decoration establishes nothing. Both refuse; they are
+    # counted apart because they call for different operator actions.
     assert oracle["foreign_workbook_evidence"] == ["name='Different Workbook'"]
+    assert oracle["name_only_evidence"] == []
 
 
 def test_a_foreign_luid_is_refused_even_when_the_workbook_name_matches_exactly(tmp_path: Path) -> None:
@@ -3421,6 +3452,9 @@ def test_a_foreign_luid_is_refused_when_this_unit_cannot_establish_a_luid_at_all
     """
     _write_spec(tmp_path, ["Revenue"])
     _write_report(tmp_path, ["Revenue"])
+    spec = json.loads((tmp_path / "migration-spec.json").read_text(encoding="utf-8"))
+    del spec["source"]
+    (tmp_path / "migration-spec.json").write_text(json.dumps(spec), encoding="utf-8")
     _write_oracle_manifest(
         tmp_path,
         ["Revenue"],
@@ -3458,7 +3492,7 @@ def test_a_windows_recorded_source_id_still_yields_its_luid(tmp_path: Path) -> N
         },
     )
 
-    assert cu._unit_source_claims(tmp_path)[1] == ["adc431bb-aeeb-43fe-8ecb-092d4bae8bfa"]
+    assert set(cu._unit_source_claims(tmp_path)[1]) == {"adc431bb-aeeb-43fe-8ecb-092d4bae8bfa"}
     assert [identity.luid for identity in cu._unit_workbook_identities(tmp_path)] == [
         "adc431bb-aeeb-43fe-8ecb-092d4bae8bfa"
     ]
@@ -3502,7 +3536,7 @@ def test_a_unit_local_reference_manifest_is_not_certified_by_its_location(tmp_pa
     """
     _write_spec(tmp_path, ["Revenue"])
     _write_report(tmp_path, ["Revenue"])
-    _write_reference_manifest(tmp_path, ["Revenue"], workbook=None)
+    _write_reference_manifest(tmp_path, ["Revenue"], workbook=None, source_sha=None)
 
     oracle = cu.check_oracle_coverage(tmp_path, None, None)
 
@@ -3786,7 +3820,7 @@ def test_two_producing_workbooks_slugging_alike_are_both_refused(tmp_path: Path)
     """
     _write_full_spec(tmp_path, dashboards=[("Sales", []), ("Ops", [])], worksheets=[])
     _write_report(tmp_path, ["Sales", "Ops"])
-    _write_oracle_manifest(tmp_path, ["Sales"], workbook="Bo ok")
+    _write_oracle_manifest(tmp_path, ["Sales"], workbook="Bo ok", workbook_luid=None)
     manifest = tmp_path / "_oracle" / "oracle-manifest.json"
     payload = json.loads(manifest.read_text(encoding="utf-8"))
     _png(tmp_path / "_oracle" / "images/Ops__1.png")
@@ -3804,12 +3838,13 @@ def test_two_producing_workbooks_slugging_alike_are_both_refused(tmp_path: Path)
     oracle = cu.check_oracle_coverage(tmp_path, None, None)
 
     assert oracle["visual_present"] == 0
-    # Reported as the identity that was compared, not as a bare name: since #450 a refusal may turn
-    # on a LUID rather than a name, and a reader deciding what to re-capture needs to see which.
+    # ⚠️ Round-3 B-B: the two-sided uniqueness question these were written to pose is moot - the
+    # lossy rescue they guarded is deleted, so a sanitised spelling can no longer admit anything at
+    # all. They are refused for differing from this unit's stem, which is a stronger statement.
     assert oracle["foreign_workbook_evidence"] == ["name='Bo ok'", "name='Bo-ok'"]
 
 
-def test_one_producing_workbook_still_binds_through_a_sanitised_spelling(tmp_path: Path) -> None:
+def test_a_sanitised_spelling_no_longer_binds_because_a_name_is_not_identity(tmp_path: Path) -> None:
     """The lossy workbook fallback survives its second guard.
 
     It is justified here and only here: the unit side is a filesystem-sanitised artifact STEM, so
@@ -3846,20 +3881,19 @@ def test_the_normalized_index_is_what_bindable_workbooks_consults(tmp_path: Path
 # delete `_oracle_caveats`, these tests and their two DISCLOSURE mutations together.
 
 
-def test_a_loosely_attributed_workbook_carries_a_caveat_naming_it(tmp_path: Path) -> None:
-    """An operator reading a PASS must be told WHICH producer was matched loosely, by name."""
+def test_a_name_only_refusal_carries_a_caveat_naming_it(tmp_path: Path) -> None:
+    """An operator must be told WHICH producer was refused for carrying only a name, by name."""
     _write_spec(tmp_path, ["Sales"])
     _write_report(tmp_path, ["Sales"], name="Bo ok")
-    _write_oracle_manifest(tmp_path, ["Sales"], workbook="Bo-ok")
+    _write_oracle_manifest(tmp_path, ["Sales"], workbook="Bo ok", workbook_luid=None)
 
     oracle = cu.check_oracle_coverage(tmp_path, None, None)
 
-    assert oracle["status"] == cu.STATUS_PASS
+    assert oracle["status"] == cu.STATUS_NOT_CHECKED
     caveats = oracle["known_gap_caveats"]
     assert len(caveats) == 1
-    assert "#450" in caveats[0]
-    assert "WORKBOOK MATCHED LOOSELY" in caveats[0]
-    assert "'Bo-ok'" in caveats[0], "the caveat must name the producer, not disclaim generically"
+    assert "NAME-ONLY EVIDENCE REFUSED" in caveats[0]
+    assert "'Bo ok'" in caveats[0], "the caveat must name the producer, not disclaim generically"
 
 
 def test_an_exactly_attributed_workbook_prints_no_caveat(tmp_path: Path) -> None:
@@ -3889,9 +3923,9 @@ def test_the_caveats_reach_the_rendered_cli_output(tmp_path: Path) -> None:
     """A payload key nobody prints is not a disclosure."""
     _write_spec(tmp_path, ["Sales"])
     _write_report(tmp_path, ["Sales"], name="Bo ok")
-    _write_oracle_manifest(tmp_path, ["Sales"], workbook="Bo-ok")
+    _write_oracle_manifest(tmp_path, ["Sales"], workbook="Bo ok", workbook_luid=None)
 
     rendered = cu.render(cu.run_all(tmp_path, scope=cu.SCOPE_REPORT))
 
-    assert "#450 WORKBOOK MATCHED LOOSELY" in rendered
-    assert "'Bo-ok'" in rendered
+    assert "NAME-ONLY EVIDENCE REFUSED" in rendered
+    assert "'Bo ok'" in rendered

--- a/tests/test_check_unit.py
+++ b/tests/test_check_unit.py
@@ -3634,6 +3634,110 @@ def test_a_manifest_whose_luid_agrees_with_its_matching_sha_still_certifies(tmp_
     assert (oracle["visual_present"], oracle["admitted_evidence"]) == (1, 1)
 
 
+# --------------------------------------------------------------------------------------------
+# Round 2 of PR #454: conflicting LUID declarations at different SCOPES were collapsed to one
+# --------------------------------------------------------------------------------------------
+
+
+def _luid_at_scopes(unit: Path, *, entry: str | None = None, state: str | None = None) -> None:
+    """Stamp `workbook_luid` at the dashboard-entry and/or state scope of a written manifest."""
+    manifest = unit / "reference" / "manifest.json"
+    payload = json.loads(manifest.read_text(encoding="utf-8"))
+    for dashboard in payload["dashboards"]:
+        if entry is not None:
+            dashboard["workbook_luid"] = entry
+        for recorded in dashboard.get("states", []) if state is not None else []:
+            recorded["workbook_luid"] = state
+    manifest.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_an_entry_luid_does_not_silently_supersede_a_contradicting_manifest_luid(tmp_path: Path) -> None:
+    """THE round-2 finding at the EXIT gate. Verbatim before this fix::
+
+        B_EXIT_MULTISCOPE {"status":"PASS","visual_present":1,"numeric_present":1,
+          "admitted_evidence":1,"foreign_workbook_evidence":[]}
+
+    `_declared_workbook` read ``entry.get("workbook_luid") or outer.get("workbook_luid")``, so an
+    entry-level LUID naming this unit discarded a manifest-level LUID naming another workbook and
+    the contradiction never reached `WorkbookIdentity.attribute`. No schema makes the narrower scope
+    an override; every non-blank claim must agree.
+
+    ``_attribute_record`` is asserted directly because it names WHICH guard refused - at least four
+    others in this gate also produce ``visual_present == 0``.
+    """
+    _write_spec(tmp_path, ["Revenue"])
+    _write_report(tmp_path, ["Revenue"])
+    source = _write_unit_source(tmp_path, b"the workbook this unit was built from")
+    _write_reference_manifest(
+        tmp_path, ["Revenue"], workbook=None, source_sha=_sha256(source), workbook_luid=OTHER_LUID
+    )
+    _luid_at_scopes(tmp_path, entry=UNIT_LUID)
+
+    records, _ = cu._reference_oracles(tmp_path, None)
+    verdict = cu._attribute_record(cu._unit_workbook_identities(tmp_path), records[0])
+    oracle = cu.check_oracle_coverage(tmp_path, None, None)
+
+    assert verdict.route == oid.WB_CONFLICT
+    assert verdict.admitted is False
+    assert oracle["status"] == cu.STATUS_NOT_CHECKED
+    assert (oracle["visual_present"], oracle["numeric_present"], oracle["admitted_evidence"]) == (0, 0, 0)
+    assert oracle["foreign_workbook_evidence"] != [], "a refusal nobody can see is not a guard"
+
+
+def test_a_state_scope_luid_is_read_at_this_gate_too(tmp_path: Path) -> None:
+    """The near neighbour: the entry gate reads the STATE scope and this one used not to.
+
+    A scope one gate compares while the other ignores it is a hole by construction - measured on this
+    branch before the fix, ``PASS route=sha256 admitted=1`` on a manifest whose only state declared
+    another workbook's LUID. States are collapsed into one record here, so their claims are claims
+    about that record and must agree with the entry's and the manifest's.
+    """
+    _write_spec(tmp_path, ["Revenue"])
+    _write_report(tmp_path, ["Revenue"])
+    source = _write_unit_source(tmp_path, b"the workbook this unit was built from")
+    _write_reference_manifest(tmp_path, ["Revenue"], workbook=None, source_sha=_sha256(source))
+    _luid_at_scopes(tmp_path, state=OTHER_LUID)
+
+    records, _ = cu._reference_oracles(tmp_path, None)
+    verdict = cu._attribute_record(cu._unit_workbook_identities(tmp_path), records[0])
+    oracle = cu.check_oracle_coverage(tmp_path, None, None)
+
+    assert verdict.route == oid.WB_CONFLICT
+    assert (oracle["status"], oracle["visual_present"], oracle["admitted_evidence"]) == (cu.STATUS_NOT_CHECKED, 0, 0)
+
+
+def test_scopes_that_agree_or_stay_silent_still_certify_at_the_exit_gate(tmp_path: Path) -> None:
+    """THE positive control: refusing every multi-scope manifest would pass both tests above.
+
+    Every ordinary shape must still PASS on the matching sha256 - all three scopes agreeing, a case
+    difference (a LUID is a machine id), a blank scope beside a real one, and no LUID at all. An
+    absent claim is SILENT; only an actively contradicting one refuses.
+    """
+    for label, luids in (
+        ("all three agree", {"manifest": UNIT_LUID, "entry": UNIT_LUID, "state": UNIT_LUID}),
+        ("case differs only", {"manifest": UNIT_LUID, "state": UNIT_LUID.upper()}),
+        ("blank is absence", {"manifest": UNIT_LUID, "entry": "   ", "state": None}),
+        ("no luid anywhere", {}),
+    ):
+        unit = tmp_path / label.replace(" ", "-")
+        unit.mkdir()
+        _write_spec(unit, ["Revenue"])
+        _write_report(unit, ["Revenue"])
+        source = _write_unit_source(unit, b"the workbook this unit was built from")
+        _write_reference_manifest(
+            unit, ["Revenue"], workbook=None, source_sha=_sha256(source), workbook_luid=luids.get("manifest")
+        )
+        _luid_at_scopes(unit, entry=luids.get("entry"), state=luids.get("state"))
+
+        records, _ = cu._reference_oracles(unit, None)
+        verdict = cu._attribute_record(cu._unit_workbook_identities(unit), records[0])
+        oracle = cu.check_oracle_coverage(unit, None, None)
+
+        assert verdict.route == oid.WB_SHA, label
+        assert oracle["status"] == cu.STATUS_PASS, label
+        assert (oracle["visual_present"], oracle["numeric_present"], oracle["admitted_evidence"]) == (1, 1, 1), label
+
+
 def test_a_sha_bearing_record_is_refused_when_the_unit_cannot_hash_its_source(tmp_path: Path) -> None:
     """Fail-CLOSED on unknown: no locatable source means the recorded sha cannot be checked.
 

--- a/tests/test_reference_evidence.py
+++ b/tests/test_reference_evidence.py
@@ -602,10 +602,162 @@ def test_every_refusal_is_counted_so_it_can_be_told_from_a_missing_capture(bundl
         "name": 1,
         "revision-unconfirmed": 0,
         "stale": 0,
+        # No record here claims two machine axes at once, so nothing contradicts itself.
+        "conflicting-identity": 0,
         # Two foreign: a differing display name, and a LUID this unit CAN answer and that disagrees.
         "foreign": 2,
         "unknown": 0,
     }
+
+
+# --------------------------------------------------------------------------------------------
+# Round-N review of PR #454, BLOCKING FINDING A: ambiguous provenance selected the first SHA hit
+# --------------------------------------------------------------------------------------------
+
+
+def write_ambiguous_provenance(root: Path, source: Path, luids: list[str]) -> None:
+    """A `source-provenance.json` stamping ONE source sha256 against several workbook LUIDs.
+
+    A real stamp run can produce this: `stamp_tableau_provenance.py` writes one input record per
+    harvested asset, and two assets whose bytes are identical - a workbook copied between projects,
+    or re-published under a second name - hash the same while matching different site items.
+    """
+    digest = hashlib.sha256(source.read_bytes()).hexdigest()
+    (root / "source-provenance.json").write_text(
+        json.dumps(
+            {
+                "inputs": [
+                    {
+                        "input": {"file": source.name, "sha256": digest},
+                        "origin": {
+                            "workbook_luid": luid,
+                            "workbook_name": "Published Name",
+                            "matched_by": "luid",
+                            "match": "name_only",
+                            "revision_match": "same",
+                        },
+                    }
+                    for luid in luids
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_provenance_naming_two_workbooks_for_one_source_cannot_establish_an_identity(bundle: Path) -> None:
+    """BLOCKING FINDING A: the SHA loop returned on its first hit and never looked for a second.
+
+    One of those two records is about a different workbook and nothing in the file says which, so
+    this unit has no workbook identity. `CANNOT_ESTABLISH` is explicitly not a pass.
+    """
+    build_unit(bundle, "WB", worksheets=["Revenue Trend"])
+    write_ambiguous_provenance(bundle, bundle.parent / "assets" / "WB.twb", [UNIT_LUID, OTHER_LUID])
+    write_oracle(bundle, [{"view_name": "Revenue Trend", "view_type": "worksheet", "workbook_luid": UNIT_LUID}])
+
+    unit = crr.scan(bundle)["units"][0]
+    assert unit["status"] == "CANNOT_ESTABLISH"
+    assert "workbook identity is ambiguous" in unit["detail"]
+    assert UNIT_LUID in unit["detail"] and OTHER_LUID in unit["detail"]
+    # 3, not 1: `CANNOT_ESTABLISH` has its own exit code precisely so "I formed no opinion" cannot be
+    # read as "I looked and found problems".
+    assert crr.main([str(bundle), "--quiet"]) == crr.EXIT_CANNOT_ESTABLISH
+
+
+def test_the_ambiguous_provenance_verdict_does_not_depend_on_the_array_order(bundle: Path) -> None:
+    """The PROPERTY, tested as a property: byte-identical evidence, two orderings, one verdict.
+
+    Verbatim before this fix, reversing only the two records in the JSON array::
+
+        AMBIGUOUS_FIRST    = {"status":"READY",   "pages_ready":1, "luid":1,    "exit":0}
+        AMBIGUOUS_REVERSED = {"status":"FINDINGS","pages_ready":0, "foreign":1, "exit":1}
+
+    Asserting only "it refuses" would not have caught that: one ORDER already refused. The whole unit
+    result is compared, so nothing - not the census, not the detail string, not the page rows - may
+    differ between the two readings.
+    """
+    build_unit(bundle, "WB", worksheets=["Revenue Trend"])
+    source = bundle.parent / "assets" / "WB.twb"
+    write_oracle(bundle, [{"view_name": "Revenue Trend", "view_type": "worksheet", "workbook_luid": UNIT_LUID}])
+
+    write_ambiguous_provenance(bundle, source, [UNIT_LUID, OTHER_LUID])
+    forward = crr.scan(bundle)
+    forward_exit = crr.main([str(bundle), "--quiet"])
+    write_ambiguous_provenance(bundle, source, [OTHER_LUID, UNIT_LUID])
+    reversed_ = crr.scan(bundle)
+    reversed_exit = crr.main([str(bundle), "--quiet"])
+
+    assert forward["units"] == reversed_["units"]
+    assert (forward["status"], forward_exit) == (reversed_["status"], reversed_exit)
+    assert forward["status"] == "CANNOT_ESTABLISH" and forward_exit == crr.EXIT_CANNOT_ESTABLISH
+
+
+def test_two_provenance_records_agreeing_on_one_workbook_still_establish_it(bundle: Path) -> None:
+    """The discriminating control: DUPLICATION is not ambiguity, so the fix is not "refuse two rows".
+
+    Without this, deleting the identity join entirely - or refusing whenever more than one record
+    matches - would pass the two tests above and quietly blind every unit whose provenance was
+    stamped twice.
+    """
+    build_unit(bundle, "WB", worksheets=["Revenue Trend"])
+    write_ambiguous_provenance(bundle, bundle.parent / "assets" / "WB.twb", [UNIT_LUID, UNIT_LUID.upper()])
+    write_oracle(bundle, [{"view_name": "Revenue Trend", "view_type": "worksheet", "workbook_luid": UNIT_LUID}])
+
+    report = crr.scan(bundle)
+    assert report["units"][0]["status"] == "READY"
+    assert report["evidence_attributed"]["luid"] == 1
+
+
+# --------------------------------------------------------------------------------------------
+# Round-N review of PR #454, BLOCKING FINDING B: a contradictory machine identity was admitted
+# --------------------------------------------------------------------------------------------
+
+
+def test_a_reference_manifest_whose_luid_contradicts_its_matching_sha_certifies_nothing(bundle: Path) -> None:
+    """BLOCKING FINDING B at the entry gate. Verbatim before this fix::
+
+        CONTRADICTORY_ENTRY={"status":"READY","pages_ready":1,
+          "attribution":{"sha256":1,"luid":0,"foreign":0},"page":"ready"}
+
+    Two causes, both closed here: `WorkbookIdentity.attribute` returned on the first agreeing axis,
+    and `reference_evidence._reference_states` discarded the manifest's LUID before building
+    `Evidence`, so there was nothing left to contradict with. The route is asserted, not merely the
+    refusal - a dozen other guards in this gate also produce `blind`.
+    """
+    sha = build_unit(bundle, "WB", worksheets=["Revenue Trend"])
+    write_reference(
+        bundle,
+        [("Revenue Trend", "embedded_thumbnail", ["layout_grade"])],
+        source_sha=sha,
+        workbook_luid=OTHER_LUID,
+    )
+
+    report = crr.scan(bundle)
+    assert report["units"][0]["pages"][0]["readiness"] == "blind"
+    assert report["evidence_attributed"]["conflicting-identity"] == 1
+    assert report["evidence_attributed"]["sha256"] == 0, "the matching axis must not have won"
+    assert crr.main([str(bundle), "--quiet"]) == 1
+
+
+def test_a_reference_manifest_whose_luid_agrees_with_its_sha_still_certifies(bundle: Path) -> None:
+    """The positive control for reading the manifest LUID at all.
+
+    Carrying a second machine axis into `Evidence` must strengthen the check, not break the ordinary
+    case: a manifest whose sha256 AND LUID both name this unit is the strongest evidence this gate
+    can be handed, and it must still reach READY.
+    """
+    sha = build_unit(bundle, "WB", worksheets=["Revenue Trend"])
+    write_reference(
+        bundle,
+        [("Revenue Trend", "embedded_thumbnail", ["layout_grade"])],
+        source_sha=sha,
+        workbook_luid=UNIT_LUID,
+    )
+
+    report = crr.scan(bundle)
+    assert report["units"][0]["pages"][0]["readiness"] == "ready"
+    assert report["evidence_attributed"]["sha256"] == 1
+    assert report["evidence_attributed"]["conflicting-identity"] == 0
 
 
 def test_a_sha256_confirmed_provenance_luid_is_trusted(bundle: Path) -> None:

--- a/tests/test_reference_evidence.py
+++ b/tests/test_reference_evidence.py
@@ -249,30 +249,45 @@ def test_evidence_attribution_uses_the_exact_workbook_name(bundle: Path) -> None
 # --------------------------------------------------------------------------------------------
 
 
-def write_provenance(root: Path, source: Path, *, luid: str, match: str, matched_by: str | None = None) -> None:
+def write_provenance(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    root: Path,
+    source: Path,
+    *,
+    luid: str,
+    match: str,
+    matched_by: str | None = None,
+    remote_sha: str | None = "aa" * 32,
+    noisy_remote: bool = False,
+) -> None:
     """A `source-provenance.json` as `stamp_tableau_provenance.py` writes it.
 
     ``matched_by`` and ``match`` are two INDEPENDENT axes and the fixture keeps them separate:
     ``find_origin`` records *how the workbook was found* in the first and *how strongly the bytes
     were confirmed* in the second. Omitting ``matched_by`` - the default here - is the shape of an
     origin that establishes identity by neither route.
+
+    ``noisy_remote`` writes a SECOND entry for the same LUID with a different ``remote_sha256``,
+    which is what the real estate looks like: ``content_sha256(luid)`` is one request, and on the 407
+    capture it returned different digests for 18 of 30 workbooks inside a single run because the
+    server repacks a `.twbx` per download. A fixture that could not express that could not tell a
+    sound byte comparison from a meaningless one.
     """
     origin: dict[str, object] = {"workbook_luid": luid, "workbook_name": "Published Name", "match": match}
     if matched_by is not None:
         origin["matched_by"] = matched_by
-    (root / "source-provenance.json").write_text(
-        json.dumps(
-            {
-                "inputs": [
-                    {
-                        "input": {"file": source.name, "sha256": hashlib.sha256(source.read_bytes()).hexdigest()},
-                        "origin": origin,
-                    }
-                ]
-            }
-        ),
-        encoding="utf-8",
-    )
+    if remote_sha is not None:
+        origin["remote_sha256"] = remote_sha
+    entry = {
+        "input": {"file": source.name, "sha256": hashlib.sha256(source.read_bytes()).hexdigest()},
+        "origin": origin,
+    }
+    inputs = [entry]
+    if noisy_remote:
+        twin = json.loads(json.dumps(entry))
+        twin["input"] |= {"file": f"{source.stem}.twbx", "sha256": "ff" * 32}
+        twin["origin"]["remote_sha256"] = "ee" * 32
+        inputs.append(twin)
+    (root / "source-provenance.json").write_text(json.dumps({"inputs": inputs}), encoding="utf-8")
 
 
 def test_a_name_only_provenance_luid_is_not_trusted(bundle: Path) -> None:
@@ -294,14 +309,63 @@ def test_a_name_only_provenance_luid_is_not_trusted(bundle: Path) -> None:
     assert crr.main([str(bundle), "--quiet"]) == 1
 
 
-def test_a_luid_matched_provenance_survives_a_changed_revision(bundle: Path) -> None:
-    """Issue #450, symptom A: `matched_by: "luid"` establishes identity even when the bytes differ.
+def test_a_luid_matched_provenance_still_establishes_identity_but_not_the_revision(bundle: Path) -> None:
+    """Issue #450 symptom A, and round-1 review of PR #454's blocker 2, in one test.
 
     ``find_origin``'s own docstring: "a LUID match with ``name_only`` means 'this is provably the same
     item on the site, and it has changed since we harvested it', which is a different and more useful
-    statement than a name collision". Measured on the reference estate, 48 of 78 inputs are
-    ``name_only`` while matched BY LUID - the common case - and every one of them lost its identity
-    and fell back to comparing an artifact stem against a published display name.
+    statement than a name collision". Both halves are load-bearing, and each was got wrong once:
+
+    * **identity** must resolve, or the artifact stem ``HR_Dashboard`` gets compared against the
+      published name ``HR Dashboard`` and 23 attributable renders are discarded (issue #450). The
+      record's ``workbook_name`` here is deliberately ``Not WB``, so only the LUID can match it.
+    * **the revision must NOT be claimed.** Reading these pages as current made a capture that might
+      be of another BUILD read as a clean `READY`, carrying the generic oracle grade and disclosing
+      nothing.
+
+    ⚠️ ``noisy_remote`` is the ORDINARY estate shape, not an edge case - see
+    :func:`test_a_reproducible_byte_difference_is_the_only_thing_that_proves_drift`. So this page is
+    admitted with ``revision: "unconfirmed"``, and the report counts and prints it.
+    """
+    build_unit(bundle, "WB", worksheets=["Revenue Trend"])
+    write_provenance(
+        bundle,
+        bundle.parent / "assets" / "WB.twb",
+        luid="luid-1",
+        match="name_only",
+        matched_by="luid",
+        noisy_remote=True,
+    )
+    write_oracle(
+        bundle,
+        [
+            {
+                "view_name": "Revenue Trend",
+                "view_type": "worksheet",
+                "workbook_luid": "luid-1",
+                "workbook_name": "Not WB",
+            }
+        ],
+    )
+
+    report = crr.scan(bundle)
+    page = report["units"][0]["pages"][0]
+    assert page["readiness"] == "ready", "identity resolved by LUID"
+    assert page["revision"] == "unconfirmed", "and the revision did NOT"
+    assert report["pages_revision_unconfirmed"] == 1
+    assert "[REVISION NOT ESTABLISHED]" in crr.render(report)
+    assert report["evidence_attributed"]["luid"] == 1
+
+
+def test_a_reproducible_byte_difference_is_the_only_thing_that_proves_drift(bundle: Path) -> None:
+    """The sound half of blocker 2: with ONE reproducible remote digest, `name_only` IS drift.
+
+    ⚠️ This distinction is measured, not chosen. `find_origin` compares the harvested bytes against
+    ``content_sha256(luid)``, a fresh download. On the 407 reference estate that identical request
+    was issued **twice for each of 30 workbooks inside one run** and returned **different digests for
+    18 of them** - the server repacks a `.twbx` per request. Reading `name_only` alone as drift
+    marked 18 of 67 units, 246 records and 125 pages unverifiable on an estate where nothing had
+    changed; requiring the comparison to be reproducible flagged **0**, while still firing here.
     """
     build_unit(bundle, "WB", worksheets=["Revenue Trend"])
     write_provenance(bundle, bundle.parent / "assets" / "WB.twb", luid="luid-1", match="name_only", matched_by="luid")
@@ -317,9 +381,57 @@ def test_a_luid_matched_provenance_survives_a_changed_revision(bundle: Path) -> 
         ],
     )
 
+    report = crr.scan(bundle)
+    page = report["units"][0]["pages"][0]
+    assert page["readiness"] == "unverifiable"
+    assert "DIFFERENT build" in page["matched_by"]
+    assert report["evidence_attributed"]["stale"] == 1
+    assert report["evidence_attributed"]["luid"] == 0, "a stale render is not an admission"
+    assert crr.main([str(bundle), "--quiet"]) == 1
+
+
+def test_a_byte_confirmed_provenance_luid_certifies_normally(bundle: Path) -> None:
+    """The discriminating twin: identity AND revision both established must still reach READY.
+
+    Without it, "call everything stale" passes the tests above and the LUID route - the whole point
+    of issue #450 - is dead.
+    """
+    build_unit(bundle, "WB", worksheets=["Revenue Trend"])
+    write_provenance(bundle, bundle.parent / "assets" / "WB.twb", luid="luid-1", match="sha256", matched_by="luid")
+    write_oracle(
+        bundle,
+        [
+            {
+                "view_name": "Revenue Trend",
+                "view_type": "worksheet",
+                "workbook_luid": "luid-1",
+                "workbook_name": "Not WB",
+            }
+        ],
+    )
+
+    report = crr.scan(bundle)
+    assert report["units"][0]["pages"][0]["readiness"] == "ready"
+    assert report["units"][0]["pages"][0]["revision"] == "confirmed"
+    assert report["pages_revision_unconfirmed"] == 0
+    assert report["evidence_attributed"]["luid"] == 1
+    assert report["evidence_attributed"]["stale"] == 0
+
+
+def test_a_stale_render_cannot_contest_a_legitimate_one_in_another_unit(bundle: Path) -> None:
+    """A stale render takes no `render_key`, so exclusivity does not drag a good page down with it.
+
+    Admitting it "but marking it" would have been the easy shape; it is also how a refusal becomes a
+    second-order fail-closed bug, because cross-unit exclusivity keys on the render digest and would
+    have seen two claims on one image.
+    """
+    build_unit(bundle, "WB", worksheets=["Revenue Trend"])
+    write_provenance(bundle, bundle.parent / "assets" / "WB.twb", luid="luid-1", match="name_only", matched_by="luid")
+    write_oracle(bundle, [{"view_name": "Revenue Trend", "view_type": "worksheet", "workbook_luid": "luid-1"}])
+
     page = crr.scan(bundle)["units"][0]["pages"][0]
-    assert page["readiness"] == "ready"
-    assert crr.scan(bundle)["evidence_attributed"]["luid"] == 1
+    assert page["readiness"] == "unverifiable"
+    assert "render_key" not in page
 
 
 def test_a_luid_matched_provenance_still_refuses_another_workbooks_render(bundle: Path) -> None:
@@ -400,7 +512,7 @@ def test_every_refusal_is_counted_so_it_can_be_told_from_a_missing_capture(bundl
     )
 
     census = crr.scan(bundle)["evidence_attributed"]
-    assert census == {"sha256": 0, "luid": 0, "name": 1, "foreign": 1, "unknown": 1}
+    assert census == {"sha256": 0, "luid": 0, "name": 1, "stale": 0, "foreign": 1, "unknown": 1}
 
 
 def test_a_sha256_confirmed_provenance_luid_is_trusted(bundle: Path) -> None:
@@ -412,11 +524,18 @@ def test_a_sha256_confirmed_provenance_luid_is_trusted(bundle: Path) -> None:
     assert crr.scan(bundle)["units"][0]["pages"][0]["readiness"] == "ready"
 
 
-def test_a_record_carrying_both_luid_and_name_can_still_fall_back_to_the_name(bundle: Path) -> None:
-    """Round-2 finding 3, mirror image: carrying a LUID used to DISCARD the name.
+def test_a_record_whose_luid_this_unit_cannot_answer_is_not_rescued_by_its_name(bundle: Path) -> None:
+    """BLOCKER 1 from round-1 review of PR #454. This test asserted the OPPOSITE.
 
-    Removing source provenance then made correctly-named records return `0/3 blind`, so the
-    documented name fallback could not be reached by any record a real capture produces.
+    ⚠️ It read *"a record carrying both LUID and name can still fall back to the name"*, pinning
+    round-2's mirror-image fix (carrying a LUID used to DISCARD the name). That fix was right about
+    the record and wrong about the unit: a real oracle record ALWAYS carries both, so skipping an
+    *unshared* LUID and admitting on an equal display name let a **foreign workbook** certify a page.
+    Measured on this fixture: `READY 1/1`, `pages_blind=0`, and the exit gate certified visual AND
+    numeric from the same record.
+
+    The rule is now: a machine identity the unit cannot answer is ``unknown``, full stop. The name is
+    reached only when the record claims no machine identity at all - which is the twin below.
     """
     build_unit(bundle, "WB", worksheets=["Revenue Trend"])
     write_oracle(
@@ -424,7 +543,26 @@ def test_a_record_carrying_both_luid_and_name_can_still_fall_back_to_the_name(bu
         [{"view_name": "Revenue Trend", "view_type": "worksheet", "workbook_luid": "luid-1", "workbook_name": "WB"}],
     )
 
-    assert crr.scan(bundle)["units"][0]["pages"][0]["readiness"] == "ready"
+    report = crr.scan(bundle)
+    assert report["units"][0]["pages"][0]["readiness"] == "blind"
+    assert report["evidence_attributed"]["unknown"] == 1
+    assert report["evidence_attributed"]["name"] == 0
+    assert crr.main([str(bundle), "--quiet"]) == 1
+
+
+def test_a_record_claiming_no_machine_identity_at_all_may_still_match_on_the_name(bundle: Path) -> None:
+    """The twin: the name route must survive, or a hand-written manifest can never be used.
+
+    `capture_tableau_reference.py` and hand-maintained manifests carry no LUID, so refusing on the
+    name axis outright would delete the only route those producers have. This is the weakest
+    admitting route and every admission through it is counted separately.
+    """
+    build_unit(bundle, "WB", worksheets=["Revenue Trend"])
+    write_oracle(bundle, [{"view_name": "Revenue Trend", "view_type": "worksheet", "workbook_name": "WB"}])
+
+    report = crr.scan(bundle)
+    assert report["units"][0]["pages"][0]["readiness"] == "ready"
+    assert report["evidence_attributed"]["name"] == 1
 
 
 # --------------------------------------------------------------------------------------------

--- a/tests/test_reference_evidence.py
+++ b/tests/test_reference_evidence.py
@@ -569,6 +569,12 @@ def test_a_filename_luid_that_contradicts_provenance_establishes_nothing(bundle:
 
     Picking whichever was read first is the coin toss issue #438 named; here the render is refused
     and the page reports blind rather than being certified on a contested identity.
+
+    ⚠️ Round 2 of PR #454 re-aimed the census assertion, deliberately. This used to be counted as
+    ``unknown`` - "the render declares an identity this unit cannot answer" - which was not true: the
+    unit answered twice, with two different LUIDs. Now that a contradiction is a VALUE rather than
+    silence (:data:`object_identity.LUID_CONTRADICTED`) the refusal names itself, and ``unknown`` is
+    pinned to 0 so a regression to the vaguer route fails here. The readiness verdict is unchanged.
     """
     luid = "adc431bb-aeeb-43fe-8ecb-092d4bae8bfa"
     other = "007f70ac-bf40-4838-9d73-134d40f504db"
@@ -584,7 +590,8 @@ def test_a_filename_luid_that_contradicts_provenance_establishes_nothing(bundle:
 
     report = crr.scan(bundle)
     assert report["units"][0]["pages"][0]["readiness"] == "blind"
-    assert report["evidence_attributed"]["unknown"] == 1
+    assert report["evidence_attributed"]["conflicting-identity"] == 1
+    assert report["evidence_attributed"]["unknown"] == 0
 
 
 def test_every_refusal_is_counted_so_it_can_be_told_from_a_missing_capture(bundle: Path) -> None:
@@ -767,6 +774,140 @@ def test_a_reference_manifest_whose_luid_agrees_with_its_sha_still_certifies(bun
     assert report["units"][0]["pages"][0]["readiness"] == "ready"
     assert report["evidence_attributed"]["sha256"] == 1
     assert report["evidence_attributed"]["conflicting-identity"] == 0
+
+
+# --------------------------------------------------------------------------------------------
+# Round 2 of PR #454: the same fail-open, one layer earlier - conflicting SCOPES were collapsed
+# --------------------------------------------------------------------------------------------
+
+
+def test_a_manifest_scope_that_contradicts_a_narrower_one_is_not_silently_superseded(bundle: Path) -> None:
+    """THE round-2 finding at the entry gate. Verbatim before this fix::
+
+        B_ENTRY_MULTISCOPE_CONFLICT {"status":"READY","page":"ready","pages_ready":1,
+          "sha256":1,"conflicting-identity":0,"exit":0}
+
+    A `reference/manifest.json` may declare `workbook_luid` at three scopes, and
+    `_reference_workbook_luid` returned the FIRST non-blank one - state, then entry, then manifest.
+    So a state-level LUID naming this unit discarded a manifest-level LUID naming another workbook,
+    and the contradiction was gone before `WorkbookIdentity.attribute` could see it. No schema makes
+    a narrower scope an override; every non-blank claim must agree.
+
+    The route is asserted rather than the readiness alone: `blind` is produced by a dozen guards in
+    this gate, and `sha256 == 0` pins that the matching axis did not quietly win instead.
+    """
+    sha = build_unit(bundle, "WB", worksheets=["Revenue Trend"])
+    write_reference(
+        bundle,
+        [("Revenue Trend", "embedded_thumbnail", ["layout_grade"])],
+        source_sha=sha,
+        state_luid=UNIT_LUID,
+        workbook_luid=OTHER_LUID,
+    )
+
+    report = crr.scan(bundle)
+    assert report["units"][0]["pages"][0]["readiness"] == "blind"
+    assert report["evidence_attributed"]["conflicting-identity"] == 1
+    assert report["evidence_attributed"]["sha256"] == 0, "the agreeing scope must not have won"
+    assert crr.main([str(bundle), "--quiet"]) == 1
+
+
+def test_an_entry_scope_that_contradicts_the_manifest_is_refused_too(bundle: Path) -> None:
+    """The middle scope, because a fix aimed at ONE pair of scopes is not the rule.
+
+    ``state`` beats ``entry`` beats ``manifest`` in the old precedence, so a fix that only compared
+    the state against the manifest would leave the entry level selecting exactly as before.
+    """
+    sha = build_unit(bundle, "WB", worksheets=["Revenue Trend"])
+    write_reference(
+        bundle,
+        [("Revenue Trend", "embedded_thumbnail", ["layout_grade"])],
+        source_sha=sha,
+        entry_luid=UNIT_LUID,
+        workbook_luid=OTHER_LUID,
+    )
+
+    report = crr.scan(bundle)
+    assert report["evidence_attributed"]["conflicting-identity"] == 1
+    assert report["units"][0]["pages"][0]["readiness"] == "blind"
+
+
+def test_three_scopes_of_which_two_agree_are_still_a_contradiction(bundle: Path) -> None:
+    """A majority is not a verdict: one dissenting scope is enough, and agreement is not a vote."""
+    sha = build_unit(bundle, "WB", worksheets=["Revenue Trend"])
+    write_reference(
+        bundle,
+        [("Revenue Trend", "embedded_thumbnail", ["layout_grade"])],
+        source_sha=sha,
+        state_luid=UNIT_LUID,
+        entry_luid=UNIT_LUID,
+        workbook_luid=OTHER_LUID,
+    )
+
+    report = crr.scan(bundle)
+    assert report["evidence_attributed"]["conflicting-identity"] == 1
+    assert report["units"][0]["pages"][0]["readiness"] == "blind"
+
+
+def test_scopes_that_agree_or_stay_silent_still_certify(bundle: Path) -> None:
+    """THE positive control: refusing every multi-scope manifest would pass all three tests above.
+
+    Four ordinary shapes must still reach READY on the matching sha256 - three scopes agreeing, two
+    agreeing but for CASE (a LUID is a machine id, so case is not a disagreement), a blank scope
+    beside a real one, and no LUID at all. The asymmetry this pins is the one round 3 established:
+    an absent claim is SILENT, only an actively contradicting one refuses.
+    """
+    for label, luids in (
+        ("all three agree", {"state_luid": UNIT_LUID, "entry_luid": UNIT_LUID, "workbook_luid": UNIT_LUID}),
+        ("case differs only", {"state_luid": UNIT_LUID.upper(), "workbook_luid": UNIT_LUID}),
+        ("blank is absence", {"state_luid": "   ", "workbook_luid": UNIT_LUID}),
+        ("no luid anywhere", {}),
+    ):
+        root = bundle / label
+        (root.parent.parent / "assets").mkdir(parents=True, exist_ok=True)
+        sha = build_unit(root, "WB", worksheets=["Revenue Trend"])
+        write_reference(root, [("Revenue Trend", "embedded_thumbnail", ["layout_grade"])], source_sha=sha, **luids)
+
+        report = crr.scan(root)
+        assert report["units"][0]["pages"][0]["readiness"] == "ready", label
+        assert report["evidence_attributed"]["sha256"] == 1, label
+        assert report["evidence_attributed"]["conflicting-identity"] == 0, label
+        assert crr.main([str(root), "--quiet"]) == 0, label
+
+
+def test_an_oracle_manifests_own_luid_is_read_at_this_gate_too(bundle: Path) -> None:
+    """The near neighbour: the SAME conflict arriving through the oracle reader.
+
+    `check_unit._declared_workbook` has always read an oracle manifest's top-level ``workbook_luid``
+    (it is the ``container`` argument), while this gate read only the view record - so a scope one
+    gate compares and the other ignores was a hole by construction. Measured on this branch before
+    the fix: ``READY / ready / luid=1 / conflicting-identity=0 / exit 0``.
+    """
+    build_unit(bundle, "WB", worksheets=["Revenue Trend"])
+    write_oracle(bundle, [{"view_name": "Revenue Trend", "view_type": "worksheet", "workbook_luid": UNIT_LUID}])
+    manifest = bundle / "_oracle" / "oracle-manifest.json"
+    payload = json.loads(manifest.read_text(encoding="utf-8"))
+    payload["workbook_luid"] = OTHER_LUID
+    manifest.write_text(json.dumps(payload), encoding="utf-8")
+
+    report = crr.scan(bundle)
+    assert report["units"][0]["pages"][0]["readiness"] == "blind"
+    assert report["evidence_attributed"]["conflicting-identity"] == 1
+    assert report["evidence_attributed"]["luid"] == 0, "the view-level claim must not have won"
+
+
+def test_an_oracle_manifest_agreeing_with_its_views_still_certifies(bundle: Path) -> None:
+    """The control for the reader above: reading a second scope must not break the ordinary one."""
+    build_unit(bundle, "WB", worksheets=["Revenue Trend"])
+    write_oracle(bundle, [{"view_name": "Revenue Trend", "view_type": "worksheet", "workbook_luid": UNIT_LUID}])
+    manifest = bundle / "_oracle" / "oracle-manifest.json"
+    payload = json.loads(manifest.read_text(encoding="utf-8"))
+    payload["workbook_luid"] = UNIT_LUID.upper()
+    manifest.write_text(json.dumps(payload), encoding="utf-8")
+
+    report = crr.scan(bundle)
+    assert report["units"][0]["pages"][0]["readiness"] == "ready"
+    assert report["evidence_attributed"]["luid"] == 1
 
 
 def test_a_sha256_confirmed_provenance_luid_is_trusted(bundle: Path) -> None:

--- a/tests/test_reference_evidence.py
+++ b/tests/test_reference_evidence.py
@@ -257,7 +257,7 @@ def write_provenance(  # pylint: disable=too-many-arguments,too-many-positional-
     match: str,
     matched_by: str | None = None,
     remote_sha: str | None = "aa" * 32,
-    noisy_remote: bool = False,
+    revision_match: str | None = None,
 ) -> None:
     """A `source-provenance.json` as `stamp_tableau_provenance.py` writes it.
 
@@ -266,28 +266,30 @@ def write_provenance(  # pylint: disable=too-many-arguments,too-many-positional-
     were confirmed* in the second. Omitting ``matched_by`` - the default here - is the shape of an
     origin that establishes identity by neither route.
 
-    ``noisy_remote`` writes a SECOND entry for the same LUID with a different ``remote_sha256``,
-    which is what the real estate looks like: ``content_sha256(luid)`` is one request, and on the 407
-    capture it returned different digests for 18 of 30 workbooks inside a single run because the
-    server repacks a `.twbx` per download. A fixture that could not express that could not tell a
-    sound byte comparison from a meaningless one.
+    ``revision_match`` is the REPRODUCIBLE verdict, from a content-normalised
+    `object_identity.RevisionKey` on both sides. Omitting it - also the default - is the shape of a
+    manifest stamped before that key existed, which must read ``unconfirmed`` and never ``mismatch``.
     """
     origin: dict[str, object] = {"workbook_luid": luid, "workbook_name": "Published Name", "match": match}
     if matched_by is not None:
         origin["matched_by"] = matched_by
     if remote_sha is not None:
         origin["remote_sha256"] = remote_sha
-    entry = {
-        "input": {"file": source.name, "sha256": hashlib.sha256(source.read_bytes()).hexdigest()},
-        "origin": origin,
-    }
-    inputs = [entry]
-    if noisy_remote:
-        twin = json.loads(json.dumps(entry))
-        twin["input"] |= {"file": f"{source.stem}.twbx", "sha256": "ff" * 32}
-        twin["origin"]["remote_sha256"] = "ee" * 32
-        inputs.append(twin)
-    (root / "source-provenance.json").write_text(json.dumps({"inputs": inputs}), encoding="utf-8")
+    if revision_match is not None:
+        origin["revision_match"] = revision_match
+    (root / "source-provenance.json").write_text(
+        json.dumps(
+            {
+                "inputs": [
+                    {
+                        "input": {"file": source.name, "sha256": hashlib.sha256(source.read_bytes()).hexdigest()},
+                        "origin": origin,
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
 
 
 def test_a_name_only_provenance_luid_is_not_trusted(bundle: Path) -> None:
@@ -323,9 +325,9 @@ def test_a_luid_matched_provenance_still_establishes_identity_but_not_the_revisi
       be of another BUILD read as a clean `READY`, carrying the generic oracle grade and disclosing
       nothing.
 
-    ⚠️ ``noisy_remote`` is the ORDINARY estate shape, not an edge case - see
-    :func:`test_a_reproducible_byte_difference_is_the_only_thing_that_proves_drift`. So this page is
-    admitted with ``revision: "unconfirmed"``, and the report counts and prints it.
+    ⚠️ A manifest stamped before the reproducible key existed carries no ``revision_match`` at all,
+    which is the ordinary shape today and the one this test uses. It is admitted with
+    ``revision: "unconfirmed"``, and the report counts and prints it.
     """
     build_unit(bundle, "WB", worksheets=["Revenue Trend"])
     write_provenance(
@@ -334,7 +336,6 @@ def test_a_luid_matched_provenance_still_establishes_identity_but_not_the_revisi
         luid="luid-1",
         match="name_only",
         matched_by="luid",
-        noisy_remote=True,
     )
     write_oracle(
         bundle,
@@ -358,17 +359,23 @@ def test_a_luid_matched_provenance_still_establishes_identity_but_not_the_revisi
 
 
 def test_a_reproducible_byte_difference_is_the_only_thing_that_proves_drift(bundle: Path) -> None:
-    """The sound half of blocker 2: with ONE reproducible remote digest, `name_only` IS drift.
+    """Drift is claimed from the REPRODUCIBLE key, never from a raw byte difference.
 
-    ⚠️ This distinction is measured, not chosen. `find_origin` compares the harvested bytes against
-    ``content_sha256(luid)``, a fresh download. On the 407 reference estate that identical request
-    was issued **twice for each of 30 workbooks inside one run** and returned **different digests for
-    18 of them** - the server repacks a `.twbx` per request. Reading `name_only` alone as drift
-    marked 18 of 67 units, 246 records and 125 pages unverifiable on an estate where nothing had
-    changed; requiring the comparison to be reproducible flagged **0**, while still firing here.
+    ⚠️ Round 2 of PR #454 got half of this right. `match: "name_only"` is not evidence of drift - a
+    `.twbx` is repacked per download, measured 27 of 49 archives across three downloads in one run -
+    but the conclusion that *no* reproducible comparison existed was wrong: the wrong digest was
+    being taken. `stamp_tableau_provenance` now records a content-normalised
+    `object_identity.RevisionKey` on both sides and writes the verdict as `revision_match`.
     """
     build_unit(bundle, "WB", worksheets=["Revenue Trend"])
-    write_provenance(bundle, bundle.parent / "assets" / "WB.twb", luid="luid-1", match="name_only", matched_by="luid")
+    write_provenance(
+        bundle,
+        bundle.parent / "assets" / "WB.twb",
+        luid="luid-1",
+        match="name_only",
+        matched_by="luid",
+        revision_match="differs",
+    )
     write_oracle(
         bundle,
         [
@@ -388,6 +395,70 @@ def test_a_reproducible_byte_difference_is_the_only_thing_that_proves_drift(bund
     assert report["evidence_attributed"]["stale"] == 1
     assert report["evidence_attributed"]["luid"] == 0, "a stale render is not an admission"
     assert crr.main([str(bundle), "--quiet"]) == 1
+
+
+def test_a_repacked_archive_is_confirmed_rather_than_merely_unconfirmed(bundle: Path) -> None:
+    """Round-3 finding: `unconfirmed` was an artifact of the DIGEST, not a property of the estate.
+
+    `match: "name_only"` with `revision_match: "same"` is the ordinary shape for a `.twbx` - the raw
+    bytes differ because the server repacked the zip, and the content is identical. Reporting that as
+    `unconfirmed` leaves the disclosure note as the only thing between a page and being cited as
+    verified; the evidence supports `confirmed`.
+    """
+    build_unit(bundle, "WB", worksheets=["Revenue Trend"])
+    write_provenance(
+        bundle,
+        bundle.parent / "assets" / "WB.twb",
+        luid="luid-1",
+        match="name_only",
+        matched_by="luid",
+        revision_match="same",
+    )
+    write_oracle(
+        bundle,
+        [
+            {
+                "view_name": "Revenue Trend",
+                "view_type": "worksheet",
+                "workbook_luid": "luid-1",
+                "workbook_name": "Not WB",
+            }
+        ],
+    )
+
+    report = crr.scan(bundle)
+    assert report["units"][0]["pages"][0]["readiness"] == "ready"
+    assert report["units"][0]["pages"][0]["revision"] == "confirmed"
+    assert report["pages_revision_unconfirmed"] == 0
+    assert report["evidence_attributed"]["stale"] == 0
+
+
+def test_a_manifest_stamped_before_the_key_existed_is_unconfirmed_not_drifted(bundle: Path) -> None:
+    """Versioning, in the direction that matters: an old capture must not raise a false alarm.
+
+    A pre-existing `source-provenance.json` carries `match: "name_only"` and no `revision_match` at
+    all. Reading that as drift would mark every capture taken before this change as stale - a nasty
+    regression dressed up as a safety improvement.
+    """
+    build_unit(bundle, "WB", worksheets=["Revenue Trend"])
+    write_provenance(bundle, bundle.parent / "assets" / "WB.twb", luid="luid-1", match="name_only", matched_by="luid")
+    write_oracle(
+        bundle,
+        [
+            {
+                "view_name": "Revenue Trend",
+                "view_type": "worksheet",
+                "workbook_luid": "luid-1",
+                "workbook_name": "Not WB",
+            }
+        ],
+    )
+
+    report = crr.scan(bundle)
+    assert report["units"][0]["pages"][0]["readiness"] == "ready"
+    assert report["units"][0]["pages"][0]["revision"] == "unconfirmed"
+    assert report["pages_revision_unconfirmed"] == 1
+    assert report["evidence_attributed"]["stale"] == 0, "no key is CANNOT COMPARE, never drift"
 
 
 def test_a_byte_confirmed_provenance_luid_certifies_normally(bundle: Path) -> None:
@@ -426,7 +497,14 @@ def test_a_stale_render_cannot_contest_a_legitimate_one_in_another_unit(bundle: 
     have seen two claims on one image.
     """
     build_unit(bundle, "WB", worksheets=["Revenue Trend"])
-    write_provenance(bundle, bundle.parent / "assets" / "WB.twb", luid="luid-1", match="name_only", matched_by="luid")
+    write_provenance(
+        bundle,
+        bundle.parent / "assets" / "WB.twb",
+        luid="luid-1",
+        match="name_only",
+        matched_by="luid",
+        revision_match="differs",
+    )
     write_oracle(bundle, [{"view_name": "Revenue Trend", "view_type": "worksheet", "workbook_luid": "luid-1"}])
 
     page = crr.scan(bundle)["units"][0]["pages"][0]

--- a/tests/test_reference_evidence.py
+++ b/tests/test_reference_evidence.py
@@ -237,6 +237,12 @@ def test_evidence_attribution_uses_the_exact_workbook_name(bundle: Path) -> None
     `Ops  Summary` would have been attributed to a unit named `Ops Summary` - the same collapse
     defect, on WORKBOOK identity, at a layer neither the reviewer nor I had enumerated. If a
     published workbook name genuinely differs from the unit name, the LUID route is the answer.
+
+    ⚠️ **Asserting `blind` alone could not kill the mutant this test exists for**, and
+    `mutation_reference_readiness.py` measured it SURVIVING. Since round 3 a matched display name is
+    a refusal too, so both the exact comparison (`foreign` - the names differ) and the lossy one
+    (`name` - they collapse to equal) end in `blind` and exit 1. The census names WHICH guard
+    refused, which is the only assertion that can tell them apart.
     """
     build_unit(bundle, "Ops Summary", worksheets=["Revenue Trend"])
     write_oracle(
@@ -244,7 +250,10 @@ def test_evidence_attribution_uses_the_exact_workbook_name(bundle: Path) -> None
         [{"view_name": "Revenue Trend", "view_type": "worksheet", "workbook_name": "Ops  Summary"}],
     )
 
-    assert crr.scan(bundle)["units"][0]["pages"][0]["readiness"] == "blind"
+    report = crr.scan(bundle)
+    assert report["units"][0]["pages"][0]["readiness"] == "blind"
+    assert report["evidence_attributed"]["foreign"] == 1, "the names DIFFER; they must not collapse to equal"
+    assert report["evidence_attributed"]["name"] == 0
     assert crr.main([str(bundle), "--quiet"]) == 1
 
 

--- a/tests/test_reference_evidence.py
+++ b/tests/test_reference_evidence.py
@@ -24,6 +24,8 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
 import check_reference_readiness as crr  # noqa: E402  # pylint: disable=wrong-import-position
 
 from test_check_reference_readiness import (  # noqa: E402  # pylint: disable=wrong-import-position
+    OTHER_LUID,
+    UNIT_LUID,
     build_unit,
     bundle_fixture,
     write_engine_report,
@@ -135,8 +137,8 @@ def test_a_stale_capture_stops_counting_when_the_source_changes(bundle: Path) ->
     assert crr.scan(bundle)["units"][0]["pages"][0]["readiness"] == "blind"
 
 
-def test_oracle_evidence_is_scoped_by_workbook_name(bundle: Path) -> None:
-    """Oracle records carry `workbook_name`/`workbook_luid`; one for another workbook must not count."""
+def test_oracle_evidence_is_scoped_by_workbook(bundle: Path) -> None:
+    """Oracle records carry `workbook_luid`; one for another workbook must not count."""
     build_unit(bundle, "WB", worksheets=["Revenue Trend"])
     write_oracle(bundle, [{"view_name": "Revenue Trend", "view_type": "worksheet", "workbook_name": "Other Book"}])
 
@@ -144,9 +146,9 @@ def test_oracle_evidence_is_scoped_by_workbook_name(bundle: Path) -> None:
 
 
 def test_oracle_evidence_for_this_workbook_does_count(bundle: Path) -> None:
-    """Discriminating twin of the scoping test above."""
+    """Discriminating twin of the scoping test above - now on the LUID axis, as a real capture is."""
     build_unit(bundle, "WB", worksheets=["Revenue Trend"])
-    write_oracle(bundle, [{"view_name": "Revenue Trend", "view_type": "worksheet", "workbook_name": "WB"}])
+    write_oracle(bundle, [{"view_name": "Revenue Trend", "view_type": "worksheet", "workbook_luid": UNIT_LUID}])
 
     page = crr.scan(bundle)["units"][0]["pages"][0]
     assert page["readiness"] == "ready"
@@ -219,7 +221,9 @@ def test_a_manifest_with_no_recorded_hash_cannot_be_trusted(bundle: Path) -> Non
 def test_oracle_evidence_is_integrity_checked_too(bundle: Path) -> None:
     """The oracle route records `sha256`/`bytes`/`dimensions_px` and they are checked identically."""
     build_unit(bundle, "WB", worksheets=["Revenue Trend"])
-    oracle = write_oracle(bundle, [{"view_name": "Revenue Trend", "view_type": "worksheet", "workbook_name": "WB"}])
+    oracle = write_oracle(
+        bundle, [{"view_name": "Revenue Trend", "view_type": "worksheet", "workbook_luid": UNIT_LUID}]
+    )
     assert crr.scan(bundle)["status"] == "READY"
 
     write_png(oracle / "images" / "view-0.png", 400, 300)
@@ -351,11 +355,13 @@ def test_a_luid_matched_provenance_still_establishes_identity_but_not_the_revisi
 
     report = crr.scan(bundle)
     page = report["units"][0]["pages"][0]
-    assert page["readiness"] == "ready", "identity resolved by LUID"
-    assert page["revision"] == "unconfirmed", "and the revision did NOT"
+    assert page["readiness"] == "unverifiable", "identity resolved by LUID; the REVISION did not"
+    assert page["revision"] == "unconfirmed"
+    assert "REVISION NOT ESTABLISHED" in page["matched_by"]
+    assert report["pages_ready"] == 0
     assert report["pages_revision_unconfirmed"] == 1
-    assert "[REVISION NOT ESTABLISHED]" in crr.render(report)
-    assert report["evidence_attributed"]["luid"] == 1
+    assert report["evidence_attributed"]["revision-unconfirmed"] == 1
+    assert report["evidence_attributed"]["luid"] == 0, "an unconfirmed render is not an admission"
 
 
 def test_a_reproducible_byte_difference_is_the_only_thing_that_proves_drift(bundle: Path) -> None:
@@ -455,7 +461,7 @@ def test_a_manifest_stamped_before_the_key_existed_is_unconfirmed_not_drifted(bu
     )
 
     report = crr.scan(bundle)
-    assert report["units"][0]["pages"][0]["readiness"] == "ready"
+    assert report["units"][0]["pages"][0]["readiness"] == "unverifiable"
     assert report["units"][0]["pages"][0]["revision"] == "unconfirmed"
     assert report["pages_revision_unconfirmed"] == 1
     assert report["evidence_attributed"]["stale"] == 0, "no key is CANNOT COMPARE, never drift"
@@ -590,7 +596,16 @@ def test_every_refusal_is_counted_so_it_can_be_told_from_a_missing_capture(bundl
     )
 
     census = crr.scan(bundle)["evidence_attributed"]
-    assert census == {"sha256": 0, "luid": 0, "name": 1, "stale": 0, "foreign": 1, "unknown": 1}
+    assert census == {
+        "sha256": 0,
+        "luid": 0,
+        "name": 1,
+        "revision-unconfirmed": 0,
+        "stale": 0,
+        # Two foreign: a differing display name, and a LUID this unit CAN answer and that disagrees.
+        "foreign": 2,
+        "unknown": 0,
+    }
 
 
 def test_a_sha256_confirmed_provenance_luid_is_trusted(bundle: Path) -> None:
@@ -615,7 +630,9 @@ def test_a_record_whose_luid_this_unit_cannot_answer_is_not_rescued_by_its_name(
     The rule is now: a machine identity the unit cannot answer is ``unknown``, full stop. The name is
     reached only when the record claims no machine identity at all - which is the twin below.
     """
-    build_unit(bundle, "WB", worksheets=["Revenue Trend"])
+    # No provenance and no harvest prefix, so this unit establishes NO machine identity of its own -
+    # which is the precondition for the defect: the record's LUID has nothing to be compared against.
+    build_unit(bundle, "WB", worksheets=["Revenue Trend"], luid=None)
     write_oracle(
         bundle,
         [{"view_name": "Revenue Trend", "view_type": "worksheet", "workbook_luid": "luid-1", "workbook_name": "WB"}],
@@ -628,19 +645,28 @@ def test_a_record_whose_luid_this_unit_cannot_answer_is_not_rescued_by_its_name(
     assert crr.main([str(bundle), "--quiet"]) == 1
 
 
-def test_a_record_claiming_no_machine_identity_at_all_may_still_match_on_the_name(bundle: Path) -> None:
-    """The twin: the name route must survive, or a hand-written manifest can never be used.
+def test_a_record_claiming_no_machine_identity_at_all_is_refused_and_counted(bundle: Path) -> None:
+    """Round-3 review, B-B. This test asserted the OPPOSITE, and that was the moved boundary.
 
-    `capture_tableau_reference.py` and hand-maintained manifests carry no LUID, so refusing on the
-    name axis outright would delete the only route those producers have. This is the weakest
-    admitting route and every admission through it is counted separately.
+    ⚠️ It read "the name route must survive, or a hand-written manifest can never be used". The
+    premise is false for every real producer: `capture_tableau_reference.py` writes
+    ``source_workbook_sha256`` and `capture_tableau_oracle.py` writes ``workbook_luid``, so both have
+    a machine axis. What the name route actually served was a record with NO corroboration at all -
+    the case where a display name is least trustworthy, because a workbook of the same name in
+    another project is indistinguishable from it. Measured on the 407 estate: ``census["name"] == 0``,
+    so nothing real was relying on it.
+
+    The route is still COUNTED, because "a name matched and a name is not identity" is a different
+    operator action from "nothing matched at all".
     """
     build_unit(bundle, "WB", worksheets=["Revenue Trend"])
     write_oracle(bundle, [{"view_name": "Revenue Trend", "view_type": "worksheet", "workbook_name": "WB"}])
 
     report = crr.scan(bundle)
-    assert report["units"][0]["pages"][0]["readiness"] == "ready"
+    assert report["units"][0]["pages"][0]["readiness"] == "blind"
+    assert report["pages_ready"] == 0
     assert report["evidence_attributed"]["name"] == 1
+    assert crr.main([str(bundle), "--quiet"]) == 1
 
 
 # --------------------------------------------------------------------------------------------

--- a/tests/test_reference_evidence.py
+++ b/tests/test_reference_evidence.py
@@ -249,15 +249,24 @@ def test_evidence_attribution_uses_the_exact_workbook_name(bundle: Path) -> None
 # --------------------------------------------------------------------------------------------
 
 
-def write_provenance(root: Path, source: Path, *, luid: str, match: str) -> None:
-    """A `source-provenance.json` as `stamp_tableau_provenance.py` writes it."""
+def write_provenance(root: Path, source: Path, *, luid: str, match: str, matched_by: str | None = None) -> None:
+    """A `source-provenance.json` as `stamp_tableau_provenance.py` writes it.
+
+    ``matched_by`` and ``match`` are two INDEPENDENT axes and the fixture keeps them separate:
+    ``find_origin`` records *how the workbook was found* in the first and *how strongly the bytes
+    were confirmed* in the second. Omitting ``matched_by`` - the default here - is the shape of an
+    origin that establishes identity by neither route.
+    """
+    origin: dict[str, object] = {"workbook_luid": luid, "workbook_name": "Published Name", "match": match}
+    if matched_by is not None:
+        origin["matched_by"] = matched_by
     (root / "source-provenance.json").write_text(
         json.dumps(
             {
                 "inputs": [
                     {
                         "input": {"file": source.name, "sha256": hashlib.sha256(source.read_bytes()).hexdigest()},
-                        "origin": {"workbook_luid": luid, "workbook_name": "Published Name", "match": match},
+                        "origin": origin,
                     }
                 ]
             }
@@ -267,10 +276,15 @@ def write_provenance(root: Path, source: Path, *, luid: str, match: str) -> None
 
 
 def test_a_name_only_provenance_luid_is_not_trusted(bundle: Path) -> None:
-    """`match: "name_only"` means local and server bytes DIFFER and figures will not reproduce.
+    """An origin that establishes identity by NEITHER route yields no LUID.
 
-    `stamp_tableau_provenance.py:191-192` says so outright, yet that LUID was making server oracle
-    evidence ready. The repo's own provenance is 26 `sha256` / 15 `name_only` / 6 unmatched.
+    ⚠️ Re-aimed by issue #450, and the distinction is the whole point. This fixture records no
+    ``matched_by`` at all AND unconfirmed bytes, so nothing says how the workbook was found - it may
+    have been a name collision, which ``find_origin`` falls back to and counts in ``same_name_count``.
+    Refusing is right. It is NOT right for ``matched_by: "luid"``, which is the discriminating twin
+    below: `stamp_tableau_provenance.find_origin` documents the two fields as "two independent axes",
+    and reading the revision one as if it were the identity one is what discarded 23 correctly
+    attributed renders on the reference estate.
     """
     build_unit(bundle, "WB", worksheets=["Revenue Trend"])
     write_provenance(bundle, bundle.parent / "assets" / "WB.twb", luid="luid-1", match="name_only")
@@ -278,6 +292,115 @@ def test_a_name_only_provenance_luid_is_not_trusted(bundle: Path) -> None:
 
     assert crr.scan(bundle)["units"][0]["pages"][0]["readiness"] == "blind"
     assert crr.main([str(bundle), "--quiet"]) == 1
+
+
+def test_a_luid_matched_provenance_survives_a_changed_revision(bundle: Path) -> None:
+    """Issue #450, symptom A: `matched_by: "luid"` establishes identity even when the bytes differ.
+
+    ``find_origin``'s own docstring: "a LUID match with ``name_only`` means 'this is provably the same
+    item on the site, and it has changed since we harvested it', which is a different and more useful
+    statement than a name collision". Measured on the reference estate, 48 of 78 inputs are
+    ``name_only`` while matched BY LUID - the common case - and every one of them lost its identity
+    and fell back to comparing an artifact stem against a published display name.
+    """
+    build_unit(bundle, "WB", worksheets=["Revenue Trend"])
+    write_provenance(bundle, bundle.parent / "assets" / "WB.twb", luid="luid-1", match="name_only", matched_by="luid")
+    write_oracle(
+        bundle,
+        [
+            {
+                "view_name": "Revenue Trend",
+                "view_type": "worksheet",
+                "workbook_luid": "luid-1",
+                "workbook_name": "Not WB",
+            }
+        ],
+    )
+
+    page = crr.scan(bundle)["units"][0]["pages"][0]
+    assert page["readiness"] == "ready"
+    assert crr.scan(bundle)["evidence_attributed"]["luid"] == 1
+
+
+def test_a_luid_matched_provenance_still_refuses_another_workbooks_render(bundle: Path) -> None:
+    """The discriminating twin of the test above: trusting the LUID must still REFUSE a foreign one.
+
+    Deliberately named identically to this unit, because that is the case a name fallback would get
+    wrong: two projects may hold workbooks with the same display name.
+    """
+    build_unit(bundle, "WB", worksheets=["Revenue Trend"])
+    write_provenance(bundle, bundle.parent / "assets" / "WB.twb", luid="luid-1", match="name_only", matched_by="luid")
+    write_oracle(
+        bundle,
+        [{"view_name": "Revenue Trend", "view_type": "worksheet", "workbook_luid": "luid-2", "workbook_name": "WB"}],
+    )
+
+    report = crr.scan(bundle)
+    assert report["units"][0]["pages"][0]["readiness"] == "blind"
+    assert report["evidence_attributed"]["foreign"] == 1
+    assert report["evidence_attributed"]["luid"] == 0
+
+
+def test_the_asset_filename_luid_prefix_attributes_evidence_with_no_provenance_at_all(bundle: Path) -> None:
+    """`harvest_estate_assets.py` names downloads `<luid>_<name>`, which needs no server to read.
+
+    A harvested estate is the ordinary shape (`_runs/<NNN>-<slug>/assets/`), so this is the route a
+    unit takes whenever provenance stamping was skipped or could not reach the site.
+    """
+    luid = "adc431bb-aeeb-43fe-8ecb-092d4bae8bfa"
+    build_unit(bundle, f"{luid}_WB", worksheets=["Revenue Trend"])
+    write_oracle(
+        bundle,
+        [{"view_name": "Revenue Trend", "view_type": "worksheet", "workbook_luid": luid, "workbook_name": "Published"}],
+    )
+
+    report = crr.scan(bundle)
+    assert report["units"][0]["pages"][0]["readiness"] == "ready"
+    assert report["evidence_attributed"]["luid"] == 1
+
+
+def test_a_filename_luid_that_contradicts_provenance_establishes_nothing(bundle: Path) -> None:
+    """Two identities that disagree are LESS evidence than none, so the join falls closed.
+
+    Picking whichever was read first is the coin toss issue #438 named; here the render is refused
+    and the page reports blind rather than being certified on a contested identity.
+    """
+    luid = "adc431bb-aeeb-43fe-8ecb-092d4bae8bfa"
+    other = "007f70ac-bf40-4838-9d73-134d40f504db"
+    build_unit(bundle, f"{luid}_WB", worksheets=["Revenue Trend"])
+    write_provenance(
+        bundle,
+        bundle.parent / "assets" / f"{luid}_WB.twb",
+        luid=other,
+        match="sha256",
+        matched_by="luid",
+    )
+    write_oracle(bundle, [{"view_name": "Revenue Trend", "view_type": "worksheet", "workbook_luid": luid}])
+
+    report = crr.scan(bundle)
+    assert report["units"][0]["pages"][0]["readiness"] == "blind"
+    assert report["evidence_attributed"]["unknown"] == 1
+
+
+def test_every_refusal_is_counted_so_it_can_be_told_from_a_missing_capture(bundle: Path) -> None:
+    """A refusal nobody can see is indistinguishable from a render that was never taken.
+
+    That ambiguity is exactly how issue #450's inert guard passed for six review rounds: coverage
+    numbers alone cannot tell "the guard refused this" from "nobody captured it", so a fix that only
+    makes `pages_ready` go up cannot be told apart from one that deleted the guard.
+    """
+    build_unit(bundle, "WB", worksheets=["Revenue Trend"])
+    write_oracle(
+        bundle,
+        [
+            {"view_name": "Revenue Trend", "view_type": "worksheet", "workbook_name": "WB"},
+            {"view_name": "Revenue Trend", "view_type": "worksheet", "workbook_name": "Other Book"},
+            {"view_name": "Orphan", "view_type": "worksheet", "workbook_luid": "luid-9"},
+        ],
+    )
+
+    census = crr.scan(bundle)["evidence_attributed"]
+    assert census == {"sha256": 0, "luid": 0, "name": 1, "foreign": 1, "unknown": 1}
 
 
 def test_a_sha256_confirmed_provenance_luid_is_trusted(bundle: Path) -> None:

--- a/tests/test_shared_identity_pin.py
+++ b/tests/test_shared_identity_pin.py
@@ -51,18 +51,24 @@ UPSTREAM_COMMIT = "0fae0cf75bee7c49489573b4735788106af5d8e0"
 #: Why the pin last moved. An edit to shared surface is a two-gate contract change; this is the
 #: record of the one that was reviewed.
 PIN_PROVENANCE = (
-    "master@0fae0cf7 plus issue #450 and its round-1 and round-3 safety reviews: `object_identity.py` "
-    "carries the WORKBOOK-identity join both gates share, closed by ONE rule (a machine identity the "
-    "unit cannot answer is `unknown`, never rescued by a weaker axis), and now the REVISION key too. "
-    "Measured 2026-09-03 on the live site, three downloads of every item in one run: a raw sha256 "
-    "differed for 27 of 49 archives while a content-normalised key differed for 0 of 67; re-stamping "
-    "the reference estate then showed 28 remaining false `differs` were entirely a Tableau SERVER "
-    "build-stamp comment, which the key now normalises. `tests/test_object_identity.py` is UNCHANGED."
+    "master@0fae0cf7 plus issue #450 and its round-1, round-3 and round-N safety reviews: "
+    "`object_identity.py` carries the WORKBOOK-identity join both gates share, closed by ONE rule (a "
+    "machine identity the unit cannot answer is `unknown`, never rescued by a weaker axis), and now "
+    "the REVISION key too. Measured 2026-09-03 on the live site, three downloads of every item in one "
+    "run: a raw sha256 differed for 27 of 49 archives while a content-normalised key differed for 0 "
+    "of 67. ⚠️ The pin was ALREADY stale before this change and that was a lost pin update, not a "
+    "surprise edit: digest 7642b526 is object_identity.py as of ca4d395, and the salvage commit "
+    "b9ef38e (+76/-31, recovered after a host crash) made WB_NAME a refusal, added WB_UNCONFIRMED and "
+    "moved the revision key to v3 without re-deriving it. This pin additionally covers round N's "
+    "blocking finding B: two MACHINE axes that both answer and DISAGREE are `WB_CONFLICT`, a refusal "
+    "in its own right, because `attribute` used to return on the first axis that agreed and admitted "
+    "a record whose sha256 matched this unit while its LUID named another workbook. "
+    "`tests/test_object_identity.py` is UNCHANGED."
 )
 
 #: SHA-256 of each shared file, over LF-normalized bytes.
 PINNED: dict[str, str] = {
-    "scripts/object_identity.py": "7642b5261c5f15c51061113970b8abf15c609c32aea810b92aec6615eafe8620",
+    "scripts/object_identity.py": "63c18e143ff35174827bcc2a9f6acf0de89ad18d46bf05793d155a0b0f230452",
     "tests/test_object_identity.py": "11d6881a960fa3c23beaa6928706de88a83fc1605b051314038ffdc14711c967",
 }
 

--- a/tests/test_shared_identity_pin.py
+++ b/tests/test_shared_identity_pin.py
@@ -51,7 +51,8 @@ UPSTREAM_COMMIT = "0fae0cf75bee7c49489573b4735788106af5d8e0"
 #: Why the pin last moved. An edit to shared surface is a two-gate contract change; this is the
 #: record of the one that was reviewed.
 PIN_PROVENANCE = (
-    "master@0fae0cf7 plus issue #450 and its round-1, round-3 and round-N safety reviews: "
+    "master@0fae0cf7 plus issue #450 and its round-1, round-3, round-N and round-2-of-#454 safety "
+    "reviews: "
     "`object_identity.py` carries the WORKBOOK-identity join both gates share, closed by ONE rule (a "
     "machine identity the unit cannot answer is `unknown`, never rescued by a weaker axis), and now "
     "the REVISION key too. Measured 2026-09-03 on the live site, three downloads of every item in one "
@@ -63,12 +64,23 @@ PIN_PROVENANCE = (
     "blocking finding B: two MACHINE axes that both answer and DISAGREE are `WB_CONFLICT`, a refusal "
     "in its own right, because `attribute` used to return on the first axis that agreed and admitted "
     "a record whose sha256 matched this unit while its LUID named another workbook. "
+    "⚠️ The pin moved from 63c18e14 for a THIRD, deliberate reason, and it is a two-gate contract "
+    "change by construction: round 2 of PR #454 found that both readers folded several DECLARED "
+    "LUIDs into one claim by SCOPE PRECEDENCE, so a contradicting manifest-level LUID vanished "
+    "before `attribute` was ever called (entry gate READY/ready/sha256=1/conflicting-identity=0/exit "
+    "0; exit gate PASS visual=1 numeric=1 admitted=1). `agreed_luid` therefore now returns the new "
+    "`LUID_CONTRADICTED` sentinel instead of None when claims disagree - None is indistinguishable "
+    "from absence, and absence is deliberately SILENT - and `attribute` reads that sentinel on "
+    "EITHER side as `WB_CONFLICT` before the axis walk. Consequence to review: a UNIT whose own two "
+    "source claims name different workbooks is now `conflicting-identity` where it was `unknown`, "
+    "which is the more honest verdict (it established two identities, not none) and does not change "
+    "any readiness or PASS/FAIL outcome. "
     "`tests/test_object_identity.py` is UNCHANGED."
 )
 
 #: SHA-256 of each shared file, over LF-normalized bytes.
 PINNED: dict[str, str] = {
-    "scripts/object_identity.py": "63c18e143ff35174827bcc2a9f6acf0de89ad18d46bf05793d155a0b0f230452",
+    "scripts/object_identity.py": "20a83cfb433afca42ff6aeb6049ed90643be6c58237d305e5d367447885acb31",
     "tests/test_object_identity.py": "11d6881a960fa3c23beaa6928706de88a83fc1605b051314038ffdc14711c967",
 }
 

--- a/tests/test_shared_identity_pin.py
+++ b/tests/test_shared_identity_pin.py
@@ -1,24 +1,30 @@
-"""Byte-identity gate for the SHARED identity type this branch reuses from PR #428.
+"""Byte-identity gate for the SHARED identity type BOTH offline gates join on.
 
-`scripts/object_identity.py` and `tests/test_object_identity.py` are not ours. They are carried here
-byte-identical so `check_unit` can join on the same type the reference-readiness gate does, and so
-whichever PR merges second does not silently overwrite the other's contract.
+`scripts/object_identity.py` and `tests/test_object_identity.py` are shared surface:
+`check_reference_readiness` (the entry gate) and `check_unit` (the exit gate) both resolve identity
+through them, so an edit here changes a contract in two places at once and must be deliberate.
 
-Round 3 measured why this needs to be a gate rather than a claim: the copy on this branch was the
-sibling's ROUND-3 version, and the sibling had since renamed `IdentityIndex` to
+Round 3 measured why this needs to be a gate rather than a claim: the copy on the then-open branch was
+the sibling's ROUND-3 version, and the sibling had since renamed `IdentityIndex` to
 `EngineIndex`/`CandidateIndex`, added `__post_init__` validation and made `__bool__` raise. "Either PR
 can merge first" was false, and nothing said so.
+
+⚠️ **What this pin means changed when both PRs landed on master.** While they were open it proved
+"this branch has not edited a file it does not own". Both have merged, so `origin/master` IS the
+shared truth (`verify_shared_identity_pin.PREFERRED_REFS` already said so), and the pin's job is now
+to make an edit to shared surface a REVIEWED event rather than a silent one: a change here fails this
+test, and clearing it means re-deriving the digest below and saying in the PR why both gates want it.
 
 Two halves, because they prove different things and only one of them can run in CI:
 
 * :func:`test_shared_identity_files_are_unmodified` pins the SHA-256 of both files. It is offline and
-  runs everywhere, and it proves this branch has not edited a file it does not own. `actions/checkout@v4`
-  makes a shallow clone, so no other ref exists in CI and a ref-diff cannot run there.
-* `tests/verify_shared_identity_pin.py` compares against the sibling ref itself and **fails when it
+  runs everywhere. `actions/checkout@v4` makes a shallow clone, so no other ref exists in CI and a
+  ref-diff cannot run there.
+* `tests/verify_shared_identity_pin.py` compares against `origin/master` itself and **fails when it
   cannot compare** - "I could not check" is never "it is fine". Run it whenever the pin is updated.
 
-Updating the pin is deliberate: re-take both files with `git checkout <ref> -- <paths>`, run the
-verifier, then paste the new digests and provenance here.
+Updating the pin is deliberate: make the change, run `ruff format`, re-derive with :func:`digest`
+below, paste the new value, and record the reason in ``PIN_PROVENANCE``.
 
 ⚠️ **The digest is taken over LINE-ENDING-NORMALIZED bytes**, and that is not cosmetic. The first CI
 run of this gate failed on a file nobody had touched: `git checkout` applies `core.autocrlf`, so the
@@ -35,17 +41,26 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 #: Where the pinned bytes came from. Recorded so the pin is auditable rather than self-referential.
-#: ⚠️ Taken from ``UPSTREAM_COMMIT`` and then ``ruff format``-ed on landing, so the pinned digest is
-#: NOT the digest of that commit's blob: the round-6 fix arrived unformatted and ``ruff format
-#: --check`` exited 1 on it. Re-take with ``git checkout <ref> -- <paths>``, re-run ``ruff format``,
-#: then re-derive the digests with ``digest()`` below - never with a raw ``sha256(read_bytes())``,
-#: which yields a different, CRLF-dependent value on Windows.
-UPSTREAM_REF = "origin/feat/reference-readiness-gate"
-UPSTREAM_COMMIT = "6ef21241caa9427e6d249e411785baf1b2b1ccf3"
+#: ⚠️ Digests are taken AFTER ``ruff format``, so a pinned digest is not necessarily the digest of the
+#: named commit's blob: the round-6 fix arrived unformatted and ``ruff format --check`` exited 1 on
+#: it. Re-derive with :func:`digest` below - never with a raw ``sha256(read_bytes())``, which yields a
+#: different, CRLF-dependent value on Windows.
+UPSTREAM_REF = "origin/master"
+UPSTREAM_COMMIT = "0fae0cf75bee7c49489573b4735788106af5d8e0"
 
-#: SHA-256 of each shared file, over LF-normalized bytes, as taken from ``UPSTREAM_COMMIT``.
+#: Why the pin last moved. An edit to shared surface is a two-gate contract change; this is the
+#: record of the one that was reviewed.
+PIN_PROVENANCE = (
+    "master@0fae0cf7 plus issue #450: `object_identity.py` gained the WORKBOOK-identity join "
+    "(WorkbookIdentity/Attribution/harvest_luid/agreed_luid) that both gates now share, because "
+    "each had invented its own key for 'whose workbook is this render of' - one fail-closed "
+    "(23 attributable renders discarded, 0/7 pages ready) and one fail-open (360 of 360 records "
+    "ownerless and admitted anyway). `tests/test_object_identity.py` is UNCHANGED."
+)
+
+#: SHA-256 of each shared file, over LF-normalized bytes.
 PINNED: dict[str, str] = {
-    "scripts/object_identity.py": "3929b02c716f2521452be6e12e32645612d65aaf627dae31491ea004993eab21",
+    "scripts/object_identity.py": "de42e60387e100e42a8df0b8c17e6a410b84f3900b321cc810c21da509a03e58",
     "tests/test_object_identity.py": "11d6881a960fa3c23beaa6928706de88a83fc1605b051314038ffdc14711c967",
 }
 
@@ -56,15 +71,25 @@ def digest(relative: str) -> str:
 
 
 def test_shared_identity_files_are_unmodified() -> None:
-    """Kills: editing a shared file this branch does not own, or letting the copy drift silently."""
+    """Kills: editing shared surface both gates join on without anyone reviewing the contract."""
     actual = {relative: digest(relative) for relative in PINNED}
 
     assert actual == PINNED, (
         "a shared identity file differs from the bytes pinned from "
-        f"{UPSTREAM_REF}@{UPSTREAM_COMMIT[:8]}. This branch must not edit it: re-take it with "
-        "`git checkout <ref> -- scripts/object_identity.py tests/test_object_identity.py`, run "
-        "`python tests/verify_shared_identity_pin.py`, then update PINNED here."
+        f"{UPSTREAM_REF}@{UPSTREAM_COMMIT[:8]}. Both offline gates join on it, so this is a two-gate "
+        "contract change: run `ruff format`, re-derive with `digest()`, update PINNED and "
+        "PIN_PROVENANCE here, then run `python tests/verify_shared_identity_pin.py`."
     )
+
+
+def test_the_pin_provenance_names_a_reason_rather_than_only_a_commit() -> None:
+    """Kills: re-taking the digest to silence the gate without recording what changed or why.
+
+    A pin whose provenance is only a SHA cannot be audited - the whole value of this gate is that a
+    shared-surface edit leaves a reviewable trace, and "I re-ran digest()" is not one.
+    """
+    assert len(PIN_PROVENANCE) > 120
+    assert UPSTREAM_COMMIT[:8] in PIN_PROVENANCE
 
 
 def test_the_digest_is_line_ending_independent(tmp_path: Path) -> None:

--- a/tests/test_shared_identity_pin.py
+++ b/tests/test_shared_identity_pin.py
@@ -51,16 +51,18 @@ UPSTREAM_COMMIT = "0fae0cf75bee7c49489573b4735788106af5d8e0"
 #: Why the pin last moved. An edit to shared surface is a two-gate contract change; this is the
 #: record of the one that was reviewed.
 PIN_PROVENANCE = (
-    "master@0fae0cf7 plus issue #450: `object_identity.py` gained the WORKBOOK-identity join "
-    "(WorkbookIdentity/Attribution/harvest_luid/agreed_luid) that both gates now share, because "
-    "each had invented its own key for 'whose workbook is this render of' - one fail-closed "
-    "(23 attributable renders discarded, 0/7 pages ready) and one fail-open (360 of 360 records "
-    "ownerless and admitted anyway). `tests/test_object_identity.py` is UNCHANGED."
+    "master@0fae0cf7 plus issue #450 and its round-1 safety review: `object_identity.py` carries the "
+    "WORKBOOK-identity join both gates share (WorkbookIdentity/Attribution/harvest_luid/agreed_luid/"
+    "persisted_stem), because each had invented its own key for 'whose workbook is this render of' - "
+    "one fail-closed (23 attributable renders discarded, 0/7 pages ready) and one fail-open (360 of "
+    "360 records ownerless and admitted anyway). Round 1 then found four more fail-opens of ONE "
+    "class and they are closed by ONE rule: a machine identity the unit cannot answer is `unknown`, "
+    "never rescued by a weaker axis. `tests/test_object_identity.py` is UNCHANGED."
 )
 
 #: SHA-256 of each shared file, over LF-normalized bytes.
 PINNED: dict[str, str] = {
-    "scripts/object_identity.py": "de42e60387e100e42a8df0b8c17e6a410b84f3900b321cc810c21da509a03e58",
+    "scripts/object_identity.py": "fe9b2adbd999cdf48ea4699dfacbafbcc2e13af7b6fb4be95e424fcc1876eeae",
     "tests/test_object_identity.py": "11d6881a960fa3c23beaa6928706de88a83fc1605b051314038ffdc14711c967",
 }
 

--- a/tests/test_shared_identity_pin.py
+++ b/tests/test_shared_identity_pin.py
@@ -51,18 +51,18 @@ UPSTREAM_COMMIT = "0fae0cf75bee7c49489573b4735788106af5d8e0"
 #: Why the pin last moved. An edit to shared surface is a two-gate contract change; this is the
 #: record of the one that was reviewed.
 PIN_PROVENANCE = (
-    "master@0fae0cf7 plus issue #450 and its round-1 safety review: `object_identity.py` carries the "
-    "WORKBOOK-identity join both gates share (WorkbookIdentity/Attribution/harvest_luid/agreed_luid/"
-    "persisted_stem), because each had invented its own key for 'whose workbook is this render of' - "
-    "one fail-closed (23 attributable renders discarded, 0/7 pages ready) and one fail-open (360 of "
-    "360 records ownerless and admitted anyway). Round 1 then found four more fail-opens of ONE "
-    "class and they are closed by ONE rule: a machine identity the unit cannot answer is `unknown`, "
-    "never rescued by a weaker axis. `tests/test_object_identity.py` is UNCHANGED."
+    "master@0fae0cf7 plus issue #450 and its round-1 and round-3 safety reviews: `object_identity.py` "
+    "carries the WORKBOOK-identity join both gates share, closed by ONE rule (a machine identity the "
+    "unit cannot answer is `unknown`, never rescued by a weaker axis), and now the REVISION key too. "
+    "Measured 2026-09-03 on the live site, three downloads of every item in one run: a raw sha256 "
+    "differed for 27 of 49 archives while a content-normalised key differed for 0 of 67; re-stamping "
+    "the reference estate then showed 28 remaining false `differs` were entirely a Tableau SERVER "
+    "build-stamp comment, which the key now normalises. `tests/test_object_identity.py` is UNCHANGED."
 )
 
 #: SHA-256 of each shared file, over LF-normalized bytes.
 PINNED: dict[str, str] = {
-    "scripts/object_identity.py": "fe9b2adbd999cdf48ea4699dfacbafbcc2e13af7b6fb4be95e424fcc1876eeae",
+    "scripts/object_identity.py": "7642b5261c5f15c51061113970b8abf15c609c32aea810b92aec6615eafe8620",
     "tests/test_object_identity.py": "11d6881a960fa3c23beaa6928706de88a83fc1605b051314038ffdc14711c967",
 }
 

--- a/tests/test_stamp_tableau_provenance.py
+++ b/tests/test_stamp_tableau_provenance.py
@@ -21,6 +21,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
 
+import object_identity as oid  # noqa: E402  # pylint: disable=wrong-import-position
 import stamp_tableau_provenance as prov  # noqa: E402  # pylint: disable=wrong-import-position
 
 
@@ -35,9 +36,10 @@ def _twbx(tmp_path: Path, name: str = "Superstore", payload: bytes = b"<workbook
 class FakeLookup:
     """A site that answers by name, and hands back whatever content it was told to."""
 
-    def __init__(self, workbooks, remote_sha="deadbeef"):
+    def __init__(self, workbooks, remote_sha="deadbeef", remote_key=None):
         self._workbooks = workbooks
         self._remote_sha = remote_sha
+        self._remote_key = remote_key
         self.base, self.site = "https://x.online.tableau.com", "site"
         self.product_version, self.version = "2026.2.5", "3.29"
         self.signed_out = False
@@ -47,6 +49,9 @@ class FakeLookup:
 
     def content_sha256(self, workbook_id):  # noqa: ARG002
         return self._remote_sha
+
+    def content_revision_key(self, workbook_id):  # noqa: ARG002
+        return self._remote_key
 
     def sign_out(self):
         self.signed_out = True
@@ -80,9 +85,12 @@ def test_a_plain_twb_has_no_members(tmp_path):
 
 def test_matching_bytes_are_recorded_as_a_sha256_match(tmp_path):
     path = _twbx(tmp_path)
-    local = prov.fingerprint(path)["sha256"]
-    lookup = FakeLookup([{"id": "luid-1", "name": "Superstore", "project": {"name": "Samples"}}], remote_sha=local)
-    origin = prov.find_origin(lookup, "Superstore", local)
+    record = prov.fingerprint(path)
+    lookup = FakeLookup(
+        [{"id": "luid-1", "name": "Superstore", "project": {"name": "Samples"}}],
+        remote_sha=record["sha256"],
+    )
+    origin = prov.find_origin(lookup, "Superstore", record)
     assert origin["match"] == "sha256"
     assert origin["workbook_luid"] == "luid-1"
     assert origin["tableau_product_version"] == "2026.2.5"
@@ -94,7 +102,7 @@ def test_a_same_named_but_different_build_is_never_claimed_as_the_source(tmp_pat
     the reader cannot see why."""
     path = _twbx(tmp_path)
     lookup = FakeLookup([{"id": "luid-2", "name": "Superstore"}], remote_sha="a-different-build")
-    origin = prov.find_origin(lookup, "Superstore", prov.fingerprint(path)["sha256"])
+    origin = prov.find_origin(lookup, "Superstore", prov.fingerprint(path))
     assert origin["match"] == "name_only"
     assert origin["remote_sha256"] == "a-different-build"
 
@@ -103,7 +111,7 @@ def test_duplicate_names_on_the_site_are_counted_not_hidden():
     """Tableau permits the same workbook name in different projects. Silently taking the first is how
     a name-keyed join produces a confident wrong answer - a hazard this toolchain has hit four times."""
     lookup = FakeLookup([{"id": "a", "name": "Sales"}, {"id": "b", "name": "Sales"}])
-    assert prov.find_origin(lookup, "Sales", "x")["same_name_count"] == 2
+    assert prov.find_origin(lookup, "Sales", {"sha256": "x"})["same_name_count"] == 2
 
 
 def test_a_workbook_absent_from_the_site_yields_no_origin():
@@ -123,7 +131,7 @@ def test_a_harvested_filename_matches_by_luid_not_by_its_mangled_stem():
     demonstrably existed. The LUID in the filename is exact identity; use it.
     """
     lookup = FakeLookup([{"id": HARVEST_LUID, "name": "Sales - Q3 Review", "project": {"name": "Finance"}}])
-    origin = prov.find_origin(lookup, f"{HARVEST_LUID}_Sales___Q3_Review", "x")
+    origin = prov.find_origin(lookup, f"{HARVEST_LUID}_Sales___Q3_Review", {"sha256": "x"})
     assert origin is not None, "a harvested workbook present on the site must be found"
     assert origin["matched_by"] == "luid"
     assert origin["workbook_name"] == "Sales - Q3 Review"
@@ -133,7 +141,7 @@ def test_luid_match_survives_a_rename_on_the_site():
     """The LUID is stable across renames, which is the whole point of preferring it: the name in our
     filename is a snapshot from harvest time and may be stale."""
     lookup = FakeLookup([{"id": HARVEST_LUID, "name": "Renamed Since Harvest"}])
-    origin = prov.find_origin(lookup, f"{HARVEST_LUID}_Original_Name", "x")
+    origin = prov.find_origin(lookup, f"{HARVEST_LUID}_Original_Name", {"sha256": "x"})
     assert origin["matched_by"] == "luid"
 
 
@@ -141,14 +149,14 @@ def test_luid_matching_is_case_insensitive():
     """REST hands back LUIDs lowercased, but a filename can be round-tripped through tooling that
     upper-cases it; a case difference must not read as 'not on the site'."""
     lookup = FakeLookup([{"id": HARVEST_LUID, "name": "Sales"}])
-    assert prov.find_origin(lookup, f"{HARVEST_LUID.upper()}_Sales", "x")["matched_by"] == "luid"
+    assert prov.find_origin(lookup, f"{HARVEST_LUID.upper()}_Sales", {"sha256": "x"})["matched_by"] == "luid"
 
 
 def test_a_deleted_and_recreated_workbook_falls_back_to_the_sanitized_name():
     """A new LUID for the same name is the shape of a delete-and-republish. Falling back keeps the
     record useful, and `matched_by` says plainly that it was NOT an identity match."""
     lookup = FakeLookup([{"id": "a-brand-new-luid", "name": "Sales / Q3: Review"}])
-    origin = prov.find_origin(lookup, f"{HARVEST_LUID}_Sales___Q3__Review", "x")
+    origin = prov.find_origin(lookup, f"{HARVEST_LUID}_Sales___Q3__Review", {"sha256": "x"})
     assert origin["matched_by"] == "sanitized_name"
 
 
@@ -157,18 +165,18 @@ def test_the_sanitized_fallback_is_NOT_offered_to_hand_placed_files():
     plain `Sales_Q3_Review.twbx` a human dropped in a folder must not fuzzy-match `Sales/Q3 Review`
     - that would be exactly the name-is-not-identity error this module exists to prevent."""
     lookup = FakeLookup([{"id": "a", "name": "Sales/Q3 Review"}])
-    assert prov.find_origin(lookup, "Sales_Q3_Review", "x") is None
+    assert prov.find_origin(lookup, "Sales_Q3_Review", {"sha256": "x"}) is None
 
 
 def test_a_plain_name_still_matches_exactly_as_before():
     """The harvested path must not regress the ordinary one."""
     lookup = FakeLookup([{"id": "a", "name": "Superstore"}])
-    assert prov.find_origin(lookup, "Superstore", "x")["matched_by"] == "name"
+    assert prov.find_origin(lookup, "Superstore", {"sha256": "x"})["matched_by"] == "name"
 
 
 def test_a_luid_prefixed_stem_whose_luid_is_gone_still_matches_the_exact_name():
     lookup = FakeLookup([{"id": "some-other-luid", "name": "Superstore"}])
-    origin = prov.find_origin(lookup, f"{HARVEST_LUID}_Superstore", "x")
+    origin = prov.find_origin(lookup, f"{HARVEST_LUID}_Superstore", {"sha256": "x"})
     assert origin["matched_by"] == "name"
 
 
@@ -189,7 +197,7 @@ def test_same_name_count_still_counts_names_when_matched_by_luid():
     """`same_name_count` answers 'is this name ambiguous on the site', which stays worth knowing even
     when we resolved the file by LUID."""
     lookup = FakeLookup([{"id": HARVEST_LUID, "name": "Sales"}, {"id": "other", "name": "Sales"}])
-    assert prov.find_origin(lookup, f"{HARVEST_LUID}_Sales", "x")["same_name_count"] == 2
+    assert prov.find_origin(lookup, f"{HARVEST_LUID}_Sales", {"sha256": "x"})["same_name_count"] == 2
 
 
 # --------------------------------------------------------------------------- build()
@@ -248,3 +256,80 @@ def test_partial_credentials_do_not_attempt_a_lookup(tmp_path, key):
     _twbx(tmp_path)
     result = prov.build(tmp_path, {key: "present"})
     assert result["inputs"][0].get("origin") is None
+
+
+# --------------------------------------------------------------------------- revision key (round 3)
+
+
+def _repack(path: Path) -> bytes:
+    """The same archive with reversed member ORDER and different mtimes - what the server does."""
+    import io
+    import zipfile
+
+    with zipfile.ZipFile(path) as source:
+        members = [(info.filename, source.read(info.filename)) for info in reversed(source.infolist())]
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as target:
+        for name, data in members:
+            target.writestr(zipfile.ZipInfo(name, date_time=(2026, 9, 3, 11, 22, 33)), data)
+    return buffer.getvalue()
+
+
+def test_fingerprint_records_a_reproducible_revision_key(tmp_path):
+    """The outer hash was already documented here as unstable; nothing acted on it.
+
+    Measured 2026-09-03 against the live site, three downloads of every item in one run: the raw
+    digest differed for 27 of 49 archives while the content-normalised key differed for 0 of 67.
+    """
+    record = prov.fingerprint(_twbx(tmp_path))
+
+    assert record["revision_key"]["algo"] == oid.REVISION_ALGO_ARCHIVE
+    assert record["revision_key"]["value"] != record["sha256"], "the key is not the raw hash"
+
+
+def test_a_repacked_site_copy_is_recorded_as_the_same_revision(tmp_path):
+    """THE round-3 test on the producer side: a repack must read `revision_match: "same"`.
+
+    `match` still says `name_only`, because the raw bytes genuinely differ - and that is exactly why
+    it could never carry the revision claim on its own.
+    """
+    path = _twbx(tmp_path)
+    record = prov.fingerprint(path)
+    lookup = FakeLookup(
+        [{"id": "luid-1", "name": "Superstore"}],
+        remote_sha="a-repacked-blob",
+        remote_key=oid.revision_key(_repack(path)),
+    )
+
+    origin = prov.find_origin(lookup, "Superstore", record)
+
+    assert origin["match"] == "name_only", "the raw bytes DO differ - that is the whole point"
+    assert origin["revision_match"] == "same"
+    assert origin["remote_revision_key"]["algo"] == oid.REVISION_ALGO_ARCHIVE
+
+
+def test_genuinely_different_site_content_is_recorded_as_differs(tmp_path):
+    """The negative control: normalisation must not launder a real change into agreement."""
+    lookup = FakeLookup(
+        [{"id": "luid-1", "name": "Superstore"}],
+        remote_sha="x",
+        remote_key=oid.revision_key(_twbx(tmp_path, name="Other", payload=b"<workbook edited='1'/>").read_bytes()),
+    )
+
+    origin = prov.find_origin(lookup, "Superstore", prov.fingerprint(_twbx(tmp_path)))
+
+    assert origin["revision_match"] == "differs"
+
+
+def test_an_uncomparable_remote_key_is_recorded_as_neither(tmp_path):
+    """A site copy this build cannot key says nothing - `None`, never `"differs"`.
+
+    A false drift alarm on every capture taken before the key existed would be a nastier regression
+    than the gap it closes.
+    """
+    lookup = FakeLookup([{"id": "luid-1", "name": "Superstore"}], remote_sha="x", remote_key=None)
+
+    origin = prov.find_origin(lookup, "Superstore", prov.fingerprint(_twbx(tmp_path)))
+
+    assert origin["revision_match"] is None
+    assert origin["remote_revision_key"] is None

--- a/tests/test_workbook_identity.py
+++ b/tests/test_workbook_identity.py
@@ -1,0 +1,226 @@
+"""Tests for the WORKBOOK-identity half of `scripts/object_identity.py` (issue #450).
+
+Everything in `test_object_identity.py` answers "which OBJECT is this a picture of". This file
+answers the question one level up - "whose workbook is it" - which is where issue #450 lived, twice:
+
+* `check_reference_readiness` discarded a LUID whenever ``origin.match`` said the bytes had changed,
+  then fell back to comparing the artifact stem ``HR_Dashboard`` against the published display name
+  ``HR Dashboard``. Measured on the reference estate: 23 correctly-typed, correctly-attributed
+  renders, and 0 of 7 pages ready. **Fail-closed.**
+* `check_unit` read a manifest key named ``workbook`` that no capture producer writes, so every
+  record arrived ownerless - measured 360 of 360 - and was **admitted anyway**. **Fail-open.**
+
+One cause: the two gates had each invented their own key for the same question. The join is now one
+function, and these tests pin its two directions independently. A test here that only proves an
+admission would be indistinguishable from deleting the guard, so every admission has a discriminating
+refusal beside it.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import object_identity as oid  # noqa: E402  # pylint: disable=wrong-import-position
+
+LUID_A = "adc431bb-aeeb-43fe-8ecb-092d4bae8bfa"
+LUID_B = "007f70ac-bf40-4838-9d73-134d40f504db"
+
+
+def test_the_workbook_route_vocabulary_is_pinned_to_its_literal_values() -> None:
+    """Without this the file is vacuous in one direction.
+
+    Every other assertion compares the code's answer against the code's own constant, so redefining
+    ``WB_FOREIGN = WB_LUID`` would change BOTH sides and every test would still pass. This is the
+    same pin `test_check_reference_readiness.py` takes over the status vocabulary, for the same
+    reason.
+    """
+    assert (oid.WB_SHA, oid.WB_LUID, oid.WB_NAME) == ("sha256", "luid", "name")
+    assert (oid.WB_FOREIGN, oid.WB_UNKNOWN) == ("foreign", "unknown")
+    assert oid.WB_ROUTES == ("sha256", "luid", "name")
+    assert oid.WB_ADMITTING == frozenset({"sha256", "luid", "name"})
+    # The two refusals are NOT admitting routes. Stated separately because `WB_ADMITTING` above is
+    # the thing under test everywhere else, and a mutation that added "foreign" to it would
+    # otherwise only be caught by the equality above.
+    assert oid.WB_FOREIGN not in oid.WB_ADMITTING
+    assert oid.WB_UNKNOWN not in oid.WB_ADMITTING
+
+
+# ------------------------------------------------------------------------------------------------
+# Fail-open: a foreign workbook's render must never certify this unit's page
+# ------------------------------------------------------------------------------------------------
+
+
+def test_a_matching_luid_admits_and_names_the_luid_axis() -> None:
+    """The positive control. Without it, "refuse everything" would pass every test below."""
+    unit = oid.WorkbookIdentity(luid=LUID_A, name="HR_Dashboard")
+    record = oid.WorkbookIdentity(luid=LUID_A, name="HR Dashboard")
+
+    verdict = unit.attribute(record)
+    assert verdict.route == oid.WB_LUID
+    assert verdict.admitted is True
+
+
+def test_a_luid_mismatch_is_foreign_even_when_the_display_names_are_identical() -> None:
+    """Kills: falling through to a weaker axis after a stronger one has already answered.
+
+    This is the whole fail-open direction. Two projects may hold workbooks with the SAME display
+    name - the ambiguity `_runs/<NNN>-<slug>/` numbering exists to avoid elsewhere in this repo - so
+    a name that matches after a LUID that does not is precisely the case where the name must not be
+    consulted.
+    """
+    unit = oid.WorkbookIdentity(luid=LUID_A, name="Sales Dashboard")
+    record = oid.WorkbookIdentity(luid=LUID_B, name="Sales Dashboard")
+
+    verdict = unit.attribute(record)
+    assert verdict.route == oid.WB_FOREIGN
+    assert verdict.axis == oid.WB_LUID
+    assert verdict.admitted is False
+
+
+def test_a_sha_mismatch_is_foreign_even_when_the_luid_matches() -> None:
+    """The same rule one axis up: a stale capture of the RIGHT workbook is still refused.
+
+    A capture taken against an older revision does not silently remain valid, because a stale picture
+    is worse than a missing one - it looks like evidence.
+    """
+    unit = oid.WorkbookIdentity(luid=LUID_A, name="WB", sha256="a" * 64)
+    record = oid.WorkbookIdentity(luid=LUID_A, name="WB", sha256="b" * 64)
+
+    verdict = unit.attribute(record)
+    assert verdict.route == oid.WB_FOREIGN
+    assert verdict.axis == oid.WB_SHA
+
+
+def test_a_name_axis_refusal_is_reported_as_such_so_a_lossy_rescue_can_tell_them_apart() -> None:
+    """`check_unit`'s lossy rescue is allowed on the NAME axis only, and it reads ``axis`` to know.
+
+    Without a distinguishable axis the rescue would have to guess, and a rescue that cannot tell "the
+    LUIDs differ" from "the display names differ" re-opens the fail-open above through the back door.
+    """
+    unit = oid.WorkbookIdentity(name="HR_Dashboard")
+    record = oid.WorkbookIdentity(name="HR Dashboard")
+
+    verdict = unit.attribute(record)
+    assert (verdict.route, verdict.axis) == (oid.WB_FOREIGN, oid.WB_NAME)
+
+
+# ------------------------------------------------------------------------------------------------
+# Fail-closed: an unestablished workbook certifies nothing
+# ------------------------------------------------------------------------------------------------
+
+
+def test_no_shared_axis_is_unknown_and_unknown_never_admits() -> None:
+    """Kills issue #450's actual fail-open: an ownerless record defaulting to "belongs to this unit".
+
+    `check_unit._admissible_oracle_records` used to count such a record in ``unattributed`` and then
+    fall through to ``admissible`` - and because the field it read was one no producer writes, that
+    was EVERY record on a real capture.
+    """
+    unit = oid.WorkbookIdentity(luid=LUID_A, name="WB")
+    record = oid.WorkbookIdentity()
+
+    verdict = unit.attribute(record)
+    assert verdict.route == oid.WB_UNKNOWN
+    assert verdict.admitted is False
+
+
+def test_a_unit_with_no_identity_admits_nothing_either() -> None:
+    """Symmetric: "I do not know who I am" is not a licence to accept any render."""
+    verdict = oid.WorkbookIdentity().attribute(oid.WorkbookIdentity(luid=LUID_A, name="WB"))
+
+    assert verdict.route == oid.WB_UNKNOWN
+    assert verdict.admitted is False
+
+
+def test_blank_fields_are_absence_rather_than_an_empty_string_that_matches_itself() -> None:
+    """Kills: two records with `workbook_name: ""` attributing to each other on the name axis."""
+    unit = oid.WorkbookIdentity.of(luid="   ", name="", sha256=None)
+    record = oid.WorkbookIdentity.of(luid=None, name="  ", sha256="")
+
+    assert (unit.luid, unit.name, unit.sha256) == (None, None, None)
+    assert unit.established is False
+    assert unit.attribute(record).route == oid.WB_UNKNOWN
+
+
+def test_a_non_string_manifest_value_is_absence_not_a_crash() -> None:
+    """Manifests are external input; a number or a dict where a name was expected is not identity."""
+    identity = oid.WorkbookIdentity.of(luid=17, name={"a": 1}, sha256=["x"])
+
+    assert (identity.luid, identity.name, identity.sha256) == (None, None, None)
+
+
+# ------------------------------------------------------------------------------------------------
+# The join is not a condition, and the name axis is not normalized
+# ------------------------------------------------------------------------------------------------
+
+
+def test_an_attribution_is_never_a_condition() -> None:
+    """`route` is a non-empty string for a REFUSAL too, so `if unit.attribute(r):` would admit it.
+
+    Absence is not prohibition (the rule this module was built on): omitting ``__bool__`` would make
+    the object truthy, which is the opposite of a guard. It raises.
+    """
+    verdict = oid.WorkbookIdentity(luid=LUID_A).attribute(oid.WorkbookIdentity(luid=LUID_B))
+
+    with pytest.raises(oid.AmbiguousIdentity):
+        bool(verdict)
+    with pytest.raises(oid.AmbiguousIdentity):
+        assert verdict  # the exact expression a call site would write
+
+
+def test_the_name_axis_is_exact_and_does_not_normalize() -> None:
+    """Kills: attributing one workbook's captures to another whose name differs only in spelling.
+
+    `Evidence.is_for` once compared workbook names through the lossy key, so a capture for
+    `Ops  Summary` was attributed to a unit named `Ops Summary` - the collapse defect, on WORKBOOK
+    identity. If a published name genuinely differs from the local stem, the LUID is the answer.
+    """
+    unit = oid.WorkbookIdentity(name="Ops Summary")
+
+    assert unit.attribute(oid.WorkbookIdentity(name="Ops  Summary")).route == oid.WB_FOREIGN
+    assert unit.attribute(oid.WorkbookIdentity(name="ops summary")).route == oid.WB_FOREIGN
+    assert unit.attribute(oid.WorkbookIdentity(name="Ops Summary")).route == oid.WB_NAME
+
+
+def test_a_luid_is_compared_case_insensitively() -> None:
+    """A LUID is a machine id: the REST API and a filename may disagree on case, never on identity."""
+    assert oid.WorkbookIdentity(luid=LUID_A.upper()).attribute(oid.WorkbookIdentity(luid=LUID_A)).route == oid.WB_LUID
+
+
+# ------------------------------------------------------------------------------------------------
+# The offline LUID routes
+# ------------------------------------------------------------------------------------------------
+
+
+def test_harvest_luid_reads_the_prefix_and_refuses_every_other_shape() -> None:
+    """`harvest_estate_assets.py` names downloads `<luid>_<sanitized-name>`; nothing else counts.
+
+    A hand-placed or renamed workbook must gain nothing it did not ask for - it keeps the weaker
+    routes rather than acquiring an identity from a filename that never encoded one.
+    """
+    assert oid.harvest_luid(f"{LUID_A}_HR_Dashboard") == LUID_A
+    assert oid.harvest_luid(f"{LUID_A.upper()}_HR_Dashboard") == LUID_A.upper()
+    assert oid.harvest_luid("HR_Dashboard") is None
+    assert oid.harvest_luid(f"{LUID_A}") is None  # a bare LUID with no `_<name>` is not the shape
+    assert oid.harvest_luid("not-a-luid_HR_Dashboard") is None
+    assert oid.harvest_luid(None) is None
+
+
+def test_agreed_luid_refuses_two_claims_that_disagree() -> None:
+    """Two identities that contradict each other are LESS evidence than none.
+
+    A filename prefix that disagrees with the stamped provenance means one of them is about a
+    different workbook, and picking whichever was read first is the coin toss issue #438 named.
+    """
+    assert oid.agreed_luid(LUID_A, LUID_A) == LUID_A
+    assert oid.agreed_luid(LUID_A, None) == LUID_A
+    assert oid.agreed_luid(None, LUID_A) == LUID_A
+    assert oid.agreed_luid(LUID_A.upper(), LUID_A) == LUID_A  # case is not a disagreement
+    assert oid.agreed_luid(LUID_A, LUID_B) is None
+    assert oid.agreed_luid(None, None) is None
+    assert oid.agreed_luid("  ", "") is None

--- a/tests/test_workbook_identity.py
+++ b/tests/test_workbook_identity.py
@@ -18,7 +18,10 @@ refusal beside it.
 
 from __future__ import annotations
 
+import hashlib
+import io
 import sys
+import zipfile
 from pathlib import Path, PurePosixPath, PureWindowsPath
 
 import pytest
@@ -343,3 +346,175 @@ def test_agreed_luid_refuses_two_claims_that_disagree() -> None:
     assert oid.agreed_luid(LUID_A, LUID_B) is None
     assert oid.agreed_luid(None, None) is None
     assert oid.agreed_luid("  ", "") is None
+
+
+# ------------------------------------------------------------------------------------------------
+# ROUND 3: the revision key must survive a REPACK, and only a repack
+# ------------------------------------------------------------------------------------------------
+
+
+def _archive(members: list[tuple[str, bytes]], *, date_time: tuple[int, int, int, int, int, int]) -> bytes:
+    """A zip written with an explicit member ORDER and mtime - the two things a repack changes."""
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as archive:
+        for name, data in members:
+            archive.writestr(zipfile.ZipInfo(name, date_time=date_time), data)
+    return buffer.getvalue()
+
+
+MEMBERS = [("Book.twb", b"<workbook><worksheets/></workbook>"), ("Data/Extracts/x.hyper", b"\x00\x01extract-bytes")]
+
+
+def test_a_repack_changes_the_raw_digest_and_not_the_revision_key() -> None:
+    """THE round-3 test. Kills: reverting the revision key to a raw digest.
+
+    ⚠️ Both halves are asserted, and the first is what makes the second mean anything. Measured
+    2026-09-03 against the live site, three downloads of every item in one run: the RAW digest
+    differed for **27 of 49 archives** (18 of 48 workbooks, 9 of 19 datasources) while the
+    content-normalised key differed for **0 of 67**. This fixture reproduces that mechanism offline -
+    same members, different order and mtimes - so a raw digest MUST differ here or the fixture is not
+    a repack at all and the test would be vacuous.
+    """
+    original = _archive(MEMBERS, date_time=(2026, 1, 1, 0, 0, 0))
+    repacked = _archive(list(reversed(MEMBERS)), date_time=(2026, 9, 3, 11, 22, 33))
+
+    assert hashlib.sha256(original).hexdigest() != hashlib.sha256(repacked).hexdigest(), (
+        "the fixture is not a repack, so this test could not detect a raw digest"
+    )
+    assert oid.revision_key(original) == oid.revision_key(repacked)
+    assert oid.revision_key(original).algo == oid.REVISION_ALGO_ARCHIVE
+
+
+def test_genuinely_different_content_still_differs() -> None:
+    """The negative control: normalisation must not launder a real change into agreement.
+
+    ⚠️ The rename is `Cook.twb`, not `Renamed.twb`, and that is load-bearing. `Renamed.twb` sorts
+    AFTER `Data/Extracts/x.hyper` while `Book.twb` sorts before it, so a renamed-member assertion
+    built that way passes because the member ORDER changed - it would still pass with the member name
+    dropped from the digest entirely. The mutation probe caught exactly that vacuity in an earlier
+    draft of this test. `Cook.twb` keeps the sort position, so only hashing the NAME can detect it.
+    """
+    original = _archive(MEMBERS, date_time=(2026, 1, 1, 0, 0, 0))
+    edited = _archive(
+        [("Book.twb", b"<workbook><worksheets><worksheet/></worksheets></workbook>"), MEMBERS[1]],
+        date_time=(2026, 1, 1, 0, 0, 0),
+    )
+    renamed = _archive([("Cook.twb", MEMBERS[0][1]), MEMBERS[1]], date_time=(2026, 1, 1, 0, 0, 0))
+
+    assert [name for name, _ in sorted(MEMBERS)] != ["Cook.twb", MEMBERS[1][0]], "sanity: the name changed"
+    assert sorted(n for n, _ in MEMBERS).index("Book.twb") == 0, "sanity: the rename keeps sort position"
+    assert oid.revision_key(original).agrees_with(oid.revision_key(edited)) is False
+    assert oid.revision_key(original).agrees_with(oid.revision_key(renamed)) is False, (
+        "a member NAME is part of the content: hashing only the bytes would miss a rename"
+    )
+
+
+def test_a_non_archive_uses_its_own_shape_and_says_so() -> None:
+    """⚠️ Contradicts the round-3 brief's "not a readable zip -> unconfirmed", with a measurement.
+
+    18 of 48 workbooks on the live site download as plain `.twb` XML rather than a zip, and ALL 18
+    returned a stable raw digest across three downloads - zero counter-examples. Refusing to confirm
+    them would make 37% of the estate permanently unconfirmable on the strength of a rule aimed at
+    zip repacking, which does not apply to them.
+
+    This is NOT the silent fallback the brief warns about: the algorithm is chosen by SHAPE, recorded
+    in the key, and compared only against the same algorithm. The dangerous case - bytes that ARE an
+    archive and will not open - is the test below.
+    """
+    key = oid.revision_key(b"<workbook><worksheets/></workbook>")
+
+    assert key.algo == oid.REVISION_ALGO_XML
+    assert key.value == hashlib.sha256(b"<workbook><worksheets/></workbook>").hexdigest(), (
+        "with no comment to strip, the XML key is just the sha of the bytes"
+    )
+
+
+def test_an_unreadable_archive_yields_no_key_rather_than_a_raw_one() -> None:
+    """The silent fallback the brief names, refused: truncated zip bytes must NOT be hashed raw.
+
+    A raw hash of a repacked archive is the unstable value this type exists to avoid, so producing
+    one here would re-open the defect while looking like a fix.
+    """
+    truncated = _archive(MEMBERS, date_time=(2026, 1, 1, 0, 0, 0))[:64]
+
+    assert truncated.startswith(oid.ZIP_MAGIC)
+    assert oid.revision_key(truncated) is None
+    assert oid.revision_key(b"") is None
+
+
+def test_a_key_never_compares_across_algorithms() -> None:
+    """Versioning: an old manifest reads as CANNOT COMPARE, never as drift.
+
+    `agrees_with` returns None rather than False, because a false drift alarm on every pre-existing
+    capture would be a nastier regression than the gap it closes.
+    """
+    archive = oid.RevisionKey(algo=oid.REVISION_ALGO_ARCHIVE, value="a" * 64)
+    flat = oid.RevisionKey(algo=oid.REVISION_ALGO_FLAT, value="a" * 64)
+
+    assert archive.agrees_with(flat) is None, "same value, different algorithm: not comparable"
+    assert archive.agrees_with(None) is None
+    assert archive.agrees_with(oid.RevisionKey(algo=oid.REVISION_ALGO_ARCHIVE, value="a" * 64)) is True
+    assert archive.agrees_with(oid.RevisionKey(algo=oid.REVISION_ALGO_ARCHIVE, value="b" * 64)) is False
+
+
+def test_a_key_round_trips_through_json_with_its_algorithm() -> None:
+    """A value persisted without its algorithm is uncomparable, so both halves always travel."""
+    key = oid.RevisionKey(algo=oid.REVISION_ALGO_ARCHIVE, value="c" * 64)
+
+    assert oid.RevisionKey.from_json(key.as_json()) == key
+    assert oid.RevisionKey.from_json({"value": "c" * 64}) is None, "a bare value is not a key"
+    assert oid.RevisionKey.from_json({"algo": oid.REVISION_ALGO_ARCHIVE}) is None
+    assert oid.RevisionKey.from_json("c" * 64) is None
+
+
+BUILD_STAMP_LOCAL = b"<?xml version='1.0'?>\n<!-- build 20263.26.0824.1544   -->\n<workbook><worksheets/></workbook>"
+BUILD_STAMP_REMOTE = b"<?xml version='1.0'?>\n<!-- build 20263.26.0828.1352   -->\n<workbook><worksheets/></workbook>"
+
+
+def test_the_server_build_stamp_does_not_count_as_a_changed_workbook() -> None:
+    """⚠️ MEASURED, and it is why the archive key is v2 and a flat XML key exists at all.
+
+    Normalising the zip alone was not enough. Re-stamping the 78 harvested assets of the reference
+    estate against the live site, **28 reported a content difference**; diffing six of them - three
+    inside a `.twbx`, three served flat - showed the ENTIRE difference was one line, every time::
+
+        -<!-- build 20263.26.0824.1544 -->
+        +<!-- build 20263.26.0828.1352 -->
+
+    That is the Tableau SERVER build that serialised the file. It moved because the site was upgraded
+    between the harvest and the check; most of those files were byte-identical in length. With it
+    normalised, 28 false `differs` became 0.
+    """
+    assert hashlib.sha256(BUILD_STAMP_LOCAL).hexdigest() != hashlib.sha256(BUILD_STAMP_REMOTE).hexdigest(), (
+        "the fixture must genuinely differ raw, or this test cannot detect the normalisation"
+    )
+    assert oid.revision_key(BUILD_STAMP_LOCAL) == oid.revision_key(BUILD_STAMP_REMOTE)
+    assert oid.revision_key(BUILD_STAMP_LOCAL).algo == oid.REVISION_ALGO_XML
+
+
+def test_the_build_stamp_is_normalised_inside_an_archive_too() -> None:
+    """The same nonce, the same file, one layer in - a `.twb` is XML whether or not it is zipped."""
+    local = _archive([("Book.twb", BUILD_STAMP_LOCAL), MEMBERS[1]], date_time=(2026, 1, 1, 0, 0, 0))
+    remote = _archive([MEMBERS[1], ("Book.twb", BUILD_STAMP_REMOTE)], date_time=(2026, 9, 3, 11, 22, 33))
+
+    assert hashlib.sha256(local).hexdigest() != hashlib.sha256(remote).hexdigest()
+    assert oid.revision_key(local) == oid.revision_key(remote)
+
+
+def test_normalisation_does_not_reach_past_comments_into_content() -> None:
+    """The negative control for the nonce fix: only COMMENTS are stripped.
+
+    Everything a migration cares about - marks, calculations, connections, parameters - lives in
+    elements and attributes, and a change to any of them must still read as a different build.
+    """
+    edited = BUILD_STAMP_LOCAL.replace(b"<worksheets/>", b"<worksheets><worksheet name='New'/></worksheets>")
+
+    assert oid.revision_key(BUILD_STAMP_LOCAL).agrees_with(oid.revision_key(edited)) is False
+
+
+def test_a_non_xml_non_archive_payload_keeps_its_raw_bytes_and_a_distinct_algorithm() -> None:
+    """The third SHAPE, named rather than fallen into - and never comparable with the other two."""
+    key = oid.revision_key(b"\x00\x01not xml and not a zip")
+
+    assert key.algo == oid.REVISION_ALGO_FLAT
+    assert key.agrees_with(oid.RevisionKey(algo=oid.REVISION_ALGO_XML, value=key.value)) is None

--- a/tests/test_workbook_identity.py
+++ b/tests/test_workbook_identity.py
@@ -45,8 +45,16 @@ def test_the_workbook_route_vocabulary_is_pinned_to_its_literal_values() -> None
     assert (oid.WB_SHA, oid.WB_LUID, oid.WB_NAME) == ("sha256", "luid", "name")
     assert (oid.WB_STALE, oid.WB_FOREIGN, oid.WB_UNKNOWN) == ("stale", "foreign", "unknown")
     assert oid.WB_UNCONFIRMED == "revision-unconfirmed"
+    assert oid.WB_CONFLICT == "conflicting-identity"
     assert oid.WB_ROUTES == ("sha256", "luid"), "a display NAME is not an admitting route"
-    assert oid.WB_REFUSALS == ("name", "revision-unconfirmed", "stale", "foreign", "unknown")
+    assert oid.WB_REFUSALS == (
+        "name",
+        "revision-unconfirmed",
+        "stale",
+        "conflicting-identity",
+        "foreign",
+        "unknown",
+    )
     assert oid.WB_MACHINE_AXES == ("sha256", "luid")
     assert oid.WB_ADMITTING == frozenset({"sha256", "luid"})
     # Every refusal is NOT an admitting route. Stated separately because `WB_ADMITTING` above is the
@@ -116,6 +124,91 @@ def test_a_machine_axis_the_record_does_not_claim_falls_through_to_the_next_one(
     record = oid.WorkbookIdentity(luid=LUID_A, name="Not Book")
 
     assert unit.attribute(record).route == oid.WB_LUID
+
+
+# ------------------------------------------------------------------------------------------------
+# Round-N review of PR #454: two machine axes that DISAGREE are a refusal, not a race
+# ------------------------------------------------------------------------------------------------
+
+
+def test_a_matching_sha_does_not_admit_a_record_whose_luid_names_another_workbook() -> None:
+    """BLOCKING FINDING B. The walk returned on the first axis that agreed and never saw the other.
+
+    Measured by the reviewer on a record whose sha256 WAS this unit's source and whose declared LUID
+    belonged to a different workbook::
+
+        entry gate: {"status":"READY","pages_ready":1,"attribution":{"sha256":1,"luid":0}}
+        exit  gate: {"status":"PASS","visual_present":1,"numeric_present":1,"admitted_evidence":1}
+
+    Conflicting machine identities are LESS evidence than none - one of the two claims is wrong and
+    the record itself does not say which - so this is its own refusal, named, rather than a win for
+    whichever axis happens to be consulted first.
+    """
+    unit = oid.WorkbookIdentity(luid=LUID_A, name="WB", sha256="a" * 64)
+    record = oid.WorkbookIdentity(luid=LUID_B, name="WB", sha256="a" * 64)
+
+    verdict = unit.attribute(record)
+    assert verdict.route == oid.WB_CONFLICT
+    assert verdict.axis == oid.WB_LUID
+    assert verdict.admitted is False
+    assert "contradictory machine identities" in verdict.detail
+
+
+def test_a_matching_luid_does_not_admit_a_record_whose_sha_is_another_workbooks() -> None:
+    """The same defect from the other side, so the fix cannot be one-directional.
+
+    ⚠️ Ordering alone would have hidden this one: sha256 is consulted FIRST, so a disagreeing sha is
+    already refused as ``foreign`` before the LUID is reached. It is asserted anyway because the fix
+    must be a property of the pair, not of the walk order - reordering
+    :data:`object_identity.WB_MACHINE_AXES` must not turn a refusal into an admission.
+    """
+    unit = oid.WorkbookIdentity(luid=LUID_A, name="WB", sha256="a" * 64)
+    record = oid.WorkbookIdentity(luid=LUID_A, name="WB", sha256="b" * 64)
+
+    assert unit.attribute(record).admitted is False
+
+
+def test_an_axis_the_unit_cannot_answer_is_not_the_same_as_one_that_contradicts() -> None:
+    """The asymmetry the fix must keep, and the over-strict direction it must not fall into.
+
+    A machine axis the record does not CLAIM is silent - "less evidence" - so an agreeing LUID still
+    admits even though the unit knows a sha256 the record never mentions. Collapsing "absent" into
+    "contradictory" would refuse almost every real oracle capture, whose producer writes
+    ``workbook_luid``/``workbook_name`` and no source digest at all.
+    """
+    unit = oid.WorkbookIdentity(luid=LUID_A, name="WB", sha256="a" * 64)
+    record = oid.WorkbookIdentity(luid=LUID_A, name="WB")
+
+    verdict = unit.attribute(record)
+    assert verdict.route == oid.WB_LUID
+    assert verdict.admitted is True
+
+
+def test_a_luid_the_unit_cannot_answer_is_still_unknown_rather_than_a_contradiction() -> None:
+    """The other half of the asymmetry: unanswerable is not contradictory, and stays ``unknown``.
+
+    ⚠️ The two states call for different operator actions - re-stamp this unit's provenance, versus
+    throw the capture away because its own metadata disagrees with itself - so the contradiction
+    route must not swallow the older, weaker one.
+    """
+    unit = oid.WorkbookIdentity(name="WB", sha256="a" * 64)
+    record = oid.WorkbookIdentity(luid=LUID_B, name="WB")
+
+    verdict = unit.attribute(record)
+    assert (verdict.route, verdict.axis) == (oid.WB_UNKNOWN, oid.WB_LUID)
+
+
+def test_a_display_name_that_disagrees_never_contradicts_a_machine_axis() -> None:
+    """The other over-strict direction: a NAME is decoration and may not veto a proven identity.
+
+    The artifact stem ``HR_Dashboard`` is a filesystem-sanitised spelling of the published name
+    ``HR Dashboard``, so a name disagreement is the NORMAL state of a harvested unit. Treating it as
+    a contradiction would refuse every unit this toolkit downloads.
+    """
+    unit = oid.WorkbookIdentity(luid=LUID_A, name="HR_Dashboard", sha256="a" * 64)
+    record = oid.WorkbookIdentity(luid=LUID_A, name="HR Dashboard", sha256="a" * 64)
+
+    assert unit.attribute(record).route == oid.WB_SHA
 
 
 # ------------------------------------------------------------------------------------------------

--- a/tests/test_workbook_identity.py
+++ b/tests/test_workbook_identity.py
@@ -281,8 +281,8 @@ def test_harvest_luid_reads_the_prefix_and_refuses_every_other_shape() -> None:
     [
         r"_runs\407-dryrun-gates\assets\adc431bb-aeeb-43fe-8ecb-092d4bae8bfa_HR_Dashboard.twbx",
         "_runs/407-dryrun-gates/assets/adc431bb-aeeb-43fe-8ecb-092d4bae8bfa_HR_Dashboard.twbx",
-        r"C:\Users\x\_runs\407\assets\adc431bb-aeeb-43fe-8ecb-092d4bae8bfa_HR_Dashboard.twb",
-        "/home/runner/work/_runs/407/assets/adc431bb-aeeb-43fe-8ecb-092d4bae8bfa_HR_Dashboard.twb",
+        r"D:\build\_runs\407\assets\adc431bb-aeeb-43fe-8ecb-092d4bae8bfa_HR_Dashboard.twb",
+        "/var/lib/ci/_runs/407/assets/adc431bb-aeeb-43fe-8ecb-092d4bae8bfa_HR_Dashboard.twb",
         "adc431bb-aeeb-43fe-8ecb-092d4bae8bfa_HR_Dashboard.twbx",
     ],
 )

--- a/tests/test_workbook_identity.py
+++ b/tests/test_workbook_identity.py
@@ -46,6 +46,8 @@ def test_the_workbook_route_vocabulary_is_pinned_to_its_literal_values() -> None
     assert (oid.WB_STALE, oid.WB_FOREIGN, oid.WB_UNKNOWN) == ("stale", "foreign", "unknown")
     assert oid.WB_UNCONFIRMED == "revision-unconfirmed"
     assert oid.WB_CONFLICT == "conflicting-identity"
+    assert oid.LUID_CONTRADICTED == "<contradicted-luid-declarations>"
+    assert oid.LUID_CONTRADICTED != oid.agreed_luid(), "a contradiction must not be spelled as absence"
     assert oid.WB_ROUTES == ("sha256", "luid"), "a display NAME is not an admitting route"
     assert oid.WB_REFUSALS == (
         "name",
@@ -436,14 +438,78 @@ def test_agreed_luid_refuses_two_claims_that_disagree() -> None:
 
     A filename prefix that disagrees with the stamped provenance means one of them is about a
     different workbook, and picking whichever was read first is the coin toss issue #438 named.
+
+    ⚠️ **Round 2 of PR #454 changed what a disagreement RETURNS, and the change is the fix.** It used
+    to be ``None``, which is indistinguishable from "nobody declared a LUID" - and absence is
+    deliberately SILENT, so both readers went on to admit the record on a weaker axis. A
+    contradiction now returns :data:`object_identity.LUID_CONTRADICTED`, which
+    :meth:`WorkbookIdentity.attribute` refuses as ``conflicting-identity``. The two are asserted to
+    be DIFFERENT values here, because collapsing them again is precisely the fail-open.
     """
     assert oid.agreed_luid(LUID_A, LUID_A) == LUID_A
     assert oid.agreed_luid(LUID_A, None) == LUID_A
     assert oid.agreed_luid(None, LUID_A) == LUID_A
     assert oid.agreed_luid(LUID_A.upper(), LUID_A) == LUID_A  # case is not a disagreement
-    assert oid.agreed_luid(LUID_A, LUID_B) is None
+    assert oid.agreed_luid(LUID_A, LUID_B) == oid.LUID_CONTRADICTED
+    assert oid.agreed_luid(LUID_A, LUID_B, LUID_A) == oid.LUID_CONTRADICTED, "one dissenter is enough"
+    assert oid.LUID_CONTRADICTED is not None, "absence is silent; a contradiction must not be"
     assert oid.agreed_luid(None, None) is None
     assert oid.agreed_luid("  ", "") is None
+    # Absence stays absence however it is spelled, including through the values a JSON reader hands
+    # over: a blank LUID must never become a refusal (`WorkbookIdentity.of` normalises the same way).
+    assert oid.agreed_luid(" \t ", None, LUID_A) == LUID_A
+    assert oid.agreed_luid(0, [], {}, LUID_A) == LUID_A
+
+
+def test_a_self_contradicted_luid_is_refused_by_name_whichever_side_declared_it() -> None:
+    """Round 2 of PR #454: a side may contradict ITSELF, before any comparison happens.
+
+    Both gates read a LUID from several scopes - a reference manifest's state/entry/manifest, a
+    unit's handover slice and migration spec - and both took the first non-blank one. So a
+    contradicting claim was discarded before :meth:`WorkbookIdentity.attribute` saw the record, and
+    the sha256 that DID match was allowed to certify it.
+
+    The route is asserted, not merely ``admitted is False``: this file's whole point is that one
+    refusal can be told from another, and at least four other guards in each gate also produce
+    "not admitted". A contradiction is ``conflicting-identity`` on the LUID axis - never ``foreign``
+    (someone else's capture, ignore it) and never ``unknown`` (nothing identified it).
+    """
+    contradicted = oid.WorkbookIdentity.of(luid=oid.agreed_luid(LUID_A, LUID_B), sha256="a" * 64)
+    unit = oid.WorkbookIdentity(luid=LUID_A, name="WB", sha256="a" * 64)
+
+    from_record = unit.attribute(contradicted)
+    assert (from_record.route, from_record.axis, from_record.admitted) == (oid.WB_CONFLICT, oid.WB_LUID, False)
+    assert "the record declares two different workbook LUIDs" in from_record.detail
+
+    from_unit = contradicted.attribute(oid.WorkbookIdentity(luid=LUID_A, sha256="a" * 64))
+    assert (from_unit.route, from_unit.admitted) == (oid.WB_CONFLICT, False)
+    assert "this unit declares two different workbook LUIDs" in from_unit.detail
+
+
+def test_a_contradicted_luid_refuses_even_the_axis_that_would_otherwise_admit() -> None:
+    """The discriminating twin: without it, "refuse everything" would pass the test above.
+
+    A record whose LUID declarations contradict each other is refused even when its sha256 IS this
+    unit's source bytes - that is the whole finding - while the same record with agreeing (or absent)
+    LUID declarations still certifies on that same sha256. Both halves are asserted here so a fix
+    that simply stopped admitting sha-bearing records cannot pass.
+    """
+    unit = oid.WorkbookIdentity(luid=LUID_A, name="WB", sha256="a" * 64)
+
+    def record(*claims: str | None, sha256: str | None = "a" * 64) -> oid.WorkbookIdentity:
+        return oid.WorkbookIdentity.of(luid=oid.agreed_luid(*claims), sha256=sha256)
+
+    # sha256 is the first machine axis, so an agreeing record is admitted BY IT - with the LUID
+    # compared rather than skipped (`_contradiction`). The route is named so "it refused" and "it
+    # admitted for the wrong reason" cannot both satisfy this.
+    assert unit.attribute(record(LUID_A, LUID_B)).route == oid.WB_CONFLICT
+    assert unit.attribute(record(LUID_A, LUID_A)).route == oid.WB_SHA
+    assert unit.attribute(record(LUID_A.upper(), LUID_A)).route == oid.WB_SHA
+    assert unit.attribute(record(None, "  ")).route == oid.WB_SHA
+    assert unit.attribute(record()).route == oid.WB_SHA
+    # LUID-only records, so the luid route itself is exercised rather than inferred.
+    assert unit.attribute(record(LUID_A, LUID_A, sha256=None)).route == oid.WB_LUID
+    assert unit.attribute(record(LUID_A, LUID_B, sha256=None)).route == oid.WB_CONFLICT
 
 
 # ------------------------------------------------------------------------------------------------

--- a/tests/test_workbook_identity.py
+++ b/tests/test_workbook_identity.py
@@ -19,7 +19,7 @@ refusal beside it.
 from __future__ import annotations
 
 import sys
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 
 import pytest
 
@@ -40,14 +40,74 @@ def test_the_workbook_route_vocabulary_is_pinned_to_its_literal_values() -> None
     reason.
     """
     assert (oid.WB_SHA, oid.WB_LUID, oid.WB_NAME) == ("sha256", "luid", "name")
-    assert (oid.WB_FOREIGN, oid.WB_UNKNOWN) == ("foreign", "unknown")
+    assert (oid.WB_STALE, oid.WB_FOREIGN, oid.WB_UNKNOWN) == ("stale", "foreign", "unknown")
     assert oid.WB_ROUTES == ("sha256", "luid", "name")
+    assert oid.WB_REFUSALS == ("stale", "foreign", "unknown")
+    assert oid.WB_MACHINE_AXES == ("sha256", "luid")
     assert oid.WB_ADMITTING == frozenset({"sha256", "luid", "name"})
-    # The two refusals are NOT admitting routes. Stated separately because `WB_ADMITTING` above is
-    # the thing under test everywhere else, and a mutation that added "foreign" to it would
-    # otherwise only be caught by the equality above.
-    assert oid.WB_FOREIGN not in oid.WB_ADMITTING
-    assert oid.WB_UNKNOWN not in oid.WB_ADMITTING
+    # Every refusal is NOT an admitting route. Stated separately because `WB_ADMITTING` above is the
+    # thing under test everywhere else, and a mutation that added one to it would otherwise only be
+    # caught by the equality above.
+    assert not oid.WB_ADMITTING & set(oid.WB_REFUSALS)
+    # ⚠️ The name axis is deliberately NOT a machine axis: a display name is not unique across
+    # projects, so it can never be the thing that makes a record's identity "answerable".
+    assert oid.WB_NAME not in oid.WB_MACHINE_AXES
+
+
+# ------------------------------------------------------------------------------------------------
+# THE ONE RULE (round-1 review of PR #454): a machine identity the unit cannot answer is `unknown`
+# ------------------------------------------------------------------------------------------------
+
+
+def test_a_luid_the_unit_cannot_answer_is_unknown_and_the_name_never_rescues_it() -> None:
+    """BLOCKER 1: the single highest-value assertion in this file.
+
+    A real oracle record ALWAYS carries ``workbook_luid`` AND ``workbook_name``. Skipping an
+    *unshared* LUID - because the unit could not establish one - and then admitting on an equal
+    display name let a FOREIGN workbook certify a page in both gates. The record has told us how it
+    must be checked; a unit that cannot check it has established nothing.
+    """
+    unit = oid.WorkbookIdentity(name="Book")
+    record = oid.WorkbookIdentity(luid=LUID_B, name="Book")
+
+    verdict = unit.attribute(record)
+    assert verdict.route == oid.WB_UNKNOWN
+    assert verdict.axis == oid.WB_LUID
+    assert verdict.admitted is False
+
+
+def test_a_sha_the_unit_cannot_answer_is_unknown_too() -> None:
+    """BLOCKER 3, at the type level: a `reference/manifest.json` carries `source_workbook_sha256`.
+
+    A unit that cannot hash its own source asset cannot check that claim, so location - the only
+    thing left - must not stand in for it.
+    """
+    unit = oid.WorkbookIdentity(luid=LUID_A, name="Book")
+    record = oid.WorkbookIdentity(sha256="ab" * 32)
+
+    verdict = unit.attribute(record)
+    assert (verdict.route, verdict.axis) == (oid.WB_UNKNOWN, oid.WB_SHA)
+
+
+def test_the_unanswerable_rule_does_not_swallow_a_record_that_claims_no_machine_identity() -> None:
+    """The twin that stops the rule collapsing into "refuse everything".
+
+    A hand-written or `capture_tableau_reference.py` manifest carries no LUID at all, so the name is
+    the only axis on offer and it must still work - it is simply the weakest, and it is counted
+    separately wherever a gate reports a census.
+    """
+    unit = oid.WorkbookIdentity(luid=LUID_A, name="Book", sha256="ab" * 32)
+    record = oid.WorkbookIdentity(name="Book")
+
+    assert unit.attribute(record).route == oid.WB_NAME
+
+
+def test_a_machine_axis_the_record_does_not_claim_falls_through_to_the_next_one() -> None:
+    """An oracle record carries a LUID and no sha; that must reach the LUID axis, not stop at sha."""
+    unit = oid.WorkbookIdentity(luid=LUID_A, name="Book", sha256="ab" * 32)
+    record = oid.WorkbookIdentity(luid=LUID_A, name="Not Book")
+
+    assert unit.attribute(record).route == oid.WB_LUID
 
 
 # ------------------------------------------------------------------------------------------------
@@ -209,6 +269,65 @@ def test_harvest_luid_reads_the_prefix_and_refuses_every_other_shape() -> None:
     assert oid.harvest_luid(f"{LUID_A}") is None  # a bare LUID with no `_<name>` is not the shape
     assert oid.harvest_luid("not-a-luid_HR_Dashboard") is None
     assert oid.harvest_luid(None) is None
+
+
+# ------------------------------------------------------------------------------------------------
+# BLOCKER 4: a path recorded by ANOTHER host is text, not a Path
+# ------------------------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "recorded",
+    [
+        r"_runs\407-dryrun-gates\assets\adc431bb-aeeb-43fe-8ecb-092d4bae8bfa_HR_Dashboard.twbx",
+        "_runs/407-dryrun-gates/assets/adc431bb-aeeb-43fe-8ecb-092d4bae8bfa_HR_Dashboard.twbx",
+        r"C:\Users\x\_runs\407\assets\adc431bb-aeeb-43fe-8ecb-092d4bae8bfa_HR_Dashboard.twb",
+        "/home/runner/work/_runs/407/assets/adc431bb-aeeb-43fe-8ecb-092d4bae8bfa_HR_Dashboard.twb",
+        "adc431bb-aeeb-43fe-8ecb-092d4bae8bfa_HR_Dashboard.twbx",
+    ],
+)
+def test_a_recorded_path_yields_its_luid_on_either_host(recorded: str) -> None:
+    """Kills blocker 4, ON ANY HOST - which is the whole point, since the hosts disagreed.
+
+    ``pathlib.Path`` is the RUNNING host's flavour. A real handover slice records
+    ``_runs\\407-...\\assets\\<luid>_HR_Dashboard.twbx``; on POSIX those backslashes are ordinary
+    filename characters, so ``Path(...).stem`` returns the whole string, `harvest_luid` sees no
+    prefix, and the unit ends up with NO machine identity - on Linux CI only, while a Windows
+    workstation reports the guard working. A safety guard that behaves differently in the two places
+    we look is the worst possible shape.
+
+    This test needs no POSIX host: it asserts the parse is separator-agnostic, and
+    :func:`test_the_recorded_path_parse_does_not_use_the_running_hosts_flavour` proves the same input
+    under BOTH flavours explicitly.
+    """
+    assert oid.harvest_luid(oid.persisted_stem(recorded)) == LUID_A
+
+
+def test_the_recorded_path_parse_does_not_use_the_running_hosts_flavour() -> None:
+    """The controlled experiment behind the parametrised test above, runnable anywhere.
+
+    ``PureWindowsPath`` and ``PurePosixPath`` are pure classes, so both flavours can be exercised on
+    one host. The measurement that made this a blocker: the SAME input yields the LUID under one and
+    ``None`` under the other, and the shipped code must agree with neither host's accident.
+    """
+    recorded = r"_runs\407\assets\adc431bb-aeeb-43fe-8ecb-092d4bae8bfa_HR_Dashboard.twbx"
+
+    assert oid.harvest_luid(PureWindowsPath(recorded).stem) == LUID_A
+    assert oid.harvest_luid(PurePosixPath(recorded).stem) is None, "this is the defect, reproduced"
+    assert oid.harvest_luid(oid.persisted_stem(recorded)) == LUID_A, "the fix must agree with neither"
+
+
+def test_persisted_name_and_stem_are_separator_agnostic_and_keep_dots_in_names() -> None:
+    """The parse is a filename split, not a heuristic: pin the edges it has to get right."""
+    assert oid.persisted_name(r"a\b\c.twbx") == "c.twbx"
+    assert oid.persisted_name("a/b/c.twbx") == "c.twbx"
+    assert oid.persisted_name(r"a/b\c.twbx") == "c.twbx"
+    assert oid.persisted_name("c.twbx") == "c.twbx"
+    assert oid.persisted_name("a\\b\\") == "b"
+    assert oid.persisted_name("") == ""
+    assert oid.persisted_name(None) == ""
+    assert oid.persisted_stem("Q1.2026 Sales.twbx") == "Q1.2026 Sales"
+    assert oid.persisted_stem(r"a\b\c.tar.gz") == "c.tar"
 
 
 def test_agreed_luid_refuses_two_claims_that_disagree() -> None:

--- a/tests/test_workbook_identity.py
+++ b/tests/test_workbook_identity.py
@@ -44,10 +44,11 @@ def test_the_workbook_route_vocabulary_is_pinned_to_its_literal_values() -> None
     """
     assert (oid.WB_SHA, oid.WB_LUID, oid.WB_NAME) == ("sha256", "luid", "name")
     assert (oid.WB_STALE, oid.WB_FOREIGN, oid.WB_UNKNOWN) == ("stale", "foreign", "unknown")
-    assert oid.WB_ROUTES == ("sha256", "luid", "name")
-    assert oid.WB_REFUSALS == ("stale", "foreign", "unknown")
+    assert oid.WB_UNCONFIRMED == "revision-unconfirmed"
+    assert oid.WB_ROUTES == ("sha256", "luid"), "a display NAME is not an admitting route"
+    assert oid.WB_REFUSALS == ("name", "revision-unconfirmed", "stale", "foreign", "unknown")
     assert oid.WB_MACHINE_AXES == ("sha256", "luid")
-    assert oid.WB_ADMITTING == frozenset({"sha256", "luid", "name"})
+    assert oid.WB_ADMITTING == frozenset({"sha256", "luid"})
     # Every refusal is NOT an admitting route. Stated separately because `WB_ADMITTING` above is the
     # thing under test everywhere else, and a mutation that added one to it would otherwise only be
     # caught by the equality above.
@@ -92,17 +93,21 @@ def test_a_sha_the_unit_cannot_answer_is_unknown_too() -> None:
     assert (verdict.route, verdict.axis) == (oid.WB_UNKNOWN, oid.WB_SHA)
 
 
-def test_the_unanswerable_rule_does_not_swallow_a_record_that_claims_no_machine_identity() -> None:
-    """The twin that stops the rule collapsing into "refuse everything".
+def test_a_record_carrying_only_a_display_name_is_refused_and_named() -> None:
+    """Round-3 review, B-B. This assertion used to read ``== WB_NAME`` and call it an admission.
 
-    A hand-written or `capture_tableau_reference.py` manifest carries no LUID at all, so the name is
-    the only axis on offer and it must still work - it is simply the weakest, and it is counted
-    separately wherever a gate reports a census.
+    A record claiming NO machine identity is the case where a name is LEAST trustworthy, because
+    nothing corroborates it - a workbook of the same display name in another project is
+    indistinguishable from it. The route is still REPORTED, because "a name matched, and a name is
+    not identity" is a different operator action from "nothing matched".
     """
     unit = oid.WorkbookIdentity(luid=LUID_A, name="Book", sha256="ab" * 32)
     record = oid.WorkbookIdentity(name="Book")
 
-    assert unit.attribute(record).route == oid.WB_NAME
+    verdict = unit.attribute(record)
+    assert verdict.route == oid.WB_NAME
+    assert verdict.admitted is False
+    assert "not identity" in verdict.detail
 
 
 def test_a_machine_axis_the_record_does_not_claim_falls_through_to_the_next_one() -> None:


### PR DESCRIPTION
# Round 3 - the revision key is reproducible, so `confirmed` is reachable

The review was right: *"no reproducible comparison exists"* was false. One existed - I was hashing the
container instead of the contents - and 129 of 167 ready pages carrying `revision=unconfirmed` was an
artifact of that choice, not a property of the estate.

**I re-measured independently rather than re-running the reviewer's script**: three downloads (not
two) of every item in one run, datasources as well as workbooks, asset shape recorded per item.

| 48 workbooks + 19 datasources, 3 downloads each | raw sha256 DIFFERS | content key DIFFERS |
|---|---|---|
| archives (49) | **27** | **0** |
| non-archives (18, plain `.twb` XML) | **0** | n/a |
| **content key unstable anywhere** | | **NONE** |

## Two contradictions of the brief, both measured, both load-bearing

**1. "Not a readable zip -> `unconfirmed`" would strand 18 of 48 workbooks.** They download as plain
`.twb` XML, and **all 18** had a stable raw digest across three downloads - zero counter-examples.
Refusing to confirm 37% of the estate on the strength of a rule about zip repacking, which does not
apply to them, is a fail-closed regression. The key is therefore keyed by **shape** - archive /
Tableau XML / neither - each with its own versioned algorithm. ⚠️ This is *not* the silent fallback
the brief forbids: a payload that **is** an archive and will not open still yields **no key at all**.

**2. A content digest alone was NOT sufficient - and shipping it would have been worse than the bug.**
Re-stamping the 78 harvested assets against the site, **28 still reported `differs`**. Diffing six of
them - three inside a `.twbx`, three served flat - the entire difference was one line, every time:

```
-<!-- build 20263.26.0824.1544 -->
+<!-- build 20263.26.0828.1352 -->
```

That is the Tableau **server** build stamp: the site was upgraded between the harvest and the check,
and most of those files were byte-identical in length. Left in, it trades 129 false `unconfirmed` for
**28 false `differs`** - a *refusal*, at scale, on evidence that is fine. XML comments are now
normalised out (archive key -> `twbx-content-v2`), and the 28 became **0**.

## Re-measured estate (fixture backed up, re-stamped, measured, restored)

| | round 2 | round 3 |
|---|---|---|
| `pages_ready` | 167 | **167** |
| `pages_blind` | 49 | **49** (floor ~46) |
| `pages_unverifiable` | 4 | **4** |
| `units_ready` | 25 | **25** |
| **`pages_revision_unconfirmed`** | **129** | **0** (168 `confirmed`) |
| census | `luid=295 foreign=12851 unknown=0 stale=0` | **unchanged** |

Provenance verdicts after re-stamping: `sha256/same` 20, `name_only/same` **28**, `name_only/None`
30 (a flat `.twb` local vs an archive remote - genuinely not comparable, and `None` never means
drift). Zero `differs`.

## The mutation harness is committed - `tests/mutate_revision_key.py`, 9/9

⚠️ Every mutant carries a **probe** that calls the patched object and asserts a mutation-specific
result *before* the anchor runs, per the brief. It earned its keep immediately: one probe **refused
to fire**, exposing a vacuous assertion in my own test - a renamed zip member changed the **sort
order**, so `test_genuinely_different_content_still_differs` would have passed with the member name
dropped from the digest entirely. The rename is now `Cook.twb`, which keeps the sort position.

Mutants: raw-hash the container · drop the member name · silently key an unreadable archive · compare
across algorithms · read a missing `revision_match` as drift · ignore `revision_match` · stop
recording the local key · stop normalising the build stamp · hash flat XML raw.

## Residual, named

`capture_tableau_reference.py`'s `source_workbook_sha256` is still a raw digest, and
`check_unit` still compares it raw. Both sides are **local file reads**, where a raw digest is
deterministic, so this is not the measured defect - but a reference captured against one download and
checked against a re-harvest of the same content would read FOREIGN. Fail-closed, and `check_unit.py`
is deliberately untouched here because PR #451 overlaps it.

## Gates - by exit code, every one the CI job runs

| gate | exit |
|---|---|
| `pytest tests/` | **1** - `3 failed, 4102 passed, 6 skipped`; the 3 are the pre-existing `test_upstream_repro_pins.py` engine-drift failures |
| `pytest .github/skills/pbip-model-refresh/tests/` | **0** (306 passed) |
| `ruff format --check conftest.py scripts tests .github/skills` | **0** |
| `ruff check conftest.py scripts tests .github/skills` | **0** |
| `pylint scripts` / `conftest.py` / `pbip-model-refresh` / `powerbi-ai-readiness` | **0** / **0** / **0** / **0** |
| `validate_spec.py --all --check` | **0** |
| **`set_data_folder.py --check` (privacy)** | **0** |
| `check_datamodel.py --all` | **0** |
| `check_navigation_index.py` | **0** |
| `check_agent_capabilities.py` | **0** |
| `sync_agent_conventions.py --check` | **0** |
| `set_ai_instructions.py --check` | **0** |
| `check_identity_normalization.py` | **0** |
| `mutate_revision_key.py` / `mutation_reference_readiness.py` / `mutate_check_unit.py` | **9/9** / **77/77** / **94/94** |

---

# Round 2 — four fail-open blockers, one rule

Round 1 found four fail-open blockers and they are **one class**: a record whose **machine identity
could not be established or compared** was rescued by something weaker — a display name, or merely
its location. Per the stop rule in `docs/review-throughput-postmortem.md`, this is one rule, not four
patches:

> **If a record carries a machine identity (LUID or sha256) that the unit cannot establish or
> compare, the result is `unknown`. Never fall through to a weaker axis. Never let location override
> a failed or unestablished join.**

It lives in `WorkbookIdentity.attribute`, which now walks the machine axes first: *the record makes
no claim on this axis* → try the next; *the record claims it and the unit cannot answer* → **`unknown`,
stop**; *both answer* → decisive. The display name decides only when the record claims no machine
identity at all.

Every blocker was rebuilt as a reproduction **before** any fix.

| blocker | reproduction, before | after |
|---|---|---|
| **B1** an unanswerable LUID rescued by an equal name — entry gate | `readiness=ready`, `pages_ready=1`, `pages_blind=0`, admitted by `name` | `readiness=blind`, `pages_ready=0`, **`unknown=1`** |
| **B1** the same record — exit gate | `PASS`, visual **and** numeric, `admitted_evidence=1` | `NOT_CHECKED`, visual 0 / numeric 0, **`unattributed=1`** |
| **B2** changed-revision certified as current | `readiness=ready`, generic oracle grade, **nothing disclosed** | admitted with **`revision: "unconfirmed"`**, `pages_revision_unconfirmed=1`, `[REVISION NOT ESTABLISHED]` printed — and `unverifiable` + `stale=1` when drift is soundly established |
| **B3** location certifies a unit-local reference manifest | `PASS`, visual **and** numeric, `admitted_evidence=1` | `NOT_CHECKED`, `admitted_evidence=0`, **`unattributed=1`** |
| **B3b** …the same, with a sha naming **another workbook** | `PASS`, `admitted_evidence=1` | `NOT_CHECKED`, **`foreign=1`** |
| **B4** Windows handover path on POSIX | `PureWindowsPath`→LUID, **`PurePosixPath`→`None`** | LUID on **both** flavours, both path spellings |
| **M1** non-packaged unit 3 levels below the run | oracle dirs found: `[]` | `['oracle']` — and a package still inherits nothing |
| **M2** merged census | `first name=1` + `second foreign=7` → merged **`foreign=0`** | merged **`foreign=7`**, `name=1` |

⚠️ **B1's old negative test omitted `workbook_name`, so it never exercised the path.** The replacement
supplies both fields, as every real oracle record does, and there is now a second exit-gate test for
the case the existing one *structurally could not reach* — a unit with **no** LUID at all.

## ⚠️ Contradicting the review, with a measurement: `name_only` is not evidence of a changed build

The review asked for `match: "name_only"` to be classified stale/unverifiable. Implemented literally,
that **regressed the estate from 167 ready pages to 42**, marking 18 of 67 units, 246 records and 125
pages unverifiable. Before accepting either outcome I measured *why* those inputs are `name_only`.

`find_origin` compares the harvested bytes against `content_sha256(luid)` — a fresh download. On the
407 estate that **identical request was issued twice for each of 30 workbooks inside one run**:

| observation | count |
|---|---|
| LUIDs whose two calls returned **different** digests (server repacks a `.twbx` per request) | **18 / 30** |
| LUIDs where the remote digest was stable — and the `.twbx` matched it **exactly** (`sha256`) | 12 / 30 |
| single-file LUIDs | 18, **all `sha256`** |
| units flagged stale by `match` alone | **18** |
| units flagged stale when the comparison must be **reproducible** | **0** |

So on this estate `name_only` is 100% explained by download packaging and 0% by drift. Treating it as
drift refuses correct evidence at a rate that gets a gate switched off — which this repo names as how
a good gate dies.

**The review's own escape clause — "unless the capture is independently bound to the migrated
revision" — is what resolves it**, and the revision axis is now three-valued:

- **`confirmed`** — a sha join, or `match: "sha256"`. Certifies normally.
- **`mismatch`** — `name_only` **and** every `remote_sha256` for that LUID agrees, so the comparison
  is reproducible. → `WB_STALE`, page **UNVERIFIABLE**, refused and counted. (Fires on the fixture;
  flags 0 healthy units.)
- **`unconfirmed`** — anything else, including no provenance. Admitted, and **never silently claimed
  as current**: `row["revision"]`, `pages_revision_unconfirmed`, and a rendered
  `[REVISION NOT ESTABLISHED]` line.

That satisfies blocker 2's substance — *nothing discloses the mismatch* — at zero false-alarm cost.
If you still want `unconfirmed` to be a hard finding, `--require-validation-grade` already refuses
oracle-grade evidence outright; say the word and I will make it a first-class flag instead.

## Estate — no regression, plus the safety counters

| | round 1 | round 2 |
|---|---|---|
| `pages_ready` | 167 | **167** |
| `pages_blind` | 49 (never 0) | **49** |
| `pages_unverifiable` | 4 | **4** |
| `units_ready` | 25 | **25** |
| `pages_revision_unconfirmed` | *not reported* | **129** (39 confirmed) |
| census | `luid=295, foreign=12851` | `luid=295, foreign=12851, unknown=0, stale=0` |
| HR_Dashboard | 4/7, `luid=23, foreign=290` | **4/7, `luid=23, foreign=290`** |
| exit gate, HR package | `PASS 7/7`, admitted 23 | **`PASS 7/7`, admitted 23, unattributed 0** |
| exit gate, **foreign** unit | `NOT_CHECKED 0/7` | **`NOT_CHECKED 0/7`** |

**Per the review's closing lesson, the safety counters are now reported beside the coverage numbers
by default** — `[ATTRIBUTION]` names admissions by route and refusals by reason, and
`[REVISION NOT ESTABLISHED]` names the pages whose revision was not proven. A 4x coverage rise can no
longer be mistaken for a cleared gate.

## The mutation harness is committed, not claimed

Folded into the two existing runners rather than a third framework:
**`mutation_reference_readiness.py` 77/77** (153 anchor/control checks) and
**`mutate_check_unit.py` 94/94**, negative controls surviving as required.

Three honest notes from doing it:

- A mutant aimed at `Evidence.is_for` and one aimed at `_readiness_result`'s old signature had gone
  **vacuous** — reporting CAUGHT while patching something the gate no longer called, or failing on a
  `TypeError`. Both are re-aimed.
- `a-luid-record-discards-its-workbook-name` became **inert by construction** (a LUID-bearing record
  never reaches the name axis now) and is re-aimed at the case where the name is still load-bearing.
- ⚠️ **There is deliberately no `check_unit` mutant for `Path(...).stem` vs `persisted_stem`.** On
  Windows `WindowsPath` accepts both separators, so no fixture exists that `Path` mishandles — the
  mutant is unkillable on this host **by construction**, and an entry that can only ever report
  CAUGHT on Linux is a vacuity. The property is pinned by
  `test_the_recorded_path_parse_does_not_use_the_running_hosts_flavour` (exercises both pure flavours
  on one host) and `test_a_windows_recorded_source_id_still_yields_its_luid` (fails on POSIX CI).

## Residuals, named

- **The rule is one-directional.** A record carrying *only* a display name is still admitted against a
  unit that has a LUID, because nothing stronger is on offer from that producer. It is the weakest
  route and every admission through it is counted separately (`census["name"]`).
- **A unit that cannot locate its source asset refuses sha-bearing evidence.** That is blocker 3's
  cost, stated rather than hidden, and it is counted in `unattributed_evidence`.
- `scripts/package_unit.py` (PR #451) still implements the unit-LUID rule a second time; converging it
  on `object_identity` is a follow-up, not this PR.

## Gates — by exit code

| gate | exit |
|---|---|
| `pytest tests/` | **1** — `3 failed, 4086 passed, 6 skipped`; the 3 are the pre-existing `test_upstream_repro_pins.py` engine-drift failures (they import only `engine_source`) |
| `ruff format --check .` / `ruff check .` | **0** / **0** |
| `pylint scripts` | **0** (it printed `10.00/10` while exiting **24** and then **16** before three real findings were fixed: two `too-many-locals`, a line-length, an over-cap module and an inner import) |
| `pylint conftest.py` | **0** |
| `check_navigation_index.py` / `sync_agent_conventions.py --check` / `check_identity_normalization.py` | **0** / **0** / **0** |
| `set_data_folder.py --check` (privacy) / `check_agent_capabilities.py` / `check_datamodel.py --all` | **0** / **0** / **0** |

⚠️ **The privacy gate caught a real leak and I had not been running it.** My blocker-4 path fixtures used `C:\Users\x\...` and `/home/runner/...` — exactly the shapes
`set_data_folder.py --check` exists to keep out of tracked files. It failed CI on `30a40cc` and is fixed in `3736c48` (`D:\build\...` and `/var/lib/ci/...` exercise the same
parse without matching the pattern). Both rounds' gate lists were incomplete; this is the full one the CI job runs.

`scripts/bundle_corpus.py` remains the one file outside the brief's four — it now owns the whole
ancestor walk, which is the M1 fix.

---

# Round 1 — join evidence to a workbook by LUID

`Fixes #450`

Both migration gates discard oracle evidence that exists — in **opposite directions** — from one
cause: each had invented its own key for *"whose workbook is this render of"*.

| gate | unit side | record side | measured |
|---|---|---|---|
| `check_reference_readiness` (entry) | artifact stem; LUID only when `origin.match == "sha256"` | `workbook_luid` / `workbook_name` | LUID discarded whenever the bytes differ → `HR_Dashboard` compared against `HR Dashboard` → **23 attributable renders thrown away, 0/7 pages ready**. Fail-**closed**. |
| `check_unit` (exit) | artifact stems | `record["workbook"]` — **a key no producer writes** | every record ownerless (**360 of 360**), counted in `unattributed` and then **falling through to `admissible`** → the foreign-workbook guard had never once fired. Fail-**open**. |

## Invariant and direction

- **fail-open (blocks merge)** — a *foreign* workbook's render certifies a page in this unit, or a
  record whose workbook cannot be established is admitted.
- **fail-closed (an issue, not a blocker)** — a render that legitimately belongs to this unit is
  refused, so the page reports BLIND.

Both were live. **Neither was traded for the other**, and the controls below assert the
discrimination rather than the total.

## The fix — one join, in the module both gates already share

`object_identity` gains the workbook half of identity:

```python
WorkbookIdentity(luid, name, sha256).attribute(record) -> Attribution(route, detail, axis)
```

- Compares on the **strongest axis BOTH sides carry**: `sha256` → `luid` → `name`.
- **That axis is decisive.** A mismatch returns `foreign` and never falls through to a weaker one —
  otherwise a foreign workbook sharing a display name is admitted *after* its LUID has said no. That
  fall-through is the identity-loss join this module exists to make unrepresentable.
- **The name axis is exact.** Two projects may hold workbooks with the same name; that is the
  ambiguity `_runs/<NNN>-<slug>/` numbering exists to avoid.
- **No shared axis is `unknown`** — *cannot establish*, never "belongs to this unit".
- `Attribution.__bool__` **raises**: `route` is a non-empty string for a refusal too, so
  `if unit.attribute(record):` would admit a foreign render. `.admitted` is the only reader.

Unit-side LUID, offline, from two claims that must agree (`agreed_luid`; two identities that
contradict each other are *less* evidence than none):

1. `source-provenance.json` — trusted when `matched_by == "luid"` **or** `match == "sha256"`.
   ⚠️ The old rule read `match` alone. `stamp_tableau_provenance.find_origin` documents the two as
   *"two independent axes: a LUID match with `name_only` means 'this is provably the same item on the
   site, and it has changed since we harvested it'"*. Reading the **revision** axis as the
   **identity** axis bought nothing: the fallback (artifact stem vs display name) is weaker on
   identity *and* carries no revision guarantee. On the reference estate **48 of 78** inputs are
   `matched_by: luid` + `match: name_only` — the common case, not an edge one.
2. the asset filename's `<luid>_` prefix (`harvest_estate_assets.py`'s own record of what it
   downloaded).

`Evidence.is_for` is **deleted**, not kept as a delegate — see "what review found", below.

### Second fix: evidence discovery prefers the package — in BOTH gates

`_default_dirs` stops walking up when a `package-manifest.json` sits beside the target (#451). A
package assembled inside a run directory saw its own `oracle/` **and** the run's flat capture two
levels up; every view matched twice and the gate refused the pair as *"2 records share this name once
normalized"* — every page went ready → unverifiable, silently, making packaging strictly worse than
not packaging. The walk-up is **unchanged** for a non-packaged unit and is pinned by a paired control
in the same run.

⚠️ **The brief scoped this to the entry gate; enumerating the closed surface found the identical
defect in the exit gate, and it is fixed here too.** `check_unit._oracle_dirs` walks up to
`target.parent` for the same reason, so a package at `_runs/<run>/<unit>/` beside the run capture
read both manifests. Measured on a synthetic package **before** fixing it: every page refused as
*"2 producer records are named 'Revenue'"* — **0 visual coverage**, silently. Fixing it locally a
second time is exactly the 66%-recurrence pattern
[`docs/review-throughput-postmortem.md`](docs/review-throughput-postmortem.md) measures, so the rule
lives **once**, in `bundle_corpus.is_self_contained` — the module whose own header says the
`check_*` gates *"should not keep separate copies of the same filesystem-discovery rules"*. That is
the one file outside the brief's four that this PR touches, and it is a **+30-line addition**, no
behaviour change to its existing helpers.

## Controls — all four, same run, on `_runs/407-dryrun-gates` (67 units, 313 usable of 360 views)

| control | before | after |
|---|---|---|
| **positive** — estate `pages_ready` | 42 | **167** |
| **positive** — `HR_Dashboard` | **0/7 ready**, 7 blind | **4/7 ready**; the 3 remaining blind are `page_status: dropped_unexplained` (a conversion gap, not an evidence gap) |
| **negative** — a foreign unit certified by HR's renders (`check_unit`) | **PASS, 7/7 visual + numeric** | **NOT_CHECKED, 0/7** |
| **negative** — refusals counted, not dropped | `foreign=0`, `unattributed=360` | `foreign=12851`, `unattributed=0`, `luid=295` |
| **fail-closed on unknown** | admitted (`admitted_evidence` 360 of 360) | refused, `admitted_evidence` 0, counted in `unattributed` |
| **no manufactured coverage** — `pages_blind` | 178 | **49, never 0** — 46 records have no render leg at all (a failed `/data` leg suppressed the image leg) |

Page-status cross-tab, which is what shows nothing was manufactured:

| | before | after |
|---|---|---|
| `emitted` + ready | 39 | 164 |
| `emitted` + blind | 158 | 29 |
| `emitted` + unverifiable | 0 | 4 |
| `dropped_unexplained` + blind | 20 | **20 (unchanged)** |
| `dropped_explained` + ready | 3 | 3 |

⚠️ The 4 new `unverifiable` are **fail-closed and correct**, not a regression: two workbooks in this
estate are the same content published twice, so their renders are **byte-identical**
(`sha256 a9f7a76d…` and `c5cde58b…` each appear under two view LUIDs) and cross-unit exclusivity
refuses them. They were invisible before only because those pages had no evidence at all.

## Closed surface — N = 21

Every consumer, phase and identity-loss join that can affect workbook attribution. Its absence is why
this defect existed in two places.

**Producers (6)** — `capture_tableau_oracle.py` (`views[].workbook_luid`/`workbook_name`) ·
`capture_tableau_reference.py` (`source_workbook_sha256`, **no workbook name at all**) ·
`stamp_tableau_provenance.py` (`origin.{workbook_luid,matched_by,match,same_name_count}`,
`input.sha256`) · `harvest_estate_assets.py` (asset filename `<luid>_<name>`) · engine handover slice
(`workbook.source_id`, `workbook.name`) · engine artifact stems (`<Name>.Report`,
`<Name>.SemanticModel`).

**Entry gate (7)** — `_provenance_luid` (unit LUID) · `resolve_source` (which asset is this unit's) ·
`_identify` (unit identity) · `_reference_states` (record sha) · `_oracle_record` (record luid+name) ·
`Evidence.attribution` (**the join**) · `_scope_evidence` (admit/refuse + census).

**Exit gate (5)** — `_reference_oracles` (record sha + `unit_local` location) ·
`_oracle_capture_oracles` (record luid+name) · `_unit_workbook_identities` (unit identity) ·
`_admissible_oracle_records` (**the join**) · `_lossy_workbook_rescue` (the name-only fallback).

**Location-based scope, which precedes every identity join (3)** —
`check_reference_readiness._default_dirs` (walks up 2) · `check_unit._oracle_dirs` (walks up 1) ·
`check_unit._reference_dirs` (never walks up — which is what makes a unit-local reference manifest
attributable by location). The first two now share `bundle_corpus.is_self_contained`.

**Independent second guard (1)** — `_enforce_exclusivity`: one render may not certify pages in two
units, keyed on the verified render digest. Unchanged here, and it is what catches the byte-identical
pair above.

### Residuals, named

- ⚠️ **`package_unit.py` (PR #451) implements the same rule a second time** — its `workbook_identity()`
  resolves a unit LUID from `source-provenance.json` cross-checked against the asset filename prefix,
  which is exactly `_provenance_luid`'s rule. A sibling agent owns that file right now, so converging
  it on `object_identity.WorkbookIdentity` is deliberately **not** in this PR. Filing a follow-up is
  the right move; two implementations of one identity rule is the shape this PR exists to remove.
- **`check_unit._bindable_workbooks` / `_unit_workbook_keys`** join a *handover slice* to a unit, not
  a render to a workbook. Same class, different artifact; already two-sided-uniqueness guarded and
  untouched.
- **`group_oracle_by_workbook.py`, `assess_estate.py`, `tableau_lineage.py`, `build_reconcile_items.py`**
  read `workbook_luid`/`workbook_name` for splitting, inventory and reconciliation. No gate verdict
  rides on them.
- **A unit whose LUID cannot be established** (no provenance entry, no harvest filename prefix) still
  joins on the exact display name, and in `check_unit` on the uniqueness-guarded lossy name. Both are
  disclosed (`evidence_attributed.name`; `known_gap_caveats`). This is the fail-closed-side residual:
  such a unit reports BLIND for a render whose display name differs from its stem.
- **`check_unit` reads the handover slice for the unit LUID**, so a raw `<bundle>/pbip/<Unit>` target
  (no `handover/` inside it) gets no LUID and falls to the name routes. A package or a migration unit
  has it. Not a regression — it had no LUID at all before.

## Can each test reach the production path?

21 targeted mutations, each applied to the real source file, each with a **control test that must
still pass** so a broken import cannot score as a kill. **21/21 killed** — and the first run was
15/18 (then 17/21 once the exit-gate fix was added), which is the evidence that the harness is not rubber-stamping:

- one mutation was **UNAPPLIED** (a stale pattern after `ruff format`) — fixed, then killed;
- one **SURVIVED** because my own mutation was a no-op (`luid = None or agreed_luid(...)`) — fixed,
  then killed;
- one **SURVIVED** genuinely: deleting the explicit `continue` after `unattributed += 1` changed no
  verdict, because the lossy rescue refuses an unestablished record too. Rather than accept a
  double-guarded line as "proved", the test now asserts the observable contract — an unattributed
  record is counted **once**, in `unattributed`, and **not** as `foreign` — which kills it.

Both committed mutation runners are green against the new code: `mutate_check_unit.py` **91/91
caught** with its negative control surviving, `mutation_reference_readiness.py` **69/69 matched (137
anchor/control checks)**.

## What review found that the brief did not — two corrections

1. **The brief says `check_reference_readiness._provenance_luid()` "deliberately returns no trusted
   LUID" because provenance records `match: "name_only"`. That is the symptom; the cause is one field
   narrower.** The record also carries `matched_by: "luid"`, and `find_origin` documents the two as
   independent axes. So the fix is *not* "trust `name_only`" — an origin with **no `matched_by`** and
   unconfirmed bytes may be a name collision (`find_origin` falls back to `name` and records
   `same_name_count`), and it is still refused. The existing test asserting that
   (`test_a_name_only_provenance_luid_is_not_trusted`) **still passes unchanged**; its docstring is
   re-aimed and a discriminating twin added.

2. **Deleting `Evidence.is_for` was forced by a measurement, not by taste.** It was first kept as a
   one-line delegate to `attribution()`. `mutation_reference_readiness.py` then reported two mutants
   as CAUGHT while patching a method the gate no longer called — i.e. two guards had become vacuous
   without any test noticing. Both mutants are re-aimed (one at `Evidence.attribution`, one at
   `object_identity._axis_equal`, so the lossy-name mutant now tests the join **both** gates use), and
   the boolean is gone. A second reader of one contract is where two answers diverge, which is the
   whole shape of #450.

One existing test was **reversed on purpose**:
`test_oracle_evidence_declaring_no_workbook_is_admitted_but_flagged` asserted the fail-open, on the
premise *"real oracle manifests carry no workbook field, so refusing them outright would reject every
capture in the estate."* The premise was false in the only way that mattered — a real manifest carries
`workbook_luid` and `workbook_name`; it carries no `workbook`, which is a defect in the **reader**. It
is now `test_a_record_whose_workbook_cannot_be_established_certifies_nothing`, with a positive twin
proving the fields a real capture writes ARE read.

`tests/test_shared_identity_pin.py` is re-taken deliberately: both PRs that shared
`object_identity.py` have merged, so `origin/master` is the shared truth (as
`verify_shared_identity_pin.PREFERRED_REFS` already said). The pin's job is now to make a shared-surface
edit a **reviewed** event; a new `PIN_PROVENANCE` records what moved and why, and a test asserts the
provenance names a reason rather than only a SHA.

## Gates — by exit code

| gate | exit |
|---|---|
| `pytest tests/` | **1** — `3 failed, 4064 passed, 6 skipped`; the 3 are the pre-existing `test_upstream_repro_pins.py` engine-drift failures, which import only `engine_source` and touch none of these files. CI (`checks` + `windows-bundle`) is **green**. |
| `ruff format --check .` | **0** |
| `ruff check .` | **0** |
| `pylint scripts` | **0** (⚠️ it printed `10.00/10` while exiting **24** before three real findings were fixed: two `too-many-locals`, two `line-too-long`) |
| `pylint conftest.py` | **0** |
| `check_navigation_index.py` | **0** |
| `sync_agent_conventions.py --check` | **0** |
| `check_identity_normalization.py` | **0** — the lossy comparison stays quarantined |

## Scope

`scripts/{object_identity,reference_evidence,check_reference_readiness,check_unit}.py` and their
tests, **plus a +30-line addition to `scripts/bundle_corpus.py`** (see the second fix above: putting
the package marker anywhere else would have duplicated one discovery rule across two gates, which
is the defect class this PR removes). `scripts/README.md`, `docs/agent-capability-wiring.md`, `docs/operator-runbook.md`,
`scripts/package_unit.py` and `tests/test_package_unit*.py` are untouched (PR #451 owns them).


