### PR TITLE
Document the three-phase migration pipeline, and name the packages/ location

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -722,6 +722,11 @@ _runs/<NNN>-<slug>/
     assets/             harvest_estate_assets.py-shaped downloads
     bundle/              run_estate.py-shaped conversion output
     oracle/               capture_tableau_oracle.py-shaped reference capture
+    packages/              package_unit.py's per-unit, agent-facing handover packages — ⚠️ `--out`
+                            names a subdirectory INSIDE this one (`packages/<batch>/<Unit>/`), never
+                            `packages/` itself: `conflicting_evidence_dirs` refuses an `--out` whose
+                            parent holds `oracle/`, and a run root always does (measured: bare exits
+                            2, one level deeper exits 0). See `docs/migration-phases.md`
     deliverables/          operator-facing outputs meant for the CUSTOMER, never for git —
                             the `ses-prep/` near-miss (issue #322): a `connections.json`/`.md`
                             naming 17 real customer servers landed unprefixed, unignored, at the
@@ -736,7 +741,7 @@ ignored, which proves nothing; see `harvest_estate_assets.py`'s own guard for th
 
 **`scripts/work_dirs.py`** is the single source of truth for these paths — `sanitize_unit_key`,
 `allocate_run` (atomic `mkdir`-exclusive, retry on collision, never a read-then-write race),
-`RunPaths` (the six subdirs above as properties), and `list_runs`. It resolves the repo root from
+`RunPaths` (the seven subdirs above as properties), and `list_runs`. It resolves the repo root from
 its **own file location**, never from `Path.cwd()` — an empty stray `fabric/` was once written at
 the repo root by a script that resolved a relative path against whatever CWD an agent happened to
 invoke it from, which is exactly the failure a single importable resolver removes.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 &nbsp;![Migrations](https://img.shields.io/badge/migrations-16-2ea44f)
 &nbsp;![Parser tests](https://img.shields.io/badge/parser_tests-48%2F48-2ea44f)
 
-**[TL;DR](#tldr)** &nbsp;·&nbsp; **[Quickstart](#quickstart)** &nbsp;·&nbsp; **[What you get](#what-you-get)** &nbsp;·&nbsp; **[Repo layout](#repo-layout)** &nbsp;·&nbsp; **[How it works](#how-it-works)** &nbsp;·&nbsp; **[Prerequisites](#prerequisites)** &nbsp;·&nbsp; **[Capabilities &amp; limits](docs/capabilities-and-limitations.md)**
+**[TL;DR](#tldr)** &nbsp;·&nbsp; **[Quickstart](#quickstart)** &nbsp;·&nbsp; **[What you get](#what-you-get)** &nbsp;·&nbsp; **[Repo layout](#repo-layout)** &nbsp;·&nbsp; **[Three phases](#the-three-phase-pipeline)** &nbsp;·&nbsp; **[How it works](#how-it-works)** &nbsp;·&nbsp; **[Prerequisites](#prerequisites)** &nbsp;·&nbsp; **[Capabilities &amp; limits](docs/capabilities-and-limitations.md)**
 
 </div>
 
@@ -178,7 +178,39 @@ original dashboards belongs to their respective Tableau Public authors.
 | [`scripts/`](scripts/) | The CLI surface; [`scripts/README.md`](scripts/README.md) is the map. |
 | [`docs/`](docs/) | Start with [`INDEX.md`](docs/INDEX.md), the map of maps. |
 | [`.github/{agents,skills}/`](.github/) | The Copilot agent personas and reusable knowledge bundles. |
-| `_runs/<NNN>-<slug>/` | Per-run working state. Gitignored by construction (`/_*`) and safe to delete. |
+| `_runs/<NNN>-<slug>/` | Per-run working state — the first two phases below. Gitignored by construction (`/_*`) and safe to delete. |
+
+## The three-phase pipeline
+
+A migration moves through **three locations, one direction**. Knowing which is which is most of
+knowing where to find something. Full explanation, with the measured figures and the gates:
+**[`docs/migration-phases.md`](docs/migration-phases.md)**.
+
+| Phase | Where it lands | What produces it | What you get |
+| --- | --- | --- | --- |
+| **1. Collect & convert** | `_runs/<NNN>-<slug>/` | `run_engine_survey.py` → `assess_estate.py` → `harvest_estate_assets.py` → `run_estate.py`, plus `capture_tableau_oracle.py` | `assessment/` (what exists, what is used, migration order), `assets/` (the downloads), `bundle/` (the engine's conversion output), `oracle/` (Tableau's own renders and numbers) |
+| **2. Package for the agent** | `_runs/<NNN>-<slug>/packages/<batch>/<Unit>/` | [`scripts/package_unit.py`](scripts/package_unit.py) | one self-contained folder per migration unit — source, engine output, handover queue and reference evidence together, which **both gates accept with no flags** |
+| **3. Ship** | `migrations/{workbooks,datasources}/<slug>/fabric/` | ⚠️ a manual copy — no tool yet (issue [#458](https://github.com/Guust-Franssens/tableau-to-powerbi-migration/issues/458)) | the PBIP project a customer opens in Power BI Desktop |
+
+Two gates sit on phase 2: `check_reference_readiness.py` is the **entry** gate (per report page, is
+there trustworthy Tableau reference evidence to start from — `ready` or `blind`?), and
+`check_unit.py` is the **exit** gate (is this unit done?).
+
+Three things about that flow are worth knowing before you touch it, and each has cost someone real
+work:
+
+- Inside `bundle/`, **`reports/` is the pristine engine-truth baseline and `pbip/` is the working
+  copy** agents edit. There is no `out/` level.
+- **`bundle/semantic_models/` is not a per-workbook guarantee** — on our 62-unit reference run only
+  **18** units had a model baseline. A missing counterpart is **BASELINE UNAVAILABLE**, never a
+  clean diff.
+- **Phase 2 → 3 is the riskiest hop.** The copy is where `definition.pbir`'s `byPath` stops
+  resolving, and a wrong one opens as *a report with no model* while
+  `powerbi-report-author validate` still returns `errorCount: 0` — it checks reference shape, not
+  target.
+
+Running the pipeline yourself? The command-by-command procedure, with timings, exit codes and a
+failure playbook, is **[`docs/operator-runbook.md`](docs/operator-runbook.md)**.
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ original dashboards belongs to their respective Tableau Public authors.
 | [`scripts/`](scripts/) | The CLI surface; [`scripts/README.md`](scripts/README.md) is the map. |
 | [`docs/`](docs/) | Start with [`INDEX.md`](docs/INDEX.md), the map of maps. |
 | [`.github/{agents,skills}/`](.github/) | The Copilot agent personas and reusable knowledge bundles. |
-| `_runs/<NNN>-<slug>/` | Per-run working state — the first two phases below. Gitignored by construction (`/_*`) and safe to delete. |
+| `_runs/<NNN>-<slug>/` | Per-run working state — the first two phases below. Gitignored by construction (`/_*`), but **not disposable**: only its `scratch/` subdir is, and a whole run becomes safe to delete only after its units are promoted and verified. |
 
 ## The three-phase pipeline
 
@@ -193,21 +193,27 @@ knowing where to find something. Full explanation, with the measured figures and
 | **3. Ship** | `migrations/{workbooks,datasources}/<slug>/fabric/` | ⚠️ a manual copy — no tool yet (issue [#458](https://github.com/Guust-Franssens/tableau-to-powerbi-migration/issues/458)) | the PBIP project a customer opens in Power BI Desktop |
 
 Two gates sit on phase 2: `check_reference_readiness.py` is the **entry** gate (per report page, is
-there trustworthy Tableau reference evidence to start from — `ready` or `blind`?), and
-`check_unit.py` is the **exit** gate (is this unit done?).
+there trustworthy Tableau reference evidence to start from?) and `check_unit.py` is the **exit** gate
+(is this unit done?). ⚠️ A page the entry gate calls **`blind` is a finding, not a pass** — it means a
+fidelity bug on that page would be structurally unfalsifiable, so it exits non-zero and you deal with
+it before building.
 
 Three things about that flow are worth knowing before you touch it, and each has cost someone real
 work:
 
-- Inside `bundle/`, **`reports/` is the pristine engine-truth baseline and `pbip/` is the working
-  copy** agents edit. There is no `out/` level.
+- Inside `bundle/`, **`reports/` is the pristine engine-truth baseline and `pbip/` is a working
+  copy** agents edit. There is no `out/` level. (It is not the only one — see the third bullet.)
 - **`bundle/semantic_models/` is not a per-workbook guarantee** — on our 62-unit reference run only
   **18** units had a model baseline. A missing counterpart is **BASELINE UNAVAILABLE**, never a
   clean diff.
-- **Phase 2 → 3 is the riskiest hop.** The copy is where `definition.pbir`'s `byPath` stops
-  resolving, and a wrong one opens as *a report with no model* while
-  `powerbi-report-author validate` still returns `errorCount: 0` — it checks reference shape, not
-  target.
+- **Phase 2 → 3 is a high-risk hop**, for two evidenced reasons. The copy is where
+  `definition.pbir`'s `byPath` stops resolving, and a wrong one opens as *a report with no model*
+  while `powerbi-report-author validate` still returns `errorCount: 0` — it checks reference shape,
+  not target. And **which location you copy FROM is currently unsettled**: the phase-2 package's
+  `fabric/` is a physical copy of `bundle/pbip/`, the two diverge as soon as an agent edits either,
+  and the repo documents both as "the working copy"
+  ([#460](https://github.com/Guust-Franssens/tableau-to-powerbi-migration/issues/460)). Promote from
+  whichever one carries the edits, and verify before and after.
 
 Running the pipeline yourself? The command-by-command procedure, with timings, exit codes and a
 failure playbook, is **[`docs/operator-runbook.md`](docs/operator-runbook.md)**.

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -72,6 +72,7 @@ Eligible files: tracked Markdown knowledge/navigation files, `.github/pbi.kb/**/
 | Find migration guidance | [`docs/deterministic-tier-integration.md`](../docs/deterministic-tier-integration.md) | Engine and handoff integration. |
 | Find migration guidance | [`docs/dry-run-findings-2026-08-11.md`](../docs/dry-run-findings-2026-08-11.md) | Durable F00x dry-run findings. |
 | Find migration guidance | [`docs/engine-gap-harvest.md`](../docs/engine-gap-harvest.md) | Attribute and classify the `reports/` vs `pbip/` delta into engine-gap evidence — provenance delegated to the `--tamper` gate's own adjudicator. |
+| Find migration guidance | [`docs/migration-phases.md`](../docs/migration-phases.md) | The three-phase pipeline shape: what each phase produces, where it lands, which gate guards each hop, and the known gaps. |
 | Find migration guidance | [`docs/migration-programme.md`](../docs/migration-programme.md) | Programme phases and operating model. |
 | Find migration guidance | [`docs/migration-spec.md`](../docs/migration-spec.md) | `migration-spec.json` contract. |
 | Find migration guidance | [`docs/operator-runbook.md`](../docs/operator-runbook.md) | Manual pipeline operation. |

--- a/docs/migration-phases.md
+++ b/docs/migration-phases.md
@@ -228,18 +228,35 @@ silently, with no gate firing**.
 both before and after.** Do not assume — check:
 
 ```powershell
-# BEFORE promoting: which of the two carries the agent's work?
+# BEFORE promoting — have the two candidate sources diverged at all?
 git diff --no-index --stat <bundle>\reports\<WB>.Report <bundle>\pbip\<WB>\<WB>.Report
 git diff --no-index --stat <bundle>\pbip\<WB> <run>\packages\<batch>\<Unit>\fabric
-# AFTER promoting: the deliverable must match the location you promoted FROM
+
+# AFTER promoting, model per workbook — ONE comparison
 git diff --no-index --stat <source-you-chose> migrations\workbooks\<slug>\fabric
+
+# AFTER promoting, shared datasource — TWO comparisons, because the halves split up
+git diff --no-index --stat <source>\<Name>.Report        migrations\workbooks\<slug>\fabric\<Name>.Report
+git diff --no-index --stat <source>\<Name>.SemanticModel migrations\datasources\<ds-slug>\fabric\<Name>.SemanticModel
 ```
 
-Reading it: on the second command, **exit 0 with no output means the two are still identical** — no
-one has edited either since packaging, so the choice does not matter yet. A stat line means they have
-diverged, and the side with the extra insertions is the one holding the agent's work. ✅ Both commands
-run: measured on the reference bundle, the first returned
-`22 files changed, 1807 insertions(+), 194 deletions(-)` and the second exited 0 with no output.
+⚠️ **`--stat` proves DIVERGENCE ONLY; it cannot establish provenance.** Exit 0 with no output means
+the two are still identical, so the choice does not matter yet — measured on a fresh package. A
+non-empty result means they have diverged, **and nothing more**. In particular the **insertion count
+does not identify the edited side**: ✅ measured, a deletion-only edit *inside the package* reports
+`1 file changed, 9 deletions(-)` — no extra insertions on the edited side at all; a replacement
+yields equal insertions and deletions; and both trees may have been edited. To establish which side
+is authoritative, use the **full diff** (drop `--stat`), the `_build/generated-edit-declarations/`
+records where they exist ([`powerbi-report-gotchas` §3](../.github/skills/powerbi-report-gotchas/SKILL.md)),
+and your own knowledge of where the agent was told to work. **If you cannot establish it, stop and do
+not promote** — an unresolved provenance question is exactly the silent-loss case this section exists
+to prevent.
+
+⚠️ **Never use the whole-tree form on a shared datasource — it calls a correct promotion wrong.**
+✅ Measured on a correctly split promotion: source-unit vs workbook destination exits **1**
+(`20 files changed, 1272 deletions(-)`) *precisely because the model correctly landed under
+`migrations/datasources/`*, while the report half and the model half each exit **0**. The whole-tree
+form is right only for the model-per-workbook case (measured: exit **0**).
 
 ⚠️ Require a real stat line, not just the exit code — `git diff --no-index` exits **1** both when
 trees differ and when a path is wrong. And on Windows use `git diff`, never bare `diff`: that is a

--- a/docs/migration-phases.md
+++ b/docs/migration-phases.md
@@ -30,7 +30,8 @@ The pipeline has three locations, and the direction is one-way:
             │            entry gate: check_reference_readiness.py   (ready / blind)
             │            exit  gate: check_unit.py                  (is this unit done?)
             │
-            │  PHASE 3 — ship   ⚠️ NO TOOL: manual copy today (issue #458)
+            │  PHASE 3 — ship   ⚠️ NO TOOL: manual copy today (issue #458), and the source
+            │                      location is itself unsettled (issue #460)
             ▼
    migrations/{workbooks,datasources}/<slug>/fabric/
        the deliverable a customer opens in Power BI Desktop
@@ -39,6 +40,11 @@ The pipeline has three locations, and the direction is one-way:
 Everything under `_runs/` is gitignored by construction — `.gitignore:162` is a root-anchored `/_*`
 — so phases 1 and 2 never risk a commit. Phase 3 is the only location where committing is possible,
 which is also why it is the one with a privacy footgun (see below).
+
+⚠️ **Gitignored is not the same as disposable.** A run directory holds the agent's editable working
+copy *and* the evidence trail behind every verdict. Only `scratch/` is disposable — `work_dirs.py`
+calls it "the only subdir a future `--prune` may ever delete". A whole run becomes safe to delete
+only **after** its units have been promoted to phase 3 and that promotion has been verified.
 
 Measured figures below come from **one real cold run** against a 48-workbook Tableau Cloud site,
 `_runs/408-…`, 2026-09-03. They are *our* reference estate, not a customer's — never quote them as a
@@ -76,11 +82,13 @@ on" versus "what did we download" — so a mismatch between them is not a defect
 
 ### Two things about `bundle/` that mislead people
 
-**1. `reports/` is the engine-truth BASELINE and must never be edited; `pbip/` is the working copy.**
-There is **no `out/` level** — a bundle is `{pbip,reports,semantic_models,handover,data}`. Agents
-edit `pbip/`; `reports/` stays pristine so the engine-gap delta remains attributable. Compare the
-pair with `git diff --no-index --stat`, never PowerShell's `diff` (which is an alias for
-`Compare-Object` and compares the two path *strings*). Source:
+**1. `reports/` is the engine-truth BASELINE and must never be edited; `pbip/` is a working copy.**
+There is **no `out/` level** — a bundle is `{pbip,reports,semantic_models,handover,data}`. Per
+`AGENTS.md:773` agents edit `pbip/`; `reports/` stays pristine so the engine-gap delta remains
+attributable. ⚠️ It is not the *only* documented working copy — the phase-2 package ships a
+`copytree` of it that its own README also calls the place to edit (#460, phase 3 below). Compare the
+baseline/working pair with `git diff --no-index --stat`, never PowerShell's `diff` (which is an alias
+for `Compare-Object` and compares the two path *strings*). Source:
 [`.github/skills/powerbi-report-gotchas/SKILL.md` §3](../.github/skills/powerbi-report-gotchas/SKILL.md).
 
 **2. `semantic_models/` is NOT a per-workbook guarantee.** ✅ Measured on run 408: **18 model
@@ -114,7 +122,7 @@ Per-unit layout (authoritative list: `package_unit.py`'s module docstring):
     source-provenance.json       SCOPED; the only trusted route to a workbook LUID
     engine-output-receipt.json   what built this, so version drift stays checkable
     assets/<luid>_<Name>.twb(x)  the source, under the name resolve_source() already looks for
-    fabric/<Name>.Report/        the engine WORKING COPY (pbip/), never the reports/ baseline
+    fabric/<Name>.Report/        the engine WORKING COPY (a copytree of pbip/), never the baseline
     fabric/<Model>.SemanticModel/
     handover/<Unit>.json         the engine's per-workbook slice, verbatim
     handover.md                  flat, one finding per line, emptied visuals FIRST
@@ -135,6 +143,12 @@ discriminator and its resolver is non-fatal by design.
 ⚠️ **Attribution is fail-closed and by LUID only.** A render that cannot be tied to a workbook by
 `workbook_luid` is omitted with its reason recorded, never copied in because it was in the same
 capture. A display name is not an identity (#450).
+
+❌ **`fabric/` here is a `shutil.copytree` of `<bundle>/pbip/<unit>/` (`scripts/package_unit.py:847`),
+not a link — so edits made here do NOT appear in the bundle, and vice versa.** The package's own
+README says to edit here; `AGENTS.md:773` says to edit in `<bundle>/pbip/`. Which one is
+authoritative is an open design question, **#460**; it matters most at phase 3, where promoting from
+the wrong one silently ships unedited engine output. See phase 3 below before you copy anything.
 
 ### Where `packages/` goes, and the constraint that decides it
 
@@ -186,23 +200,67 @@ on oracle imagery alone is overstated (issue #194).
 The deliverable lands in `migrations/workbooks/<slug>/fabric/` (a workbook's report + model) or
 `migrations/datasources/<ds-slug>/fabric/` (a shared/published datasource's model).
 
-❌ **There is no tool for the phase 2 → phase 3 hop. It is a manual copy today.** That gap is
-tracked as **#458**. It matters because this is the highest-cost mistake in the pipeline: the copy
-is where `definition.pbir`'s `byPath` stops resolving, and nothing in the toolkit catches it.
+❌ **There is no tool for the phase 2 → phase 3 hop. It is a manual copy today**, tracked as **#458**.
+It is a high-risk hop for two evidenced reasons: the copy is where `definition.pbir`'s `byPath` stops
+resolving, and no gate checks that the *target* resolves (below); and **which location you copy FROM
+is currently unsettled** (below, #460).
 
-Source for everything in this section:
-[`.github/skills/powerbi-report-gotchas/SKILL.md` §3](../.github/skills/powerbi-report-gotchas/SKILL.md)
-(🟢 verified 2026-08-11).
+### ⚠️ First decide WHERE you are promoting from — the repo currently gives two answers
 
-**Model per workbook — plain copy, but copy the CONTENTS.** `<bundle>/pbip/<wb>/` already holds
+❌ **Open design question, tracked as #460 — do not treat either location as settled.** The toolkit
+documents two different places an agent edits, and they are physical copies of each other:
+
+| what says it | where it says agents edit |
+|---|---|
+| `AGENTS.md:773` (shared conventions) | `<bundle>/pbip/` — *"agents edit **here**"* |
+| the package README `package_unit.py` writes (`scripts/package_unit.py:785`) | `<package>/fabric/` — *"the engine WORKING COPY - edit here"* |
+
+The package's `fabric/` is a **`shutil.copytree`** of `<bundle>/pbip/<unit>/`
+(`scripts/package_unit.py:847`), not a link, so an edit in one is invisible in the other. ✅ Proven by
+sentinel edit during review of this document: after editing inside the package,
+`PACKAGE_EDIT_EXISTS=True` / `BUNDLE_EDIT_EXISTS=False`. ✅ Corroborated here — immediately after
+packaging the two trees are byte-identical (`git diff --no-index` exit 0, no output), so they can
+only diverge by someone editing one of them. Promoting from `<bundle>/pbip/` when the agent worked in
+the package ships **unchanged engine output and loses every agent-authored TMDL/PBIR change,
+silently, with no gate firing**.
+
+**Interim instruction until #460 is decided: promote from wherever the edits actually are, and verify
+both before and after.** Do not assume — check:
+
+```powershell
+# BEFORE promoting: which of the two carries the agent's work?
+git diff --no-index --stat <bundle>\reports\<WB>.Report <bundle>\pbip\<WB>\<WB>.Report
+git diff --no-index --stat <bundle>\pbip\<WB> <run>\packages\<batch>\<Unit>\fabric
+# AFTER promoting: the deliverable must match the location you promoted FROM
+git diff --no-index --stat <source-you-chose> migrations\workbooks\<slug>\fabric
+```
+
+Reading it: on the second command, **exit 0 with no output means the two are still identical** — no
+one has edited either since packaging, so the choice does not matter yet. A stat line means they have
+diverged, and the side with the extra insertions is the one holding the agent's work. ✅ Both commands
+run: measured on the reference bundle, the first returned
+`22 files changed, 1807 insertions(+), 194 deletions(-)` and the second exited 0 with no output.
+
+⚠️ Require a real stat line, not just the exit code — `git diff --no-index` exits **1** both when
+trees differ and when a path is wrong. And on Windows use `git diff`, never bare `diff`: that is a
+PowerShell alias for `Compare-Object` and compares the two path *strings*.
+
+### The `byPath` mechanics (still correct, and still necessary)
+
+Source: [`.github/skills/powerbi-report-gotchas/SKILL.md` §3](../.github/skills/powerbi-report-gotchas/SKILL.md)
+(🟢 verified 2026-08-11). These apply whichever source location you promote from.
+
+**Model per workbook — plain copy, but copy the CONTENTS.** The promoted unit folder already holds
 `<Name>.Report/` and `<Name>.SemanticModel/` as **siblings**, with `"path": "../<Name>.SemanticModel"`,
-and the delivery folder has the identical shape. So copy the *contents* of `<bundle>/pbip/<wb>/`, not
-the folder — that folder is named for the **workbook**, the model inside for the **datasource**, so
-copying the folder itself nests them wrongly.
+and the delivery folder has the identical shape. So copy the *contents* of that folder, not the folder
+itself — it is named for the **workbook**, the model inside for the **datasource**, so copying the
+folder nests them wrongly.
 
-**Shared/published datasource — the reference MUST be rewritten.** The model lands once in
-`migrations/datasources/<ds-slug>/fabric/` while each report goes to
-`migrations/workbooks/<slug>/fabric/`. They are no longer siblings, so `definition.pbir` becomes:
+**Shared/published datasource — the reference MUST be rewritten, and the two halves SPLIT UP.**
+⚠️ The report and model do **not** both stay under the workbook's own `fabric/`: the model lands
+**once** in `migrations/datasources/<ds-slug>/fabric/` and is shared, while each downstream report
+goes to its own `migrations/workbooks/<slug>/fabric/`. They are no longer siblings, so
+`definition.pbir` becomes:
 
 ```
 "../../../../datasources/<ds-slug>/fabric/<Name>.SemanticModel"
@@ -211,8 +269,8 @@ copying the folder itself nests them wrongly.
 — four levels up from inside `<Name>.Report/`. **Verify it resolves on disk after writing it.**
 
 ⚠️ **A wrong `byPath` opens as a report with NO MODEL, and `powerbi-report-author validate` returns
-`errorCount: 0` for it** — it checks reference *shape*, not *target*. So the one failure mode that
-matters most here is invisible to the validator you would reach for.
+`errorCount: 0` for it** — it checks reference *shape*, not *target*. So this failure mode is
+invisible to the validator you would reach for.
 
 ⚠️ **Never ship `<bundle>/reports/` itself.** It is a reference-only baseline: `reports/` holds only
 `*.Report` folders, so the `byPath` beside it has no model to point at, and its exact (unresolvable)
@@ -221,7 +279,7 @@ value is engine-version dependent.
 ⚠️ **A shipped deliverable can be structurally present and functionally EMPTY.** Assert the shipped
 `<Name>.Report/definition/pages/` enumerates real pages *with visuals* and the shipped
 `<Name>.SemanticModel/definition/tables/` holds real tables. A folder count is not a content check,
-and verifying a fix in `<bundle>/pbip/` proves nothing about `migrations/**/fabric/`.
+and verifying a fix in one location proves nothing about `migrations/**/fabric/`.
 
 ### What is actually tracked in git here
 
@@ -277,10 +335,11 @@ user, so the rename is cheap today and gets more expensive the moment one appear
 | # | gap | status |
 |---|---|---|
 | 1 | No tool for phase 2 → phase 3; the `byPath` rewrite is manual and a wrong one validates clean | ❌ open, tracked as **#458** |
-| 2 | `semantic_models/` baselines exist for only 18 of 62 units on the reference run, so model churn cannot be measured for the rest | ❌ report as **BASELINE UNAVAILABLE** (#274, #359) |
-| 3 | `deliverables/` is a convention with no writer, and its name collides with phase 3's meaning | ⚠️ documented, not fixed |
-| 4 | Phase 1 stages still default to their own `_assessment*/` / `_oracle*/` / `_bundle*/` paths rather than the `_runs/` layout | ⚠️ deliberate scope limit of issue #234; migrating them is follow-up |
-| 5 | Oracle evidence is layout/text grade only; validation grade requires a render you captured yourself | ⚠️ provider limit, not an oversight (#194) |
+| 2 | Two documented edit locations — `<bundle>/pbip/` (`AGENTS.md:773`) and `<package>/fabric/` (`package_unit.py:785`) — diverge because the package is a `copytree`, so promoting from the wrong one silently loses agent work | ❌ open design question, tracked as **#460**; promote from wherever the edits are and verify both ways |
+| 3 | `semantic_models/` baselines exist for only 18 of 62 units on the reference run, so model churn cannot be measured for the rest | ❌ report as **BASELINE UNAVAILABLE** (#274, #359) |
+| 4 | `deliverables/` is a convention with no writer, and its name collides with phase 3's meaning | ⚠️ documented, not fixed |
+| 5 | Phase 1 stages still default to their own `_assessment*/` / `_oracle*/` / `_bundle*/` paths rather than the `_runs/` layout | ⚠️ deliberate scope limit of issue #234; migrating them is follow-up |
+| 6 | Oracle evidence is layout/text grade only; validation grade requires a render you captured yourself | ⚠️ provider limit, not an oversight (#194) |
 
 ## See also
 

--- a/docs/migration-phases.md
+++ b/docs/migration-phases.md
@@ -1,0 +1,293 @@
+# The three-phase migration pipeline
+
+Where everything lives, what moves between the locations, and which gate guards each hop.
+
+Read this when you are picking up a migration and need to know *where to find what*. The
+command-by-command procedure — flags, timings, exit codes, failure playbook — is
+[`docs/operator-runbook.md`](operator-runbook.md); this document explains the **shape** that runbook
+walks through.
+
+The pipeline has three locations, and the direction is one-way:
+
+```
+   TABLEAU SITE  /  .twb .twbx .tds .tdsx
+            │
+            │  PHASE 1 — collect and convert  (deterministic; scripts only)
+            ▼
+   _runs/<NNN>-<slug>/
+       assessment/   what exists, what is used, migration ORDER
+       assets/       the downloaded workbooks and datasources
+       bundle/       the engine's conversion output
+       oracle/       Tableau's OWN renders and numbers
+       packages/     ┐
+       deliverables/ ├─ see phase 2 and the "not a stage" note below
+       scratch/      ┘
+            │
+            │  PHASE 2 — package for the agent  (scripts/package_unit.py)
+            ▼
+   _runs/<NNN>-<slug>/packages/<batch>/<Unit>/
+       one self-contained folder per migration unit; BOTH gates accept it with NO flags
+            │            entry gate: check_reference_readiness.py   (ready / blind)
+            │            exit  gate: check_unit.py                  (is this unit done?)
+            │
+            │  PHASE 3 — ship   ⚠️ NO TOOL: manual copy today (issue #458)
+            ▼
+   migrations/{workbooks,datasources}/<slug>/fabric/
+       the deliverable a customer opens in Power BI Desktop
+```
+
+Everything under `_runs/` is gitignored by construction — `.gitignore:162` is a root-anchored `/_*`
+— so phases 1 and 2 never risk a commit. Phase 3 is the only location where committing is possible,
+which is also why it is the one with a privacy footgun (see below).
+
+Measured figures below come from **one real cold run** against a 48-workbook Tableau Cloud site,
+`_runs/408-…`, 2026-09-03. They are *our* reference estate, not a customer's — never quote them as a
+customer's numbers.
+
+---
+
+## Phase 1 — collect and convert
+
+One numbered run directory per pipeline run, allocated by
+[`scripts/work_dirs.py`](../scripts/work_dirs.py) (`allocate_run`). **The number is the identity**
+— never renamed, never reused, because generated bundle output embeds absolute self-paths. The slug
+is decoration for human navigation; nothing may parse it back into a display name (two projects can
+legitimately hold same-named workbooks — issue #234, rule 2).
+
+`CANONICAL_SUBDIRS` (`scripts/work_dirs.py:72`) is the single source of truth for the layout:
+
+| subdir | produced by | contents | measured on run 408 |
+|---|---|---|---|
+| `assessment/` | `run_engine_survey.py`, then `assess_estate.py` | what exists on the site, what is actually **used**, migration **order**, `estate.db`, `report.md`, `estate_survey.json` | 48 workbooks, 0 listing errors, 11 required published datasources |
+| `assets/` | `harvest_estate_assets.py` | the downloads under `assets/assets/`, plus an estate-wide `parse-sweep.md`/`.json` | 67 assets (48 workbooks + 19 published datasources); **0 parse failures on either tier** |
+| `bundle/` | `run_estate.py` (wraps the deterministic engine) | `pbip/`, `reports/`, `semantic_models/`, `handover/`, `data/` | 62 `pbip/` units, 48 report baselines, **18** model baselines, 46 handover slices |
+| `oracle/` | `capture_tableau_oracle.py` | Tableau's OWN renders and numbers, keyed by **view LUID** | 360 views (60 dashboards / 300 worksheets), 288 captured complete |
+| `packages/` | `package_unit.py` | phase 2 — see below | |
+| `deliverables/` | *nothing* | a safety convention, not a stage — see below | **empty in every run on this machine** |
+| `scratch/` | whoever needs it | disposable, run-owned; the only subdir a future `--prune` may ever delete | |
+
+✅ Verified 2026-09-03 by direct measurement of `_runs/408-…` (`oracle-manifest.json` `view_count` /
+`view_types`; `assets/parse-sweep.md`; `assessment/estate_survey.json` `summary`; directory counts
+under `bundle/`).
+
+⚠️ **`assessment/estate_survey.json` counts *required* datasources (11), `assets/` counts *harvested*
+ones (19).** They answer different questions — "which published datasources does a workbook depend
+on" versus "what did we download" — so a mismatch between them is not a defect.
+
+### Two things about `bundle/` that mislead people
+
+**1. `reports/` is the engine-truth BASELINE and must never be edited; `pbip/` is the working copy.**
+There is **no `out/` level** — a bundle is `{pbip,reports,semantic_models,handover,data}`. Agents
+edit `pbip/`; `reports/` stays pristine so the engine-gap delta remains attributable. Compare the
+pair with `git diff --no-index --stat`, never PowerShell's `diff` (which is an alias for
+`Compare-Object` and compares the two path *strings*). Source:
+[`.github/skills/powerbi-report-gotchas/SKILL.md` §3](../.github/skills/powerbi-report-gotchas/SKILL.md).
+
+**2. `semantic_models/` is NOT a per-workbook guarantee.** ✅ Measured on run 408: **18 model
+baselines for 62 `pbip/` units**. That tree is keyed by *model*, not by workbook, and is emitted for
+models not owned by a single workbook (published/shared datasources). A missing counterpart must be
+reported as **BASELINE UNAVAILABLE** — never as a clean or no-change diff. The miss is silent:
+`git diff --no-index` exits **1** both for *"could not access"* and for *"they differ"*, so an absent
+baseline reads as "large diff, do not re-run" (issue #274, #359).
+
+---
+
+## Phase 2 — package for the agent
+
+[`scripts/package_unit.py`](../scripts/package_unit.py) (issues #446 / #451) assembles **one
+self-contained folder per migration unit that both gates accept with NO flags.**
+
+That "no flags" property is the entire point. Before it, the three things an agent needs lived in
+four naming schemes across two trees — the engine keys `pbip/`, `reports/` and `handover/` by
+sanitized workbook name, the oracle keys renders and numbers by bare view LUID in a flat tree
+*outside* the bundle, and the source asset is a LUID-prefixed filename in a third place. So both
+gates needed `--source`/`--oracle` paths that **cannot be derived from the unit path**, and getting
+one wrong reads as *"this unit is broken"* rather than *"you did not tell me where the workbook
+is"*.
+
+Per-unit layout (authoritative list: `package_unit.py`'s module docstring):
+
+```
+<out>/<Unit>/
+    migration-spec.json          parse_tableau.py; check_unit.py's expected page set (#443)
+    report.json                  the engine's own classification, SCOPED to this unit
+    source-provenance.json       SCOPED; the only trusted route to a workbook LUID
+    engine-output-receipt.json   what built this, so version drift stays checkable
+    assets/<luid>_<Name>.twb(x)  the source, under the name resolve_source() already looks for
+    fabric/<Name>.Report/        the engine WORKING COPY (pbip/), never the reports/ baseline
+    fabric/<Model>.SemanticModel/
+    handover/<Unit>.json         the engine's per-workbook slice, verbatim
+    handover.md                  flat, one finding per line, emptied visuals FIRST
+    oracle/
+        oracle-manifest.json     THIS unit's views only, paths rewritten
+        dashboard/{images,data}/<Object>.<ext>
+        worksheet/{images,data}/<Object>.<ext>
+        unknown/{images,data}/<Object>.<ext>
+    package-manifest.json        what was packaged, and every omission with its reason
+    README.md
+```
+
+⚠️ **The oracle kind directories are SINGULAR on purpose** — `dashboard/`, `worksheet/`, `unknown/`
+are `object_identity`'s `KIND_*` values *verbatim*, never a pluralised copy. `unknown/` is carried
+but **marked** (`UNTYPED_RENDER`), never filed as either kind, because `view_type` is the only type
+discriminator and its resolver is non-fatal by design.
+
+⚠️ **Attribution is fail-closed and by LUID only.** A render that cannot be tied to a workbook by
+`workbook_luid` is omitted with its reason recorded, never copied in because it was in the same
+capture. A display name is not an identity (#450).
+
+### Where `packages/` goes, and the constraint that decides it
+
+```powershell
+python scripts\package_unit.py --bundle _runs\<NNN>-<slug>\bundle `
+    --out _runs\<NNN>-<slug>\packages\<batch> `
+    --json _runs\<NNN>-<slug>\packages\<batch>\packaging.json
+# then, per unit, with NO flags at all:
+python scripts\check_reference_readiness.py _runs\<NNN>-<slug>\packages\<batch>\<Unit>
+python scripts\check_unit.py                _runs\<NNN>-<slug>\packages\<batch>\<Unit>
+```
+
+⚠️ **`--out` must name a subdirectory INSIDE `packages/`, never `packages/` itself.** The gates
+discover evidence by scanning the target, its parent **and its grandparent** for `reference/` /
+`oracle/` / `_oracle/`, so `package_unit.conflicting_evidence_dirs`
+(`scripts/package_unit.py:819`) refuses an `--out` whose parent already holds one. A run root
+*always* holds `oracle/`, because `allocate_run` creates every canonical subdir.
+
+✅ Measured 2026-09-03 against run 408's bundle:
+
+| `--out` | exit | outcome |
+|---|---|---|
+| `_runs/<NNN>-<slug>/packages` | **2** | refused: *"sits beside evidence the gates also scan … Choose an `--out` outside the capture tree"* |
+| `_runs/<NNN>-<slug>/packages/<batch>` | **0** | packaged; the readiness gate then reports **0 unverifiable**, i.e. no shadowing |
+
+Were the bare form used, every page would silently drop from `ready` to `unverifiable` — strictly
+worse than not packaging at all — which is why it is refused rather than documented.
+`tests/test_work_dirs.py::test_package_out_must_be_a_child_of_packages_not_packages_itself` pins
+this so the command above stays runnable.
+
+### The two gates
+
+| gate | question | verdicts |
+|---|---|---|
+| [`check_reference_readiness.py`](../scripts/check_reference_readiness.py) — the **ENTRY** gate | per report page, is there trustworthy Tableau reference evidence to *start from*? | exit 0 ready / 1 findings / 3 `CANNOT_ESTABLISH`; a page is `ready`, `blind`, `unverifiable`, or below the required grade. Neither 1 nor 3 is a pass |
+| [`check_unit.py`](../scripts/check_unit.py) — the **EXIT** gate | *"answer whether one migration unit is done by aggregating existing gates without merging them"* (`check_unit.py:2`) | per-scope `model` / `report` / `integration` / `all` |
+
+A **blind** page means an equivalent fidelity bug there is *structurally unfalsifiable*, not merely
+unverified. Detail: [`docs/reference-readiness.md`](reference-readiness.md).
+
+⚠️ An oracle capture is **layout/text grade only** — default view state, no `?vf_` filter pinning —
+regardless of render leg. Record that ceiling in `limitations_encountered`; a visual PASS signed off
+on oracle imagery alone is overstated (issue #194).
+
+---
+
+## Phase 3 — ship
+
+The deliverable lands in `migrations/workbooks/<slug>/fabric/` (a workbook's report + model) or
+`migrations/datasources/<ds-slug>/fabric/` (a shared/published datasource's model).
+
+❌ **There is no tool for the phase 2 → phase 3 hop. It is a manual copy today.** That gap is
+tracked as **#458**. It matters because this is the highest-cost mistake in the pipeline: the copy
+is where `definition.pbir`'s `byPath` stops resolving, and nothing in the toolkit catches it.
+
+Source for everything in this section:
+[`.github/skills/powerbi-report-gotchas/SKILL.md` §3](../.github/skills/powerbi-report-gotchas/SKILL.md)
+(🟢 verified 2026-08-11).
+
+**Model per workbook — plain copy, but copy the CONTENTS.** `<bundle>/pbip/<wb>/` already holds
+`<Name>.Report/` and `<Name>.SemanticModel/` as **siblings**, with `"path": "../<Name>.SemanticModel"`,
+and the delivery folder has the identical shape. So copy the *contents* of `<bundle>/pbip/<wb>/`, not
+the folder — that folder is named for the **workbook**, the model inside for the **datasource**, so
+copying the folder itself nests them wrongly.
+
+**Shared/published datasource — the reference MUST be rewritten.** The model lands once in
+`migrations/datasources/<ds-slug>/fabric/` while each report goes to
+`migrations/workbooks/<slug>/fabric/`. They are no longer siblings, so `definition.pbir` becomes:
+
+```
+"../../../../datasources/<ds-slug>/fabric/<Name>.SemanticModel"
+```
+
+— four levels up from inside `<Name>.Report/`. **Verify it resolves on disk after writing it.**
+
+⚠️ **A wrong `byPath` opens as a report with NO MODEL, and `powerbi-report-author validate` returns
+`errorCount: 0` for it** — it checks reference *shape*, not *target*. So the one failure mode that
+matters most here is invisible to the validator you would reach for.
+
+⚠️ **Never ship `<bundle>/reports/` itself.** It is a reference-only baseline: `reports/` holds only
+`*.Report` folders, so the `byPath` beside it has no model to point at, and its exact (unresolvable)
+value is engine-version dependent.
+
+⚠️ **A shipped deliverable can be structurally present and functionally EMPTY.** Assert the shipped
+`<Name>.Report/definition/pages/` enumerates real pages *with visuals* and the shipped
+`<Name>.SemanticModel/definition/tables/` holds real tables. A folder count is not a content check,
+and verifying a fix in `<bundle>/pbip/` proves nothing about `migrations/**/fabric/`.
+
+### What is actually tracked in git here
+
+⚠️ **Phase 3 artifacts are NOT blanket-gitignored** — this is a common misreading, and it is the
+reason the privacy rules exist. ✅ Measured 2026-09-03 with `git check-ignore -v`:
+
+| path | status |
+|---|---|
+| `migrations/workbooks/<slug>/fabric/<Name>.Report/**` | **trackable** (no ignore rule matches) |
+| `migrations/workbooks/<slug>/reference/**` | ignored (`.gitignore:82`) |
+| `migrations/workbooks/<slug>/data/**` | ignored (`**/data/`) |
+| `migrations/workbooks/<slug>/source/*.twbx` | ignored (`**/source/*.twbx`) |
+| `migrations/workbooks/<slug>/migration-brief.md` | ignored (`**/migration-brief.md`) |
+| `migrations/{workbooks,datasources}/<prefix>-<slug>/**` for `customer-`, `workshop-`, `engagement-` | ignored (`.gitignore:46-51`) |
+
+So a customer migration is kept out of this public repo by **prefixing the slug**
+(`customer-<name>`), not by any rule on `fabric/`. Today exactly **3** files are tracked under
+`migrations/` — the three `README.md` navigation files — because no public-safe migration has been
+committed there yet.
+
+---
+
+## `packages/` versus `deliverables/` — one is a stage, one is not
+
+⚠️ **`deliverables/` is empty in every run on this machine, and no script in `scripts/` writes to
+it.** ✅ Verified 2026-09-03: of nine directories under `_runs/`, the three allocated through
+`work_dirs.py` have a `deliverables/` and all three contain **0 items**; the six legacy directories
+have no such subdir at all. The only `scripts/` matches for the word are prose in
+`check_migration_progress.py` and `run_estate.py`, not writes to this path.
+
+It exists purely as a **preventive convention** from issue #322: an operator-facing
+`connections.json`/`.md` naming real customer servers once landed unprefixed at the **repo root**,
+one `git add -A` away from being committed to this public repository. `deliverables/` is a landing
+zone that `.gitignore`'s root-anchored `/_*` covers by construction.
+
+| | `packages/` | `deliverables/` |
+|---|---|---|
+| consumer | the **agent** (machine-read) | a **human / the customer** |
+| produced by | `package_unit.py` | by hand, or a one-off script |
+| granularity | one folder per unit | whole-run, ad hoc |
+| a pipeline stage? | **yes** | **no** |
+
+⚠️ **"Deliverable" unfortunately means two different things in this repo**: this run-local
+`deliverables/` subdirectory (an operator's ad-hoc output, never git) and phase 3's
+`migrations/**/fabric/` (the customer's actual Power BI deliverable, which *is* trackable). Renaming
+the subdirectory — to something like `operator-output/` — is worth considering; it has no current
+user, so the rename is cheap today and gets more expensive the moment one appears.
+
+---
+
+## Known gaps
+
+| # | gap | status |
+|---|---|---|
+| 1 | No tool for phase 2 → phase 3; the `byPath` rewrite is manual and a wrong one validates clean | ❌ open, tracked as **#458** |
+| 2 | `semantic_models/` baselines exist for only 18 of 62 units on the reference run, so model churn cannot be measured for the rest | ❌ report as **BASELINE UNAVAILABLE** (#274, #359) |
+| 3 | `deliverables/` is a convention with no writer, and its name collides with phase 3's meaning | ⚠️ documented, not fixed |
+| 4 | Phase 1 stages still default to their own `_assessment*/` / `_oracle*/` / `_bundle*/` paths rather than the `_runs/` layout | ⚠️ deliberate scope limit of issue #234; migrating them is follow-up |
+| 5 | Oracle evidence is layout/text grade only; validation grade requires a render you captured yourself | ⚠️ provider limit, not an oversight (#194) |
+
+## See also
+
+- [`docs/operator-runbook.md`](operator-runbook.md) — the command-by-command procedure, timings, exit
+  codes and failure playbook.
+- [`docs/reference-readiness.md`](reference-readiness.md) — the entry gate in detail.
+- [`docs/reference-capture.md`](reference-capture.md) — how Tableau reference evidence is captured
+  and graded.
+- [`AGENTS.md`](../AGENTS.md) — the dispatcher's intake, the engine-source rule, and the canonical
+  work layout this document expands on.

--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -702,16 +702,23 @@ unit path**, and getting one wrong is silent: `check_reference_readiness.py` ret
 me where the workbook is"* (issue #446).
 
 ```powershell
-python scripts\package_unit.py --bundle _bundle --out _packages --json _packages\packaging.json
+python scripts\package_unit.py --bundle _bundle --out _runs\<NNN>-<slug>\packages\<batch> `
+    --json _runs\<NNN>-<slug>\packages\<batch>\packaging.json
 # then, per unit, with NO flags at all:
-python scripts\check_reference_readiness.py _packages\<Unit>
-python scripts\check_unit.py _packages\<Unit>
+python scripts\check_reference_readiness.py _runs\<NNN>-<slug>\packages\<batch>\<Unit>
+python scripts\check_unit.py _runs\<NNN>-<slug>\packages\<batch>\<Unit>
 ```
 
-⚠️ **`--out` must sit outside the capture tree.** The readiness gate scans the target's *grandparent*
-for `oracle/` and `reference/`, so a package written beside the flat capture is matched against BOTH
-and every page drops from `ready` to `unverifiable` — worse than not packaging, and silent. That
-layout is refused with exit 2 rather than documented.
+⚠️ **`--out` must sit outside the capture tree — so name a subdirectory INSIDE `packages/`, never
+`packages/` itself.** The readiness gate scans the target's *grandparent* for `oracle/` and
+`reference/`, so a package written beside the flat capture is matched against BOTH and every page
+drops from `ready` to `unverifiable` — worse than not packaging, and silent. That layout is refused
+with exit 2 rather than documented (`package_unit.conflicting_evidence_dirs`,
+`scripts/package_unit.py:819`). ✅ Measured 2026-09-03: `--out _runs\<NNN>-<slug>\packages` exits
+**2**, `--out _runs\<NNN>-<slug>\packages\<batch>` exits **0** and the readiness gate then reports 0
+unverifiable. `packages/` is a canonical run subdir (`scripts/work_dirs.py:72`), which is what makes
+`<batch>` the right depth; the shape is explained in
+[`docs/migration-phases.md`](migration-phases.md).
 
 What to check in the output:
 
@@ -720,7 +727,7 @@ What to check in the output:
   produced no report plus 1 datasource — and they are still packaged for their source, reference and
   handover. Deriving the unit list from `pbip/` alone drops them silently.
 - **`handover.md` is the agent's entry point**, one finding per line with a stable prefix, emptied
-  visuals first: `grep '^EMPTIED_VISUAL' _packages\<Unit>\handover.md`. They render blank on a report
+  visuals first: `grep '^EMPTIED_VISUAL' _runs\<NNN>-<slug>\packages\<batch>\<Unit>\handover.md`. They render blank on a report
   that validates clean, and nothing else in the toolkit surfaces them.
 - **`package-manifest.json` carries every omission with its reason.** A render is attributed by
   **`workbook_luid` only** — a display name is not an identity, and #450 measured that class failing
@@ -1240,13 +1247,16 @@ deliverables and the re-runnable `_build/` scripts. Confirm nothing scratch leak
 reporting done.
 
 **Canonical pre-bundle layout (issue #291/#234):** new work allocates a numbered, per-run home under
-`_runs/<NNN>-<slug>/{assessment,assets,bundle,oracle,deliverables,scratch}/` via
+`_runs/<NNN>-<slug>/{assessment,assets,bundle,oracle,packages,deliverables,scratch}/` via
 `python scripts/work_dirs.py <unit-name> --json`, rather than inventing another `_*` root. The number
 is the identity — never renamed or reused — and the whole tree is ignored by construction (`/_*` in
 `.gitignore`; verify with `git check-ignore -v -- <path>`, **no trailing slash**, before trusting it).
 `deliverables/` is specifically for operator-facing outputs that name real customer infrastructure
 (e.g. `connections_manifest.py`'s `connections.json`/`.md`) — the `ses-prep/` near-miss (#322) landed
-exactly that kind of output unprefixed and unignored at the repo root.
+exactly that kind of output unprefixed and unignored at the repo root. `packages/` holds
+`package_unit.py`'s per-unit agent-facing packages, one subdirectory per packaging batch (§ *Package
+one folder per unit*); the whole shape is explained in
+[`docs/migration-phases.md`](migration-phases.md).
 
 ⚠️ **Today's tools have not been migrated onto this yet.** `assess_estate.py --out _assessment`,
 `harvest_estate_assets.py --out _sweep`, `capture_tableau_oracle.py --out _oracle` and

--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -727,7 +727,9 @@ What to check in the output:
   produced no report plus 1 datasource — and they are still packaged for their source, reference and
   handover. Deriving the unit list from `pbip/` alone drops them silently.
 - **`handover.md` is the agent's entry point**, one finding per line with a stable prefix, emptied
-  visuals first: `grep '^EMPTIED_VISUAL' _runs\<NNN>-<slug>\packages\<batch>\<Unit>\handover.md`. They render blank on a report
+  visuals first:
+  `Select-String -Path _runs\<NNN>-<slug>\packages\<batch>\<Unit>\handover.md -Pattern '^EMPTIED_VISUAL'`
+  (this runbook's commands are PowerShell; `grep` is not available there). They render blank on a report
   that validates clean, and nothing else in the toolkit surfaces them.
 - **`package-manifest.json` carries every omission with its reason.** A render is attributed by
   **`workbook_luid` only** — a display name is not an identity, and #450 measured that class failing

--- a/scripts/work_dirs.py
+++ b/scripts/work_dirs.py
@@ -3,7 +3,7 @@ purpose: single source of truth for the canonical PRE-BUNDLE work layout - resol
          expose per-unit, per-run scratch/output paths so scripts stop inventing their own
          (`_assessment`, `_sweep`, `_oracle`, an ad hoc `_work/<name>`, or a stray `fabric/` from a
          CWD-relative path). See issue #291 (gaps 1 and 3) and issue #234, whose corrected design
-         this module implements: `_runs/<NNN>-<slug>/{assessment,assets,bundle,oracle,
+         this module implements: `_runs/<NNN>-<slug>/{assessment,assets,bundle,oracle,packages,
          deliverables,scratch}/`.
 usage:   python scripts/work_dirs.py <unit-name> [--repo-root PATH] [--json]
          from work_dirs import allocate_run, sanitize_unit_key, runs_root, list_runs
@@ -61,9 +61,23 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 #   assets/       harvest_estate_assets.py-shaped downloads (.twbx / .tdsx)
 #   bundle/       run_estate.py-shaped conversion output (report.json, pbip/, handover/)
 #   oracle/       capture_tableau_oracle.py-shaped visual + numeric reference capture
+#   packages/     package_unit.py-shaped per-unit, agent-facing handover packages (issue #446).
+#                 ⚠️ `--out` must name a subdirectory INSIDE this one (one per packaging batch,
+#                 e.g. `packages/<bundle-name>/<Unit>/`), never `packages/` itself:
+#                 `package_unit.conflicting_evidence_dirs` refuses an `--out` whose parent holds
+#                 `oracle/`, and this run root always does. Measured: `--out <run>/packages` exits
+#                 2, `--out <run>/packages/<batch>` exits 0. See `tests/test_work_dirs.py`.
 #   deliverables/ operator-facing outputs meant for the customer, never for git (issue #322)
 #   scratch/      disposable, run-owned - the only subdir a future `--prune` may ever delete
-CANONICAL_SUBDIRS: tuple[str, ...] = ("assessment", "assets", "bundle", "oracle", "deliverables", "scratch")
+CANONICAL_SUBDIRS: tuple[str, ...] = (
+    "assessment",
+    "assets",
+    "bundle",
+    "oracle",
+    "packages",
+    "deliverables",
+    "scratch",
+)
 
 _RUN_DIR_RE = re.compile(r"^(\d+)(?:-.*)?$")
 # Matches the Fabric artifact-name ceiling used elsewhere in this org's conventions (table names
@@ -142,6 +156,15 @@ class RunPaths:
     def oracle(self) -> Path:
         """`capture_tableau_oracle.py`-shaped visual + numeric reference capture for this run."""
         return self.subdir("oracle")
+
+    @property
+    def packages(self) -> Path:
+        """`package_unit.py`-shaped per-unit, agent-facing handover packages (issue #446).
+
+        Point `--out` at a subdirectory of this, never at this directory itself - see the
+        `CANONICAL_SUBDIRS` comment for the measured reason.
+        """
+        return self.subdir("packages")
 
     @property
     def deliverables(self) -> Path:

--- a/tests/test_work_dirs.py
+++ b/tests/test_work_dirs.py
@@ -87,6 +87,7 @@ def test_allocate_run_starts_at_one_and_creates_canonical_subdirs(tmp_path: Path
     assert run.assets == run.subdir("assets")
     assert run.bundle == run.subdir("bundle")
     assert run.oracle == run.subdir("oracle")
+    assert run.packages == run.subdir("packages")
     assert run.deliverables == run.subdir("deliverables")
     assert run.scratch == run.subdir("scratch")
 
@@ -177,6 +178,33 @@ def test_subdir_rejects_a_noncanonical_name(tmp_path: Path) -> None:
     run = allocate_run("acme", repo_root=tmp_path)
     with pytest.raises(ValueError):
         run.subdir("not-a-real-subdir")
+
+
+def test_packages_is_canonical_and_ordered_after_oracle_before_deliverables() -> None:
+    """`packages/` names where `package_unit.py --out` writes (issue #446). Order is also display
+    order in the CLI, so it is asserted rather than left to chance."""
+    assert "packages" in CANONICAL_SUBDIRS
+    assert CANONICAL_SUBDIRS.index("oracle") < CANONICAL_SUBDIRS.index("packages")
+    assert CANONICAL_SUBDIRS.index("packages") < CANONICAL_SUBDIRS.index("deliverables")
+
+
+def test_package_out_must_be_a_child_of_packages_not_packages_itself(tmp_path: Path) -> None:
+    """The reason `docs/migration-phases.md` and `docs/operator-runbook.md` write
+    `packages/<batch>/` and never a bare `packages/`.
+
+    `package_unit.conflicting_evidence_dirs` refuses an `--out` that sits beside evidence the gates
+    also scan, checking `<out>` and `<out>.parent` for `reference/`/`oracle/`/`_oracle/`. A run root
+    ALWAYS holds `oracle/` (allocate_run creates every canonical subdir), so a bare
+    `--out <run>/packages` is refused - measured, exit 2 with "sits beside evidence the gates also
+    scan". One level deeper is accepted. This test is what keeps the documented command runnable.
+    """
+    from package_unit import conflicting_evidence_dirs  # local: keeps the import cost off collection
+
+    run = allocate_run("acme", repo_root=tmp_path)
+
+    assert run.oracle.is_dir(), "the premise failed: a run root must hold oracle/ for this to prove anything"
+    assert conflicting_evidence_dirs(run.packages) == [run.oracle]
+    assert conflicting_evidence_dirs(run.packages / "coldrun") == []
 
 
 # --------------------------------------------------------------------------------------


### PR DESCRIPTION
## What this is

The toolkit has a clear three-phase shape and **no document explained it** — `docs/operator-runbook.md`
carries the individual commands but never says why there are three separate locations or what moves
between them. This adds the explanation, and makes one small code change so the doc describes reality
rather than an aspiration.

- **`docs/migration-phases.md`** (new) — phase by phase: what it produces, which tool, where it lands,
  what the gate is, what the known gaps are. ASCII flow diagram, the `packages/` vs `deliverables/`
  distinction, and the phase 2 → 3 `byPath` hazard.
- **`README.md`** — a general-overview `## The three-phase pipeline` section that links into the doc
  and the runbook, plus a nav-bar entry.
- **`scripts/work_dirs.py`** — `packages` joins `CANONICAL_SUBDIRS` (after `oracle`, before
  `deliverables`) with a matching `RunPaths.packages` property, so `package_unit.py --out` has a
  canonical home rather than the ad-hoc `_packages` the runbook used.
- **`tests/test_work_dirs.py`**, **`docs/operator-runbook.md`**, **`AGENTS.md`**, **`docs/INDEX.md`** —
  follow-through.

`package_unit.py` itself is unchanged.

## What I verified

Everything measured against `_runs/408-…`, a real 48-workbook cold run, on 2026-09-03.

| claim in the doc | how |
|---|---|
| 48 workbooks, 0 listing errors | `assessment/estate_survey.json` `summary` |
| 360 views = 60 dashboards / 300 worksheets | `oracle/oracle-manifest.json` `view_count` / `view_types` |
| 67 assets, 0 parse failures on either tier | `assets/parse-sweep.md` |
| 62 pbip units / 48 report baselines / **18** model baselines / 46 handover slices | directory counts under `bundle/` |
| `deliverables/` is empty and nothing writes to it | 3 of 9 `_runs/` dirs have one, all 0 items; the other 6 have no such subdir. Only `scripts/` matches for the word are prose in `check_migration_progress.py` / `run_estate.py` |
| phase 3 artifacts are **not** blanket-gitignored | `git check-ignore -v` on six representative paths; `git ls-files migrations` = 3 READMEs |
| issue #458 exists and is about the missing promote step | `gh issue view 458` |

**The `--out` constraint was measured, not reasoned:** `python scripts\package_unit.py --bundle <real
bundle> --out <run>\packages` exits **2** — *"sits beside evidence the gates also scan … Choose an
`--out` outside the capture tree"* — while `--out <run>\packages\<batch>` exits **0**, and
`check_reference_readiness.py` on the resulting package (no flags) reports **0 unverifiable**, i.e. no
shadowing.

**The new tests were mutation-tested.** Removing `"packages"` from `CANONICAL_SUBDIRS` fails 3 tests;
swapping its order with `"oracle"` fails 1. The nav-index gate was mutation-tested too: deleting the
`docs/migration-phases.md` row makes `check_navigation_index.py` exit 1 naming the file.

## Gates (by exit code)

| command | exit |
|---|---|
| `ruff format --check conftest.py scripts tests .github/skills` | 0 |
| `ruff check conftest.py scripts tests .github/skills` | 0 |
| `pylint scripts` | 0 |
| `check_navigation_index.py` | 0 |
| `check_agent_capabilities.py` | 0 |
| `set_data_folder.py --check` | 0 |
| `pytest -q tests/test_work_dirs.py` | 0 (25 passed) |
| `sync_agent_conventions.py --check` | 0 (AGENTS.md edit is outside the synced block) |
| `pytest -q -n auto --dist loadfile -m "not (serial or timing)"` | 1 — 4548 passed, 6 failed, all known/unrelated (see below) |

The 6: 3 in `tests/test_upstream_repro_pins.py` (known-expected), 2 in `tests/test_gui_marker_gate.py`
(xdist-only, issue #415), and `test_check_datamodel.py::test_biff8_gate_reaches_the_cli_exit_code`,
which **passes in isolation** (exit 0) and is an xdist encoding flake — my diff touches no file it
reads.

## What I did NOT verify

- **The `packages/<batch>` depth is a design choice, not the only possible fix.** Making the guard
  aware of the run layout, or letting `package_unit.py` accept the bare `packages/` and create the
  batch level itself, would work too. I did not change `package_unit.py`, so `--out` stays free-form
  and nothing *enforces* the nested form beyond the guard and the docs.
- **No re-run of `run_estate.py` / `assess_estate.py` / the oracle capture.** All phase-1 figures are
  read from artifacts an earlier run left on disk, not reproduced.
- **The `deliverables/` finding is machine-local.** It is "empty in every run on this machine", not
  "empty everywhere"; and "no script writes to it" is a grep of `scripts/`, not of every possible
  caller.
- **Phase 3's `byPath` rules are quoted from `.github/skills/powerbi-report-gotchas/SKILL.md` §3**
  (🟢 verified there 2026-08-11). I did not re-execute a shared-datasource ship or open the result in
  Power BI Desktop.
- The `packages/` addition is inert for existing runs — `allocate_run` only creates subdirs at
  allocation time, so runs allocated before this change have no `packages/` and nothing backfills it.
  I did not add a migration helper (that is #234 follow-up).

The phase 2 → phase 3 step remains a manual copy; that gap is tracked as #458 and this PR only
documents it.
