### PR TITLE
docs(README): fix two false claims my own correction introduced

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,10 +198,10 @@ _runs/<NNN>-<slug>/                     ◀── PHASE 1  collect & convert  (g
 │   └── parse-sweep.json  parse-sweep.md      both parsers' failure distribution over them
 ├── oracle/                                 Tableau's OWN renders and numbers
 │   ├── images/  data/                        ⚠️ only for views that captured — 288 of 360 here
-│   └── oracle-manifest.json                  every view: captured, or refused with a reason
+│   └── oracle-manifest.json                  every view: captured, or not — with status and reason
 ├── bundle/                                 the deterministic engine's conversion output
 │   ├── reports/<WB>.Report/                  ⚠️ engine truth — NEVER edit
-│   ├── semantic_models/<Model>.SemanticModel/ ⚠️ engine truth — NEVER edit; conditional, 18 here
+│   ├── semantic_models/<Model>.SemanticModel/ ⚠️ engine truth — NEVER edit; 18 for 62 pbip/ units
 │   ├── pbip/<Unit>/                          the working copy: .Report + .SemanticModel + .pbip
 │   ├── handover/<WB>.json                    the per-workbook remediation queue
 │   ├── data/                                 materialised extract rows
@@ -214,30 +214,34 @@ _runs/<NNN>-<slug>/                     ◀── PHASE 1  collect & convert  (g
 │   │   ├── <WB>.Report/                      PBIR
 │   │   ├── <Model>.SemanticModel/            TMDL
 │   │   └── <WB>.pbip
-│   ├── assets/<luid>_<Unit>.<ext>          the original source, alongside
+│   ├── assets/<luid>_<Unit>.<ext>          the original source, alongside          (65 of 67)
 │   ├── handover/<WB>.json                  this unit's slice of the queue       (46 of 67)
 │   ├── oracle/                             this unit's reference evidence       (46 of 67)
 │   │   ├── worksheet/{images,data}/
-│   │   ├── dashboard/{images,data}/
+│   │   ├── dashboard/{images,data}/          (an `unknown/` tier appears if a view's type is unset)
 │   │   └── oracle-manifest.json
 │   ├── report.json  source-provenance.json   gate input, and source-to-LUID attribution
+│   ├── engine-output-receipt.json            which engine version built this      (67 of 67)
 │   └── package-manifest.json               what was packaged, and every omission with its reason
 │
 ├── deliverables/                           customer-facing outputs — never committed
 └── scratch/                                the ONLY subdir that is safe to delete
 
-migrations/workbooks/<slug>/            ◀── PHASE 3  ship
-├── data/                                   materialised rows — gitignored
-└── fabric/                                 the trackable deliverable
-    ├── <WB>.Report/
-    ├── <Model>.SemanticModel/
-    └── <WB>.pbip                           ← what the customer opens in Power BI Desktop
+migrations/workbooks/<slug>/fabric/      ◀── PHASE 3  ship  (the deliverable only — the unit
+├── <WB>.Report/                                root may also hold source/, data/,
+├── <Model>.SemanticModel/                      reference/ and migration-spec.json)
+└── <WB>.pbip                               ← what the customer opens in Power BI Desktop
 ```
 
-⚠️ **A unit is not uniformly workbook-shaped.** The per-line counts above are from a 67-package
-reference run: a datasource-only unit (`.tds`) ships no report, no PBIP, no handover and no oracle
-evidence, so treat those four as **conditional**. Phase 3 is *trackable*, not automatically
-committed — `data/` and customer-prefixed units are gitignored, so commit only what is public-safe.
+⚠️ **Every counted entry above is conditional — and the rule is NOT the source type.** On the
+67-package reference run, **5 units had no engine working copy** (`Meridian_Calc_Gauntlet`,
+`Meridian_Collision_Alpha`, `Meridian_Trip_Economics`, `RESTAPISample`, `TS_Users`) — four of them
+*workbooks*, so this is a per-unit conversion gap, not "datasources lack a report". 18 of the 19
+`.tds` units **do** ship a report, model and PBIP. Handover and oracle evidence exist for 46 of 67.
+The tree shows selected entries, not an exhaustive listing.
+
+⚠️ **Phase 3 is *trackable*, not automatically committed** — `data/` and customer-prefixed units are
+gitignored, so commit only what is public-safe.
 
 ⚠️ **Which copy to edit is currently unsettled** ([#460](https://github.com/Guust-Franssens/tableau-to-powerbi-migration/issues/460)):
 `AGENTS.md` says `bundle/pbip/`, the generated package README says `<package>/fabric/`, and the


### PR DESCRIPTION
Round-2 blind review of the #467 correction. Five of the original ten findings closed cleanly, but the fix **moved two boundaries instead of removing them** - the exact failure mode this repo briefs reviewers to look for. Both are corrected here.

## Two false claims my own correction introduced

**1. The datasource rule was wrong.** #467 said *"a datasource-only unit (`.tds`) ships no report, no PBIP, no handover and no oracle evidence"*. Measured:

| | |
|---|---:|
| `.tds` units | 19 |
| ...that **do** ship a report + model + PBIP | **18** |
| units with no working copy, all sources | **5 of 67** |
| ...of those 5 that are **workbooks**, not datasources | **4** |

The five are `Meridian_Calc_Gauntlet`, `Meridian_Collision_Alpha`, `Meridian_Trip_Economics`, `RESTAPISample`, `TS_Users`. So it is a **per-unit conversion gap**, not a source-type rule. I replaced one wrong generalisation with another; it now states the measurement instead of a rule.

**2. "refused with a reason" was wrong.** The manifest's non-OK statuses are `failed` (40 image / 45 data), `session_lost` (5) and `source_credential` (27). Only the last is a refusal. Now "captured, or not - with status and reason".

## Also closed from that review

- `engine-output-receipt.json` is in **67 of 67** packages and was omitted while the tree read as exhaustive - added, plus an explicit "selected entries, not an exhaustive listing"
- `assets/` was unqualified; it is **65 of 67**
- "18 here" -> "18 for 62 `pbip/` units", naming the denominator
- Phase 3 started at `<slug>/` while omitting `source/`, `reference/` and `migration-spec.json` - it now starts at `<slug>/fabric/` with the root contents named, which is one of the two shapes the reviewer said were acceptable
- `oracle/unknown/` tier noted (from `package_unit.py`; no live instance in this fixture)

## Gates

`check_navigation_index.py` 0 - `set_data_folder.py --check` 0. Counts re-measured independently before editing.
