### PR TITLE
fix(work_dirs): detect a renumbered _runs/ directory, and state the prohibition where an agent reads it

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -72,10 +72,10 @@ Eligible files: tracked Markdown knowledge/navigation files, `.github/pbi.kb/**/
 | Find migration guidance | [`docs/deterministic-tier-integration.md`](../docs/deterministic-tier-integration.md) | Engine and handoff integration. |
 | Find migration guidance | [`docs/dry-run-findings-2026-08-11.md`](../docs/dry-run-findings-2026-08-11.md) | Durable F00x dry-run findings. |
 | Find migration guidance | [`docs/engine-gap-harvest.md`](../docs/engine-gap-harvest.md) | Attribute and classify the `reports/` vs `pbip/` delta into engine-gap evidence — provenance delegated to the `--tamper` gate's own adjudicator. |
-| Find migration guidance | [`docs/migration-phases.md`](../docs/migration-phases.md) | The three-phase pipeline shape: what each phase produces, where it lands, which gate guards each hop, and the known gaps. |
+| Find migration guidance | [`docs/migration-phases.md`](../docs/migration-phases.md) | The three-phase pipeline shape: what each phase produces, where it lands, which gate guards each hop, the `_runs/<NNN>-<slug>` identity rule (never renamed/renumbered; one run per pipeline run, **not** per workbook), and the known gaps. |
 | Find migration guidance | [`docs/migration-programme.md`](../docs/migration-programme.md) | Programme phases and operating model. |
 | Find migration guidance | [`docs/migration-spec.md`](../docs/migration-spec.md) | `migration-spec.json` contract. |
-| Find migration guidance | [`docs/operator-runbook.md`](../docs/operator-runbook.md) | Manual pipeline operation. |
+| Find migration guidance | [`docs/operator-runbook.md`](../docs/operator-runbook.md) | Manual pipeline operation, the failure playbook, and §4.12 **Windows/PowerShell misreads** — `NativeCommandError` on a command that exited 0, long-path `Remove-Item`, `Start-Process -ArgumentList` mangling a multi-word `--workbook`, and `requests`+certifi failing TLS where the toolkit's `urllib` + Windows certificate store succeeds. |
 | Test the offline deployment rehearsal | [`docs/offline-mock-harness.md`](offline-mock-harness.md) | Offline Tableau-to-Fabric mock harness and fidelity boundary. |
 | Run the test suite | [`docs/parallel-test-loop.md`](parallel-test-loop.md) | Fast parallel loop vs the serial pre-PR gate, and the `serial` marker. |
 | Find migration guidance | [`docs/reference-capture.md`](../docs/reference-capture.md) | Tableau reference capture and evidence grading. |
@@ -84,7 +84,7 @@ Eligible files: tracked Markdown knowledge/navigation files, `.github/pbi.kb/**/
 | Improve review throughput | [`docs/review-throughput-postmortem.md`](../docs/review-throughput-postmortem.md) | Measured 2026-09-01/02 review-round costs, causes, counterexamples, and the replacement brief contract. |
 | Find migration guidance | [`docs/tableau-dax-translation-guide.md`](../docs/tableau-dax-translation-guide.md) | Translate Tableau calcs/LODs/table calcs. |
 | Find migration guidance | [`docs/tableau-map-to-azuremaps.md`](../docs/tableau-map-to-azuremaps.md) | Translate Tableau maps to Azure Maps. |
-| Find migration guidance | [`docs/windows-path-limits.md`](../docs/windows-path-limits.md) | Windows MAX_PATH ceilings a shipped bundle must respect. |
+| Find migration guidance | [`docs/windows-path-limits.md`](../docs/windows-path-limits.md) | Windows MAX_PATH ceilings a shipped bundle must respect — and how to DELETE a tree that is already over one (`\\?\` prefix plus a chmod handler, because git objects are read-only). |
 | Find migration guidance | [`docs/upstream-issue-gate.md`](../docs/upstream-issue-gate.md) | Route engine issues upstream vs local. |
 | Invoke subagent | [`.github/agents/dry-run-operator.agent.md`](../.github/agents/dry-run-operator.agent.md) | Full customer-shaped pipeline dry-run persona; read-only against the toolkit. |
 | Invoke subagent | [`.github/agents/pbi-migration-validator.agent.md`](../.github/agents/pbi-migration-validator.agent.md) | Read-only fidelity validator persona. |

--- a/docs/migration-phases.md
+++ b/docs/migration-phases.md
@@ -60,6 +60,21 @@ One numbered run directory per pipeline run, allocated by
 is decoration for human navigation; nothing may parse it back into a display name (two projects can
 legitimately hold same-named workbooks — issue #234, rule 2).
 
+⚠️ **"Per pipeline run" means per *invocation*, not per workbook.** Run 408 below is **one** run
+covering a 48-workbook site; its per-workbook units live inside that run's `bundle/pbip/`, never in
+48 sibling run directories. `unit_key` names what the run is *about* (a site, a project, or a single
+workbook when that is genuinely the whole job) — it is not a promise that each workbook gets a run.
+A customer's agent read `work_dirs.py`, inferred one-run-per-workbook, and renumbered **14** run
+directories in the resulting reorg, breaking the absolute self-paths inside each one (issue #470).
+
+⚠️ **Renaming an existing run is destructive, and it is now detectable.** `allocate_run` records the
+directory name it allocated, and `python scripts/work_dirs.py --verify` reports each run as
+`intact` (exit 0), `moved` (exit 1 — renamed or renumbered since allocation, naming both directories)
+or `unverifiable` (exit 3 — allocated before the check existed, so the question cannot be answered
+from the manifest). **`unverifiable` is not a pass**; every run predating the change lands there,
+including run 408 below. The comparison is on the directory *name*, so cloning or moving the
+repository — or working in a `git worktree` — does not report `moved`.
+
 `CANONICAL_SUBDIRS` (`scripts/work_dirs.py:72`) is the single source of truth for the layout:
 
 | subdir | produced by | contents | measured on run 408 |

--- a/docs/migration-phases.md
+++ b/docs/migration-phases.md
@@ -67,13 +67,26 @@ workbook when that is genuinely the whole job) — it is not a promise that each
 A customer's agent read `work_dirs.py`, inferred one-run-per-workbook, and renumbered **14** run
 directories in the resulting reorg, breaking the absolute self-paths inside each one (issue #470).
 
-⚠️ **Renaming an existing run is destructive, and it is now detectable.** `allocate_run` records the
-directory name it allocated, and `python scripts/work_dirs.py --verify` reports each run as
-`intact` (exit 0), `moved` (exit 1 — renamed or renumbered since allocation, naming both directories)
-or `unverifiable` (exit 3 — allocated before the check existed, so the question cannot be answered
-from the manifest). **`unverifiable` is not a pass**; every run predating the change lands there,
-including run 408 below. The comparison is on the directory *name*, so cloning or moving the
-repository — or working in a `git worktree` — does not report `moved`.
+⚠️ **Renaming an existing run is destructive, and it is now detectable.** `allocate_run` records both
+the directory name and the absolute path it allocated, and `python scripts/work_dirs.py --verify`
+reports each run as `intact` (exit 0 — recorded name *and* recorded path both still match), `moved`
+(exit 1 — renamed or renumbered since allocation, naming both directories) or `unverifiable`
+(exit 3 — the question cannot be answered from the evidence). **`unverifiable` is not a pass.**
+
+⚠️ **`--verify` is a GATE, so it never silently drops what it cannot assess.** A run directory whose
+`run.json` is missing, empty, truncated, malformed, locked, or holds valid JSON that is not an object
+counts as `unverifiable` and exits 3. It used to be skipped in silence and counted in *no* bucket at
+all, so a half-written run — exactly what an allocation interrupted between `mkdir` and the manifest
+write leaves behind — printed `0 run(s): 0 intact, 0 moved, 0 unverifiable`, exit 0.
+
+⚠️ **A run that is where it was allocated but at a different absolute path is `unverifiable`, not
+`intact`.** A basename is unchanged by a run-only move *and* by a copy, so the name alone cannot
+answer "still there": moving `source/_runs/001-acme` to `moved/_runs/001-acme` reported `INTACT`,
+exit 0. Whether the whole checkout moved (legitimate) or this one run was moved or copied
+(corruption) cannot be told apart from a single run's evidence — and **both** break the absolute
+self-paths embedded under `bundle/`, so neither is reported as healthy. Note that a clone and a
+fresh `git worktree` carry no runs at all (`_runs/` is git-ignored: `git check-ignore -v --
+_runs/001-acme/run.json` → `.gitignore:162:/_*`), so this is not a fresh-clone false alarm.
 
 `CANONICAL_SUBDIRS` (`scripts/work_dirs.py:72`) is the single source of truth for the layout:
 

--- a/docs/migration-phases.md
+++ b/docs/migration-phases.md
@@ -73,11 +73,19 @@ reports each run as `intact` (exit 0 — recorded name *and* recorded path both 
 (exit 1 — renamed or renumbered since allocation, naming both directories) or `unverifiable`
 (exit 3 — the question cannot be answered from the evidence). **`unverifiable` is not a pass.**
 
-⚠️ **`--verify` is a GATE, so it never silently drops what it cannot assess.** A run directory whose
-`run.json` is missing, empty, truncated, malformed, locked, or holds valid JSON that is not an object
-counts as `unverifiable` and exits 3. It used to be skipped in silence and counted in *no* bucket at
-all, so a half-written run — exactly what an allocation interrupted between `mkdir` and the manifest
-write leaves behind — printed `0 run(s): 0 intact, 0 moved, 0 unverifiable`, exit 0.
+⚠️ **`--verify` is a GATE, so it never silently drops what it cannot assess.** It rests on one
+invariant, implemented in one discovery function and one classification function: **every child
+directory of an existing `_runs/` root is a candidate run, any candidate whose identity cannot be
+positively established from its own evidence is `unverifiable`, and `intact` is only ever returned
+on positive proof.** Five shapes land there, and every one of them used to exit 0:
+
+| shape | what it printed before |
+|---|---|
+| `run.json` missing, empty, truncated, malformed, locked, or valid JSON that is not an object | `0 run(s): 0 intact, 0 moved, 0 unverifiable`, exit 0 — a half-written run, exactly what an allocation interrupted between `mkdir` and the manifest write leaves behind |
+| the directory renamed out of the `<NNN>-` pattern **and** its manifest deleted; or the `_runs/` root itself unreadable | `(no run directories found)`, exit 0 — discovery filtered on the *current* name and turned an `OSError` on the root into an empty list, while the tree was still on disk |
+| `run` contradicts the `<NNN>-<slug>` directory it sits in (`2`, or `10**100`, inside `001-acme`) | `1 intact`, exit 0 — only the *type* of `run` was checked, never its agreement with the directory. The number **is** the identity, so a manifest claiming a different one is contradictory evidence |
+| `allocated_abs_path` recorded as a **relative** path | `1 intact`, exit 0 — it was completed against the *verifier's* current directory, so the verdict depended on where the operator was standing |
+| recorded name matches but the recorded absolute path does not | see below |
 
 ⚠️ **A run that is where it was allocated but at a different absolute path is `unverifiable`, not
 `intact`.** A basename is unchanged by a run-only move *and* by a copy, so the name alone cannot

--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -1333,12 +1333,29 @@ workbook: a 48-workbook estate sweep is a single run whose per-workbook units li
 python scripts/work_dirs.py --verify          # exit 0 all intact / 1 something moved / 3 unverifiable
 ```
 
-⚠️ **Exit 3 is `unverifiable`, and that is NOT a pass.** A run allocated before the check existed
-recorded no self-path, so the question cannot be answered from its manifest — which is a different
-thing from answering it "fine". Measured on this machine: all three runs under `_runs/` report
-`unverifiable`, exit 3. Only `moved` (exit 1) is an established finding, and it names both the
-recorded and the actual directory. The comparison is on the directory **name**, so a repo that has
-been cloned, moved, or checked out as a `git worktree` stays `intact`.
+⚠️ **Exit 3 is `unverifiable`, and that is NOT a pass.** It means the question could not be answered
+from the evidence — a different thing from answering it "fine". Four ways to land there, and the
+first one is why `--verify` is a gate rather than a status query:
+
+| shape | why it is `unverifiable` |
+|---|---|
+| `run.json` missing, empty, truncated, malformed, locked, or valid JSON that is not an object | there is nothing to assess. This used to be skipped in **silence** and counted in no bucket at all: a canonical `_runs/001-acme/` with no manifest printed `0 run(s): 0 intact, 0 moved, 0 unverifiable`, exit 0 — the `unverifiable` bucket sitting at 0 exactly when something was unverifiable. It is also what an allocation interrupted between `mkdir` and the manifest write leaves behind |
+| `run.json` parsed but carries no usable `run` number | the run number is the identity; without one it is not an assessable manifest |
+| allocated before the check existed, so no self-path was recorded | nothing to compare against |
+| recorded name matches but the recorded **absolute path** does not | see below |
+
+⚠️ **A relocated run is `unverifiable`, never `intact`.** A basename survives both a run-only move and
+a copy, so the name alone cannot answer "still there": moving `source\_runs\001-acme` to
+`moved\_runs\001-acme` reported `INTACT 001-acme`, exit 0, and so did a copy of a run into a second
+`_runs\` root. Whether the whole checkout moved (legitimate) or this one run was moved or copied
+(corruption) **cannot be distinguished from a single run's evidence**, and both break the absolute
+self-paths embedded under `bundle/` — so the verdict is "cannot establish", not "fine". This is not a
+fresh-clone false alarm: `_runs/` is git-ignored, so a clone and a fresh `git worktree` carry no runs
+at all (`git check-ignore -v -- _runs/001-acme/run.json` → `.gitignore:162:/_*`).
+
+Only `moved` (exit 1) is an established finding, and it names both the recorded and the actual
+directory. If you did move the whole checkout deliberately, re-verify the bundles under each run
+before trusting them; there is no acknowledge-and-clear switch, on purpose.
 
 The whole tree is ignored by construction (`/_*` in
 `.gitignore`; verify with `git check-ignore -v -- <path>`, **no trailing slash**, before trusting it).

--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -1088,6 +1088,75 @@ signal is missing; that assessment is usable, with the retire tier flagged as un
 The pass-1 inventory is written to `_assessment/raw/` **before** the flakier passes run, so even a
 later failure leaves the expensive part on disk.
 
+### 4.12 Windows and PowerShell misreads — four ways the shell lies to you
+
+All four are self-reported time sinks from a real customer engagement (issue #470), and none of them
+is a defect in this toolkit. They are here because each one *looks* like one.
+
+**① A succeeding command that looks failed: `NativeCommandError`.** PowerShell turns anything a
+native process writes to **stderr** into an error record, and plenty of healthy tools report
+*progress* on stderr — `git clone`'s `Receiving objects: …`, `pip`/`uv` progress bars, and any Python
+script using `print(..., file=sys.stderr)` (which this repo does deliberately, so progress never
+contaminates a `--json` stdout payload). Under `$ErrorActionPreference = 'Stop'` a red
+`NativeCommandError` therefore appears for a command that **exited 0**.
+
+> **Judge a native command by `$LASTEXITCODE`, never by whether red text appeared.** Capture it
+> immediately, and never through a truncating pipe — `... | Select-Object -First 5` sets
+> `$LASTEXITCODE` from the *pipeline*, not from your program:
+>
+> ```powershell
+> git clone <url> <dir> 2>&1 | Out-String   # red output here means nothing on its own
+> $code = $LASTEXITCODE                     # <- this is the verdict
+> ```
+>
+> The same rule is why every gate in this repo is specified by exit code: `pylint` has been measured
+> printing *"rated at 10.00/10"* while exiting 16.
+
+**② `Remove-Item` cannot delete a bundle you were able to write.** Python is long-path aware, so the
+pipeline can create paths that Explorer and `Remove-Item` refuse. The fix is documented — the `\\?\`
+prefix **plus** a chmod handler, because a git repo inside the tree has read-only objects:
+
+```python
+shutil.rmtree("\\\\?\\" + str(root), onexc=lambda f, p, e: (os.chmod(p, stat.S_IWRITE), f(p)))
+```
+
+Full context, and why the ceiling bites in the first place:
+[`docs/windows-path-limits.md`](windows-path-limits.md) (§5 *Reproducing it*).
+
+**③ `Start-Process -ArgumentList` silently mangles a multi-word argument.** `-ArgumentList` joins its
+elements with spaces and passes the result to the OS, so a display name containing a space is split
+into two arguments. Measured cost: a whole `capture_tableau_oracle.py --workbook "Some Long Name"`
+launch that matched **zero** views and reported no error, because `--workbook` is an exact,
+case-insensitive published-name filter and the mangled value simply matched nothing.
+
+> Do not hand-quote your way out of it. Put the command in a `.ps1`/`.py` file and launch **that**,
+> or call the executable directly (`python scripts\capture_tableau_oracle.py --workbook "Some Long
+> Name" --out _oracle`) where PowerShell's own parser handles the quoting. If you must use
+> `Start-Process`, verify the child actually received the argument before trusting the run.
+
+**④ An SSL probe fails where the toolkit succeeds — `requests` vs the Windows certificate store.**
+✅ Verified 2026-09-03 against this repo: **`scripts/` contains no `requests` import at all.** Every
+Tableau call goes through `urllib.request` (`scripts/tableau_http.py`, `capture_tableau_oracle.py`,
+`assess_estate.py`, `tableau_render_capability.py`, `deploy_estate.py`, …), which uses CPython's
+default `SSLContext`. On Windows that context is populated from the **Windows certificate store** via
+`ssl.enum_certificates`, so an enterprise private CA or a TLS-inspecting proxy that an admin has
+installed machine-wide is trusted automatically.
+
+`requests` does not do this: it verifies against **certifi**'s static bundled PEM, which contains only
+public roots. So an ad-hoc `requests.get(...)` probe raises `SSLCertVerificationError` against a
+server the toolkit talks to happily — and the probe, not the server, is what is wrong.
+
+Measured on the machine that wrote this:
+
+```powershell
+python -c "import ssl; print(len(ssl.create_default_context().get_ca_certs()), len(ssl.enum_certificates('ROOT')))"
+# 98 69   -> the default context carries 98 CAs, 69 of them from the Windows ROOT store
+```
+
+> **Probe with the same transport the toolkit uses.** If you must use `requests`, point it at the
+> Windows store (`pip install truststore` and `truststore.inject_into_ssl()`), and **never** reach
+> for `verify=False` — that turns a diagnostic into a silent downgrade of every later call.
+
 ---
 
 ## 5. Verification checklist
@@ -1251,7 +1320,27 @@ reporting done.
 **Canonical pre-bundle layout (issue #291/#234):** new work allocates a numbered, per-run home under
 `_runs/<NNN>-<slug>/{assessment,assets,bundle,oracle,packages,deliverables,scratch}/` via
 `python scripts/work_dirs.py <unit-name> --json`, rather than inventing another `_*` root. The number
-is the identity — never renamed or reused — and the whole tree is ignored by construction (`/_*` in
+is the identity — **never renamed, never renumbered, never reused**, because generated bundle output
+embeds absolute self-paths, so renaming a run afterwards breaks every bundle beneath it (refresh, the
+report's `byPath` model binding, `_build/` replay). One run per **pipeline run**, not one per
+workbook: a 48-workbook estate sweep is a single run whose per-workbook units live inside its
+`bundle/pbip/`. A real customer reorg renumbered **14** run directories on that misunderstanding
+(issue #470) — allocate a new run instead; numbering is cheap and gaps are expected.
+
+**Check it, don't assume it:**
+
+```powershell
+python scripts/work_dirs.py --verify          # exit 0 all intact / 1 something moved / 3 unverifiable
+```
+
+⚠️ **Exit 3 is `unverifiable`, and that is NOT a pass.** A run allocated before the check existed
+recorded no self-path, so the question cannot be answered from its manifest — which is a different
+thing from answering it "fine". Measured on this machine: all three runs under `_runs/` report
+`unverifiable`, exit 3. Only `moved` (exit 1) is an established finding, and it names both the
+recorded and the actual directory. The comparison is on the directory **name**, so a repo that has
+been cloned, moved, or checked out as a `git worktree` stays `intact`.
+
+The whole tree is ignored by construction (`/_*` in
 `.gitignore`; verify with `git check-ignore -v -- <path>`, **no trailing slash**, before trusting it).
 `deliverables/` is specifically for operator-facing outputs that name real customer infrastructure
 (e.g. `connections_manifest.py`'s `connections.json`/`.md`) — the `ses-prep/` near-miss (#322) landed

--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -1334,15 +1334,23 @@ python scripts/work_dirs.py --verify          # exit 0 all intact / 1 something 
 ```
 
 ⚠️ **Exit 3 is `unverifiable`, and that is NOT a pass.** It means the question could not be answered
-from the evidence — a different thing from answering it "fine". Four ways to land there, and the
-first one is why `--verify` is a gate rather than a status query:
+from the evidence — a different thing from answering it "fine". The gate rests on ONE invariant,
+implemented in one discovery function and one classification function: **every child directory of an
+existing `_runs/` root is a candidate run, any candidate whose identity cannot be positively
+established from its own evidence is `unverifiable`, and `intact` is only ever returned on positive
+proof.** Seven ways to land there, and each of the first five printed **exit 0** before it was
+closed — they were found in two review rounds, one site at a time, which is why the fix collapsed
+the surface rather than adding a guard per site:
 
-| shape | why it is `unverifiable` |
+| shape | why it is `unverifiable`, and what it used to print |
 |---|---|
-| `run.json` missing, empty, truncated, malformed, locked, or valid JSON that is not an object | there is nothing to assess. This used to be skipped in **silence** and counted in no bucket at all: a canonical `_runs/001-acme/` with no manifest printed `0 run(s): 0 intact, 0 moved, 0 unverifiable`, exit 0 — the `unverifiable` bucket sitting at 0 exactly when something was unverifiable. It is also what an allocation interrupted between `mkdir` and the manifest write leaves behind |
+| `run.json` missing, empty, truncated, malformed, locked, or valid JSON that is not an object | there is nothing to assess. Skipped in **silence** and counted in no bucket: a canonical `_runs/001-acme/` with no manifest printed `0 run(s): 0 intact, 0 moved, 0 unverifiable`, exit 0 — the `unverifiable` bucket sitting at 0 exactly when something was unverifiable. It is also what an allocation interrupted between `mkdir` and the manifest write leaves behind |
+| the directory was renamed out of the `<NNN>-` pattern **and** its manifest deleted | discovery reported only children whose *current* name matched `<NNN>` or which still held a `run.json`, so a real run that lost both was invisible: `(no run directories found)`, exit 0. The tree was still on disk — this is **not** the accepted "the run was deleted entirely" residual |
+| the `_runs/` root itself cannot be enumerated (permissions, or it is a file) | the `OSError` became an empty list, i.e. "zero runs, exit 0", while every run beneath it still existed and simply could not be discovered |
+| `run` contradicts the `<NNN>-<slug>` directory it sits in | only the *type* of `run` was checked. Changing nothing but `"run"` in a freshly allocated `001-acme` — to `2`, or to `10**100` — reported `1 intact`, exit 0. The number **is** the identity in this convention, so a manifest claiming a different one is contradictory evidence, not a healthy run |
+| `allocated_abs_path` recorded as a **relative** path | it is *required* to be absolute, but the comparison completed it against the **verifier's** current directory, so a forged relative value reported `INTACT 001-acme`, exit 0 — a location verdict that depended on where the operator was standing |
 | `run.json` parsed but carries no usable `run` number | the run number is the identity; without one it is not an assessable manifest |
-| allocated before the check existed, so no self-path was recorded | nothing to compare against |
-| recorded name matches but the recorded **absolute path** does not | see below |
+| allocated before the check existed, so no self-path was recorded; or the recorded name matches but the recorded **absolute path** does not | nothing to compare against, or see below |
 
 ⚠️ **A relocated run is `unverifiable`, never `intact`.** A basename survives both a run-only move and
 a copy, so the name alone cannot answer "still there": moving `source\_runs\001-acme` to

--- a/docs/windows-path-limits.md
+++ b/docs/windows-path-limits.md
@@ -287,9 +287,20 @@ npx --yes @microsoft/powerbi-desktop-bridge-cli status --pid <literal pid> --wai
 Stop-Process -Id <literal pid> -Force
 ```
 
-> ⚠️ Deleting a >259-char fixture needs the `\\?\` prefix, and a git repo inside it needs a chmod
-> handler because git objects are read-only:
-> `shutil.rmtree("\\\\?\\" + str(root), onexc=lambda f, p, e: (os.chmod(p, stat.S_IWRITE), f(p)))`
+### Deleting a tree that is already over the ceiling
+
+⚠️ **Plain `Remove-Item` (and Explorer) will refuse it, even though Python happily wrote it.** This
+is the symptom people hit first and it reads like a permissions problem, not a path-length one.
+Deleting a >259-char tree needs the `\\?\` prefix, and a git repo inside it *additionally* needs a
+chmod handler because git's object files are read-only:
+
+```python
+shutil.rmtree("\\\\?\\" + str(root), onexc=lambda f, p, e: (os.chmod(p, stat.S_IWRITE), f(p)))
+```
+
+Both halves are load-bearing: the prefix alone still fails on `.git/objects/`, and the handler alone
+never gets far enough to matter. Reported cost of rediscovering this by trial and error on a customer
+engagement: real, and avoidable — issue #470.
 
 ### One correction to the crash report's framing
 

--- a/scripts/work_dirs.py
+++ b/scripts/work_dirs.py
@@ -40,8 +40,8 @@ TRACKED. Per-run scratch is the reverse (nothing under it is tracked), so it liv
 instead - a root-anchored `/_*` rule already covers it (verified: `git check-ignore -v -- _runs`
 reports `.gitignore:127:/_*`), same as every other top-level scratch root in this repo.
 
-⚠️ The run NUMBER is identity: never renamed, never renumbered, never reused
------------------------------------------------------------------------------
+WARNING - the run NUMBER is identity: never renamed, never renumbered, never reused
+------------------------------------------------------------------------------------
 Renaming or renumbering an ALREADY-ALLOCATED run directory is destructive, not tidying. Generated
 bundle output under `<run>/bundle/` embeds ABSOLUTE self-paths, so moving a run after the fact
 breaks every bundle beneath it - PBIP refresh, the report's `byPath` model binding, and `_build/`
@@ -61,8 +61,15 @@ records the directory name it allocated under the `allocated_dir_name` key, and 
 `unverifiable`. `unverifiable` is NOT a soft `intact` - see `check_run_location`.
 
 Map: `docs/INDEX.md`. The same rule is stated in `docs/migration-phases.md` (Phase 1) and
-`docs/operator-runbook.md` (§6.4 Scratch).
+`docs/operator-runbook.md` (section 6.4, Scratch).
 """
+
+# ⚠️ This module docstring is argparse's `description`, and Windows defaults stdout to cp1252, so it
+# must stay ASCII-ONLY or `--help` dies before printing anything - measured: adding one "warning
+# sign + variation-selector-16" glyph to it turned
+# `tests/test_scripts_help.py::test_help_exits_zero_on_a_cp1252_stdout[work_dirs.py]` red (F003 in
+# `docs/dry-run-findings-2026-08-11.md`). Glyphs are fine HERE, in a comment, and in every other
+# docstring in this file - only the module docstring is printed by `--help`.
 
 from __future__ import annotations
 

--- a/scripts/work_dirs.py
+++ b/scripts/work_dirs.py
@@ -417,13 +417,23 @@ def _is_location_independent(value: str) -> bool:
     directory produced `INTACT 001-acme`, exit 0 - a location verdict that depended on where the
     operator happened to be standing, in the one module that exists to be CWD-independent.
 
-    `isabs` is also the wrong predicate here and a version-dependent one: on Windows it answered
-    True for the drive-relative `\\_runs\\001-acme` before Python 3.13 and False from 3.13 on, and
-    a drive-relative path still resolves against the CURRENT drive. So the property is tested
-    directly instead, as two facts that are both needed: the value must be rooted within whatever
-    drive it names (`C:001-acme` is not), and it must name a drive or root of its own, which is
-    established by joining it onto unrelated anchors and demanding it come back unchanged.
-    Anything a CWD, or a current drive, would complete fails one of the two.
+    ⚠️ `isabs` is a VERSION-DEPENDENT predicate here, which is the reason not to use it - it is not
+    that `isabs` is wrong about every drive-relative shape. Measured, `ntpath.isabs`:
+
+        value                    CPython 3.11.10    CPython 3.13.2
+        '\\_runs\\001-acme'        True  <- the miss   False
+        'C:001-acme'             False              False
+
+    So on 3.13 `isabs` alone would have been enough here, and on 3.11 it would have accepted a path
+    that still resolves against whatever drive the process is on. Exactly one shape, on the older
+    interpreter - an earlier version of this note claimed two, and overstating a justification is
+    how the next reader over-trusts the next claim.
+
+    The property is therefore tested directly, as two facts that are both needed and both
+    interpreter-independent: the value must be rooted within whatever drive it names (`C:001-acme`
+    is not), and it must name a drive or root of its own, established by joining it onto unrelated
+    anchors and demanding it come back unchanged. Anything a CWD, or a current drive, would
+    complete fails one of the two.
     """
     try:
         # Fact 1 - the path must be rooted WITHIN whatever drive it names. `C:001-acme` carries a

--- a/scripts/work_dirs.py
+++ b/scripts/work_dirs.py
@@ -6,7 +6,9 @@ purpose: single source of truth for the canonical PRE-BUNDLE work layout - resol
          this module implements: `_runs/<NNN>-<slug>/{assessment,assets,bundle,oracle,packages,
          deliverables,scratch}/`.
 usage:   python scripts/work_dirs.py <unit-name> [--repo-root PATH] [--json]
+         python scripts/work_dirs.py --verify [--repo-root PATH] [--json]
          from work_dirs import allocate_run, sanitize_unit_key, runs_root, list_runs
+         from work_dirs import check_run_location
 
 Scope of THIS module - deliberately narrow (see the PR that landed it, Refs #291)
 ----------------------------------------------------------------------------------
@@ -37,6 +39,29 @@ meaning: the re-runnable `*.py` transform scripts inside an existing `_work/` tr
 TRACKED. Per-run scratch is the reverse (nothing under it is tracked), so it lives under `_runs/`
 instead - a root-anchored `/_*` rule already covers it (verified: `git check-ignore -v -- _runs`
 reports `.gitignore:127:/_*`), same as every other top-level scratch root in this repo.
+
+⚠️ The run NUMBER is identity: never renamed, never renumbered, never reused
+-----------------------------------------------------------------------------
+Renaming or renumbering an ALREADY-ALLOCATED run directory is destructive, not tidying. Generated
+bundle output under `<run>/bundle/` embeds ABSOLUTE self-paths, so moving a run after the fact
+breaks every bundle beneath it - PBIP refresh, the report's `byPath` model binding, and `_build/`
+replay all resolve against a path that no longer exists. A reorg that renumbers 14 run directories
+therefore breaks 14 bundles. That is not hypothetical: it happened on a real customer engagement
+whose agent read THIS FILE, pattern-matched the naming rules below, and never opened the two
+documents that carried the prohibition (issue #470).
+
+**Granularity: one run per PIPELINE RUN, not one per workbook.** A 48-workbook estate sweep is ONE
+run; its per-workbook units live inside that run's `bundle/pbip/`. `unit_key` names what the run is
+*about* (a site, a project, or a single workbook when that is genuinely the whole job) - it is not a
+promise that every workbook gets a run of its own.
+
+Prevention is only advice, so this module also makes a rename DETECTABLE afterwards: `allocate_run`
+records the directory name it allocated under the `allocated_dir_name` key, and `check_run_location`
+(surfaced by `list_runs` and by `python scripts/work_dirs.py --verify`) reports `intact`, `moved` or
+`unverifiable`. `unverifiable` is NOT a soft `intact` - see `check_run_location`.
+
+Map: `docs/INDEX.md`. The same rule is stated in `docs/migration-phases.md` (Phase 1) and
+`docs/operator-runbook.md` (§6.4 Scratch).
 """
 
 from __future__ import annotations
@@ -85,6 +110,33 @@ _RUN_DIR_RE = re.compile(r"^(\d+)(?:-.*)?$")
 _MAX_UNIT_KEY_LEN = 60
 _MAX_ALLOCATION_ATTEMPTS = 50  # generous; a genuine collision only ever needs one retry
 
+#: Manifest key under which `allocate_run` records the directory NAME (`<NNN>-<slug>`) it allocated.
+#: Reserved exactly like `run`/`unit_key`/`created`/`status`: written AFTER `extra_manifest` is
+#: merged, so a caller can neither supply nor clobber it.
+#:
+#: Why the NAME and not an absolute path: the name is what a renumber/rename changes, and it is
+#: invariant under every LEGITIMATE relocation - cloning the repo, moving the checkout, or working
+#: in a `git worktree` all change the absolute path while the run keeps its identity. A check that
+#: fired on a fresh clone would be noise, and a noisy check is one people learn to ignore. See
+#: `check_run_location`.
+RUN_LOCATION_KEY = "allocated_dir_name"
+
+#: The three states `check_run_location` reports. They are mutually exclusive and a caller must be
+#: able to tell them apart: `UNVERIFIABLE` is NOT a soft `INTACT`. Collapsing unassessable input
+#: into the clean bucket is this repo's dominant defect class, and it is precisely the defect issue
+#: #470 is about - a renumbered run that read back as healthy.
+RUN_LOCATION_INTACT = "intact"
+RUN_LOCATION_MOVED = "moved"
+RUN_LOCATION_UNVERIFIABLE = "unverifiable"
+RUN_LOCATION_STATES: tuple[str, ...] = (RUN_LOCATION_INTACT, RUN_LOCATION_MOVED, RUN_LOCATION_UNVERIFIABLE)
+
+#: Values of `RunLocationCheck.derived_name_check` - a strictly SUBORDINATE hint, only ever set on an
+#: `UNVERIFIABLE` run, and never able to promote one to `INTACT`. See `check_run_location`.
+DERIVED_NAME_MATCHES = "matches"
+DERIVED_NAME_MISMATCH = "mismatch"
+DERIVED_NAME_UNAVAILABLE = "unavailable"
+DERIVED_NAME_NOT_CONSULTED = "not_consulted"
+
 
 def sanitize_unit_key(name: str) -> str:
     """Turn an arbitrary unit name (a Tableau workbook/site/project display name) into a
@@ -117,7 +169,7 @@ class RunPaths:
     """Everything about one allocated run. `root` is the ONLY thing on disk that identifies it -
     every other accessor is derived, never stored twice. Never rename `root` after allocation
     (issue #234, rule 1): generated bundle output embeds absolute self-paths, so moving a run after
-    the fact breaks refresh.
+    the fact breaks refresh. `check_run_location` is what detects it if someone does anyway.
     """
 
     root: Path
@@ -194,6 +246,130 @@ def _existing_run_numbers(root: Path) -> list[int]:
     return numbers
 
 
+def _run_dir_name(run_number: int, unit_key: str) -> str:
+    """The one place the `<NNN>-<slug>` directory name is formed. `allocate_run` uses it to create
+    the directory and `_derived_dir_name` uses it to reconstruct one, so the zero-padding rule
+    cannot drift between the two.
+    """
+    width = max(3, len(str(run_number)))
+    return f"{run_number:0{width}d}-{unit_key}"
+
+
+def _derived_dir_name(manifest: dict[str, Any]) -> str | None:
+    """Reconstruct the directory name a manifest's own `run`/`unit_key` IMPLY, or None if they
+    cannot. This is inference, never evidence - it depends on `_run_dir_name`'s padding rule holding
+    for the life of the run, which a recorded name does not. Its only job is to give a LEGACY
+    manifest (one written before `RUN_LOCATION_KEY` existed) a subordinate hint; it may never
+    promote such a run out of `unverifiable`.
+    """
+    run_number = manifest.get("run")
+    unit_key = manifest.get("unit_key")
+    # `isinstance(True, int)` is True in Python, so booleans have to be excluded explicitly.
+    if isinstance(run_number, bool) or not isinstance(run_number, int) or run_number < 0:
+        return None
+    if not isinstance(unit_key, str) or not unit_key:
+        return None
+    return _run_dir_name(run_number, unit_key)
+
+
+@dataclass(frozen=True)
+class RunLocationCheck:
+    """Whether a run directory is still where it was allocated. Read `state` - never `detail`.
+
+    `derived_name_check` is deliberately not part of `state`: it is a hint, it is only ever set on
+    an `unverifiable` run, and a `matches` hint does NOT mean intact.
+    """
+
+    state: str
+    actual_dir_name: str
+    recorded_dir_name: str | None
+    derived_name_check: str
+    detail: str
+
+    @property
+    def is_intact(self) -> bool:
+        """True only for a run whose RECORDED name matches where it actually sits."""
+        return self.state == RUN_LOCATION_INTACT
+
+    def as_dict(self) -> dict[str, Any]:
+        """JSON-serializable form, as attached by `list_runs` and printed by `--verify --json`."""
+        return {
+            "state": self.state,
+            "actual_dir_name": self.actual_dir_name,
+            "recorded_dir_name": self.recorded_dir_name,
+            "derived_name_check": self.derived_name_check,
+            "detail": self.detail,
+        }
+
+
+def check_run_location(manifest: dict[str, Any], run_dir: Path) -> RunLocationCheck:
+    """Compare where a run says it was allocated against where it actually sits. Pure: reads a
+    manifest dict and a path, touches no disk, mutates nothing, and never raises (issue #470).
+
+    Three states, and the third is the point:
+
+    * `intact` - the recorded `<NNN>-<slug>` name equals the directory's actual name.
+    * `moved` - they differ. The run has been renamed or renumbered since allocation, so generated
+      bundle output beneath it embeds absolute self-paths that no longer resolve. Both names are
+      reported so the damage is locatable.
+    * `unverifiable` - the manifest records no usable name. EVERY run allocated before this key
+      existed lands here, including the live `_runs/408-*` on the machine that shipped this change.
+      It is not a pass and it is not a failure; it means the question cannot be answered from the
+      evidence, which is a different thing from answering it "fine".
+
+    Comparison is on the directory NAME only, never on an absolute path: a repository that has been
+    cloned, moved or checked out as a `git worktree` is legitimately somewhere else and must not
+    report `moved` (see `RUN_LOCATION_KEY`).
+    """
+    actual = run_dir.name
+    recorded = manifest.get(RUN_LOCATION_KEY)
+
+    if isinstance(recorded, str) and recorded:
+        if recorded == actual:
+            return RunLocationCheck(
+                state=RUN_LOCATION_INTACT,
+                actual_dir_name=actual,
+                recorded_dir_name=recorded,
+                derived_name_check=DERIVED_NAME_NOT_CONSULTED,
+                detail=f"allocated as {recorded!r} and still there",
+            )
+        return RunLocationCheck(
+            state=RUN_LOCATION_MOVED,
+            actual_dir_name=actual,
+            recorded_dir_name=recorded,
+            derived_name_check=DERIVED_NAME_NOT_CONSULTED,
+            detail=(
+                f"allocated as {recorded!r} but found as {actual!r} - renamed or renumbered since "
+                "allocation; generated bundle output embeds absolute self-paths, so treat every "
+                "bundle under this run as broken until re-checked"
+            ),
+        )
+
+    if recorded is None:
+        missing = f"no {RUN_LOCATION_KEY!r} recorded (allocated before this key existed)"
+    else:
+        missing = f"{RUN_LOCATION_KEY!r} is present but is not a usable directory name ({recorded!r})"
+
+    derived = _derived_dir_name(manifest)
+    if derived is None:
+        hint, why = DERIVED_NAME_UNAVAILABLE, "and its own run/unit_key cannot reconstruct one either"
+    elif derived == actual:
+        hint, why = DERIVED_NAME_MATCHES, f"its run/unit_key imply {derived!r}, which matches - but that is INFERENCE"
+    else:
+        hint, why = (
+            DERIVED_NAME_MISMATCH,
+            f"its run/unit_key imply {derived!r}, which does NOT match {actual!r} - likely renamed or "
+            "renumbered, but that is INFERENCE, not a record",
+        )
+    return RunLocationCheck(
+        state=RUN_LOCATION_UNVERIFIABLE,
+        actual_dir_name=actual,
+        recorded_dir_name=None,
+        derived_name_check=hint,
+        detail=f"{missing}; {why}",
+    )
+
+
 def allocate_run(
     unit_key: str,
     *,
@@ -209,8 +385,22 @@ def allocate_run(
     candidate. The directory name is `<NNN>-<slug>`, zero-padded to at least 3 digits; the slug is
     decoration only (never parsed back - see `sanitize_unit_key`), the number is the identity.
 
+    ⚠️ **The directory this returns must never be renamed, renumbered or reused.** Generated bundle
+    output under `<run>/bundle/` embeds ABSOLUTE self-paths, so renaming a run afterwards breaks
+    every bundle beneath it (refresh, `byPath` report-to-model binding, `_build/` replay). A real
+    customer reorg renumbered 14 run directories on exactly this misunderstanding - see the module
+    docstring, `docs/migration-phases.md` (Phase 1) and `docs/operator-runbook.md` (§6.4), and issue
+    #470. Allocate a NEW run instead; numbering is cheap and gaps are expected.
+
+    One run per PIPELINE RUN, not one per workbook: a 48-workbook estate sweep is a single run whose
+    per-workbook units live inside its `bundle/pbip/`.
+
+    So that a rename is at least DETECTABLE afterwards, the directory name is also written into the
+    manifest under `RUN_LOCATION_KEY`; `check_run_location` compares the two.
+
     `extra_manifest` is merged in FIRST, so a caller cannot accidentally clobber the reserved
-    `run` / `unit_key` / `created` / `status` keys this function itself writes.
+    `run` / `unit_key` / `created` / `status` / `allocated_dir_name` keys this function itself
+    writes.
     """
     root = runs_root(repo_root)
     root.mkdir(parents=True, exist_ok=True)
@@ -219,8 +409,7 @@ def allocate_run(
     existing = _existing_run_numbers(root)
     candidate = (max(existing) + 1) if existing else 1
     for _ in range(_MAX_ALLOCATION_ATTEMPTS):
-        width = max(3, len(str(candidate)))
-        run_dir = root / f"{candidate:0{width}d}-{slug}"
+        run_dir = root / _run_dir_name(candidate, slug)
         try:
             run_dir.mkdir(parents=False, exist_ok=False)
         except FileExistsError:
@@ -239,6 +428,7 @@ def allocate_run(
                 "unit_key": slug,
                 "created": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
                 "status": "active",
+                RUN_LOCATION_KEY: run_dir.name,
             }
         )
         run.manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
@@ -254,6 +444,15 @@ def list_runs(repo_root: Path | None = None) -> list[dict[str, Any]]:
     """Read back every run's manifest, sorted by run number. Pure inspection - never mutates, and
     never raises on a hand-created or half-written run directory; it just skips one with no
     readable `run.json` rather than crashing a status query over it.
+
+    Two keys are DERIVED and overwrite anything of the same name in the manifest, because both
+    describe where the run is *now* and a stale recorded value silently presented as current is the
+    failure this whole function is being audited for:
+
+    * `root` - the directory it was actually found in.
+    * `location_check` - `check_run_location(...).as_dict()`, i.e. `intact` / `moved` /
+      `unverifiable`. Read `location_check["state"]`; never infer health from `root` alone, which is
+      derived from wherever the directory sits and so is true by construction (issue #470).
     """
     root = runs_root(repo_root)
     if not root.is_dir():
@@ -267,19 +466,83 @@ def list_runs(repo_root: Path | None = None) -> list[dict[str, Any]]:
             data = json.loads(manifest_path.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError):
             continue
-        data.setdefault("root", str(child))
+        # A `run.json` holding valid JSON that is not an object (a list, a bare string, a number) is
+        # not a manifest. Skipping it keeps the "never raises" promise literally true - `.get` and
+        # `.setdefault` on a list raise `AttributeError`, which used to escape this function.
+        if not isinstance(data, dict):
+            continue
+        data["root"] = str(child)
+        data["location_check"] = check_run_location(data, child).as_dict()
         manifests.append(data)
     manifests.sort(key=lambda m: m.get("run", 0))
     return manifests
 
 
+def verify_runs(repo_root: Path | None = None) -> tuple[list[dict[str, Any]], dict[str, int]]:
+    """Every run plus a count per `RUN_LOCATION_STATES` entry. Pure inspection, like `list_runs`."""
+    runs = list_runs(repo_root)
+    counts = {state: 0 for state in RUN_LOCATION_STATES}
+    for run in runs:
+        state = run.get("location_check", {}).get("state", RUN_LOCATION_UNVERIFIABLE)
+        counts[state] = counts.get(state, 0) + 1
+    return runs, counts
+
+
+def verify_exit_code(counts: dict[str, int]) -> int:
+    """Gate semantics, matching `check_reference_readiness.py`: 0 clean, 1 findings, 3 cannot
+    establish - and neither 1 nor 3 is a pass. A `moved` run outranks an `unverifiable` one because
+    it is an established finding rather than an unanswered question.
+    """
+    if counts.get(RUN_LOCATION_MOVED):
+        return 1
+    if counts.get(RUN_LOCATION_UNVERIFIABLE):
+        return 3
+    return 0
+
+
+def _print_verify_text(runs: list[dict[str, Any]], counts: dict[str, int], root: Path) -> None:
+    """Human-readable `--verify` report. The STATE is printed in caps and first on every line, so a
+    subordinate `derived name check` hint can never be mistaken for the verdict.
+    """
+    print(f"_runs/ location check: {root}")
+    if not runs:
+        print("  (no runs with a readable run.json)")
+    for run in runs:
+        check = run.get("location_check", {})
+        print(f"  {check.get('state', '?').upper():<13} {check.get('actual_dir_name', '?')}")
+        print(f"                {check.get('detail', '')}")
+    summary = ", ".join(f"{counts.get(state, 0)} {state}" for state in RUN_LOCATION_STATES)
+    print(f"{len(runs)} run(s): {summary}")
+    if counts.get(RUN_LOCATION_UNVERIFIABLE):
+        print("  'unverifiable' is NOT 'intact' - those runs predate path recording and cannot be checked.")
+
+
 def main() -> int:
-    """CLI: allocate one run for `unit` and print its canonical paths."""
+    """CLI: allocate one run for `unit` and print its canonical paths, or `--verify` the tree."""
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    parser.add_argument("unit", help="unit name/key to allocate a run for (e.g. a workbook or site slug)")
+    parser.add_argument("unit", nargs="?", help="unit name/key to allocate a run for (e.g. a workbook or site slug)")
     parser.add_argument("--repo-root", type=Path, default=None)
     parser.add_argument("--json", action="store_true", help="print the allocated paths as JSON")
+    parser.add_argument(
+        "--verify",
+        action="store_true",
+        help=(
+            "allocate nothing; report whether every run is still where it was allocated. "
+            "Exit 0 all intact / 1 at least one moved / 3 at least one unverifiable"
+        ),
+    )
     args = parser.parse_args()
+
+    if args.verify:
+        runs, counts = verify_runs(args.repo_root)
+        if args.json:
+            print(json.dumps({"runs_root": str(runs_root(args.repo_root)), "counts": counts, "runs": runs}, indent=2))
+        else:
+            _print_verify_text(runs, counts, runs_root(args.repo_root))
+        return verify_exit_code(counts)
+
+    if not args.unit:
+        parser.error("unit is required unless --verify is given")
 
     run = allocate_run(args.unit, repo_root=args.repo_root)
     subdirs = {name: str(run.subdir(name)) for name in CANONICAL_SUBDIRS}

--- a/scripts/work_dirs.py
+++ b/scripts/work_dirs.py
@@ -56,9 +56,16 @@ run; its per-workbook units live inside that run's `bundle/pbip/`. `unit_key` na
 promise that every workbook gets a run of its own.
 
 Prevention is only advice, so this module also makes a rename DETECTABLE afterwards: `allocate_run`
-records the directory name it allocated under the `allocated_dir_name` key, and `check_run_location`
-(surfaced by `list_runs` and by `python scripts/work_dirs.py --verify`) reports `intact`, `moved` or
-`unverifiable`. `unverifiable` is NOT a soft `intact` - see `check_run_location`.
+records the directory name it allocated under the `allocated_dir_name` key and the absolute path
+under `allocated_abs_path`, and `check_run_location` (surfaced by `list_runs` and by
+`python scripts/work_dirs.py --verify`) reports `intact`, `moved` or `unverifiable`. `unverifiable`
+is NOT a soft `intact` - see `check_run_location`.
+
+`--verify` is a GATE, not a status query: exit 0 all intact / 1 at least one moved / 3 at least one
+unverifiable. A run directory it cannot read at all - `run.json` missing, empty, truncated,
+malformed, locked, or holding valid JSON that is not an object - is `unverifiable` and exits 3. It
+used to be skipped silently and counted in no bucket at all, which reported a half-written run as a
+clean tree. `list_runs` still skips those, because it is inspection rather than a gate.
 
 Map: `docs/INDEX.md`. The same rule is stated in `docs/migration-phases.md` (Phase 1) and
 `docs/operator-runbook.md` (section 6.4, Scratch).
@@ -75,6 +82,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import sys
 import unicodedata
@@ -121,12 +129,32 @@ _MAX_ALLOCATION_ATTEMPTS = 50  # generous; a genuine collision only ever needs o
 #: Reserved exactly like `run`/`unit_key`/`created`/`status`: written AFTER `extra_manifest` is
 #: merged, so a caller can neither supply nor clobber it.
 #:
-#: Why the NAME and not an absolute path: the name is what a renumber/rename changes, and it is
-#: invariant under every LEGITIMATE relocation - cloning the repo, moving the checkout, or working
-#: in a `git worktree` all change the absolute path while the run keeps its identity. A check that
-#: fired on a fresh clone would be noise, and a noisy check is one people learn to ignore. See
-#: `check_run_location`.
+#: The NAME is what a renumber/rename changes, and a mismatch here is an ESTABLISHED finding
+#: (`moved`, exit 1) rather than an open question. It is not sufficient on its own - see
+#: `RUN_PATH_KEY`.
 RUN_LOCATION_KEY = "allocated_dir_name"
+
+#: Manifest key under which `allocate_run` records the ABSOLUTE path it allocated. Reserved exactly
+#: like `RUN_LOCATION_KEY`.
+#:
+#: ⚠️ This key exists because the NAME alone cannot answer the question the CLI claims to answer.
+#: Measured on the production CLI before it was added: allocate `source\_runs\001-acme`, move that
+#: one run to `moved\_runs\001-acme`, and the destination reported `INTACT 001-acme`, exit 0 - the
+#: basename never changed, so a run-only move (which breaks every bundle beneath it) was reported as
+#: healthy. Copying a run into a second `_runs/` root reported `INTACT` for the copy too.
+#:
+#: The earlier design note argued that recording an absolute path would be noise "on every clone".
+#: That premise is FALSE and is checkable in one command: `_runs/` is git-ignored
+#: (`git check-ignore -v -- _runs/001-acme/run.json` -> `.gitignore:162:/_*`), so a clone and a
+#: fresh `git worktree` carry NO runs at all - this very worktree has no `_runs/`. The only
+#: legitimate whole-tree relocation left is moving the checkout itself, and that breaks the absolute
+#: self-paths embedded in `<run>/bundle/` output exactly as a run-only move does. So it is not noise
+#: to report it; it is the same damage.
+#:
+#: What it deliberately does NOT do is guess which of the two happened. A relocated run reports
+#: `unverifiable` (exit 3, cannot establish), never `intact` and never `moved` - see
+#: `check_run_location`.
+RUN_PATH_KEY = "allocated_abs_path"
 
 #: The three states `check_run_location` reports. They are mutually exclusive and a caller must be
 #: able to tell them apart: `UNVERIFIABLE` is NOT a soft `INTACT`. Collapsing unassessable input
@@ -143,6 +171,31 @@ DERIVED_NAME_MATCHES = "matches"
 DERIVED_NAME_MISMATCH = "mismatch"
 DERIVED_NAME_UNAVAILABLE = "unavailable"
 DERIVED_NAME_NOT_CONSULTED = "not_consulted"
+
+#: Values of `RunLocationCheck.path_check`. Also subordinate: `matches` is the only one that permits
+#: `INTACT`, and it never CAUSES it on its own (the recorded NAME must match first).
+PATH_CHECK_MATCHES = "matches"
+PATH_CHECK_DIFFERS = "differs"
+PATH_CHECK_UNRECORDED = "unrecorded"
+PATH_CHECK_NOT_CONSULTED = "not_consulted"
+
+#: `manifest_status` on every entry `verify_runs` returns. The gate must be able to tell a run it
+#: ASSESSED from one it could not read at all, because collapsing the second into the clean bucket
+#: is this repo's dominant defect class.
+#:
+#:  * `ok`         - `run.json` parsed as a JSON object; `location_check` is a real verdict.
+#:  * `invalid`    - it parsed as an object but is not a usable manifest (e.g. `"run": "two"`).
+#:                   Retained, and forced to `unverifiable`.
+#:  * `unreadable` - missing, empty, truncated, malformed, locked, or valid JSON that is not an
+#:                   object. `list_runs` (inspection) omits these; `verify_runs` (the gate) MUST
+#:                   NOT - a run directory it cannot read contributes `unverifiable`, not nothing.
+MANIFEST_OK = "ok"
+MANIFEST_INVALID = "invalid"
+MANIFEST_UNREADABLE = "unreadable"
+
+#: Keys `verify_runs`/`list_runs` DERIVE onto every entry, alongside `root` and `location_check`.
+MANIFEST_STATUS_KEY = "manifest_status"
+MANIFEST_DETAIL_KEY = "manifest_detail"
 
 
 def sanitize_unit_key(name: str) -> str:
@@ -283,19 +336,20 @@ def _derived_dir_name(manifest: dict[str, Any]) -> str | None:
 class RunLocationCheck:
     """Whether a run directory is still where it was allocated. Read `state` - never `detail`.
 
-    `derived_name_check` is deliberately not part of `state`: it is a hint, it is only ever set on
-    an `unverifiable` run, and a `matches` hint does NOT mean intact.
+    `derived_name_check` and `path_check` are deliberately not part of `state`: they are hints, and
+    neither a `matches` derived name nor anything else can promote a run to `intact`.
     """
 
     state: str
     actual_dir_name: str
     recorded_dir_name: str | None
     derived_name_check: str
+    path_check: str
     detail: str
 
     @property
     def is_intact(self) -> bool:
-        """True only for a run whose RECORDED name matches where it actually sits."""
+        """True only for a run whose RECORDED name and RECORDED path both match where it sits."""
         return self.state == RUN_LOCATION_INTACT
 
     def as_dict(self) -> dict[str, Any]:
@@ -305,59 +359,78 @@ class RunLocationCheck:
             "actual_dir_name": self.actual_dir_name,
             "recorded_dir_name": self.recorded_dir_name,
             "derived_name_check": self.derived_name_check,
+            "path_check": self.path_check,
             "detail": self.detail,
         }
 
 
-def check_run_location(manifest: dict[str, Any], run_dir: Path) -> RunLocationCheck:
-    """Compare where a run says it was allocated against where it actually sits. Pure: reads a
-    manifest dict and a path, touches no disk, mutates nothing, and never raises (issue #470).
+def _normalized_path(path: Any) -> str | None:
+    """One comparable spelling of a path, or None if it cannot be formed. Used on BOTH sides -
+    written into the manifest by `allocate_run` and read back by `check_run_location` - so the
+    normalization rule cannot drift between record and check.
 
-    Three states, and the third is the point:
-
-    * `intact` - the recorded `<NNN>-<slug>` name equals the directory's actual name.
-    * `moved` - they differ. The run has been renamed or renumbered since allocation, so generated
-      bundle output beneath it embeds absolute self-paths that no longer resolve. Both names are
-      reported so the damage is locatable.
-    * `unverifiable` - the manifest records no usable name. EVERY run allocated before this key
-      existed lands here, including the live `_runs/408-*` on the machine that shipped this change.
-      It is not a pass and it is not a failure; it means the question cannot be answered from the
-      evidence, which is a different thing from answering it "fine".
-
-    Comparison is on the directory NAME only, never on an absolute path: a repository that has been
-    cloned, moved or checked out as a `git worktree` is legitimately somewhere else and must not
-    report `moved` (see `RUN_LOCATION_KEY`).
+    `abspath` (not `resolve`) on purpose: it normalizes separators, `..` and case-folding without
+    reading the filesystem, which keeps `check_run_location` pure. Returning None on a path that
+    cannot be normalized is fail-safe: None never compares equal to anything, including itself, so a
+    broken value can only ever produce `unverifiable`, never a false `intact`.
     """
-    actual = run_dir.name
-    recorded = manifest.get(RUN_LOCATION_KEY)
+    try:
+        return os.path.normcase(os.path.abspath(str(path)))
+    except (OSError, ValueError):  # pragma: no cover - a NUL byte or an unrepresentable path
+        return None
 
-    if isinstance(recorded, str) and recorded:
-        if recorded == actual:
-            return RunLocationCheck(
-                state=RUN_LOCATION_INTACT,
-                actual_dir_name=actual,
-                recorded_dir_name=recorded,
-                derived_name_check=DERIVED_NAME_NOT_CONSULTED,
-                detail=f"allocated as {recorded!r} and still there",
-            )
-        return RunLocationCheck(
-            state=RUN_LOCATION_MOVED,
-            actual_dir_name=actual,
-            recorded_dir_name=recorded,
-            derived_name_check=DERIVED_NAME_NOT_CONSULTED,
-            detail=(
-                f"allocated as {recorded!r} but found as {actual!r} - renamed or renumbered since "
-                "allocation; generated bundle output embeds absolute self-paths, so treat every "
-                "bundle under this run as broken until re-checked"
-            ),
-        )
 
+def _same_path(recorded: Any, actual: Path) -> bool:
+    """True only when both sides normalize AND are equal. Never true on an unusable value."""
+    left = _normalized_path(recorded)
+    right = _normalized_path(actual)
+    return left is not None and right is not None and left == right
+
+
+def _run_number_problem(manifest: dict[str, Any]) -> str | None:
+    """Why `manifest['run']` is not a usable run number, or None if it is.
+
+    The run NUMBER is the identity of a run, so a manifest that does not carry a usable one is not
+    assessable, however healthy the rest of it looks. It is also what `_collect_runs` sorts on:
+    sorting an unvalidated value raised `TypeError: '<' not supported between instances of 'str'
+    and 'int'` on a tree holding both `{"run": 1}` and `{"run": "two"}`, which broke the documented
+    "never raises" contract and stopped any `unverifiable` verdict from ever being reached.
+    """
+    if "run" not in manifest:
+        return "it records no 'run' number"
+    run_number = manifest.get("run")
+    # `isinstance(True, int)` is True in Python, so booleans have to be excluded explicitly.
+    if isinstance(run_number, bool) or not isinstance(run_number, int) or run_number < 0:
+        return f"its 'run' is not a usable run number ({run_number!r})"
+    return None
+
+
+def _unassessable(run_dir: Path, detail: str) -> RunLocationCheck:
+    """The verdict for a run directory whose manifest could not be read or parsed at all."""
+    return RunLocationCheck(
+        state=RUN_LOCATION_UNVERIFIABLE,
+        actual_dir_name=run_dir.name,
+        recorded_dir_name=None,
+        derived_name_check=DERIVED_NAME_UNAVAILABLE,
+        path_check=PATH_CHECK_UNRECORDED,
+        detail=detail,
+    )
+
+
+def _check_legacy_name(manifest: dict[str, Any], run_dir: Path, recorded: Any) -> RunLocationCheck:
+    """The `unverifiable` branch for a manifest that records no usable directory NAME - every run
+    allocated before `RUN_LOCATION_KEY` existed, plus any hand-edited or corrupted value.
+
+    A subordinate hint reconstructs the name the manifest's own `run`/`unit_key` IMPLY, but it can
+    never promote the run out of `unverifiable`: an inference is not a record.
+    """
     if recorded is None:
         missing = f"no {RUN_LOCATION_KEY!r} recorded (allocated before this key existed)"
     else:
         missing = f"{RUN_LOCATION_KEY!r} is present but is not a usable directory name ({recorded!r})"
 
     derived = _derived_dir_name(manifest)
+    actual = run_dir.name
     if derived is None:
         hint, why = DERIVED_NAME_UNAVAILABLE, "and its own run/unit_key cannot reconstruct one either"
     elif derived == actual:
@@ -373,8 +446,120 @@ def check_run_location(manifest: dict[str, Any], run_dir: Path) -> RunLocationCh
         actual_dir_name=actual,
         recorded_dir_name=None,
         derived_name_check=hint,
+        path_check=PATH_CHECK_NOT_CONSULTED,
         detail=f"{missing}; {why}",
     )
+
+
+def _check_intact_candidate(manifest: dict[str, Any], run_dir: Path, recorded: str) -> RunLocationCheck:
+    """A run whose recorded NAME matches where it sits. That is necessary for `intact`, never
+    sufficient - the name is a basename, and a basename survives both a run-only move and a copy.
+
+    Three ways it still fails to be `intact`, all `unverifiable` rather than `moved`, because none
+    of them ESTABLISHES corruption:
+
+    * the manifest carries no usable run number, so it is not an assessable manifest at all;
+    * no absolute allocation path was recorded (`RUN_PATH_KEY`), so a move cannot be excluded;
+    * a path was recorded and it is not where the run now sits. This is a relocation - but whether
+      the whole checkout moved (legitimate) or this run alone was moved or copied (corruption)
+      CANNOT be told apart from one run's evidence, and both break the absolute self-paths embedded
+      under `<run>/bundle/` anyway. Reporting `intact` here is the defect being fixed; reporting
+      `moved` would claim a finding that has not been established.
+    """
+    problem = _run_number_problem(manifest)
+    if problem is not None:
+        return RunLocationCheck(
+            state=RUN_LOCATION_UNVERIFIABLE,
+            actual_dir_name=run_dir.name,
+            recorded_dir_name=recorded,
+            derived_name_check=DERIVED_NAME_NOT_CONSULTED,
+            path_check=PATH_CHECK_NOT_CONSULTED,
+            detail=f"its recorded name {recorded!r} matches where it sits, but {problem} - so this is not an "
+            "assessable manifest and its location cannot be confirmed",
+        )
+
+    recorded_path = manifest.get(RUN_PATH_KEY)
+    if not isinstance(recorded_path, str) or not recorded_path:
+        return RunLocationCheck(
+            state=RUN_LOCATION_UNVERIFIABLE,
+            actual_dir_name=run_dir.name,
+            recorded_dir_name=recorded,
+            derived_name_check=DERIVED_NAME_NOT_CONSULTED,
+            path_check=PATH_CHECK_UNRECORDED,
+            detail=f"allocated as {recorded!r} and still named that, but no usable {RUN_PATH_KEY!r} was recorded "
+            "- a basename survives a run-only move and a copy, so 'still there' cannot be confirmed",
+        )
+
+    if _same_path(recorded_path, run_dir):
+        return RunLocationCheck(
+            state=RUN_LOCATION_INTACT,
+            actual_dir_name=run_dir.name,
+            recorded_dir_name=recorded,
+            derived_name_check=DERIVED_NAME_NOT_CONSULTED,
+            path_check=PATH_CHECK_MATCHES,
+            detail=f"allocated as {recorded!r} at {recorded_path} and still there",
+        )
+
+    return RunLocationCheck(
+        state=RUN_LOCATION_UNVERIFIABLE,
+        actual_dir_name=run_dir.name,
+        recorded_dir_name=recorded,
+        derived_name_check=DERIVED_NAME_NOT_CONSULTED,
+        path_check=PATH_CHECK_DIFFERS,
+        detail=f"allocated at {recorded_path} but found at {os.path.abspath(str(run_dir))} - the name is "
+        "unchanged, so this is a RELOCATION, not a rename. Moving the whole checkout and moving/copying this "
+        "run alone are indistinguishable from here, and BOTH break the absolute self-paths embedded under "
+        "bundle/, so re-check every bundle under this run rather than reading it as healthy",
+    )
+
+
+def check_run_location(manifest: Any, run_dir: Path) -> RunLocationCheck:
+    """Compare where a run says it was allocated against where it actually sits. Pure: reads a
+    manifest dict and a path, touches no disk, mutates nothing, and never raises (issue #470).
+
+    Three states, and the third is the point:
+
+    * `intact` - the recorded `<NNN>-<slug>` name equals the directory's actual name AND the
+      recorded absolute path equals where the directory actually sits. Both, because a basename
+      survives a run-only move and a copy (see `RUN_PATH_KEY`).
+    * `moved` - the recorded name and the actual name differ. The run has been renamed or
+      renumbered since allocation, so generated bundle output beneath it embeds absolute self-paths
+      that no longer resolve. Both names are reported so the damage is locatable.
+    * `unverifiable` - the question cannot be answered from the evidence: no usable manifest, no
+      recorded name, no recorded path, or a recorded path that is not where the run now sits. It is
+      not a pass and it is not a failure; it means the answer is unknown, which is a different
+      thing from answering it "fine".
+
+    `manifest` is typed `Any` on purpose - a hand-written `run.json` can hold a list, a string or a
+    number, and this function must return a verdict for it rather than raise.
+    """
+    if not isinstance(manifest, dict):
+        return _unassessable(
+            run_dir,
+            f"run.json holds {type(manifest).__name__}, not a JSON object, so it records "
+            "nothing that could place this run",
+        )
+
+    recorded = manifest.get(RUN_LOCATION_KEY)
+    if not isinstance(recorded, str) or not recorded:
+        return _check_legacy_name(manifest, run_dir, recorded)
+
+    actual = run_dir.name
+    if recorded != actual:
+        return RunLocationCheck(
+            state=RUN_LOCATION_MOVED,
+            actual_dir_name=actual,
+            recorded_dir_name=recorded,
+            derived_name_check=DERIVED_NAME_NOT_CONSULTED,
+            path_check=PATH_CHECK_NOT_CONSULTED,
+            detail=(
+                f"allocated as {recorded!r} but found as {actual!r} - renamed or renumbered since "
+                "allocation; generated bundle output embeds absolute self-paths, so treat every "
+                "bundle under this run as broken until re-checked"
+            ),
+        )
+
+    return _check_intact_candidate(manifest, run_dir, recorded)
 
 
 def allocate_run(
@@ -403,11 +588,13 @@ def allocate_run(
     per-workbook units live inside its `bundle/pbip/`.
 
     So that a rename is at least DETECTABLE afterwards, the directory name is also written into the
-    manifest under `RUN_LOCATION_KEY`; `check_run_location` compares the two.
+    manifest under `RUN_LOCATION_KEY` and its absolute path under `RUN_PATH_KEY`;
+    `check_run_location` compares both. The name alone is not enough - a basename is unchanged by a
+    run-only move or a copy, which is exactly how a moved run used to read back as `intact`.
 
     `extra_manifest` is merged in FIRST, so a caller cannot accidentally clobber the reserved
-    `run` / `unit_key` / `created` / `status` / `allocated_dir_name` keys this function itself
-    writes.
+    `run` / `unit_key` / `created` / `status` / `allocated_dir_name` / `allocated_abs_path` keys
+    this function itself writes.
     """
     root = runs_root(repo_root)
     root.mkdir(parents=True, exist_ok=True)
@@ -436,6 +623,7 @@ def allocate_run(
                 "created": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
                 "status": "active",
                 RUN_LOCATION_KEY: run_dir.name,
+                RUN_PATH_KEY: os.path.abspath(str(run_dir)),
             }
         )
         run.manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
@@ -447,47 +635,143 @@ def allocate_run(
     )
 
 
+def _iter_run_dirs(root: Path) -> list[Path]:
+    """Every child of `_runs/` that is a run DIRECTORY, readable manifest or not.
+
+    A child counts if its name matches the `<NNN>[-slug]` allocation pattern (the same rule
+    `_existing_run_numbers` uses, so anything that OCCUPIES a run number is also assessed) or if it
+    holds a `run.json` at all. Sorted by name so the caller starts from a stable order.
+    """
+    if not root.is_dir():
+        return []
+    found: list[Path] = []
+    try:
+        children = sorted(root.iterdir())
+    except OSError:  # pragma: no cover - the root vanished or is unreadable mid-scan
+        return []
+    for child in children:
+        try:
+            if not child.is_dir():
+                continue
+            if _RUN_DIR_RE.match(child.name) or (child / "run.json").is_file():
+                found.append(child)
+        except OSError:  # pragma: no cover - a child that cannot be stat'ed is still a directory
+            found.append(child)
+    return found
+
+
+def _read_run_manifest(run_dir: Path) -> tuple[dict[str, Any] | None, str, str]:
+    """`(manifest_or_None, status, detail)` for one run directory. Never raises.
+
+    `None` means "not readable as a manifest object" - missing, empty, truncated, malformed, locked
+    (a Windows `FileShare.None` handle raises `OSError`), or valid JSON that is not an object. Each
+    of those used to be a silent `continue`, which is how a run directory contributed zero to every
+    bucket of a GATE.
+    """
+    manifest_path = run_dir / "run.json"
+    try:
+        if not manifest_path.is_file():
+            return (
+                None,
+                MANIFEST_UNREADABLE,
+                (
+                    "run.json is missing - a directory exists but nothing describes it (allocation "
+                    "interrupted after mkdir, or a hand-made directory)"
+                ),
+            )
+        raw = manifest_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return None, MANIFEST_UNREADABLE, f"run.json could not be read ({exc.__class__.__name__}: {exc})"
+
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        empty = " (the file is empty)" if not raw.strip() else ""
+        return None, MANIFEST_UNREADABLE, f"run.json is not valid JSON{empty} ({exc.__class__.__name__}: {exc})"
+
+    # Valid JSON that is not an object is not a manifest. `.get`/`.setdefault` on a list raise
+    # `AttributeError`, which used to escape the `JSONDecodeError`/`OSError` guard entirely.
+    if not isinstance(data, dict):
+        return None, MANIFEST_UNREADABLE, f"run.json holds valid JSON that is not an object ({type(data).__name__})"
+
+    problem = _run_number_problem(data)
+    if problem is not None:
+        return data, MANIFEST_INVALID, f"run.json parsed, but {problem}"
+    return data, MANIFEST_OK, "run.json parsed and carries a usable run number"
+
+
+def _run_entry(run_dir: Path) -> dict[str, Any]:
+    """One entry for `list_runs`/`verify_runs`: the manifest (when there is one) plus the derived
+    `root`, `manifest_status`, `manifest_detail` and `location_check` keys."""
+    data, status, detail = _read_run_manifest(run_dir)
+    entry: dict[str, Any] = dict(data) if isinstance(data, dict) else {}
+    entry["root"] = str(run_dir)
+    entry[MANIFEST_STATUS_KEY] = status
+    entry[MANIFEST_DETAIL_KEY] = detail
+    check = check_run_location(data, run_dir) if data is not None else _unassessable(run_dir, detail)
+    entry["location_check"] = check.as_dict()
+    return entry
+
+
+def _run_sort_key(entry: dict[str, Any]) -> tuple[int, int, str]:
+    """Type-stable ordering: usable run numbers first and in numeric order, everything else after
+    them by directory name. Sorting on the raw `run` value raised `TypeError` on a tree holding both
+    `{"run": 1}` and `{"run": "two"}` - see `_run_number_problem`.
+    """
+    name = str(entry.get("location_check", {}).get("actual_dir_name", ""))
+    run_number = entry.get("run")
+    if isinstance(run_number, bool) or not isinstance(run_number, int):
+        return (1, 0, name)
+    return (0, run_number, name)
+
+
+def _collect_runs(repo_root: Path | None = None) -> list[dict[str, Any]]:
+    """EVERY run directory under `_runs/`, assessable or not, sorted by `_run_sort_key`.
+
+    This is the discovery primitive both `list_runs` (inspection, which filters) and `verify_runs`
+    (the gate, which must not) are built from. Splitting them is the fix for the fail-open defect:
+    inspection is entitled to skip a directory it cannot read, a gate never is.
+    """
+    entries = [_run_entry(run_dir) for run_dir in _iter_run_dirs(runs_root(repo_root))]
+    entries.sort(key=_run_sort_key)
+    return entries
+
+
 def list_runs(repo_root: Path | None = None) -> list[dict[str, Any]]:
-    """Read back every run's manifest, sorted by run number. Pure inspection - never mutates, and
+    """Read back every run's manifest, sorted by run number. Pure INSPECTION - never mutates, and
     never raises on a hand-created or half-written run directory; it just skips one with no
     readable `run.json` rather than crashing a status query over it.
 
-    Two keys are DERIVED and overwrite anything of the same name in the manifest, because both
-    describe where the run is *now* and a stale recorded value silently presented as current is the
-    failure this whole function is being audited for:
+    ⚠️ That skip is why this function must never be a gate's only input. A run directory it omits is
+    invisible, not clean. `verify_runs` deliberately does NOT go through here - it reports every
+    discovered directory, and classifies an unreadable one `unverifiable`. If you are deciding
+    whether a tree is healthy, call `verify_runs`.
+
+    Four keys are DERIVED and overwrite anything of the same name in the manifest, because all four
+    describe the run *now* and a stale recorded value silently presented as current is the failure
+    this whole function is being audited for:
 
     * `root` - the directory it was actually found in.
+    * `manifest_status` / `manifest_detail` - `MANIFEST_OK` or `MANIFEST_INVALID` here (an
+      unreadable manifest never survives the filter).
     * `location_check` - `check_run_location(...).as_dict()`, i.e. `intact` / `moved` /
       `unverifiable`. Read `location_check["state"]`; never infer health from `root` alone, which is
       derived from wherever the directory sits and so is true by construction (issue #470).
     """
-    root = runs_root(repo_root)
-    if not root.is_dir():
-        return []
-    manifests: list[dict[str, Any]] = []
-    for child in sorted(root.iterdir()):
-        manifest_path = child / "run.json"
-        if not manifest_path.is_file():
-            continue
-        try:
-            data = json.loads(manifest_path.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, OSError):
-            continue
-        # A `run.json` holding valid JSON that is not an object (a list, a bare string, a number) is
-        # not a manifest. Skipping it keeps the "never raises" promise literally true - `.get` and
-        # `.setdefault` on a list raise `AttributeError`, which used to escape this function.
-        if not isinstance(data, dict):
-            continue
-        data["root"] = str(child)
-        data["location_check"] = check_run_location(data, child).as_dict()
-        manifests.append(data)
-    manifests.sort(key=lambda m: m.get("run", 0))
-    return manifests
+    return [entry for entry in _collect_runs(repo_root) if entry[MANIFEST_STATUS_KEY] != MANIFEST_UNREADABLE]
 
 
 def verify_runs(repo_root: Path | None = None) -> tuple[list[dict[str, Any]], dict[str, int]]:
-    """Every run plus a count per `RUN_LOCATION_STATES` entry. Pure inspection, like `list_runs`."""
-    runs = list_runs(repo_root)
+    """Every run DIRECTORY plus a count per `RUN_LOCATION_STATES` entry. Read-only, but a GATE.
+
+    ⚠️ It does not filter, and that is the whole point. Built on `list_runs` it inherited
+    inspection's right to skip: a `_runs/001-acme/` whose `run.json` was missing, empty, truncated,
+    malformed, locked, or valid-JSON-but-not-an-object contributed ZERO to every bucket, and the CLI
+    printed `0 run(s): 0 intact, 0 moved, 0 unverifiable`, exit 0 - the `unverifiable` bucket
+    sitting at 0 precisely when something was unverifiable. Every discovered directory is counted
+    now, and one that cannot be assessed counts as `unverifiable` (exit 3).
+    """
+    runs = _collect_runs(repo_root)
     counts = {state: 0 for state in RUN_LOCATION_STATES}
     for run in runs:
         state = run.get("location_check", {}).get("state", RUN_LOCATION_UNVERIFIABLE)
@@ -509,11 +793,11 @@ def verify_exit_code(counts: dict[str, int]) -> int:
 
 def _print_verify_text(runs: list[dict[str, Any]], counts: dict[str, int], root: Path) -> None:
     """Human-readable `--verify` report. The STATE is printed in caps and first on every line, so a
-    subordinate `derived name check` hint can never be mistaken for the verdict.
+    subordinate `derived name check` or `path check` hint can never be mistaken for the verdict.
     """
     print(f"_runs/ location check: {root}")
     if not runs:
-        print("  (no runs with a readable run.json)")
+        print("  (no run directories found)")
     for run in runs:
         check = run.get("location_check", {})
         print(f"  {check.get('state', '?').upper():<13} {check.get('actual_dir_name', '?')}")
@@ -521,7 +805,10 @@ def _print_verify_text(runs: list[dict[str, Any]], counts: dict[str, int], root:
     summary = ", ".join(f"{counts.get(state, 0)} {state}" for state in RUN_LOCATION_STATES)
     print(f"{len(runs)} run(s): {summary}")
     if counts.get(RUN_LOCATION_UNVERIFIABLE):
-        print("  'unverifiable' is NOT 'intact' - those runs predate path recording and cannot be checked.")
+        print(
+            "  'unverifiable' is NOT 'intact' - those runs could not be assessed (no readable "
+            "run.json, no recorded allocation path, or relocated since allocation)."
+        )
 
 
 def main() -> int:

--- a/scripts/work_dirs.py
+++ b/scripts/work_dirs.py
@@ -62,10 +62,15 @@ under `allocated_abs_path`, and `check_run_location` (surfaced by `list_runs` an
 is NOT a soft `intact` - see `check_run_location`.
 
 `--verify` is a GATE, not a status query: exit 0 all intact / 1 at least one moved / 3 at least one
-unverifiable. A run directory it cannot read at all - `run.json` missing, empty, truncated,
-malformed, locked, or holding valid JSON that is not an object - is `unverifiable` and exits 3. It
-used to be skipped silently and counted in no bucket at all, which reported a half-written run as a
-clean tree. `list_runs` still skips those, because it is inspection rather than a gate.
+unverifiable. It rests on ONE invariant, implemented in one discovery function and one
+classification function: every child directory of an existing `_runs/` root is a candidate run, any
+candidate whose identity cannot be POSITIVELY established from its own evidence is `unverifiable`,
+and `intact` is only ever returned on positive proof. So a run directory it cannot read at all -
+`run.json` missing, empty, truncated, malformed, locked, holding valid JSON that is not an object,
+carrying a run number that contradicts its own directory, or recording a path that is not absolute
+- is `unverifiable` and exits 3. It used to be skipped silently and counted in no bucket at all,
+which reported a half-written run as a clean tree. `list_runs` still skips those, because it is
+inspection rather than a gate.
 
 Map: `docs/INDEX.md`. The same rule is stated in `docs/migration-phases.md` (Phase 1) and
 `docs/operator-runbook.md` (section 6.4, Scratch).
@@ -84,6 +89,7 @@ import argparse
 import json
 import os
 import re
+import stat
 import sys
 import unicodedata
 from dataclasses import dataclass
@@ -364,15 +370,96 @@ class RunLocationCheck:
         }
 
 
+# --------------------------------------------------------------------------------------------
+# THE ONE INVARIANT - and the two functions that implement it
+# --------------------------------------------------------------------------------------------
+# Every child DIRECTORY of an existing `_runs/` root is a candidate run. Any candidate whose
+# identity cannot be POSITIVELY established from its own evidence is `unverifiable`. `intact` is
+# only ever returned on positive proof.
+#
+# It is implemented at exactly TWO places on purpose, and adding a third is how the defect class
+# comes back:
+#
+#   * `_discover_run_dirs`  decides what a CANDIDATE is. It filters on nothing except "is this
+#     child a directory", and it never turns an error into an empty list.
+#   * `check_run_location`  decides the VERDICT. It is the only function in this module that can
+#     construct `RUN_LOCATION_INTACT`, and it does so on its last line, after every requirement
+#     below has held. Everything it calls computes a FACT (a normalized path, a derived name, a
+#     reason string) and chooses no state.
+#
+# ⚠️ Why the structure rather than more checks. Round 1 of PR #477's review fixed one fail-open
+# site (`list_runs` was the gate's only input, so an unreadable run counted as nothing). Round 2
+# then found the SAME defect class at three MORE sites - the path comparison accepted a relative
+# recorded value completed against the verifier's own CWD; discovery dropped any directory whose
+# name no longer matched `<NNN>` and had no `run.json`, and turned an `OSError` on the root into
+# zero runs; and the run-number check never compared the number against the directory it sits in.
+# Three more local guards would have left a fourth site to find. `tests/test_work_dirs.py` pins the
+# collapse structurally: `intact` may be CONSTRUCTED at exactly one site in this file.
+
+
+#: Two unrelated anchors used to decide whether a RECORDED path names a fixed location at all.
+#: BOTH are required, because neither alone is sufficient on Windows: the driveless `\wd-anchor`
+#: absorbs a drive-relative `\_runs\001-acme` (`ntpath.join` keeps the second operand's root), while
+#: the drive-bearing `Z:\wd-anchor` completes it and so exposes it. On POSIX the first is simply a
+#: relative anchor and the second is `/wd-anchor`; both reject a relative value and accept an
+#: absolute one, so the pair needs no `os.name` branch.
+_LOCATION_ANCHORS: tuple[str, ...] = ("Z:" + os.sep + "wd-anchor", os.sep + "wd-anchor")
+
+
+def _is_location_independent(value: str) -> bool:
+    """True only when `value` names the SAME place no matter where the checking process stands.
+
+    ⚠️ This is NOT `os.path.isabs`, and the difference is a measured fail-open defect (PR #477,
+    review round 2, finding 1). `allocated_abs_path` is *required* to be absolute, but the
+    comparison ran the recorded value through `abspath()`, which happily completes a RELATIVE
+    value against the verifier's current directory. Recording
+    `_review477_round2_attacks\\relative-path\\_runs\\001-acme` and running the CLI from the right
+    directory produced `INTACT 001-acme`, exit 0 - a location verdict that depended on where the
+    operator happened to be standing, in the one module that exists to be CWD-independent.
+
+    `isabs` is also the wrong predicate here and a version-dependent one: on Windows it answered
+    True for the drive-relative `\\_runs\\001-acme` before Python 3.13 and False from 3.13 on, and
+    a drive-relative path still resolves against the CURRENT drive. So the property is tested
+    directly instead, as two facts that are both needed: the value must be rooted within whatever
+    drive it names (`C:001-acme` is not), and it must name a drive or root of its own, which is
+    established by joining it onto unrelated anchors and demanding it come back unchanged.
+    Anything a CWD, or a current drive, would complete fails one of the two.
+    """
+    try:
+        # Fact 1 - the path must be rooted WITHIN whatever drive it names. `C:001-acme` carries a
+        # drive and is still completed against that drive's current directory, and it survives the
+        # anchor test below (`ntpath.join` returns a different-drive operand untouched), so the two
+        # facts are both load-bearing and neither alone is this predicate.
+        _drive, rest = os.path.splitdrive(value)
+        separators = (os.sep,) if os.altsep is None else (os.sep, os.altsep)
+        if not rest.startswith(separators):
+            return False
+        # Fact 2 - and it must name a drive/root of its own. A driveless `\_runs\001-acme` passes
+        # fact 1 and still resolves against the CURRENT drive; joining it onto a drive-bearing
+        # anchor changes it, joining an absolute path onto any anchor does not.
+        plain = os.path.normcase(os.path.normpath(value))
+        return all(
+            os.path.normcase(os.path.normpath(os.path.join(anchor, value))) == plain for anchor in _LOCATION_ANCHORS
+        )
+    except (OSError, ValueError):  # a NUL byte or an otherwise unrepresentable path
+        return False
+
+
 def _normalized_path(path: Any) -> str | None:
-    """One comparable spelling of a path, or None if it cannot be formed. Used on BOTH sides -
-    written into the manifest by `allocate_run` and read back by `check_run_location` - so the
-    normalization rule cannot drift between record and check.
+    """One comparable spelling of a path, or None if it cannot be formed.
 
     `abspath` (not `resolve`) on purpose: it normalizes separators, `..` and case-folding without
     reading the filesystem, which keeps `check_run_location` pure. Returning None on a path that
-    cannot be normalized is fail-safe: None never compares equal to anything, including itself, so a
-    broken value can only ever produce `unverifiable`, never a false `intact`.
+    cannot be normalized is fail-safe: None never compares equal to anything, including itself, so
+    a broken value can only ever produce `unverifiable`, never a false `intact`.
+
+    ⚠️ The two sides are NOT symmetrical, and pretending they were is finding 1. Completing the
+    ACTUAL run directory against the CWD is correct - it is a live path this process just
+    enumerated from a root the caller named, so it really is there. Completing the RECORDED value
+    the same way is not: it was written by a different process, at a different time, from a
+    different directory, and only an absolute value carries any meaning across that gap. The
+    recorded side therefore has to clear `_is_location_independent` BEFORE it reaches this
+    function - see `_recorded_path_problem`.
     """
     try:
         return os.path.normcase(os.path.abspath(str(path)))
@@ -380,11 +467,27 @@ def _normalized_path(path: Any) -> str | None:
         return None
 
 
-def _same_path(recorded: Any, actual: Path) -> bool:
+def _same_path(recorded: str, actual: Path) -> bool:
     """True only when both sides normalize AND are equal. Never true on an unusable value."""
     left = _normalized_path(recorded)
     right = _normalized_path(actual)
     return left is not None and right is not None and left == right
+
+
+def _recorded_path_problem(value: Any) -> str | None:
+    """Why `manifest[RUN_PATH_KEY]` cannot serve as evidence of where a run was allocated, or None.
+
+    A fact, not a verdict - `check_run_location` decides what to do with it.
+    """
+    if not isinstance(value, str) or not value:
+        return f"no usable {RUN_PATH_KEY!r} was recorded ({value!r})"
+    if not _is_location_independent(value):
+        return (
+            f"its recorded {RUN_PATH_KEY!r} ({value!r}) is not an absolute path, so it names no fixed "
+            "location - it would be completed against the VERIFIER's current directory, which makes the "
+            "verdict depend on where the check was run from rather than on where the run is"
+        )
+    return None
 
 
 def _run_number_problem(manifest: dict[str, Any]) -> str | None:
@@ -405,134 +508,114 @@ def _run_number_problem(manifest: dict[str, Any]) -> str | None:
     return None
 
 
-def _unassessable(run_dir: Path, detail: str) -> RunLocationCheck:
-    """The verdict for a run directory whose manifest could not be read or parsed at all."""
-    return RunLocationCheck(
-        state=RUN_LOCATION_UNVERIFIABLE,
-        actual_dir_name=run_dir.name,
-        recorded_dir_name=None,
-        derived_name_check=DERIVED_NAME_UNAVAILABLE,
-        path_check=PATH_CHECK_UNRECORDED,
-        detail=detail,
-    )
+def _name_agreement(manifest: dict[str, Any], actual: str) -> tuple[str, str | None]:
+    """`(derived_name_check, problem_or_None)` for "does this manifest's own identity match the
+    directory it sits in?".
+
+    ⚠️ This is finding 3 of PR #477's second review round, and it is why `_derived_dir_name` is
+    consulted on the healthy path at all. `_run_number_problem` only ever checked that `run` was a
+    non-negative integer, never that it AGREED with the `<NNN>-<slug>` directory. Changing nothing
+    but `"run"` in a freshly allocated `001-acme` - to `2`, or to `10**100` - was reported `1
+    intact`, exit 0. The run number IS the identity in this convention (issue #234), so a manifest
+    claiming a number its own directory does not carry is CONTRADICTORY evidence: `unverifiable`,
+    not healthy, and not `moved` either, because which of the two is wrong is not established.
+    """
+    derived = _derived_dir_name(manifest)
+    if derived is None:
+        return DERIVED_NAME_UNAVAILABLE, "its own 'run'/'unit_key' cannot reconstruct a directory name to check against"
+    if derived != actual:
+        return DERIVED_NAME_MISMATCH, (
+            f"its own 'run'/'unit_key' name {derived!r}, which CONTRADICTS the directory {actual!r} it "
+            "sits in - the run number is the identity of a run, so a manifest claiming a different one "
+            "is contradictory evidence, not a healthy run"
+        )
+    return DERIVED_NAME_MATCHES, None
 
 
-def _check_legacy_name(manifest: dict[str, Any], run_dir: Path, recorded: Any) -> RunLocationCheck:
-    """The `unverifiable` branch for a manifest that records no usable directory NAME - every run
-    allocated before `RUN_LOCATION_KEY` existed, plus any hand-edited or corrupted value.
+def _legacy_name_hint(manifest: dict[str, Any], actual: str, recorded: Any) -> tuple[str, str]:
+    """`(derived_name_check, detail)` for a manifest that records no usable directory NAME - every
+    run allocated before `RUN_LOCATION_KEY` existed, plus any hand-edited or corrupted value.
 
-    A subordinate hint reconstructs the name the manifest's own `run`/`unit_key` IMPLY, but it can
-    never promote the run out of `unverifiable`: an inference is not a record.
+    A subordinate hint reconstructs the name the manifest's own `run`/`unit_key` IMPLY. It can never
+    promote the run out of `unverifiable`: an inference is not a record, and the caller below does
+    not offer it that option.
     """
     if recorded is None:
         missing = f"no {RUN_LOCATION_KEY!r} recorded (allocated before this key existed)"
     else:
         missing = f"{RUN_LOCATION_KEY!r} is present but is not a usable directory name ({recorded!r})"
 
-    derived = _derived_dir_name(manifest)
-    actual = run_dir.name
-    if derived is None:
-        hint, why = DERIVED_NAME_UNAVAILABLE, "and its own run/unit_key cannot reconstruct one either"
-    elif derived == actual:
-        hint, why = DERIVED_NAME_MATCHES, f"its run/unit_key imply {derived!r}, which matches - but that is INFERENCE"
+    hint, problem = _name_agreement(manifest, actual)
+    if hint == DERIVED_NAME_UNAVAILABLE:
+        why = "and its own run/unit_key cannot reconstruct one either"
+    elif hint == DERIVED_NAME_MATCHES:
+        why = f"its run/unit_key imply {_derived_dir_name(manifest)!r}, which matches - but that is INFERENCE"
     else:
-        hint, why = (
-            DERIVED_NAME_MISMATCH,
-            f"its run/unit_key imply {derived!r}, which does NOT match {actual!r} - likely renamed or "
-            "renumbered, but that is INFERENCE, not a record",
-        )
-    return RunLocationCheck(
-        state=RUN_LOCATION_UNVERIFIABLE,
-        actual_dir_name=actual,
-        recorded_dir_name=None,
-        derived_name_check=hint,
-        path_check=PATH_CHECK_NOT_CONSULTED,
-        detail=f"{missing}; {why}",
-    )
+        why = f"{problem} - but that is INFERENCE, not a record"
+    return hint, f"{missing}; {why}"
 
 
-def _check_intact_candidate(manifest: dict[str, Any], run_dir: Path, recorded: str) -> RunLocationCheck:
-    """A run whose recorded NAME matches where it sits. That is necessary for `intact`, never
-    sufficient - the name is a basename, and a basename survives both a run-only move and a copy.
-
-    Three ways it still fails to be `intact`, all `unverifiable` rather than `moved`, because none
-    of them ESTABLISHES corruption:
-
-    * the manifest carries no usable run number, so it is not an assessable manifest at all;
-    * no absolute allocation path was recorded (`RUN_PATH_KEY`), so a move cannot be excluded;
-    * a path was recorded and it is not where the run now sits. This is a relocation - but whether
-      the whole checkout moved (legitimate) or this run alone was moved or copied (corruption)
-      CANNOT be told apart from one run's evidence, and both break the absolute self-paths embedded
-      under `<run>/bundle/` anyway. Reporting `intact` here is the defect being fixed; reporting
-      `moved` would claim a finding that has not been established.
-    """
-    problem = _run_number_problem(manifest)
-    if problem is not None:
-        return RunLocationCheck(
-            state=RUN_LOCATION_UNVERIFIABLE,
-            actual_dir_name=run_dir.name,
-            recorded_dir_name=recorded,
-            derived_name_check=DERIVED_NAME_NOT_CONSULTED,
-            path_check=PATH_CHECK_NOT_CONSULTED,
-            detail=f"its recorded name {recorded!r} matches where it sits, but {problem} - so this is not an "
-            "assessable manifest and its location cannot be confirmed",
-        )
-
-    recorded_path = manifest.get(RUN_PATH_KEY)
-    if not isinstance(recorded_path, str) or not recorded_path:
-        return RunLocationCheck(
-            state=RUN_LOCATION_UNVERIFIABLE,
-            actual_dir_name=run_dir.name,
-            recorded_dir_name=recorded,
-            derived_name_check=DERIVED_NAME_NOT_CONSULTED,
-            path_check=PATH_CHECK_UNRECORDED,
-            detail=f"allocated as {recorded!r} and still named that, but no usable {RUN_PATH_KEY!r} was recorded "
-            "- a basename survives a run-only move and a copy, so 'still there' cannot be confirmed",
-        )
-
-    if _same_path(recorded_path, run_dir):
-        return RunLocationCheck(
-            state=RUN_LOCATION_INTACT,
-            actual_dir_name=run_dir.name,
-            recorded_dir_name=recorded,
-            derived_name_check=DERIVED_NAME_NOT_CONSULTED,
-            path_check=PATH_CHECK_MATCHES,
-            detail=f"allocated as {recorded!r} at {recorded_path} and still there",
-        )
-
+def _unverifiable(
+    run_dir: Path,
+    detail: str,
+    *,
+    recorded_dir_name: str | None = None,
+    derived_name_check: str = DERIVED_NAME_NOT_CONSULTED,
+    path_check: str = PATH_CHECK_NOT_CONSULTED,
+) -> RunLocationCheck:
+    """Construct the fail-closed verdict. Every failing branch of `check_run_location` comes here,
+    so "could not establish" is the DEFAULT shape of a verdict in this module and `intact` is the
+    single exception that has to be earned."""
     return RunLocationCheck(
         state=RUN_LOCATION_UNVERIFIABLE,
         actual_dir_name=run_dir.name,
-        recorded_dir_name=recorded,
-        derived_name_check=DERIVED_NAME_NOT_CONSULTED,
-        path_check=PATH_CHECK_DIFFERS,
-        detail=f"allocated at {recorded_path} but found at {os.path.abspath(str(run_dir))} - the name is "
-        "unchanged, so this is a RELOCATION, not a rename. Moving the whole checkout and moving/copying this "
-        "run alone are indistinguishable from here, and BOTH break the absolute self-paths embedded under "
-        "bundle/, so re-check every bundle under this run rather than reading it as healthy",
+        recorded_dir_name=recorded_dir_name,
+        derived_name_check=derived_name_check,
+        path_check=path_check,
+        detail=detail,
     )
 
 
+def _unassessable(run_dir: Path, detail: str) -> RunLocationCheck:
+    """The verdict for a run directory whose manifest could not be read or parsed at all."""
+    return _unverifiable(
+        run_dir,
+        detail,
+        derived_name_check=DERIVED_NAME_UNAVAILABLE,
+        path_check=PATH_CHECK_UNRECORDED,
+    )
+
+
+# pylint: disable-next=too-many-return-statements
 def check_run_location(manifest: Any, run_dir: Path) -> RunLocationCheck:
     """Compare where a run says it was allocated against where it actually sits. Pure: reads a
     manifest dict and a path, touches no disk, mutates nothing, and never raises (issue #470).
 
+    ⚠️ **This is the module's single classification path, and the eight returns below are one
+    ordered ladder of REQUIREMENTS, not eight independent guards.** Splitting them across helpers
+    that each decided a state is what let three further fail-open sites survive round 1 of PR
+    #477's review (see the invariant block above); keeping the whole sequence here is deliberate,
+    and so is the `too-many-return-statements` waiver. Everything it calls returns a fact.
+
     Three states, and the third is the point:
 
-    * `intact` - the recorded `<NNN>-<slug>` name equals the directory's actual name AND the
-      recorded absolute path equals where the directory actually sits. Both, because a basename
-      survives a run-only move and a copy (see `RUN_PATH_KEY`).
+    * `intact` - EVERY requirement held: `run.json` is an object, it records a `<NNN>-<slug>` name
+      equal to this directory's own, it carries a usable run number, that number and `unit_key`
+      reconstruct the directory it sits in, and it records an absolute allocation path that is
+      where the directory actually is. Reached on the last line and nowhere else.
     * `moved` - the recorded name and the actual name differ. The run has been renamed or
       renumbered since allocation, so generated bundle output beneath it embeds absolute self-paths
-      that no longer resolve. Both names are reported so the damage is locatable.
-    * `unverifiable` - the question cannot be answered from the evidence: no usable manifest, no
-      recorded name, no recorded path, or a recorded path that is not where the run now sits. It is
-      not a pass and it is not a failure; it means the answer is unknown, which is a different
-      thing from answering it "fine".
+      that no longer resolve. Both names are reported so the damage is locatable. It is the ONLY
+      failure that is an established finding rather than an unanswered question.
+    * `unverifiable` - the question cannot be answered from the evidence. Not a pass and not a
+      failure: the answer is unknown, which is a different thing from answering it "fine".
 
     `manifest` is typed `Any` on purpose - a hand-written `run.json` can hold a list, a string or a
     number, and this function must return a verdict for it rather than raise.
     """
+    actual = run_dir.name
+
+    # Requirement 0 - it is a manifest at all.
     if not isinstance(manifest, dict):
         return _unassessable(
             run_dir,
@@ -541,11 +624,9 @@ def check_run_location(manifest: Any, run_dir: Path) -> RunLocationCheck:
         )
 
     recorded = manifest.get(RUN_LOCATION_KEY)
-    if not isinstance(recorded, str) or not recorded:
-        return _check_legacy_name(manifest, run_dir, recorded)
 
-    actual = run_dir.name
-    if recorded != actual:
+    # The one ESTABLISHED finding: a recorded name that differs from the directory's own.
+    if isinstance(recorded, str) and recorded and recorded != actual:
         return RunLocationCheck(
             state=RUN_LOCATION_MOVED,
             actual_dir_name=actual,
@@ -559,7 +640,69 @@ def check_run_location(manifest: Any, run_dir: Path) -> RunLocationCheck:
             ),
         )
 
-    return _check_intact_candidate(manifest, run_dir, recorded)
+    # Requirement 1 - a recorded directory name to compare at all.
+    if not isinstance(recorded, str) or not recorded:
+        hint, detail = _legacy_name_hint(manifest, actual, recorded)
+        return _unverifiable(run_dir, detail, derived_name_check=hint)
+
+    # Requirement 2 - a usable run number, because the number is the identity.
+    problem = _run_number_problem(manifest)
+    if problem is not None:
+        return _unverifiable(
+            run_dir,
+            f"its recorded name {recorded!r} matches where it sits, but {problem} - so this is not an "
+            "assessable manifest and its location cannot be confirmed",
+            recorded_dir_name=recorded,
+        )
+
+    # Requirement 3 - that number and `unit_key` must reconstruct THIS directory (finding 3).
+    hint, disagreement = _name_agreement(manifest, actual)
+    if disagreement is not None:
+        return _unverifiable(
+            run_dir,
+            f"its recorded name {recorded!r} matches where it sits, but {disagreement}",
+            recorded_dir_name=recorded,
+            derived_name_check=hint,
+        )
+
+    # Requirement 4 - an absolute allocation path, because a basename survives a move and a copy.
+    recorded_path = manifest.get(RUN_PATH_KEY)
+    path_problem = _recorded_path_problem(recorded_path)
+    if path_problem is not None:
+        return _unverifiable(
+            run_dir,
+            f"allocated as {recorded!r} and still named that, but {path_problem} - a basename survives a "
+            "run-only move and a copy, so 'still there' cannot be confirmed",
+            recorded_dir_name=recorded,
+            derived_name_check=hint,
+            path_check=PATH_CHECK_UNRECORDED,
+        )
+
+    # Requirement 5 - that path is where the directory actually sits. A relocation is `unverifiable`
+    # rather than `moved`: whether the whole checkout moved (legitimate) or this run alone was moved
+    # or copied (corruption) cannot be told apart from one run's evidence, and both break the
+    # absolute self-paths embedded under `<run>/bundle/` anyway.
+    if not _same_path(recorded_path, run_dir):
+        return _unverifiable(
+            run_dir,
+            f"allocated at {recorded_path} but found at {os.path.abspath(str(run_dir))} - the name is "
+            "unchanged, so this is a RELOCATION, not a rename. Moving the whole checkout and moving/copying "
+            "this run alone are indistinguishable from here, and BOTH break the absolute self-paths embedded "
+            "under bundle/, so re-check every bundle under this run rather than reading it as healthy",
+            recorded_dir_name=recorded,
+            derived_name_check=hint,
+            path_check=PATH_CHECK_DIFFERS,
+        )
+
+    # Every requirement held. This is the ONLY `intact` in the module - see the invariant block.
+    return RunLocationCheck(
+        state=RUN_LOCATION_INTACT,
+        actual_dir_name=actual,
+        recorded_dir_name=recorded,
+        derived_name_check=hint,
+        path_check=PATH_CHECK_MATCHES,
+        detail=f"allocated as {recorded!r} at {recorded_path} and still there",
+    )
 
 
 def allocate_run(
@@ -635,29 +778,61 @@ def allocate_run(
     )
 
 
-def _iter_run_dirs(root: Path) -> list[Path]:
-    """Every child of `_runs/` that is a run DIRECTORY, readable manifest or not.
+def _discover_run_dirs(root: Path) -> tuple[list[Path], str | None]:
+    """`(candidates, root_problem)` - the module's one discovery site. Never raises.
 
-    A child counts if its name matches the `<NNN>[-slug]` allocation pattern (the same rule
-    `_existing_run_numbers` uses, so anything that OCCUPIES a run number is also assessed) or if it
-    holds a `run.json` at all. Sorted by name so the caller starts from a stable order.
+    EVERY child directory of an existing `_runs/` root is a candidate run. There is no name
+    pattern and no "has a `run.json`" precondition, because both were fail-open filters and both
+    are finding 2 of PR #477's second review round: a real allocated run whose directory was
+    renamed to `acme-without-number` and whose manifest was deleted matched neither test, so the
+    CLI printed `(no run directories found)`, `0 run(s): 0 intact, 0 moved, 0 unverifiable`, exit
+    0. Round 1 had stopped `list_runs` from dropping runs it could not read; discovery was dropping
+    them one layer earlier. Deciding whether a directory is a run is exactly the question
+    `check_run_location` exists to answer from evidence - so discovery must not pre-answer it.
+
+    ⚠️ `root_problem` is the other half, and it is why this returns a pair rather than a list. An
+    `OSError` from enumerating the root used to become an empty list, i.e. "zero runs, exit 0",
+    while the runs underneath it still existed and simply could not be assessed. That is NOT the
+    accepted "the run was deleted entirely" residual: the tree is there. The caller turns a
+    `root_problem` into an `unverifiable` entry, so the gate exits 3.
+
+    Only a root that genuinely does not exist yields `([], None)` - nothing has been allocated, and
+    a tree with no runs in it is legitimately clean.
     """
-    if not root.is_dir():
-        return []
-    found: list[Path] = []
+    try:
+        root_mode = os.stat(root).st_mode
+    except FileNotFoundError:
+        return [], None
+    except OSError as exc:
+        return [], (
+            f"the _runs root at {root} exists but could not be examined "
+            f"({exc.__class__.__name__}: {exc}) - any run beneath it is undiscoverable, which is "
+            "not the same as there being none"
+        )
+    if not stat.S_ISDIR(root_mode):
+        return [], f"the _runs root at {root} exists but is not a directory, so no run under it can be discovered"
+
     try:
         children = sorted(root.iterdir())
-    except OSError:  # pragma: no cover - the root vanished or is unreadable mid-scan
-        return []
+    except OSError as exc:
+        return [], (
+            f"the _runs root at {root} could not be listed ({exc.__class__.__name__}: {exc}) - any "
+            "run beneath it is undiscoverable, which is not the same as there being none"
+        )
+
+    found: list[Path] = []
     for child in children:
         try:
-            if not child.is_dir():
-                continue
-            if _RUN_DIR_RE.match(child.name) or (child / "run.json").is_file():
-                found.append(child)
-        except OSError:  # pragma: no cover - a child that cannot be stat'ed is still a directory
+            child_mode = os.stat(child).st_mode
+        except OSError:
+            # Cannot establish that this is NOT a run directory, so it is assessed rather than
+            # skipped. `Path.is_dir()` is unusable here: it swallows OSError and answers False,
+            # which is the fail-open shape - "I could not look" reported as "it is not one".
             found.append(child)
-    return found
+            continue
+        if stat.S_ISDIR(child_mode):
+            found.append(child)
+    return found, None
 
 
 def _read_run_manifest(run_dir: Path) -> tuple[dict[str, Any] | None, str, str]:
@@ -680,12 +855,19 @@ def _read_run_manifest(run_dir: Path) -> tuple[dict[str, Any] | None, str, str]:
                 ),
             )
         raw = manifest_path.read_text(encoding="utf-8")
-    except OSError as exc:
+    except (OSError, ValueError) as exc:
+        # `ValueError` covers `UnicodeDecodeError` - a `run.json` holding bytes that are not UTF-8
+        # raised it straight out of `read_text`, past a guard that named only `OSError`.
         return None, MANIFEST_UNREADABLE, f"run.json could not be read ({exc.__class__.__name__}: {exc})"
 
     try:
         data = json.loads(raw)
-    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+    except (ValueError, RecursionError) as exc:
+        # `ValueError`, not `json.JSONDecodeError`: a JSON integer with more than 4300 digits makes
+        # `json.loads` raise a bare `ValueError` from CPython's int/str conversion limit, which
+        # escaped the narrower guard and exited 1 with a traceback instead of reporting
+        # `unverifiable`. `RecursionError` is the same shape for deeply nested arrays. Both are
+        # fail-CLOSED, but this function documents that it never raises, so it must not.
         empty = " (the file is empty)" if not raw.strip() else ""
         return None, MANIFEST_UNREADABLE, f"run.json is not valid JSON{empty} ({exc.__class__.__name__}: {exc})"
 
@@ -725,14 +907,30 @@ def _run_sort_key(entry: dict[str, Any]) -> tuple[int, int, str]:
     return (0, run_number, name)
 
 
+def _root_problem_entry(root: Path, problem: str) -> dict[str, Any]:
+    """An `unverifiable` entry for the `_runs/` ROOT itself, when the root exists but its children
+    cannot be enumerated. Without it, `_discover_run_dirs`'s `root_problem` would have nowhere to
+    go and the gate would report an unreadable tree as an empty one - exit 0 (finding 2)."""
+    return {
+        "root": str(root),
+        MANIFEST_STATUS_KEY: MANIFEST_UNREADABLE,
+        MANIFEST_DETAIL_KEY: problem,
+        "location_check": _unassessable(root, problem).as_dict(),
+    }
+
+
 def _collect_runs(repo_root: Path | None = None) -> list[dict[str, Any]]:
-    """EVERY run directory under `_runs/`, assessable or not, sorted by `_run_sort_key`.
+    """EVERY candidate run under `_runs/`, assessable or not, sorted by `_run_sort_key`.
 
     This is the discovery primitive both `list_runs` (inspection, which filters) and `verify_runs`
     (the gate, which must not) are built from. Splitting them is the fix for the fail-open defect:
     inspection is entitled to skip a directory it cannot read, a gate never is.
     """
-    entries = [_run_entry(run_dir) for run_dir in _iter_run_dirs(runs_root(repo_root))]
+    root = runs_root(repo_root)
+    candidates, root_problem = _discover_run_dirs(root)
+    entries = [_run_entry(run_dir) for run_dir in candidates]
+    if root_problem is not None:
+        entries.append(_root_problem_entry(root, root_problem))
     entries.sort(key=_run_sort_key)
     return entries
 
@@ -770,6 +968,11 @@ def verify_runs(repo_root: Path | None = None) -> tuple[list[dict[str, Any]], di
     printed `0 run(s): 0 intact, 0 moved, 0 unverifiable`, exit 0 - the `unverifiable` bucket
     sitting at 0 precisely when something was unverifiable. Every discovered directory is counted
     now, and one that cannot be assessed counts as `unverifiable` (exit 3).
+
+    ⚠️ "Discovered" means what `_discover_run_dirs` returns, which is EVERY child directory of the
+    root plus the root itself when the root cannot be enumerated. A directory renamed out of the
+    `<NNN>-` pattern with its manifest deleted, and an `OSError` on the root, both used to produce
+    `0 run(s)`, exit 0, with the tree still sitting on disk.
     """
     runs = _collect_runs(repo_root)
     counts = {state: 0 for state in RUN_LOCATION_STATES}

--- a/tests/test_work_dirs.py
+++ b/tests/test_work_dirs.py
@@ -4,7 +4,9 @@
 Every test uses `tmp_path` as `repo_root` so this suite never touches the real repo's `_runs/`.
 """
 
+import ast
 import json
+import os
 import shutil
 import subprocess
 import sys
@@ -31,6 +33,7 @@ from work_dirs import (
     RUN_LOCATION_MOVED,
     RUN_LOCATION_UNVERIFIABLE,
     RUN_PATH_KEY,
+    _is_location_independent,  # the one private helper a test reaches for - see its test below
     allocate_run,
     check_run_location,
     list_runs,
@@ -322,8 +325,11 @@ def test_a_freshly_allocated_run_is_intact_and_is_not_moved_or_unverifiable(tmp_
     assert check["state"] != RUN_LOCATION_MOVED  # negative control
     assert check["state"] != RUN_LOCATION_UNVERIFIABLE  # negative control
     assert check["recorded_dir_name"] == check["actual_dir_name"] == "001-acme"
-    # the verdict must rest on the RECORD, never on the run/unit_key inference
-    assert check["derived_name_check"] == DERIVED_NAME_NOT_CONSULTED
+    # The inference is now CONSULTED on the healthy path - `run`/`unit_key` must reconstruct the
+    # directory the manifest sits in (finding 3), so a contradictory number cannot read as healthy.
+    # It can still only ever DEMOTE: `test_a_legacy_manifest_with_no_recorded_name_is_unverifiable_
+    # never_intact` is the negative control that a matching inference promotes nothing.
+    assert check["derived_name_check"] == DERIVED_NAME_MATCHES
 
 
 def test_a_renumbered_run_reports_moved_and_names_both_directories(tmp_path: Path) -> None:
@@ -741,12 +747,13 @@ def test_verify_exit_code_gates_on_state_never_on_printed_text(counts: dict, exp
     assert verify_exit_code(counts) == expected
 
 
-def _run_verify_cli(repo_root: Path) -> subprocess.CompletedProcess:
+def _run_verify_cli(repo_root: Path, cwd: Path | None = None) -> subprocess.CompletedProcess:
     return subprocess.run(
         [sys.executable, str(REPO_ROOT / "scripts" / "work_dirs.py"), "--verify", "--repo-root", str(repo_root)],
         capture_output=True,
         text=True,
         check=False,
+        cwd=None if cwd is None else str(cwd),
     )
 
 
@@ -870,3 +877,377 @@ def test_the_rename_prohibition_and_its_reason_are_stated_in_work_dirs_itself(tm
     # the granularity their agent got wrong: one run per pipeline run, not one per workbook
     assert "not one per workbook" in module_doc.lower()
     assert "not one per workbook" in allocate_doc.lower()
+
+
+# --------------------------------------------------------------------------------------
+# PR #477, review round 2 - the SAME fail-open class at three more sites, and the residual
+#
+# Round 1 fixed `list_runs` being the gate's only input. Round 2 found the identical defect in the
+# path comparison, in directory discovery and in run-number validation - the signature of a class
+# narrowed one site at a time. The fix collapses discovery and classification onto ONE path each;
+# these tests pin the reproductions AND the collapse, because a passing behaviour test would not
+# stop the next guard being bolted on beside them.
+# --------------------------------------------------------------------------------------
+
+
+def _work_dirs_source() -> str:
+    return (REPO_ROOT / "scripts" / "work_dirs.py").read_text(encoding="utf-8")
+
+
+# --- Finding 1: a relative "absolute" path forges `intact` from the verifier's own CWD ---
+
+
+def test_a_relative_recorded_path_is_unverifiable_not_intact(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """`allocated_abs_path` is REQUIRED to be absolute, but the comparison ran it through
+    `abspath()`, which completes a relative value against the verifier's current directory. Real
+    CLI, measured: recording `_review477_round2_attacks\\relative-path\\_runs\\001-acme` and
+    checking from the matching directory printed `INTACT 001-acme`, `1 intact`, exit 0.
+
+    The verdict therefore depended on where the operator was standing - in the one module that
+    exists to be CWD-independent (`REPO_ROOT` is resolved from `__file__`, never `Path.cwd()`)."""
+    run = allocate_run("acme", repo_root=tmp_path)
+    manifest = json.loads(run.manifest_path.read_text(encoding="utf-8"))
+    manifest[RUN_PATH_KEY] = str(Path("_runs") / "001-acme")  # resolves to the run dir from tmp_path
+    run.manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    monkeypatch.chdir(tmp_path)  # stand exactly where the forged value resolves
+
+    check = list_runs(tmp_path)[0]["location_check"]
+
+    assert check["state"] == RUN_LOCATION_UNVERIFIABLE
+    assert check["state"] != RUN_LOCATION_INTACT  # negative control: the defect being fixed
+    assert check["path_check"] == PATH_CHECK_UNRECORDED
+    assert "not an absolute path" in check["detail"]
+
+
+def test_verify_cli_exits_3_on_a_relative_recorded_path_even_from_the_matching_cwd(tmp_path: Path) -> None:
+    """The reviewer's reproduction end to end, judged by exit code: the CLI is run FROM the
+    directory the forged relative value resolves against, which is the only place it could ever
+    have looked healthy."""
+    run = allocate_run("acme", repo_root=tmp_path)
+    manifest = json.loads(run.manifest_path.read_text(encoding="utf-8"))
+    manifest[RUN_PATH_KEY] = str(Path("_runs") / "001-acme")
+    run.manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+
+    result = _run_verify_cli(tmp_path, cwd=tmp_path)
+
+    assert result.returncode == 3, result.stdout + result.stderr
+    assert "UNVERIFIABLE" in result.stdout
+    assert "INTACT" not in result.stdout
+    assert "1 unverifiable" in result.stdout
+
+
+@pytest.mark.parametrize(
+    ("value", "independent"),
+    [
+        # accepted: these name one place wherever the process is standing
+        (str(Path.cwd().resolve()), True),
+        (r"C:\runs\001-acme", os.name == "nt"),
+        ("//server/share/runs/001-acme", True),
+        # rejected: every one of these is completed against the process's CWD or current DRIVE
+        ("001-acme", False),
+        (str(Path("..") / "_runs" / "001-acme"), False),
+        (r"\_runs\001-acme", os.name != "nt"),  # Windows drive-relative; a plain absolute path on POSIX
+        ("C:001-acme", os.name != "nt"),  # drive-relative WITH a drive letter
+        ("", False),
+    ],
+)
+def test_only_a_location_independent_path_counts_as_a_recorded_location(value: str, independent: bool) -> None:
+    """The fact requirement 4 consumes, tested directly - the black-box route can only exercise it
+    from a CWD that happens to match, which is exactly why the defect survived review round 1.
+
+    ⚠️ `os.path.isabs` is not this predicate and would have missed two rows: on Windows it answered
+    True for `\\_runs\\001-acme` before Python 3.13 and False from 3.13 on, and a drive-relative
+    path still resolves against whatever drive the process is on. Both anchors are required - the
+    driveless one absorbs a drive-relative value (`ntpath.join` keeps the second operand's root),
+    the drive-bearing one exposes it."""
+    assert _is_location_independent(value) is independent
+
+
+def test_an_absolute_recorded_path_spelled_awkwardly_is_still_intact(tmp_path: Path) -> None:
+    """The negative control for finding 1, and the one that stops the fix being "reject everything":
+    an absolute path is still absolute after a `..` hop and a case change, and must stay `intact`."""
+    run = allocate_run("acme", repo_root=tmp_path)
+    manifest = json.loads(run.manifest_path.read_text(encoding="utf-8"))
+    awkward = Path(manifest[RUN_PATH_KEY]).parent / "no-such-dir" / ".." / "001-acme"
+    manifest[RUN_PATH_KEY] = str(awkward)
+    run.manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+
+    check = list_runs(tmp_path)[0]["location_check"]
+
+    assert check["state"] == RUN_LOCATION_INTACT
+    assert check["path_check"] == PATH_CHECK_MATCHES
+
+
+# --- Finding 2: discovery silently omitted existing run directories ---
+
+
+def test_a_run_renamed_out_of_the_number_pattern_with_no_manifest_is_still_discovered(tmp_path: Path) -> None:
+    """Discovery reported only children whose CURRENT name matched `<NNN>` or which still held a
+    `run.json`, so a real allocated run that lost both matched neither test. Measured on the real
+    CLI: `(no run directories found)`, `0 run(s): 0 intact, 0 moved, 0 unverifiable`, exit 0.
+
+    ⚠️ This is NOT the accepted "the run was deleted entirely" residual - the tree is still on
+    disk, it just cannot be assessed. Deciding whether a directory is a run is the question
+    `check_run_location` exists to answer from evidence, so discovery must not pre-answer it."""
+    run = allocate_run("acme", repo_root=tmp_path)
+    run.manifest_path.unlink()
+    run.root.rename(run.root.parent / "acme-without-number")
+
+    gated, counts = verify_runs(tmp_path)
+
+    assert [Path(entry["root"]).name for entry in gated] == ["acme-without-number"]
+    assert counts[RUN_LOCATION_UNVERIFIABLE] == 1
+    assert counts[RUN_LOCATION_INTACT] == 0  # negative control
+    assert verify_exit_code(counts) == 3
+    assert not list_runs(tmp_path)  # inspection may still skip it; only the GATE may not
+
+
+def test_verify_cli_exits_3_on_a_run_renamed_out_of_the_number_pattern(tmp_path: Path) -> None:
+    """Finding 2 through the real CLI, where it was reproduced, judged by exit code."""
+    run = allocate_run("acme", repo_root=tmp_path)
+    run.manifest_path.unlink()
+    run.root.rename(run.root.parent / "acme-without-number")
+
+    result = _run_verify_cli(tmp_path)
+
+    assert result.returncode == 3, result.stdout + result.stderr
+    assert "no run directories found" not in result.stdout
+    assert "1 run(s)" in result.stdout and "1 unverifiable" in result.stdout
+
+
+def test_a_hand_made_directory_with_no_number_and_no_manifest_is_discovered(tmp_path: Path) -> None:
+    """The same hole reached without a rename: any child directory is a candidate run."""
+    root = runs_root(tmp_path)
+    (root / "scratch-notes").mkdir(parents=True)
+
+    _gated, counts = verify_runs(tmp_path)
+
+    assert counts[RUN_LOCATION_UNVERIFIABLE] == 1
+    assert verify_exit_code(counts) == 3
+
+
+def test_a_regular_file_beside_the_runs_is_not_a_candidate_run(tmp_path: Path) -> None:
+    """The negative control for discovery: unfiltered means every child DIRECTORY, not every child.
+    A future `_runs/INDEX.md` must not turn a healthy tree red."""
+    allocate_run("acme", repo_root=tmp_path)
+    (runs_root(tmp_path) / "INDEX.md").write_text("# runs\n", encoding="utf-8")
+
+    _gated, counts = verify_runs(tmp_path)
+
+    assert counts == {RUN_LOCATION_INTACT: 1, RUN_LOCATION_MOVED: 0, RUN_LOCATION_UNVERIFIABLE: 0}
+    assert verify_exit_code(counts) == 0
+
+
+def test_a_runs_root_that_cannot_be_listed_is_unverifiable_not_zero_runs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The second half of finding 2: an `OSError` from enumerating the root was converted into an
+    empty list, i.e. `0 run(s): 0 intact, 0 moved, 0 unverifiable`, exit 0 - while the runs
+    underneath it still existed and simply could not be discovered."""
+    allocate_run("acme", repo_root=tmp_path)
+    root = runs_root(tmp_path)
+    real_iterdir = Path.iterdir
+
+    def _refuse(self: Path):  # noqa: ANN202 - a generator/iterator, matching Path.iterdir
+        if self == root:
+            raise PermissionError(5, "Access is denied")
+        return real_iterdir(self)
+
+    monkeypatch.setattr(Path, "iterdir", _refuse)
+
+    gated, counts = verify_runs(tmp_path)
+
+    assert len(gated) == 1, "an unreadable root produced no entry at all"
+    assert counts[RUN_LOCATION_UNVERIFIABLE] == 1
+    assert counts[RUN_LOCATION_INTACT] == 0  # negative control
+    assert verify_exit_code(counts) == 3
+    assert "Access is denied" in gated[0]["location_check"]["detail"]
+
+
+def test_a_runs_root_that_is_a_file_is_unverifiable_not_zero_runs(tmp_path: Path) -> None:
+    """`Path.is_dir()` swallows every error and answers False, so "I could not look" and "it is not
+    a directory" were the same answer - and both meant exit 0."""
+    runs_root(tmp_path).write_text("not a directory", encoding="utf-8")
+
+    _gated, counts = verify_runs(tmp_path)
+
+    assert counts[RUN_LOCATION_UNVERIFIABLE] == 1
+    assert verify_exit_code(counts) == 3
+
+
+def test_a_runs_root_that_was_never_created_is_still_a_clean_zero(tmp_path: Path) -> None:
+    """The negative control for the root probe: "nothing has been allocated" is legitimately clean,
+    and must stay distinguishable from "the root exists and cannot be read"."""
+    _gated, counts = verify_runs(tmp_path)
+
+    assert counts == {RUN_LOCATION_INTACT: 0, RUN_LOCATION_MOVED: 0, RUN_LOCATION_UNVERIFIABLE: 0}
+    assert verify_exit_code(counts) == 0
+
+
+# --- Finding 3: a run number contradicting its own directory read as healthy ---
+
+
+@pytest.mark.parametrize("planted", [2, 0, 10**100])
+def test_a_run_number_that_contradicts_its_own_directory_is_unverifiable(tmp_path: Path, planted: int) -> None:
+    """The number IS the identity in this convention (issue #234), and nothing checked it against
+    the `<NNN>-<slug>` directory it sits in - only that it was a non-negative integer. Changing
+    nothing but `"run"` in a freshly allocated `001-acme` reported `1 intact`, exit 0, for both `2`
+    and `10**100`, while a float or a null correctly reported `1 unverifiable`, exit 3."""
+    run = allocate_run("acme", repo_root=tmp_path)
+    manifest = json.loads(run.manifest_path.read_text(encoding="utf-8"))
+    manifest["run"] = planted
+    run.manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+
+    check = list_runs(tmp_path)[0]["location_check"]
+
+    assert check["state"] == RUN_LOCATION_UNVERIFIABLE
+    assert check["state"] != RUN_LOCATION_INTACT  # negative control: the defect being fixed
+    assert check["derived_name_check"] == DERIVED_NAME_MISMATCH
+    assert "CONTRADICTS" in check["detail"]
+
+
+def test_a_unit_key_that_contradicts_its_own_directory_is_unverifiable(tmp_path: Path) -> None:
+    """The same contradiction reached through the other half of the derived name."""
+    run = allocate_run("acme", repo_root=tmp_path)
+    manifest = json.loads(run.manifest_path.read_text(encoding="utf-8"))
+    manifest["unit_key"] = "something-else"
+    run.manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+
+    assert _state_of(list_runs(tmp_path)[0]) == RUN_LOCATION_UNVERIFIABLE
+
+
+def test_verify_cli_exits_3_on_a_contradictory_run_number(tmp_path: Path) -> None:
+    """Finding 3 through the real CLI, judged by exit code."""
+    run = allocate_run("acme", repo_root=tmp_path)
+    manifest = json.loads(run.manifest_path.read_text(encoding="utf-8"))
+    manifest["run"] = 2
+    run.manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+
+    result = _run_verify_cli(tmp_path)
+
+    assert result.returncode == 3, result.stdout + result.stderr
+    assert "INTACT" not in result.stdout
+
+
+def test_an_unusable_run_number_is_reported_before_the_agreement_check(tmp_path: Path) -> None:
+    """Ordering control: `"run": "two"` is not a number at all, so it must be reported as an
+    unusable run number rather than as a name disagreement - the requirements are a ladder, and the
+    detail has to name the first rung that failed or it points at the wrong repair."""
+    run = allocate_run("acme", repo_root=tmp_path)
+    manifest = json.loads(run.manifest_path.read_text(encoding="utf-8"))
+    manifest["run"] = "two"
+    run.manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+
+    check = list_runs(tmp_path)[0]["location_check"]
+
+    assert check["state"] == RUN_LOCATION_UNVERIFIABLE
+    assert check["derived_name_check"] == DERIVED_NAME_NOT_CONSULTED
+    assert "not a usable run number" in check["detail"]
+
+
+def test_a_matching_run_number_is_still_intact(tmp_path: Path) -> None:
+    """The negative control for finding 3: demanding agreement must not make agreement impossible.
+    Rewriting `"run"` to the value it already had leaves the run `intact`."""
+    run = allocate_run("acme", repo_root=tmp_path)
+    manifest = json.loads(run.manifest_path.read_text(encoding="utf-8"))
+    manifest["run"] = 1
+    run.manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+
+    assert _state_of(list_runs(tmp_path)[0]) == RUN_LOCATION_INTACT
+
+
+# --- The residual: a manifest whose bytes make the READER raise, not the checker ---
+
+
+def test_an_oversized_json_integer_is_unverifiable_not_a_traceback(tmp_path: Path) -> None:
+    """A JSON integer over CPython's 4300-digit int/str conversion limit makes `json.loads` raise a
+    bare `ValueError`, which is NOT a `json.JSONDecodeError` and escaped the guard: the CLI exited
+    1 with a traceback instead of reporting `unverifiable`. Fail-closed, but `_read_run_manifest`
+    documents that it never raises, so it must not."""
+    root = runs_root(tmp_path)
+    (root / "001-acme").mkdir(parents=True)
+    (root / "001-acme" / "run.json").write_text('{"run": 1, "big": ' + "9" * 5000 + "}", encoding="utf-8")
+
+    _gated, counts = verify_runs(tmp_path)  # must not raise
+
+    assert counts[RUN_LOCATION_UNVERIFIABLE] == 1
+    assert verify_exit_code(counts) == 3
+
+    result = _run_verify_cli(tmp_path)
+    assert result.returncode == 3, result.stdout + result.stderr
+    assert "Traceback" not in result.stderr
+
+
+def test_a_run_json_that_is_not_utf8_is_unverifiable_not_a_traceback(tmp_path: Path) -> None:
+    """The same shape one layer earlier: `read_text` raises `UnicodeDecodeError`, a `ValueError`,
+    past a guard that named only `OSError`."""
+    root = runs_root(tmp_path)
+    (root / "001-acme").mkdir(parents=True)
+    (root / "001-acme" / "run.json").write_bytes(b'{"run": 1, "unit_key": "\xff\xfe acme"}')
+
+    _gated, counts = verify_runs(tmp_path)  # must not raise
+
+    assert counts[RUN_LOCATION_UNVERIFIABLE] == 1
+    assert verify_exit_code(counts) == 3
+
+
+# --- The collapse itself: pin the structure, not only the behaviours ---
+
+
+def _state_keyword_sites(state_constant: str) -> list[str]:
+    """Every place in `work_dirs.py` that CONSTRUCTS a verdict with `state=<constant>`, named by
+    the enclosing function. Parsed, not grepped: the invariant block quotes these literals in
+    prose, and a comment is not a construction site."""
+    tree = ast.parse(_work_dirs_source())
+    sites: list[str] = []
+    for func in ast.walk(tree):
+        if not isinstance(func, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for node in ast.walk(func):
+            if not isinstance(node, ast.keyword) or node.arg != "state":
+                continue
+            if isinstance(node.value, ast.Name) and node.value.id == state_constant:
+                sites.append(func.name)
+    return sites
+
+
+def test_intact_is_constructed_at_exactly_one_place_in_work_dirs() -> None:
+    """The stop rule this round was given: do not narrow the class one site at a time. Three more
+    local guards would have left a fourth site to find, so `check_run_location` is now the only
+    function that can produce a clean verdict, on its last line, after every requirement held.
+
+    This is what makes "the next unlisted surface cannot exist" checkable rather than asserted: a
+    second `intact` construction anywhere in the module fails here, whatever it is guarded by."""
+    intact_sites = _state_keyword_sites("RUN_LOCATION_INTACT")
+    moved_sites = _state_keyword_sites("RUN_LOCATION_MOVED")
+
+    assert intact_sites == ["check_run_location"], (
+        f"`intact` is constructed in {intact_sites} - the classification surface has re-opened"
+    )
+    assert moved_sites == ["check_run_location"], (
+        f"`moved` is constructed in {moved_sites} - it is likewise a single established finding"
+    )
+
+
+def test_discovery_applies_no_name_pattern_and_no_manifest_precondition() -> None:
+    """Finding 2 pinned structurally. `_discover_run_dirs` filtered on `_RUN_DIR_RE` and on
+    `run.json` existing; both are fail-open pre-answers to the question `check_run_location` exists
+    to answer. Parsed rather than grepped so a renamed regex or a nested helper cannot slip past."""
+    tree = ast.parse(_work_dirs_source())
+    discover = next(
+        node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == "_discover_run_dirs"
+    )
+    names = {node.id for node in ast.walk(discover) if isinstance(node, ast.Name)}
+    body = ast.get_source_segment(_work_dirs_source(), discover) or ""
+
+    assert "_RUN_DIR_RE" not in names, "discovery re-acquired a name-pattern filter"
+    assert "run.json" not in body.split('"""')[-1], "discovery re-acquired a 'has a manifest' precondition"
+
+
+def test_the_invariant_is_stated_in_work_dirs_itself() -> None:
+    """The prevention half, same reasoning as the rename prohibition: the rule has to live in the
+    file the next agent opens, or the next local guard gets added beside the last one."""
+    source = _work_dirs_source()
+
+    assert "THE ONE INVARIANT" in source
+    assert "only ever returned on positive proof" in source

--- a/tests/test_work_dirs.py
+++ b/tests/test_work_dirs.py
@@ -23,10 +23,14 @@ from work_dirs import (
     DERIVED_NAME_MISMATCH,
     DERIVED_NAME_NOT_CONSULTED,
     DERIVED_NAME_UNAVAILABLE,
+    PATH_CHECK_DIFFERS,
+    PATH_CHECK_MATCHES,
+    PATH_CHECK_UNRECORDED,
     RUN_LOCATION_INTACT,
     RUN_LOCATION_KEY,
     RUN_LOCATION_MOVED,
     RUN_LOCATION_UNVERIFIABLE,
+    RUN_PATH_KEY,
     allocate_run,
     check_run_location,
     list_runs,
@@ -249,6 +253,8 @@ def test_list_runs_skips_a_run_directory_with_no_manifest(tmp_path: Path) -> Non
     (root / "001-half-written").mkdir()  # no run.json inside
 
     assert not list_runs(tmp_path)
+    # ...but `verify_runs` is a GATE and must still see it - see the block at the end of this file.
+    assert verify_runs(tmp_path)[1][RUN_LOCATION_UNVERIFIABLE] == 1
 
 
 # --------------------------------------------------------------------------------------
@@ -415,32 +421,118 @@ def test_an_unusable_recorded_name_is_unverifiable_never_intact_and_never_crashe
     assert check["state"] != RUN_LOCATION_INTACT  # negative control
 
 
-def test_a_relocated_repository_is_still_intact_not_moved(tmp_path: Path) -> None:
-    """The brittleness trap this design exists to avoid: a repo that is cloned, moved, or checked
-    out as a `git worktree` is legitimately somewhere else, and its runs are NOT corrupt.
+def test_a_copied_run_is_unverifiable_never_intact_and_the_original_is_untouched(tmp_path: Path) -> None:
+    """Finding 2's reproduction, and the negative control is the whole point: the copy moves, the
+    original does not, so exactly ONE side of the relationship changes.
 
-    Recording an ABSOLUTE path would report all of them `moved` here, and a check that fires on
-    every clone is one people learn to ignore. Recording the directory NAME does not."""
+    ⚠️ This test previously asserted the OPPOSITE - that a `shutil.copytree`d tree is still
+    `INTACT` - on the premise that "a repo that is cloned, moved, or checked out as a `git worktree`
+    is legitimately somewhere else". That premise is false and checkable in one command: `_runs/` is
+    git-ignored (`git check-ignore -v -- _runs/001-acme/run.json` -> `.gitignore:162:/_*`), so a
+    clone and a fresh worktree carry no runs at all. What the old test actually fixtured was a COPY
+    of a run into a second location, which is corruption, and it asserted the fail-open verdict."""
     original_repo = tmp_path / "repo-here"
-    relocated_repo = tmp_path / "some" / "deeper" / "repo-there"
-    relocated_repo.parent.mkdir(parents=True)
+    copied_repo = tmp_path / "some" / "deeper" / "repo-there"
+    copied_repo.parent.mkdir(parents=True)
     allocate_run("acme", repo_root=original_repo)
     allocate_run("beta", repo_root=original_repo)
 
-    shutil.copytree(original_repo, relocated_repo)
+    shutil.copytree(original_repo, copied_repo)
 
-    states = [_state_of(run) for run in list_runs(relocated_repo)]
-    assert states == [RUN_LOCATION_INTACT, RUN_LOCATION_INTACT]
+    copied = list_runs(copied_repo)
+    assert [_state_of(run) for run in copied] == [RUN_LOCATION_UNVERIFIABLE, RUN_LOCATION_UNVERIFIABLE]
+    assert all(run["location_check"]["path_check"] == PATH_CHECK_DIFFERS for run in copied)
+    # not `moved` either: a whole-checkout move and a run-only copy are indistinguishable from here
+    assert all(_state_of(run) != RUN_LOCATION_MOVED for run in copied)
+    # the ORIGINAL is the negative control - the copy moved, it did not
+    assert [_state_of(run) for run in list_runs(original_repo)] == [RUN_LOCATION_INTACT, RUN_LOCATION_INTACT]
     # and the absolute paths really did change, or this test proves nothing
-    roots = [run["root"] for run in list_runs(relocated_repo)]
-    assert all(str(relocated_repo) in root for root in roots)
+    assert all(str(copied_repo) in run["root"] for run in copied)
+
+
+def test_a_run_moved_alone_to_a_second_runs_root_is_unverifiable_never_intact(tmp_path: Path) -> None:
+    """The reviewer's exact reproduction: allocate under `source/`, move that ONE run to
+    `moved/_runs/`, and the destination used to report `INTACT 001-acme` exit 0 because the
+    basename never changed. A run-only move breaks every absolute self-path embedded under
+    `<run>/bundle/`."""
+    source = tmp_path / "source"
+    destination = tmp_path / "moved"
+    runs_root(destination).mkdir(parents=True)
+    run = allocate_run("acme", repo_root=source)
+
+    shutil.move(str(run.root), str(runs_root(destination) / "001-acme"))
+
+    check = list_runs(destination)[0]["location_check"]
+    assert check["state"] == RUN_LOCATION_UNVERIFIABLE
+    assert check["state"] != RUN_LOCATION_INTACT  # negative control: the defect being fixed
+    assert check["path_check"] == PATH_CHECK_DIFFERS
+    assert str(source) in check["detail"] and str(destination) in check["detail"]
+
+
+def test_a_run_still_where_it_was_allocated_reports_path_check_matches(tmp_path: Path) -> None:
+    """The positive control for the path half: `intact` must rest on a RECORDED path comparison,
+    not on the name having matched."""
+    allocate_run("acme", repo_root=tmp_path)
+
+    check = list_runs(tmp_path)[0]["location_check"]
+
+    assert check["state"] == RUN_LOCATION_INTACT
+    assert check["path_check"] == PATH_CHECK_MATCHES
+
+
+def test_allocate_run_records_the_absolute_path_it_allocated_and_reserves_the_key(tmp_path: Path) -> None:
+    """Without a recorded absolute path there is nothing to compare, and a caller must not be able
+    to plant a false one - that would forge an `intact` verdict for a moved run."""
+    run = allocate_run("acme", repo_root=tmp_path, extra_manifest={RUN_PATH_KEY: r"D:\somewhere\else\001-acme"})
+
+    manifest = json.loads(run.manifest_path.read_text(encoding="utf-8"))
+    assert Path(manifest[RUN_PATH_KEY]).is_absolute()
+    assert Path(manifest[RUN_PATH_KEY]).samefile(run.root)
+    assert _state_of(list_runs(tmp_path)[0]) == RUN_LOCATION_INTACT
+
+
+def test_a_run_with_no_recorded_absolute_path_is_unverifiable_never_intact(tmp_path: Path) -> None:
+    """A manifest carrying only the NAME cannot establish `intact`, because a basename is unchanged
+    by both a run-only move and a copy."""
+    run = allocate_run("acme", repo_root=tmp_path)
+    manifest = json.loads(run.manifest_path.read_text(encoding="utf-8"))
+    del manifest[RUN_PATH_KEY]
+    run.manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+
+    check = list_runs(tmp_path)[0]["location_check"]
+
+    assert check["state"] == RUN_LOCATION_UNVERIFIABLE
+    assert check["state"] != RUN_LOCATION_INTACT  # negative control
+    assert check["path_check"] == PATH_CHECK_UNRECORDED
+
+
+@pytest.mark.parametrize("planted", [42, ["a"], {"p": "x"}, "", None])
+def test_an_unusable_recorded_absolute_path_is_unverifiable_never_intact(tmp_path: Path, planted: object) -> None:
+    """A hand-edited or corrupted `allocated_abs_path` must not be compared as if it were a path."""
+    run = allocate_run("acme", repo_root=tmp_path)
+    manifest = json.loads(run.manifest_path.read_text(encoding="utf-8"))
+    manifest[RUN_PATH_KEY] = planted
+    run.manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+
+    check = list_runs(tmp_path)[0]["location_check"]
+
+    assert check["state"] == RUN_LOCATION_UNVERIFIABLE
+    assert check["state"] != RUN_LOCATION_INTACT  # negative control
 
 
 def test_check_run_location_is_pure_and_needs_no_directory_on_disk(tmp_path: Path) -> None:
-    """`list_runs` is documented as pure inspection, so its helper must not mutate or touch disk."""
-    manifest = {"run": 7, "unit_key": "acme", RUN_LOCATION_KEY: "007-acme"}
-    before = json.dumps(manifest, sort_keys=True)
+    """`list_runs` is documented as pure inspection, so its helper must not mutate or touch disk.
+
+    The path comparison uses `abspath`, never `resolve`, for exactly this reason: it normalizes
+    separators, `..` and case without a filesystem read."""
     nonexistent = tmp_path / "no" / "such" / "007-acme"
+    manifest = {
+        "run": 7,
+        "unit_key": "acme",
+        RUN_LOCATION_KEY: "007-acme",
+        RUN_PATH_KEY: str(nonexistent),
+    }
+    before = json.dumps(manifest, sort_keys=True)
 
     check = check_run_location(manifest, nonexistent)
 
@@ -459,7 +551,13 @@ def test_check_run_location_is_pure_and_needs_no_directory_on_disk(tmp_path: Pat
 def test_list_runs_never_raises_on_a_run_json_that_is_not_a_manifest(tmp_path: Path, payload: str) -> None:
     """`list_runs` promises it "never raises on a hand-created or half-written run directory". Valid
     JSON that is not an object used to break that promise: `.setdefault` on a list raises
-    `AttributeError`, which escaped the `json.JSONDecodeError`/`OSError` guard entirely."""
+    `AttributeError`, which escaped the `json.JSONDecodeError`/`OSError` guard entirely.
+
+    ⚠️ This test used to assert the run was OMITTED, full stop - and `verify_runs` was built on
+    `list_runs`, so that omission WAS the fail-open gate (finding 1). The never-raises contract is
+    the legitimate half and is kept; the visibility half now belongs to
+    `test_verify_runs_never_drops_a_run_directory_it_cannot_assess`, which asserts the same
+    directory is `unverifiable` rather than invisible. Inspection may skip; a gate may not."""
     root = runs_root(tmp_path)
     root.mkdir(parents=True)
     (root / "001-half-written").mkdir()
@@ -467,7 +565,11 @@ def test_list_runs_never_raises_on_a_run_json_that_is_not_a_manifest(tmp_path: P
 
     runs = list_runs(tmp_path)
 
-    assert isinstance(runs, list) and not runs
+    assert isinstance(runs, list) and not runs  # inspection skips it - and never raises
+    # ...but the GATE must still see it. This pairing is the fix; asserting only the line above is
+    # what let a half-written run count as a clean tree.
+    _gate_runs, counts = verify_runs(tmp_path)
+    assert counts[RUN_LOCATION_UNVERIFIABLE] == 1
 
 
 def test_list_runs_reports_the_actual_location_not_a_stale_recorded_one(tmp_path: Path) -> None:
@@ -496,6 +598,116 @@ def test_list_runs_attaches_a_location_check_to_every_run(tmp_path: Path) -> Non
 # --------------------------------------------------------------------------------------
 # verify_runs / verify_exit_code / the --verify CLI
 # --------------------------------------------------------------------------------------
+
+
+_UNASSESSABLE_SHAPES = {
+    "missing": None,
+    "empty": "",
+    "truncated": '{"run": 1, "unit_key": "acme"',
+    "malformed": "not json at all",
+    "non_object_list": '["001-acme"]',
+    "non_object_scalar": "42",
+}
+
+
+def _plant_unassessable_run(tmp_path: Path, shape: str, dir_name: str = "001-acme") -> Path:
+    """A canonical `_runs/<NNN>-<slug>/` directory whose manifest cannot be assessed. `missing` is
+    not an exotic input: it is exactly what an allocation interrupted between `mkdir` and the
+    manifest write leaves behind."""
+    run_dir = runs_root(tmp_path) / dir_name
+    run_dir.mkdir(parents=True)
+    payload = _UNASSESSABLE_SHAPES[shape]
+    if payload is not None:
+        (run_dir / "run.json").write_text(payload, encoding="utf-8")
+    return run_dir
+
+
+@pytest.mark.parametrize("shape", sorted(_UNASSESSABLE_SHAPES))
+def test_verify_runs_never_drops_a_run_directory_it_cannot_assess(tmp_path: Path, shape: str) -> None:
+    """Finding 1. `verify_runs` used to be built on `list_runs`, so it inherited inspection's right
+    to skip: a run directory that exists but cannot be read contributed ZERO to every bucket, and
+    the CLI printed `0 run(s): 0 intact, 0 moved, 0 unverifiable`, exit 0 - the `unverifiable`
+    bucket sitting at 0 exactly when something was unverifiable."""
+    _plant_unassessable_run(tmp_path, shape)
+
+    runs, counts = verify_runs(tmp_path)
+
+    assert len(runs) == 1, "the gate dropped a run directory it could not assess"
+    assert counts[RUN_LOCATION_UNVERIFIABLE] == 1
+    assert counts[RUN_LOCATION_INTACT] == 0  # negative control: it must not land in the clean bucket
+    assert counts[RUN_LOCATION_MOVED] == 0  # negative control: nor be reported as an established finding
+    assert verify_exit_code(counts) == 3
+
+
+@pytest.mark.parametrize("shape", sorted(_UNASSESSABLE_SHAPES))
+def test_the_gate_sees_exactly_the_run_inspection_omits(tmp_path: Path, shape: str) -> None:
+    """The relationship the split exists to create, with only ONE side moving: a healthy run is in
+    both, an unassessable one is in the gate only. Asserting `len(verify) > len(list)` alone would
+    pass on a gate that invented an entry, so both halves are pinned."""
+    allocate_run("healthy", repo_root=tmp_path)
+    _plant_unassessable_run(tmp_path, shape, dir_name="002-half-written")
+
+    inspected = list_runs(tmp_path)
+    gated, counts = verify_runs(tmp_path)
+
+    assert [run["root"] for run in inspected] == [str(runs_root(tmp_path) / "001-healthy")]
+    assert [Path(run["root"]).name for run in gated] == ["001-healthy", "002-half-written"]
+    assert counts == {RUN_LOCATION_INTACT: 1, RUN_LOCATION_MOVED: 0, RUN_LOCATION_UNVERIFIABLE: 1}
+
+
+def test_a_run_json_that_cannot_be_read_at_all_is_unverifiable_not_invisible(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The reviewer's sixth shape: a manifest held open with Windows `FileShare.None`, i.e. a read
+    that raises `OSError`. Forced here through `Path.read_text` so the branch is exercised on any
+    platform rather than only where an exclusive share mode exists."""
+    run = allocate_run("acme", repo_root=tmp_path)
+    real_read_text = Path.read_text
+
+    def _refuse(self: Path, *args: object, **kwargs: object) -> str:
+        if self == run.manifest_path:
+            raise PermissionError(32, "The process cannot access the file because it is being used by another process")
+        return real_read_text(self, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(Path, "read_text", _refuse)
+
+    _runs, counts = verify_runs(tmp_path)
+
+    assert counts[RUN_LOCATION_UNVERIFIABLE] == 1
+    assert counts[RUN_LOCATION_INTACT] == 0  # negative control
+    assert verify_exit_code(counts) == 3
+
+
+def test_a_mixed_run_number_tree_does_not_raise_and_keeps_the_invalid_manifest(tmp_path: Path) -> None:
+    """Finding 3. `manifests.sort(key=lambda m: m.get("run", 0))` sorted an unvalidated value, so a
+    tree holding both `{"run": 1}` and `{"run": "two"}` raised `TypeError: '<' not supported between
+    instances of 'str' and 'int'` - breaking the documented never-raises contract AND preventing any
+    `unverifiable` verdict from ever being reached."""
+    root = runs_root(tmp_path)
+    for name, run_number in (("001-a", 1), ("002-b", "two"), ("003-c", 3)):
+        (root / name).mkdir(parents=True)
+        (root / name / "run.json").write_text(
+            json.dumps({"run": run_number, "unit_key": name[4:], RUN_LOCATION_KEY: name}), encoding="utf-8"
+        )
+
+    runs, counts = verify_runs(tmp_path)  # must not raise
+
+    assert [Path(run["root"]).name for run in runs] == ["001-a", "003-c", "002-b"]
+    assert counts[RUN_LOCATION_UNVERIFIABLE] == 3  # none of the three recorded an absolute path either
+    assert any("'two'" in run["location_check"]["detail"] for run in runs), "the invalid manifest was not retained"
+    assert not any(_state_of(run) == RUN_LOCATION_INTACT for run in runs)  # negative control
+
+
+def test_a_verified_tree_of_freshly_allocated_runs_is_still_clean(tmp_path: Path) -> None:
+    """The positive control for the whole gate: making "cannot assess" blocking must not make a
+    healthy tree blocking too, or the gate is just an always-red light."""
+    allocate_run("acme", repo_root=tmp_path)
+    allocate_run("beta", repo_root=tmp_path)
+
+    _runs, counts = verify_runs(tmp_path)
+
+    assert counts == {RUN_LOCATION_INTACT: 2, RUN_LOCATION_MOVED: 0, RUN_LOCATION_UNVERIFIABLE: 0}
+    assert verify_exit_code(counts) == 0
 
 
 def test_verify_runs_counts_each_state_separately(tmp_path: Path) -> None:
@@ -574,6 +786,50 @@ def test_verify_cli_exits_3_on_a_legacy_run_and_says_it_is_not_intact(tmp_path: 
     assert result.returncode == 3, result.stdout + result.stderr
     assert "UNVERIFIABLE" in result.stdout
     assert "is NOT 'intact'" in result.stdout
+
+
+def test_verify_cli_exits_3_on_a_run_directory_it_cannot_assess(tmp_path: Path) -> None:
+    """Finding 1 through the REAL CLI, which is where it was reproduced: a canonical
+    `_runs/001-acme/` with no `run.json` printed `0 run(s): 0 intact, 0 moved, 0 unverifiable`,
+    exit 0. Judged by exit code, never by the printed text."""
+    _plant_unassessable_run(tmp_path, "missing")
+
+    result = _run_verify_cli(tmp_path)
+
+    assert result.returncode == 3, result.stdout + result.stderr
+    assert "UNVERIFIABLE" in result.stdout
+    assert "0 intact, 0 moved, 1 unverifiable" in result.stdout
+    assert "1 run(s)" in result.stdout, "the run directory was counted as nothing at all"
+
+
+def test_verify_cli_exits_3_on_a_run_moved_alone_to_another_root(tmp_path: Path) -> None:
+    """Finding 2 through the real CLI. It reported `INTACT 001-acme`, exit 0."""
+    source = tmp_path / "source"
+    destination = tmp_path / "moved"
+    runs_root(destination).mkdir(parents=True)
+    run = allocate_run("acme", repo_root=source)
+    shutil.move(str(run.root), str(runs_root(destination) / "001-acme"))
+
+    result = _run_verify_cli(destination)
+
+    assert result.returncode == 3, result.stdout + result.stderr
+    assert "UNVERIFIABLE" in result.stdout
+    assert "INTACT" not in result.stdout  # negative control: the defect being fixed
+
+
+def test_verify_cli_does_not_crash_on_a_mixed_run_number_tree(tmp_path: Path) -> None:
+    """Finding 3 through the real CLI: it exited 1 with an uncaught `TypeError` traceback, which is
+    indistinguishable from a legitimate `moved` finding by exit code alone."""
+    root = runs_root(tmp_path)
+    for name, run_number in (("001-a", 1), ("002-b", "two")):
+        (root / name).mkdir(parents=True)
+        (root / name / "run.json").write_text(json.dumps({"run": run_number, RUN_LOCATION_KEY: name}), encoding="utf-8")
+
+    result = _run_verify_cli(tmp_path)
+
+    assert result.returncode == 3, result.stdout + result.stderr
+    assert "Traceback" not in result.stderr
+    assert "TypeError" not in result.stderr
 
 
 def test_verify_cli_needs_no_unit_argument_but_allocation_still_does(tmp_path: Path) -> None:

--- a/tests/test_work_dirs.py
+++ b/tests/test_work_dirs.py
@@ -946,8 +946,13 @@ def test_verify_cli_exits_3_on_a_relative_recorded_path_even_from_the_matching_c
         # rejected: every one of these is completed against the process's CWD or current DRIVE
         ("001-acme", False),
         (str(Path("..") / "_runs" / "001-acme"), False),
-        (r"\_runs\001-acme", os.name != "nt"),  # Windows drive-relative; a plain absolute path on POSIX
-        ("C:001-acme", os.name != "nt"),  # drive-relative WITH a drive letter
+        # ⚠️ False on EVERY platform, and the reason differs by platform - which is why the earlier
+        # `os.name != "nt"` expectation passed locally and turned Linux CI red (4696 passed, 2
+        # failed at 191d153). On Windows these are drive-relative and resolve against the current
+        # drive; on POSIX they are ordinary RELATIVE filenames that merely contain a backslash and
+        # a colon. Neither names a fixed location anywhere, so the predicate is right in both.
+        (r"\_runs\001-acme", False),
+        ("C:001-acme", False),
         ("", False),
     ],
 )
@@ -955,11 +960,20 @@ def test_only_a_location_independent_path_counts_as_a_recorded_location(value: s
     """The fact requirement 4 consumes, tested directly - the black-box route can only exercise it
     from a CWD that happens to match, which is exactly why the defect survived review round 1.
 
-    ⚠️ `os.path.isabs` is not this predicate and would have missed two rows: on Windows it answered
-    True for `\\_runs\\001-acme` before Python 3.13 and False from 3.13 on, and a drive-relative
-    path still resolves against whatever drive the process is on. Both anchors are required - the
-    driveless one absorbs a drive-relative value (`ntpath.join` keeps the second operand's root),
-    the drive-bearing one exposes it."""
+    ⚠️ `os.path.isabs` misses exactly ONE of these rows, and only on some interpreters - an earlier
+    version of this docstring claimed two, which overstated the justification. Measured on both
+    interpreters this repo can run on Windows:
+
+    | value | `ntpath.isabs` on 3.11.10 | on 3.13.2 |
+    |---|---|---|
+    | `\\_runs\\001-acme` (drive-relative) | **True** - the miss | False |
+    | `C:001-acme` (drive-relative with a drive) | False | False |
+
+    So on 3.13 `isabs` alone would have sufficed here; on 3.11 it would have accepted a path that
+    resolves against whatever drive the process is on. The two-fact predicate is chosen because it
+    does not depend on which CPython runs it - not because `isabs` is wrong about both shapes.
+    Both facts are still individually load-bearing: mutations that drop either one kill this test.
+    """
     assert _is_location_independent(value) is independent
 
 
@@ -1197,18 +1211,47 @@ def test_a_run_json_that_is_not_utf8_is_unverifiable_not_a_traceback(tmp_path: P
 def _state_keyword_sites(state_constant: str) -> list[str]:
     """Every place in `work_dirs.py` that CONSTRUCTS a verdict with `state=<constant>`, named by
     the enclosing function. Parsed, not grepped: the invariant block quotes these literals in
-    prose, and a comment is not a construction site."""
+    prose, and a comment is not a construction site.
+
+    One level of local aliasing is followed, because the reviewer got past the first version of
+    this pin with exactly that: `alias = RUN_LOCATION_INTACT` in the same function, then
+    `state=alias` at a second construction site.
+    """
     tree = ast.parse(_work_dirs_source())
     sites: list[str] = []
     for func in ast.walk(tree):
         if not isinstance(func, (ast.FunctionDef, ast.AsyncFunctionDef)):
             continue
+        aliases = {state_constant}
+        for node in ast.walk(func):
+            targets = getattr(node, "targets", None) or ([node.target] if isinstance(node, ast.AnnAssign) else [])
+            value = getattr(node, "value", None)
+            if isinstance(value, ast.Name) and value.id in aliases:
+                aliases.update(target.id for target in targets if isinstance(target, ast.Name))
         for node in ast.walk(func):
             if not isinstance(node, ast.keyword) or node.arg != "state":
                 continue
-            if isinstance(node.value, ast.Name) and node.value.id == state_constant:
+            if isinstance(node.value, ast.Name) and node.value.id in aliases:
                 sites.append(func.name)
     return sites
+
+
+def _constant_load_scopes(constant: str) -> list[str]:
+    """Every scope that LOADS `constant`, named by the innermost enclosing function/class or
+    `<module>`. A construction site elsewhere has to get the value from somewhere, so pinning the
+    reference scopes catches an alias defined in a DIFFERENT function, which `_state_keyword_sites`
+    cannot see."""
+    scopes: list[str] = []
+
+    def walk(node: ast.AST, scope: str) -> None:
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, ast.Name) and child.id == constant and isinstance(child.ctx, ast.Load):
+                scopes.append(scope)
+            inner = child.name if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)) else scope
+            walk(child, inner)
+
+    walk(ast.parse(_work_dirs_source()), "<module>")
+    return sorted(scopes)
 
 
 def test_intact_is_constructed_at_exactly_one_place_in_work_dirs() -> None:
@@ -1216,32 +1259,59 @@ def test_intact_is_constructed_at_exactly_one_place_in_work_dirs() -> None:
     local guards would have left a fourth site to find, so `check_run_location` is now the only
     function that can produce a clean verdict, on its last line, after every requirement held.
 
-    This is what makes "the next unlisted surface cannot exist" checkable rather than asserted: a
-    second `intact` construction anywhere in the module fails here, whatever it is guarded by."""
-    intact_sites = _state_keyword_sites("RUN_LOCATION_INTACT")
-    moved_sites = _state_keyword_sites("RUN_LOCATION_MOVED")
+    Two independent pins, because the first version of this test was demonstrably weak - a
+    reviewer asked to attack the pin itself got past it by constructing through `state=alias`:
 
-    assert intact_sites == ["check_run_location"], (
-        f"`intact` is constructed in {intact_sites} - the classification surface has re-opened"
+    1. construction sites, following one level of local aliasing;
+    2. the exact set of scopes that so much as LOAD the constant, which catches an alias defined
+       in another function and any second reference added anywhere in the module.
+
+    ⚠️ **Known limitation, stated rather than implied: this catches DIRECT construction and simple
+    local aliasing only.** A value routed through a container, an f-string, a function's return
+    value, or passed in as a parameter would construct `intact` without ever loading the constant
+    in that scope, and both pins would pass. Closing that needs dataflow analysis, which is not
+    worth it here - the behavioural tests above are what actually prove the verdicts, and this pin
+    exists to make an obvious regression noisy, not to be a proof. Production structure was
+    confirmed correct by review; this is a proof weakness, not a defect."""
+    assert _state_keyword_sites("RUN_LOCATION_INTACT") == ["check_run_location"]
+    assert _state_keyword_sites("RUN_LOCATION_MOVED") == ["check_run_location"]
+
+    assert _constant_load_scopes("RUN_LOCATION_INTACT") == ["<module>", "check_run_location", "is_intact"], (
+        "a new scope references `intact` - either the classification surface re-opened, or this "
+        "allowlist needs a deliberate update naming the new consumer"
     )
-    assert moved_sites == ["check_run_location"], (
-        f"`moved` is constructed in {moved_sites} - it is likewise a single established finding"
-    )
+    assert _constant_load_scopes("RUN_LOCATION_MOVED") == ["<module>", "check_run_location", "verify_exit_code"]
 
 
 def test_discovery_applies_no_name_pattern_and_no_manifest_precondition() -> None:
     """Finding 2 pinned structurally. `_discover_run_dirs` filtered on `_RUN_DIR_RE` and on
     `run.json` existing; both are fail-open pre-answers to the question `check_run_location` exists
-    to answer. Parsed rather than grepped so a renamed regex or a nested helper cannot slip past."""
-    tree = ast.parse(_work_dirs_source())
+    to answer. Parsed rather than grepped so a renamed regex or a nested helper cannot slip past.
+
+    The call allowlist is the part that matters, and it is here because the first version of this
+    pin was demonstrably weak: a reviewer asked to attack it got past by moving the filtering into
+    an external helper, which no `_RUN_DIR_RE`-name check can see. Extracting ANY new call out of
+    discovery now fails this test - which is the intended cost, because "discovery consults
+    something else before deciding" is exactly the shape being prohibited.
+
+    ⚠️ Limitation: this pins what discovery may CALL, not what those calls do. Adding a filter
+    inline with no call (e.g. `if child.name.startswith("0")`) would pass both assertions; the
+    behavioural tests above are what catch that."""
+    source = _work_dirs_source()
+    tree = ast.parse(source)
     discover = next(
         node for node in ast.walk(tree) if isinstance(node, ast.FunctionDef) and node.name == "_discover_run_dirs"
     )
     names = {node.id for node in ast.walk(discover) if isinstance(node, ast.Name)}
-    body = ast.get_source_segment(_work_dirs_source(), discover) or ""
+    calls = {ast.unparse(node.func) for node in ast.walk(discover) if isinstance(node, ast.Call)}
+    body = ast.get_source_segment(source, discover) or ""
 
     assert "_RUN_DIR_RE" not in names, "discovery re-acquired a name-pattern filter"
     assert "run.json" not in body.split('"""')[-1], "discovery re-acquired a 'has a manifest' precondition"
+    assert calls == {"os.stat", "stat.S_ISDIR", "sorted", "root.iterdir", "found.append"}, (
+        f"discovery calls {sorted(calls)} - it may only stat, list and collect. A new call is how "
+        "a filter gets re-introduced from outside, where a name check cannot see it"
+    )
 
 
 def test_the_invariant_is_stated_in_work_dirs_itself() -> None:

--- a/tests/test_work_dirs.py
+++ b/tests/test_work_dirs.py
@@ -5,6 +5,8 @@ Every test uses `tmp_path` as `repo_root` so this suite never touches the real r
 """
 
 import json
+import shutil
+import subprocess
 import sys
 from pathlib import Path
 
@@ -17,10 +19,21 @@ sys.path.insert(0, str(REPO_ROOT / "scripts"))
 # pylint: disable=wrong-import-position
 from work_dirs import (
     CANONICAL_SUBDIRS,
+    DERIVED_NAME_MATCHES,
+    DERIVED_NAME_MISMATCH,
+    DERIVED_NAME_NOT_CONSULTED,
+    DERIVED_NAME_UNAVAILABLE,
+    RUN_LOCATION_INTACT,
+    RUN_LOCATION_KEY,
+    RUN_LOCATION_MOVED,
+    RUN_LOCATION_UNVERIFIABLE,
     allocate_run,
+    check_run_location,
     list_runs,
     runs_root,
     sanitize_unit_key,
+    verify_exit_code,
+    verify_runs,
 )
 
 
@@ -252,3 +265,352 @@ def test_runs_root_is_not_cwd_dependent(tmp_path: Path, monkeypatch: pytest.Monk
     monkeypatch.chdir(elsewhere)
 
     assert runs_root(tmp_path) == tmp_path / "_runs"
+
+
+# --------------------------------------------------------------------------------------
+# check_run_location - issue #470: a renumbered run must not read back as a healthy one
+#
+# Three MUTUALLY EXCLUSIVE states, and every test below asserts WHICH one was reported plus at
+# least one negative control, because "it flagged something" is how a vacuous test survives:
+#   intact       - recorded name == actual name
+#   moved        - recorded name != actual name (renamed/renumbered since allocation)
+#   unverifiable - nothing recorded; the question CANNOT be answered, which is not "fine"
+# --------------------------------------------------------------------------------------
+
+
+def _state_of(manifest: dict) -> str:
+    return manifest["location_check"]["state"]
+
+
+def _rename_run_dir(run_dir: Path, new_name: str) -> Path:
+    """Do to a run exactly what the customer's reorg did: rename the directory in place."""
+    moved = run_dir.parent / new_name
+    run_dir.rename(moved)
+    return moved
+
+
+def test_allocate_run_records_the_directory_name_it_allocated(tmp_path: Path) -> None:
+    """The whole detection story rests on this key existing; without it every run is unverifiable."""
+    run = allocate_run("acme", repo_root=tmp_path)
+
+    manifest = json.loads(run.manifest_path.read_text(encoding="utf-8"))
+    assert manifest[RUN_LOCATION_KEY] == "001-acme" == run.root.name
+
+
+def test_allocated_dir_name_is_reserved_against_a_colliding_extra_manifest(tmp_path: Path) -> None:
+    """A caller must not be able to plant a false self-path, which would forge an `intact` verdict."""
+    run = allocate_run("acme", repo_root=tmp_path, extra_manifest={RUN_LOCATION_KEY: "999-somewhere-else"})
+
+    manifest = json.loads(run.manifest_path.read_text(encoding="utf-8"))
+    assert manifest[RUN_LOCATION_KEY] == run.root.name
+    assert _state_of(list_runs(tmp_path)[0]) == RUN_LOCATION_INTACT
+
+
+def test_a_freshly_allocated_run_is_intact_and_is_not_moved_or_unverifiable(tmp_path: Path) -> None:
+    """The positive control for `intact`, and the negative control for the other two states."""
+    allocate_run("acme", repo_root=tmp_path)
+
+    check = list_runs(tmp_path)[0]["location_check"]
+
+    assert check["state"] == RUN_LOCATION_INTACT
+    assert check["state"] != RUN_LOCATION_MOVED  # negative control
+    assert check["state"] != RUN_LOCATION_UNVERIFIABLE  # negative control
+    assert check["recorded_dir_name"] == check["actual_dir_name"] == "001-acme"
+    # the verdict must rest on the RECORD, never on the run/unit_key inference
+    assert check["derived_name_check"] == DERIVED_NAME_NOT_CONSULTED
+
+
+def test_a_renumbered_run_reports_moved_and_names_both_directories(tmp_path: Path) -> None:
+    """The customer's actual failure: 14 run directories renumbered in one reorg (issue #470)."""
+    run = allocate_run("acme", repo_root=tmp_path)
+    _rename_run_dir(run.root, "042-acme")
+
+    check = list_runs(tmp_path)[0]["location_check"]
+
+    assert check["state"] == RUN_LOCATION_MOVED
+    assert check["state"] != RUN_LOCATION_INTACT  # negative control: the defect being fixed
+    assert check["state"] != RUN_LOCATION_UNVERIFIABLE  # negative control
+    assert check["recorded_dir_name"] == "001-acme"
+    assert check["actual_dir_name"] == "042-acme"
+
+
+def test_a_run_renamed_but_keeping_its_number_also_reports_moved(tmp_path: Path) -> None:
+    """The slug is decoration, but the recorded name is the whole name - a re-slugged run is still
+    a renamed directory, and generated bundle output under it embeds the OLD absolute path."""
+    run = allocate_run("acme", repo_root=tmp_path)
+    _rename_run_dir(run.root, "001-acme-tidied-up")
+
+    assert _state_of(list_runs(tmp_path)[0]) == RUN_LOCATION_MOVED
+
+
+def test_a_legacy_manifest_with_no_recorded_name_is_unverifiable_never_intact(tmp_path: Path) -> None:
+    """EVERY run allocated before this change lands here - including the live
+    `_runs/408-coldrun2-fabric-migration-lab` on the machine that shipped it, measured at
+    `state=unverifiable`, `derived_name_check=matches`, CLI exit 3.
+
+    This is the highest-value assertion in the change: a legacy run whose derived name MATCHES is
+    still `unverifiable`, because an inference is not a record. Letting it report `intact` would
+    rebuild the exact defect issue #470 is about."""
+    run = allocate_run("coldrun2-fabric-migration-lab", repo_root=tmp_path)
+    manifest = json.loads(run.manifest_path.read_text(encoding="utf-8"))
+    del manifest[RUN_LOCATION_KEY]  # exactly the shape of every pre-change run.json
+    run.manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+
+    check = list_runs(tmp_path)[0]["location_check"]
+
+    assert check["state"] == RUN_LOCATION_UNVERIFIABLE
+    assert check["state"] != RUN_LOCATION_INTACT  # negative control: must NOT collapse into clean
+    assert check["state"] != RUN_LOCATION_MOVED  # negative control: nor into a false finding
+    assert check["recorded_dir_name"] is None
+    # the derived hint is reported, but it is subordinate and does not change the state
+    assert check["derived_name_check"] == DERIVED_NAME_MATCHES
+    assert "INFERENCE" in check["detail"]
+
+
+def test_a_legacy_manifest_whose_derived_name_mismatches_is_still_only_unverifiable(tmp_path: Path) -> None:
+    """A legacy run that LOOKS renumbered (run=1 but sitting at 042-) gets a `mismatch` hint - and
+    still only `unverifiable`, because `run`/`unit_key` reconstruct a name via a padding rule that
+    could change, which is not the same as having recorded one."""
+    run = allocate_run("acme", repo_root=tmp_path)
+    manifest = json.loads(run.manifest_path.read_text(encoding="utf-8"))
+    del manifest[RUN_LOCATION_KEY]
+    run.manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    _rename_run_dir(run.root, "042-acme")
+
+    check = list_runs(tmp_path)[0]["location_check"]
+
+    assert check["state"] == RUN_LOCATION_UNVERIFIABLE
+    assert check["state"] != RUN_LOCATION_MOVED  # negative control: an inference is not a finding
+    assert check["derived_name_check"] == DERIVED_NAME_MISMATCH
+    assert "042-acme" in check["detail"] and "001-acme" in check["detail"]
+
+
+def test_a_manifest_with_neither_a_recorded_nor_a_derivable_name_reports_unavailable(tmp_path: Path) -> None:
+    """A hand-written `run.json` carries no `run`/`unit_key` either, so even the hint is unavailable."""
+    root = runs_root(tmp_path)
+    root.mkdir(parents=True)
+    hand_made = root / "003-by-hand"
+    hand_made.mkdir()
+    (hand_made / "run.json").write_text(json.dumps({"note": "written by an agent, not allocate_run"}), encoding="utf-8")
+
+    check = list_runs(tmp_path)[0]["location_check"]
+
+    assert check["state"] == RUN_LOCATION_UNVERIFIABLE
+    assert check["derived_name_check"] == DERIVED_NAME_UNAVAILABLE
+
+
+@pytest.mark.parametrize("planted", [42, ["001-acme"], {"name": "001-acme"}, ""])
+def test_an_unusable_recorded_name_is_unverifiable_never_intact_and_never_crashes(
+    tmp_path: Path, planted: object
+) -> None:
+    """A hand-edited or corrupted `allocated_dir_name` must not be compared as if it were a name."""
+    run = allocate_run("acme", repo_root=tmp_path)
+    manifest = json.loads(run.manifest_path.read_text(encoding="utf-8"))
+    manifest[RUN_LOCATION_KEY] = planted
+    run.manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+
+    check = list_runs(tmp_path)[0]["location_check"]
+
+    assert check["state"] == RUN_LOCATION_UNVERIFIABLE
+    assert check["state"] != RUN_LOCATION_INTACT  # negative control
+
+
+def test_a_relocated_repository_is_still_intact_not_moved(tmp_path: Path) -> None:
+    """The brittleness trap this design exists to avoid: a repo that is cloned, moved, or checked
+    out as a `git worktree` is legitimately somewhere else, and its runs are NOT corrupt.
+
+    Recording an ABSOLUTE path would report all of them `moved` here, and a check that fires on
+    every clone is one people learn to ignore. Recording the directory NAME does not."""
+    original_repo = tmp_path / "repo-here"
+    relocated_repo = tmp_path / "some" / "deeper" / "repo-there"
+    relocated_repo.parent.mkdir(parents=True)
+    allocate_run("acme", repo_root=original_repo)
+    allocate_run("beta", repo_root=original_repo)
+
+    shutil.copytree(original_repo, relocated_repo)
+
+    states = [_state_of(run) for run in list_runs(relocated_repo)]
+    assert states == [RUN_LOCATION_INTACT, RUN_LOCATION_INTACT]
+    # and the absolute paths really did change, or this test proves nothing
+    roots = [run["root"] for run in list_runs(relocated_repo)]
+    assert all(str(relocated_repo) in root for root in roots)
+
+
+def test_check_run_location_is_pure_and_needs_no_directory_on_disk(tmp_path: Path) -> None:
+    """`list_runs` is documented as pure inspection, so its helper must not mutate or touch disk."""
+    manifest = {"run": 7, "unit_key": "acme", RUN_LOCATION_KEY: "007-acme"}
+    before = json.dumps(manifest, sort_keys=True)
+    nonexistent = tmp_path / "no" / "such" / "007-acme"
+
+    check = check_run_location(manifest, nonexistent)
+
+    assert check.state == RUN_LOCATION_INTACT
+    assert check.is_intact
+    assert json.dumps(manifest, sort_keys=True) == before, "check_run_location mutated the manifest"
+    assert not nonexistent.exists(), "check_run_location touched the filesystem"
+
+
+# --------------------------------------------------------------------------------------
+# list_runs - the "never raises" contract, and derived-vs-recorded precedence
+# --------------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("payload", ["[]", '"a string"', "42", "null", "not json at all", ""])
+def test_list_runs_never_raises_on_a_run_json_that_is_not_a_manifest(tmp_path: Path, payload: str) -> None:
+    """`list_runs` promises it "never raises on a hand-created or half-written run directory". Valid
+    JSON that is not an object used to break that promise: `.setdefault` on a list raises
+    `AttributeError`, which escaped the `json.JSONDecodeError`/`OSError` guard entirely."""
+    root = runs_root(tmp_path)
+    root.mkdir(parents=True)
+    (root / "001-half-written").mkdir()
+    (root / "001-half-written" / "run.json").write_text(payload, encoding="utf-8")
+
+    runs = list_runs(tmp_path)
+
+    assert isinstance(runs, list) and not runs
+
+
+def test_list_runs_reports_the_actual_location_not_a_stale_recorded_one(tmp_path: Path) -> None:
+    """`root` is DERIVED - it must describe where the run is now. A stale `root` planted in the
+    manifest must not shadow it, or a status query silently reports a location that is not real."""
+    run = allocate_run("acme", repo_root=tmp_path, extra_manifest={"root": r"D:\somewhere\that\never\existed"})
+
+    listed = list_runs(tmp_path)[0]
+
+    assert listed["root"] == str(run.root)
+
+
+def test_list_runs_attaches_a_location_check_to_every_run(tmp_path: Path) -> None:
+    """The state must be reachable from what a caller actually consumes, not only from the helper."""
+    allocate_run("acme", repo_root=tmp_path)
+    allocate_run("beta", repo_root=tmp_path)
+
+    for listed in list_runs(tmp_path):
+        assert listed["location_check"]["state"] in {
+            RUN_LOCATION_INTACT,
+            RUN_LOCATION_MOVED,
+            RUN_LOCATION_UNVERIFIABLE,
+        }
+
+
+# --------------------------------------------------------------------------------------
+# verify_runs / verify_exit_code / the --verify CLI
+# --------------------------------------------------------------------------------------
+
+
+def test_verify_runs_counts_each_state_separately(tmp_path: Path) -> None:
+    """A mixed tree must not fold three states into two - the counts drive the exit code."""
+    allocate_run("intact-one", repo_root=tmp_path)
+    to_move = allocate_run("moved-one", repo_root=tmp_path)
+    legacy = allocate_run("legacy-one", repo_root=tmp_path)
+    _rename_run_dir(to_move.root, "099-moved-one")
+    manifest = json.loads(legacy.manifest_path.read_text(encoding="utf-8"))
+    del manifest[RUN_LOCATION_KEY]
+    legacy.manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    _runs, counts = verify_runs(tmp_path)
+
+    assert counts == {RUN_LOCATION_INTACT: 1, RUN_LOCATION_MOVED: 1, RUN_LOCATION_UNVERIFIABLE: 1}
+
+
+@pytest.mark.parametrize(
+    ("counts", "expected"),
+    [
+        ({RUN_LOCATION_INTACT: 3, RUN_LOCATION_MOVED: 0, RUN_LOCATION_UNVERIFIABLE: 0}, 0),
+        ({RUN_LOCATION_INTACT: 0, RUN_LOCATION_MOVED: 0, RUN_LOCATION_UNVERIFIABLE: 0}, 0),
+        ({RUN_LOCATION_INTACT: 1, RUN_LOCATION_MOVED: 1, RUN_LOCATION_UNVERIFIABLE: 0}, 1),
+        ({RUN_LOCATION_INTACT: 1, RUN_LOCATION_MOVED: 0, RUN_LOCATION_UNVERIFIABLE: 1}, 3),
+        # an established finding outranks an unanswered question, but NEITHER is a pass
+        ({RUN_LOCATION_INTACT: 0, RUN_LOCATION_MOVED: 1, RUN_LOCATION_UNVERIFIABLE: 9}, 1),
+    ],
+)
+def test_verify_exit_code_gates_on_state_never_on_printed_text(counts: dict, expected: int) -> None:
+    """0 clean / 1 findings / 3 cannot-establish, matching `check_reference_readiness.py`."""
+    assert verify_exit_code(counts) == expected
+
+
+def _run_verify_cli(repo_root: Path) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(REPO_ROOT / "scripts" / "work_dirs.py"), "--verify", "--repo-root", str(repo_root)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_verify_cli_exits_0_for_an_all_intact_tree(tmp_path: Path) -> None:
+    """Reaches the real CLI in a subprocess, so argparse and `main()` are covered, not just helpers."""
+    allocate_run("acme", repo_root=tmp_path)
+
+    result = _run_verify_cli(tmp_path)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "INTACT" in result.stdout
+
+
+def test_verify_cli_exits_1_on_a_renumbered_run(tmp_path: Path) -> None:
+    """Exit 1 is a FINDING, and must be distinguishable from the exit 3 a legacy run produces."""
+    run = allocate_run("acme", repo_root=tmp_path)
+    _rename_run_dir(run.root, "042-acme")
+
+    result = _run_verify_cli(tmp_path)
+
+    assert result.returncode == 1, result.stdout + result.stderr
+    assert "MOVED" in result.stdout
+    assert "001-acme" in result.stdout and "042-acme" in result.stdout
+
+
+def test_verify_cli_exits_3_on_a_legacy_run_and_says_it_is_not_intact(tmp_path: Path) -> None:
+    """Reproduces the live `_runs/` tree on the machine that shipped this change: three legacy runs,
+    all `unverifiable`, CLI exit 3. Exit 3 is `check_reference_readiness.py`'s CANNOT_ESTABLISH -
+    not a pass, and distinguishable from the exit 1 a real finding produces."""
+    run = allocate_run("acme", repo_root=tmp_path)
+    manifest = json.loads(run.manifest_path.read_text(encoding="utf-8"))
+    del manifest[RUN_LOCATION_KEY]
+    run.manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    result = _run_verify_cli(tmp_path)
+
+    assert result.returncode == 3, result.stdout + result.stderr
+    assert "UNVERIFIABLE" in result.stdout
+    assert "is NOT 'intact'" in result.stdout
+
+
+def test_verify_cli_needs_no_unit_argument_but_allocation_still_does(tmp_path: Path) -> None:
+    """`--verify` allocates nothing, so it must not require a unit - and dropping the unit without
+    `--verify` must still be an argparse error rather than a silent no-op allocation."""
+    assert _run_verify_cli(tmp_path).returncode == 0
+    assert not runs_root(tmp_path).exists(), "--verify must never allocate or create anything"
+
+    bare = subprocess.run(
+        [sys.executable, str(REPO_ROOT / "scripts" / "work_dirs.py"), "--repo-root", str(tmp_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert bare.returncode == 2
+    assert "--verify" in bare.stderr
+
+
+# --------------------------------------------------------------------------------------
+# The prevention half - the prohibition must live in the artifact an agent actually reads
+# --------------------------------------------------------------------------------------
+
+
+def test_the_rename_prohibition_and_its_reason_are_stated_in_work_dirs_itself(tmp_path: Path) -> None:
+    """Issue #470's first gap: the rule lived only in `docs/`, so an agent reading this module
+    pattern-matched the naming semantics and renumbered 14 run directories. `tmp_path` is unused;
+    this asserts on docstrings, which are the artifact that failed."""
+    del tmp_path
+    import work_dirs  # pylint: disable=import-outside-toplevel
+
+    module_doc = work_dirs.__doc__ or ""
+    allocate_doc = allocate_run.__doc__ or ""
+
+    for phrase in ("never renamed", "absolute self-paths"):
+        assert phrase in module_doc.lower(), f"the module docstring no longer states {phrase!r}"
+    assert "never be renamed" in allocate_doc.lower()
+    assert "absolute self-paths" in allocate_doc.lower()
+    # the granularity their agent got wrong: one run per pipeline run, not one per workbook
+    assert "not one per workbook" in module_doc.lower()
+    assert "not one per workbook" in allocate_doc.lower()


### PR DESCRIPTION
Fixes #470

A customer's agent renumbered **14 `_runs/` directories** in one reorg. Two things failed at once: the prohibition was absent from the module the agent was reading, and afterwards there was **no way to tell**. This fixes the second properly and the first cheaply.

---

## Two premise corrections, up front

The issue's evidence is accurate about the defect, and slightly off in two places. Both are load-bearing, so they are stated rather than quietly worked around.

**1. `work_dirs.py` did already carry the rule — in the one docstring nobody reads.** The issue says the module never states it. `RunPaths` (line 155 on master) says: *"Never rename `root` after allocation (issue #234, rule 1): generated bundle output embeds absolute self-paths, so moving a run after the fact breaks refresh."* That does not weaken the issue — it sharpens it. The rule was in a **dataclass** docstring, while an agent reading "how do I make/name a run" reads the **module header** and **`allocate_run`**, which said only *"the number is the identity"* and *"the slug is decoration only"*. Placement, not absence, was the defect. So the prohibition now appears in all three, and a test asserts it stays in the two that were missing it.

**2. `run` + `unit_key` already imply the directory name — legacy runs are not information-free.** `allocate_run` names the directory `f"{run:0{max(3,len(str(run)))}d}-{unit_key}"`, and both fields are already in every manifest. A pre-change run *can* therefore be compared against its own directory name. This matters because it is exactly the trap the issue warns about: a derived answer that looks like a recorded one.

The resolution keeps both properties. `unverifiable` is a hard state that inference can never promote, **and** the derived comparison is still reported — clearly subordinate, on `unverifiable` runs only, labelled `INFERENCE` in its own message. Discarding it would have thrown away the only thing that can flag an *already*-renumbered run; letting it decide the state would have rebuilt the defect. Verified by mutation: promoting a matching derived name to `intact` turns `test_a_legacy_manifest_with_no_recorded_name_is_unverifiable_never_intact` red.

---

## The contract

| state | condition | surfaces as |
|---|---|---|
| `intact` | recorded name == actual directory name | `list_runs()[i]["location_check"]["state"]`; `--verify` prints `INTACT`; **exit 0** |
| `moved` | recorded name != actual name | same, `MOVED`, **naming both directories**; **exit 1** |
| `unverifiable` | no usable recorded name | same, `UNVERIFIABLE` + an explicit *"'unverifiable' is NOT 'intact'"* line; **exit 3** |

Exit codes deliberately mirror `check_reference_readiness.py` — 0 clean / 1 findings / 3 `CANNOT_ESTABLISH`, **and neither 1 nor 3 is a pass**. `moved` outranks `unverifiable` because an established finding beats an unanswered question; a caller gating on `-eq 0` catches both either way.

Three surfaces, one verdict function:

- `check_run_location(manifest, run_dir)` — pure, no disk, no mutation, never raises.
- `list_runs()` — attaches `location_check` to every run. Still *"pure inspection, never mutates, never raises"*; it does not repair and does not raise.
- `python scripts/work_dirs.py --verify [--json]` — new CLI mode. Allocates nothing (asserted).

**No auto-repair.** Rewriting the recorded name to match the current location would erase the only evidence that anything moved.

**`allocate_run` is unchanged where it matters.** Still `mkdir`-exclusive with retry, never read-the-max-then-write; the existing true-race test still passes. The new key is written in the **same reserved block** as `run`/`unit_key`/`created`/`status`, i.e. after `extra_manifest` is merged, so a caller cannot plant a false self-path and forge an `intact` verdict.

## Why the directory NAME, and not a path

`allocated_dir_name` holds `"408-coldrun2-fabric-migration-lab"` — not an absolute path, not a path relative to the repo.

- **A renumber/rename changes it. Every legitimate relocation does not.** Cloning the repo, moving the checkout, or working in a `git worktree` all change the absolute path while the run keeps its identity. Recording an absolute path would report *every run in a fresh clone* as `moved` — and a check that fires on a legitimate clone is one people learn to ignore, which is strictly worse than no check. `test_a_relocated_repository_is_still_intact_not_moved` copies a whole repo root elsewhere and asserts `intact`, after first asserting the absolute paths really did change (otherwise the test proves nothing).
- **Relative-to-`_runs/` would be identical here.** `list_runs` scans `_runs/` at depth 1 only, so the relative path *is* the directory name for anything it can observe. Recording both would be redundant.
- **The honest limit:** copying a run into a *different* repo's `_runs/` under the same name reports `intact`. That is a real blind spot of name-based comparison, accepted deliberately — it is rare, and closing it costs the false positive on every clone. Recorded in "not verified" below rather than hidden.

## The three questions

**Can the test reach the production code path?** Yes, and for the CLI it is proven rather than assumed. `test_verify_cli_*` shell out to `sys.executable scripts/work_dirs.py --verify --repo-root <tmp>` in a subprocess, so argparse, `main()`, the printer and the exit code are all real. The state tests consume `list_runs()`, which is what a caller actually calls, not the helper underneath it. The docstring test reads `work_dirs.__doc__` / `allocate_run.__doc__` from the imported module, so deleting the warning from the source turns it red (mutation-verified).

**Does the guard cover the whole surface its name claims?** Scoped honestly: it claims *"is this run still in the directory it was allocated in"*, and that is all it checks. It does **not** validate the bundles underneath, does not detect a run moved out of `_runs/` entirely (`list_runs` cannot see it), and does not detect the cross-repo copy above. Every run `list_runs` returns gets a `location_check` — there is no path through it that returns a run without one (`test_list_runs_attaches_a_location_check_to_every_run`), and an unusable recorded value (int, list, dict, empty string) degrades to `unverifiable`, never to `intact`.

**Does the evidence prove what the verdict claims?** For `intact`/`moved`, yes — the verdict rests on a value written by `allocate_run` at allocation time and compared to the filesystem, with `derived_name_check` pinned to `not_consulted` so it is provable no inference contributed (asserted). For `unverifiable`, the verdict is *"cannot be established"*, and that is exactly what the evidence supports: the manifest has no record. The derived hint never upgrades it.

## Verification — all by exit code

| gate | result |
|---|---|
| `ruff format` + `ruff check --fix` on both changed `.py` | exit 0, "All checks passed!" |
| `pylint scripts` (the CI invocation) | **exit 0**, 10.00/10 |
| `pylint tests/test_work_dirs.py` | exit 16, 12 findings — **all 12 pre-existing**, measured against `git show origin/master:tests/test_work_dirs.py` (exit 16, 12 findings, 8.95/10 → now 9.57/10). Zero findings added; CI does not lint `tests/` |
| `pytest tests/test_work_dirs.py` | **exit 0**, 58 passed |
| `pytest tests/test_scripts_help.py` | **exit 0**, 211 passed (see the F003 incident below) |
| `pytest -q` (tier-2 full suite) | **6 failed, 4713 passed, 10 skipped** in 1184 s — all 6 failures reproduce on `origin/master` (see below) |
| `python scripts/check_navigation_index.py` | **exit 0** |
| `python scripts/check_agent_capabilities.py` | **exit 0** |
| `python scripts/work_dirs.py --help` under `PYTHONIOENCODING=cp1252` | **exit 0** |

**The full suite caught a real regression in this branch, and one self-inflicted false alarm.** Both are recorded because the first is exactly the kind of thing a green targeted run hides:

- ❌ **Real, mine, now fixed (commit 3):** I put a `⚠️` in the **module docstring**, which is argparse's `description`. Windows defaults stdout to cp1252, so `python scripts/work_dirs.py --help` exited 1 with `UnicodeEncodeError` before printing anything — caught by this repo's own F003 guard, `test_help_exits_zero_on_a_cp1252_stdout[work_dirs.py]`. The glyph now lives in a comment directly beneath the docstring, which also states the constraint so the next editor does not re-add one. Verified after: module-docstring non-ASCII characters `[]`, `--help` exit 0 under cp1252.
- ⚠️ **False alarm, mine, not a code defect:** `test_help_exits_zero_on_a_cp1252_stdout[check_navigation_index.py]` also failed — because my own untracked scratch `pr-body.md` was sitting at the repo root, and `check_navigation_index.py` treats every untracked-but-not-ignored `.md` as an indexable candidate. That test invokes the script with `--help`, which it ignores, so it really ran the check and really failed. Scratch moved into a gitignored `_pr/`; the gate is exit 0 and the test passes. Worth recording: **a scratch `.md` at the repo root breaks the navigation gate**, and the failure surfaces under an unrelated test's name.
- ✅ **Pre-existing, not mine:** the remaining 6 failures (`test_issue_424_chart_type_pin.py` ×3, `test_upstream_repro_pins.py` ×3) reproduce identically on **`origin/master`** in a separate checkout — they pin an engine version (`- 2.260.0 / + 2.353.0`) that has moved on. Not touched.

**The live-fixture proof (the backwards-compatibility claim, not a synthetic fixture):**

```
$ python scripts/work_dirs.py --verify --repo-root <this machine's repo>
_runs/ location check: ...\_runs
  UNVERIFIABLE  406-meridian-smoke-2-339-0-20260901
  UNVERIFIABLE  407-dryrun-gates
  UNVERIFIABLE  408-coldrun2-fabric-migration-lab
                no 'allocated_dir_name' recorded (allocated before this key existed); its
                run/unit_key imply '408-coldrun2-fabric-migration-lab', which matches - but that is INFERENCE
3 run(s): 0 intact, 0 moved, 3 unverifiable
  'unverifiable' is NOT 'intact' - those runs predate path recording and cannot be checked.
EXIT: 3
```

All three real runs report `unverifiable`, **not** `intact` — including `408-coldrun2-fabric-migration-lab`, whose derived name matches.

**Mutation testing, run before opening this PR** — 9 mutations, 9 killed. Because a perfect first result deserves suspicion, the harness was itself checked two ways: one mutation was re-run by hand and its failure inspected (`AssertionError: assert 'intact' == 'moved'` — a genuine assertion, not an import error scoring as a kill), and a **negative control** (rewording an unasserted `detail` string) correctly **survived**. Mutations killed: dropping the recorded key; upgrading a matching legacy run to `intact`; comparing absolute paths instead of names; dropping `moved` from the exit code; dropping the non-dict manifest guard; reverting `root` to `setdefault`; making the key clobberable via `extra_manifest`; deleting the prohibition from the docstring; reporting a moved run as `intact`.

## Two adjacent fixes, both tightly coupled

1. **`list_runs` could raise, contradicting its own docstring.** A `run.json` holding valid JSON that is not an object (`[]`, `"str"`, `42`, `null`) reached `data.setdefault(...)` → `AttributeError`, which sails past the `json.JSONDecodeError`/`OSError` guard. Pre-existing, and directly in the way: I add a second `.get()` on the same object. Now skipped; parametrized test over all four shapes plus malformed and empty payloads.
2. **`root` was `setdefault`, not assigned.** A `root` planted via `extra_manifest` shadowed the real location — a stale recorded value silently presented as current, which is the same failure mode the issue is about. `root` is derived, so it is now assigned unconditionally and documented as such.

## Documentation

- `scripts/work_dirs.py` — prohibition + reason + granularity in the **module docstring** and **`allocate_run`**, pointing at `docs/INDEX.md`, `docs/migration-phases.md` and `docs/operator-runbook.md`.
- `docs/migration-phases.md` Phase 1 — the granularity sentence was thin, and I can name it: line 57 read *"One numbered run directory per pipeline run"* with no counter-example, immediately above a table describing run 408 as a 48-workbook sweep. It now says what it excludes: run 408 is **one** run covering 48 workbooks, not 48 sibling runs, and per-workbook units live in its `bundle/pbip/`. The rest of the section was already correct and is untouched.
- `docs/operator-runbook.md` §6.4 — same rule plus the `--verify` command and the exit-3 caveat.
- `docs/operator-runbook.md` **§4.12 (new)** — the four Windows/PowerShell misreads, in the failure playbook where an operator already looks. No new file.
- `docs/windows-path-limits.md` — content was right, discoverability was not: the deletion recipe sat in a blockquote under *"Reproducing it"*. Promoted to its own heading naming the symptom (`Remove-Item` refuses it), stating why **both** halves are load-bearing.
- `docs/INDEX.md` — searchable keywords in the three affected descriptions.

**On the `requests`/certifi item, which the brief asked me to verify rather than repeat:** ✅ **`scripts/` contains no `requests` import at all** (`Select-String -Path scripts\*.py -Pattern "import requests|from requests"` → no matches). Every Tableau call goes through `urllib.request` (`tableau_http.py`, `capture_tableau_oracle.py`, `assess_estate.py`, `tableau_render_capability.py`, `deploy_estate.py`, `harvest_tableau_public.py`), and `tableau_http.py`'s `_DeadlineHTTPSHandler` forwards the context so *"certificate verification is unchanged"*. CPython's default `SSLContext` on Windows is populated from the Windows certificate store; measured on this machine: `len(ssl.create_default_context().get_ca_certs())` = **98**, `len(ssl.enum_certificates('ROOT'))` = **69**. `requests` verifies against certifi's static PEM instead, which is why an ad-hoc probe fails where the toolkit succeeds. Stated as the repo's mechanism, with the numbers.

## What I could NOT verify

- **The customer's 14-directory reorg.** Not reproduced; taken from the issue.
- **That bundle output actually embeds absolute self-paths.** The premise of the whole prohibition, asserted by `docs/migration-phases.md`, `docs/operator-runbook.md` and #234, and repeated here. I did not open a bundle and grep for absolute paths. If it is false, the prohibition is over-strict — the *detection* still behaves correctly, it would just be guarding less than claimed.
- **The cross-repo copy blind spot** (named above) is reasoned from the design, not exercised by a test — there is deliberately no code path that could distinguish it.
- **Whether `--verify` should be wired into `check_unit.py` or preflight.** It is opt-in; nothing calls it automatically. Deliberate: `_runs/` is machine-local scratch and a repo-wide exit 3 in preflight on every existing machine would be noise on day one. Worth revisiting once most runs carry the key.
- **The four Windows items** are prose, ungated by any test. ① and ④ were re-measured here; ② is this repo's own existing documented recipe; ③ is `Start-Process` semantics plus the measured consequence recorded in the issue — I did not re-run the mangled oracle capture.
- **Whether the module docstring must be ASCII on non-Windows** — the F003 guard simulates cp1252 via `PYTHONIOENCODING`; I did not test on a real Windows console with a different code page.

## Follow-ups (not done here, on purpose)

- **`AGENTS.md`** carries the same `_runs/` convention text and arguably deserves the `--verify` pointer. Not touched — it holds a synced block that regenerates four persona files, and editing it from this branch breaks a CI check I cannot see the far side of.
- **`scripts/README.md`** would normally get the new CLI mode; another branch owns that file right now.
- A `--prune`/migration helper that backfills `allocated_dir_name` is **deliberately not** offered: writing the key now would record where a run is *today*, not where it was allocated, i.e. manufacture an `intact` verdict with no evidence behind it.

## Files

`scripts/work_dirs.py`, `tests/test_work_dirs.py`, `docs/INDEX.md`, `docs/migration-phases.md`, `docs/operator-runbook.md`, `docs/windows-path-limits.md`. Nothing outside the assigned scope; no file owned by an in-flight branch.
