### PR TITLE
fix(harvest): kill a STALLED download, not a slow one — and make the sweep tally add up

### DIFF
--- a/scripts/harvest_estate_assets.py
+++ b/scripts/harvest_estate_assets.py
@@ -50,17 +50,21 @@ fresh-per-asset completed 8/8. Slower, and the only thing that finishes.
 from __future__ import annotations
 
 import argparse
+import ctypes
 import json
 import logging
 import os
+import re
 import sqlite3
 import subprocess
 import sys
+import threading
 import time
 import traceback
 from collections import deque
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from concurrent.futures import Future, ThreadPoolExecutor
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -81,6 +85,12 @@ from engine_source import EngineNotFoundError, engine_scripts_dir  # noqa: E402 
 from tableau_env import engine_child_env, pat_secret, redact, require, resolve_env  # noqa: E402  # pylint: disable=wrong-import-position
 
 LOG = logging.getLogger("harvest_estate_assets")
+
+# The download watchdog (below) pushes this module past pylint's 1200-line limit. The precedent in
+# this repo is a module-level waiver (`assess_estate.py`, `run_estate.py`, `deploy_estate.py` and
+# three others carry the same one) rather than a cosmetic split; the watchdog is nonetheless a
+# genuine seam and would be the thing to lift out if this file grows again.
+# pylint: disable=too-many-lines
 
 # The FILES this script writes under `--out`, probed as files on purpose. Two reasons:
 #   * a directory-only rule (`/_sweep*/`, or a hand-written `_myout/assets/`) is applied by
@@ -361,11 +371,386 @@ def refuse_unignored_output(
     return True
 
 
-def download(kind: str, luid: str, out_file: Path, env: dict[str, str], scripts: Path) -> tuple[bool, str]:
+# --- download watchdog: telling a STALLED download from a merely SLOW one -----------------------
+#
+# There are TWO nested timeouts and they catch opposite failures. The engine's `fetch_tds.py` passes
+# `timeout=300` to `urlopen` (`:407`, `:423`), which is a PER-SOCKET-READ timeout: it fires when a
+# connection goes quiet. Ours was `subprocess.run(..., timeout=600)`, a TOTAL WALL CLOCK: it fires on
+# a download that is progressing perfectly well and merely large. A customer's 47-asset harvest lost
+# `IA Redemptions by Campaign Report` to the second one twice (issue #472) — very likely a healthy
+# download we killed. Raising 600 to 1200 only moves that cliff, so the ceiling is not the fix:
+# knowing whether bytes are still arriving is.
+#
+# ⚠️ A FILE-GROWTH watchdog cannot work here, and this is a property of the engine, not a guess.
+# `_http` ends `return resp.status, dict(resp.headers), resp.read()` — ONE unbounded read, the whole
+# asset buffered in RAM — and `save_outputs(raw, ...)` writes only afterwards. The destination file
+# is therefore 0 bytes until the download has already finished.
+#
+# What DOES work, measured 2026-09-03 on Windows against a local slow-stream server (a child running
+# the same `urlopen(...).read()` shape), 15 MB at ~1 MB/s versus a socket that goes quiet after 3
+# chunks:
+#
+#   sampled                                   healthy download        stalled download
+#   Popen.pid `OtherTransferCount`            Δ 0 (frozen)            Δ 0 (frozen)
+#   real interpreter `ReadTransferCount`      Δ 0 after startup       Δ 0
+#   real interpreter `OtherTransferCount`     moves every second      frozen for 19s
+#   `PagefileUsage`                           frozen after startup    frozen
+#
+# Three things that table settles, each of which would have produced a WRONG fix on its own:
+#
+#  1. Socket bytes land in Windows' OTHER I/O bucket, not Read, and they are counted as per-operation
+#     overhead (~160 B/s observed while ~1 MB/s flowed). So this is a LIVENESS signal, never a byte
+#     count — do not report it as "bytes downloaded".
+#  2. The RAM-footprint half of the hypothesis is UNSOUND: `PagefileUsage` did not move while 15 MB
+#     was buffered. Committed memory is taken in large chunks up front, so it is not a per-byte
+#     signal. Measured, not assumed.
+#  3. **`Popen.pid` is the WRONG PROCESS under a uv venv.** `.venv/Scripts/python.exe` is a
+#     trampoline: measured `Popen.pid = 35152` while the child's own `os.getpid()` reported `20856`.
+#     Sampling the handle Popen hands you measures a stub whose counters never move, so the naive
+#     design would have declared EVERY download stalled and killed all of them. The probe therefore
+#     sums the whole process SUBTREE.
+#
+# And because a signal that can be wrong must fail in the safe direction: a flatline is only ever
+# acted on after movement has been observed AT LEAST ONCE for this child. No movement ever seen
+# (unsupported platform, denied handle, trampoline we could not walk) means no stall verdict — the
+# wall-clock ceiling applies instead, i.e. exactly today's behaviour.
+
+DEFAULT_DOWNLOAD_TIMEOUT = 600.0
+DEFAULT_STALL_TIMEOUT = 120.0
+PROGRESS_POLL_SECONDS = 2.0
+# "NEVER block silently on an external system" (AGENTS.md): anything past a minute reports elapsed
+# time, so a stall is visible as a stall rather than looking like work.
+HEARTBEAT_SECONDS = 60.0
+
+PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+PROCESS_TERMINATE = 0x0001
+TH32CS_SNAPPROCESS = 0x2
+
+_HANDLE = ctypes.c_void_p
+_DWORD = ctypes.c_uint32
+_BOOL = ctypes.c_int32
+
+
+class IoCounters(ctypes.Structure):  # pylint: disable=too-few-public-methods
+    """`IO_COUNTERS` — cumulative per-process I/O, as `GetProcessIoCounters` fills it in."""
+
+    _fields_ = [
+        ("ReadOperationCount", ctypes.c_ulonglong),
+        ("WriteOperationCount", ctypes.c_ulonglong),
+        ("OtherOperationCount", ctypes.c_ulonglong),
+        ("ReadTransferCount", ctypes.c_ulonglong),
+        ("WriteTransferCount", ctypes.c_ulonglong),
+        ("OtherTransferCount", ctypes.c_ulonglong),
+    ]
+
+
+class ProcessEntry32(ctypes.Structure):  # pylint: disable=too-few-public-methods
+    """`PROCESSENTRY32` — only `th32ProcessID`/`th32ParentProcessID` are read, but the layout must
+    be complete or `Process32First` fills the wrong offsets."""
+
+    _fields_ = [
+        ("dwSize", _DWORD),
+        ("cntUsage", _DWORD),
+        ("th32ProcessID", _DWORD),
+        ("th32DefaultHeapID", ctypes.POINTER(ctypes.c_ulong)),
+        ("th32ModuleID", _DWORD),
+        ("cntThreads", _DWORD),
+        ("th32ParentProcessID", _DWORD),
+        ("pcPriClassBase", ctypes.c_long),
+        ("dwFlags", _DWORD),
+        ("szExeFile", ctypes.c_char * 260),
+    ]
+
+
+_KERNEL32: Any = None
+
+
+def kernel32() -> Any:
+    """`kernel32` with `argtypes` SET, or None off Windows.
+
+    ⚠️ The `argtypes` are not decoration. Without them ctypes passes a 64-bit `HANDLE` as `c_int`,
+    and the failure is silent-looking rather than loud: measured, `GetProcessIoCounters` returned 0
+    for `GetCurrentProcess()`'s `-1` pseudo-handle while a small real handle "succeeded" with values
+    that never moved — which reads exactly like a stalled download.
+    """
+    global _KERNEL32  # pylint: disable=global-statement
+    if _KERNEL32 is None:
+        if sys.platform != "win32":
+            return None
+        lib = ctypes.windll.kernel32  # pylint: disable=no-member  # Windows-only, guarded above
+        lib.OpenProcess.argtypes = [_DWORD, _BOOL, _DWORD]
+        lib.OpenProcess.restype = _HANDLE
+        lib.CloseHandle.argtypes = [_HANDLE]
+        lib.CloseHandle.restype = _BOOL
+        lib.TerminateProcess.argtypes = [_HANDLE, ctypes.c_uint32]
+        lib.TerminateProcess.restype = _BOOL
+        lib.GetProcessIoCounters.argtypes = [_HANDLE, ctypes.POINTER(IoCounters)]
+        lib.GetProcessIoCounters.restype = _BOOL
+        lib.CreateToolhelp32Snapshot.argtypes = [_DWORD, _DWORD]
+        lib.CreateToolhelp32Snapshot.restype = _HANDLE
+        lib.Process32First.argtypes = [_HANDLE, ctypes.POINTER(ProcessEntry32)]
+        lib.Process32First.restype = _BOOL
+        lib.Process32Next.argtypes = [_HANDLE, ctypes.POINTER(ProcessEntry32)]
+        lib.Process32Next.restype = _BOOL
+        _KERNEL32 = lib
+    return _KERNEL32
+
+
+def windows_descendants(pid: int) -> list[int]:
+    """Every descendant PID of `pid`, walked from one process snapshot. Empty off Windows."""
+    lib = kernel32()
+    if lib is None:
+        return []
+    snapshot = lib.CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0)
+    if not snapshot or snapshot == -1:
+        return []
+    entry = ProcessEntry32()
+    entry.dwSize = ctypes.sizeof(ProcessEntry32)  # pylint: disable=invalid-name,attribute-defined-outside-init
+    by_parent: dict[int, list[int]] = {}
+    try:
+        found = lib.Process32First(snapshot, ctypes.byref(entry))
+        while found:
+            by_parent.setdefault(int(entry.th32ParentProcessID), []).append(int(entry.th32ProcessID))
+            found = lib.Process32Next(snapshot, ctypes.byref(entry))
+    finally:
+        lib.CloseHandle(snapshot)
+    seen: list[int] = []
+    stack = [pid]
+    while stack:
+        for child in by_parent.get(stack.pop(), []):
+            if child not in seen and child != pid:
+                seen.append(child)
+                stack.append(child)
+    return seen
+
+
+def process_tree(pid: int) -> list[int]:
+    """`pid` and its descendants. The descendants are the point: see the trampoline note above."""
+    if sys.platform == "win32":
+        return [pid, *windows_descendants(pid)]
+    children: dict[int, list[int]] = {}
+    for entry in Path("/proc").glob("*/stat") if Path("/proc").is_dir() else []:
+        try:
+            fields = entry.read_text(encoding="utf-8", errors="replace").rsplit(")", 1)[-1].split()
+            children.setdefault(int(fields[1]), []).append(int(entry.parent.name))
+        except (OSError, ValueError, IndexError):
+            continue
+    seen: list[int] = [pid]
+    stack = [pid]
+    while stack:
+        for child in children.get(stack.pop(), []):
+            if child not in seen:
+                seen.append(child)
+                stack.append(child)
+    return seen
+
+
+def transferred_bytes(pid: int) -> int | None:
+    """A monotonic-ish I/O counter summed over `pid`'s SUBTREE, or None when unobtainable.
+
+    LIVENESS, not volume: on Windows the socket payload is not what moves this (see the measurement
+    table above), so compare it with its own previous value and never report it as bytes downloaded.
+    None means "this platform/process cannot tell us", which is a different answer from 0 and must
+    never be treated as a stall.
+    """
+    if sys.platform == "win32":
+        lib = kernel32()
+        if lib is None:  # pragma: no cover - unreachable while sys.platform is win32
+            return None
+        total: int | None = None
+        for target in process_tree(pid):
+            handle = lib.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, target)
+            if not handle:
+                continue
+            counters = IoCounters()
+            ok = lib.GetProcessIoCounters(handle, ctypes.byref(counters))
+            lib.CloseHandle(handle)
+            if not ok:
+                continue
+            total = (total or 0) + int(
+                counters.ReadTransferCount + counters.WriteTransferCount + counters.OtherTransferCount
+            )
+        return total
+    total = None
+    for target in process_tree(pid):
+        try:
+            io_text = Path(f"/proc/{target}/io").read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        for line in io_text.splitlines():
+            key, _, value = line.partition(":")
+            if key in ("rchar", "wchar"):
+                total = (total or 0) + int(value.strip() or 0)
+    return total
+
+
+def terminate_tree(proc: subprocess.Popen[str]) -> None:
+    """Kill the child AND its descendants, deepest first — the trampoline again.
+
+    `Popen.kill()` terminates only the process Popen holds. Under a uv venv that is the trampoline,
+    which would leave the real interpreter running with the socket still open, so the very download
+    we just gave up on would keep consuming the session we are about to re-establish.
+    """
+    descendants = windows_descendants(proc.pid) if sys.platform == "win32" else process_tree(proc.pid)[1:]
+    lib = kernel32()
+    for target in reversed(descendants):
+        if lib is not None:
+            handle = lib.OpenProcess(PROCESS_TERMINATE, False, target)
+            if handle:
+                lib.TerminateProcess(handle, 1)
+                lib.CloseHandle(handle)
+            continue
+        try:
+            os.kill(target, 9)
+        except OSError:
+            pass
+    try:
+        proc.kill()
+    except OSError:
+        pass
+
+
+@dataclass
+class WatchedRun:  # pylint: disable=too-few-public-methods
+    """What a watched subprocess did: its result, or WHY we stopped waiting for it."""
+
+    returncode: int | None
+    stdout: str
+    stderr: str
+    elapsed: float
+    verdict: str  # "" (ran to completion), "stalled", or "ceiling"
+    detail: str  # operator-facing failure text; empty unless `verdict` is set
+    progress_observed: bool
+
+
+def run_watched(  # pylint: disable=too-many-locals,too-many-branches,too-many-arguments,too-many-statements
+    cmd: list[str],
+    env: dict[str, str],
+    *,
+    timeout: float = DEFAULT_DOWNLOAD_TIMEOUT,
+    stall_timeout: float = DEFAULT_STALL_TIMEOUT,
+    label: str = "download",
+    probe: Callable[[int], int | None] = transferred_bytes,
+    poll_interval: float = PROGRESS_POLL_SECONDS,
+    heartbeat: float = HEARTBEAT_SECONDS,
+) -> WatchedRun:
+    """Run `cmd`, killing it when it STOPS MAKING PROGRESS rather than when it takes a long time.
+
+    Two deadlines, and which one is armed depends on evidence rather than on configuration:
+
+    * `stall_timeout` — armed only once the probe has been seen to MOVE for this child. A flatline is
+      then a genuine stall and killing is right.
+    * `timeout` — the wall clock, armed only while no movement has ever been observed, i.e. when we
+      cannot tell slow from hung. This is the pre-#472 behaviour, kept for exactly the case that
+      justified it. `0` disables it, leaving a run bounded only by progress.
+
+    A download that keeps progressing past `timeout` is NOT killed; it is announced loudly instead,
+    because "elapsed time is not progress" cuts both ways.
+    """
+    started = time.perf_counter()
+    # pylint: disable-next=consider-using-with  # the whole point is to supervise it while it runs
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, env=env)
+    collected: dict[str, str] = {"out": "", "err": ""}
+
+    def drain() -> None:
+        # communicate() in its own thread: the pipes must be read while the watchdog polls, or a
+        # chatty child fills a pipe buffer and blocks -- which would look exactly like a stall.
+        out, err = proc.communicate()
+        collected["out"], collected["err"] = out or "", err or ""
+
+    reader = threading.Thread(target=drain, name="download-drain", daemon=True)
+    reader.start()
+
+    last_value = probe(proc.pid)
+    progress_observed = False
+    last_change = started
+    last_beat = started
+    announced_over_ceiling = False
+    verdict = ""
+    while True:
+        reader.join(poll_interval)
+        now = time.perf_counter()
+        elapsed = now - started
+        if not reader.is_alive():
+            break
+        value = probe(proc.pid)
+        if value is not None:
+            if last_value is not None and value != last_value:
+                progress_observed = True
+                last_change = now
+            last_value = value
+        since_progress = now - last_change
+        if now - last_beat >= heartbeat:
+            last_beat = now
+            LOG.info(
+                "%s still running: elapsed=%.0fs, %s",
+                label,
+                elapsed,
+                (
+                    f"last progress {since_progress:.0f}s ago"
+                    if progress_observed
+                    else "no progress signal available (wall-clock ceiling applies)"
+                ),
+            )
+        if progress_observed:
+            if since_progress > stall_timeout:
+                verdict = "stalled"
+                break
+            if timeout and elapsed > timeout and not announced_over_ceiling:
+                announced_over_ceiling = True
+                LOG.warning(
+                    "%s has run %.0fs, past --download-timeout %.0fs, but is still transferring — "
+                    "NOT killing it; it will be killed only after %.0fs with no progress.",
+                    label,
+                    elapsed,
+                    timeout,
+                    stall_timeout,
+                )
+        elif timeout and elapsed > timeout:
+            verdict = "ceiling"
+            break
+
+    elapsed = time.perf_counter() - started
+    if verdict:
+        terminate_tree(proc)
+        reader.join(30)
+        detail = (
+            (
+                f"stalled: no progress for {elapsed - (last_change - started):.0f}s "
+                f"(elapsed {elapsed:.0f}s). The download was moving and then stopped, so this is a "
+                f"hung transfer, not a slow one. Raise --download-stall-timeout above "
+                f"{stall_timeout:.0f}s if the source is merely bursty, or retry the asset."
+            )
+            if verdict == "stalled"
+            else (
+                f"timeout after {timeout:.0f}s (elapsed {elapsed:.1f}s); no download-progress signal "
+                f"was available for this process, so a slow-but-healthy transfer cannot be told from "
+                f"a hang. Raise --download-timeout (or pass 0 to remove the ceiling and rely on "
+                f"--download-stall-timeout alone)."
+            )
+        )
+        return WatchedRun(None, collected["out"], collected["err"], elapsed, verdict, detail, progress_observed)
+    return WatchedRun(proc.returncode, collected["out"], collected["err"], elapsed, "", "", progress_observed)
+
+
+def download(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    kind: str,
+    luid: str,
+    out_file: Path,
+    env: dict[str, str],
+    scripts: Path,
+    *,
+    timeout: float = DEFAULT_DOWNLOAD_TIMEOUT,
+    stall_timeout: float = DEFAULT_STALL_TIMEOUT,
+    label: str = "",
+) -> tuple[bool, str]:
     """Fetch one asset BY LUID via the deterministic tier's fetcher. Returns (ok, detail).
 
     By LUID, never by name: Tableau permits duplicate names across projects, and name-keyed identity
     has already produced four separate defects in this codebase.
+
+    `timeout` is no longer a plain wall clock — see `run_watched`. A transfer that keeps moving is
+    left alone however long it takes; one that stops moving is killed after `stall_timeout`.
     """
     flag = "--workbook-luid" if kind == "workbook" else "--datasource-luid"
     cmd = [
@@ -383,17 +768,22 @@ def download(kind: str, luid: str, out_file: Path, env: dict[str, str], scripts:
         str(out_file),
     ]
     child = engine_child_env(env)
-    try:
-        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=600, check=False, env=child)
-    except subprocess.TimeoutExpired:
-        return False, "timeout after 600s"
-    if proc.returncode != 0:
+    run = run_watched(
+        cmd,
+        child,
+        timeout=timeout,
+        stall_timeout=stall_timeout,
+        label=label or f"{kind} {luid}",
+    )
+    if run.verdict:
+        return False, run.detail
+    if run.returncode != 0:
         # Redact BEFORE truncating. Slicing first can cut through the secret and leave a suffix in
         # the retained text, which is then both logged and persisted -- measured: the full secret was
         # absent while its tail survived at the start of the slice. Order matters more than the
         # scrub itself here, because the wrong order still passes a test whose sentinel happens to
         # fall inside the window.
-        raw = redact((proc.stderr or proc.stdout or "").strip(), pat_secret(env), env.get("TABLEAU_PAT_NAME", ""))
+        raw = redact((run.stderr or run.stdout or "").strip(), pat_secret(env), env.get("TABLEAU_PAT_NAME", ""))
         return False, raw[-300:]
     return True, ""
 
@@ -458,16 +848,60 @@ def parse_theirs(path: Path, scripts: Path) -> dict[str, Any]:
         return {"ok": False, "error": f"harness: {type(exc).__name__}: {exc}"}
 
 
-def summarise(results: list[dict], out: Path) -> str:  # pylint: disable=too-many-locals
+def never_downloaded(results: list[dict]) -> list[dict]:
+    """Rows that never reached a parser at all, i.e. the downloads that did not land.
+
+    They are what `len(results)` counted and no bucket claimed: `r.get("ours", {}).get("ok") is
+    False` is False for a row with NO `ours` key, so a failed download fell out of every heading
+    while still inflating the denominator. A customer read `45/47 succeeded` off a tally whose
+    arithmetic did not close (issue #472).
+    """
+    return [r for r in results if "ours" not in r or "theirs" not in r]
+
+
+def failure_shape(message: str) -> str:
+    """A grouping key for a failure message, with the varying numbers collapsed.
+
+    Digits have to go, or the very failures worth grouping stay apart: two timeouts differing only
+    in `elapsed 601.4s` vs `elapsed 612.9s` are ONE feature request, not two, and the file's own
+    rule is to group by shape.
+    """
+    return re.sub(r"\d+(?:\.\d+)?", "N", str(message)).strip()[:90] or "(no detail)"
+
+
+def grouped_by_shape(rows: list[dict], detail: Callable[[dict], str]) -> list[tuple[str, list[str]]]:
+    """`[(shape, [asset names])]`, most frequent shape first."""
+    by_shape: dict[str, list[str]] = {}
+    for row in rows:
+        by_shape.setdefault(failure_shape(detail(row)), []).append(str(row.get("name", "?")))
+    return sorted(by_shape.items(), key=lambda kv: (-len(kv[1]), kv[0]))
+
+
+def summarise(results: list[dict], out: Path) -> str:  # pylint: disable=too-many-locals,too-many-statements
     """Group failures by SHAPE, because one root cause repeated 12 times is one feature request."""
-    ours_fail = [r for r in results if r.get("ours", {}).get("ok") is False]
-    theirs_fail = [r for r in results if r.get("theirs", {}).get("ok") is False]
-    both_ok = [r for r in results if r.get("ours", {}).get("ok") and r.get("theirs", {}).get("ok")]
+    missing = never_downloaded(results)
+    missing_ids = {id(r) for r in missing}
+    parsed = [r for r in results if id(r) not in missing_ids]
+    ours_fail = [r for r in parsed if r.get("ours", {}).get("ok") is False]
+    theirs_fail = [r for r in parsed if r.get("theirs", {}).get("ok") is False]
+    both_ok = [r for r in parsed if r.get("ours", {}).get("ok") and r.get("theirs", {}).get("ok")]
+    both_fail = [r for r in ours_fail if id(r) in {id(x) for x in theirs_fail}]
 
     lines = ["# Estate parse sweep", ""]
     lines.append(
         f"**{len(results)} asset(s)** — ours failed {len(ours_fail)}, his failed {len(theirs_fail)}, "
-        f"both parsed {len(both_ok)}."
+        f"both parsed {len(both_ok)}, never downloaded {len(missing)}."
+    )
+    lines.append("")
+    # The closure line is the audit: `ours failed`/`his failed` OVERLAP when one asset defeats both
+    # parsers, so those two numbers cannot be added to anything. These five are disjoint and must
+    # sum to the denominator -- which is the property that silently failed before issue #472.
+    lines.append(
+        f"Disjoint buckets, which must add up to the {len(results)} above: "
+        f"{len(both_ok)} parsed by both + {len(ours_fail) - len(both_fail)} ours only + "
+        f"{len(theirs_fail) - len(both_fail)} his only + {len(both_fail)} both parsers + "
+        f"{len(missing)} never downloaded = "
+        f"{len(both_ok) + len(ours_fail) + len(theirs_fail) - len(both_fail) + len(missing)}."
     )
     lines.append("")
     lines.append(
@@ -475,6 +909,22 @@ def summarise(results: list[dict], out: Path) -> str:  # pylint: disable=too-man
         "(`docs/migration-programme.md` §0). A failure on both is a genuinely hard input."
     )
     lines.append("")
+
+    lines.append("## Downloads that never landed")
+    lines.append("")
+    if not missing:
+        lines.append("_none_")
+        lines.append("")
+    else:
+        lines.append(
+            f"**{len(missing)} asset(s) never reached a parser**, so nothing below this heading "
+            "says anything about them. They are not successes."
+        )
+        lines.append("")
+        for shape, names in grouped_by_shape(missing, lambda r: str(r.get("download_error", "?"))):
+            lines.append(f"- **{len(names)}x** `{shape}`")
+            lines.append(f"  - {', '.join(names[:8])}{' …' if len(names) > 8 else ''}")
+        lines.append("")
 
     for title, rows, key in (
         ("## Our parser failed", ours_fail, "ours"),
@@ -693,6 +1143,27 @@ def record_parse(
     )
 
 
+def report_failed_downloads(results: list[dict]) -> list[dict]:
+    """Say out loud, at the END of the run, which assets never landed. Returns those rows.
+
+    The per-asset `DOWNLOAD FAILED` warning has already scrolled past a 47-line run by the time the
+    summary prints, and `download_error` was otherwise written into `parse-sweep.json` and surfaced
+    NOWHERE an operator reads. The closing tally is the last thing they see, so the exceptions have
+    to be beside it or the run reads as clean (issue #472).
+    """
+    missing = never_downloaded(results)
+    if not missing:
+        return []
+    LOG.warning(
+        "%d of %d asset(s) NEVER DOWNLOADED and were not parsed at all — they are not successes:",
+        len(missing),
+        len(results),
+    )
+    for row in missing:
+        LOG.warning("  - %s (%s): %s", row.get("name", "?"), row.get("kind", "?"), row.get("download_error", "?"))
+    return missing
+
+
 def main() -> int:  # pylint: disable=too-many-locals,too-many-statements  # one linear sweep
     """Harvest and sweep. Exit 2 when `--out` is committable, 1 when nothing could be assessed."""
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -713,6 +1184,21 @@ def main() -> int:  # pylint: disable=too-many-locals,too-many-statements  # one
         help="project LUID to harvest (repeatable); same selection as --project, matched exactly",
     )
     ap.add_argument("--limit", type=int, help="stop after N assets (for a quick pass)")
+    ap.add_argument(
+        "--download-timeout",
+        type=float,
+        default=DEFAULT_DOWNLOAD_TIMEOUT,
+        help="wall-clock ceiling per asset, in seconds, applied ONLY while no download-progress "
+        f"signal is available (default {DEFAULT_DOWNLOAD_TIMEOUT:.0f}); 0 removes the ceiling. A "
+        "transfer we can see progressing is never killed by this.",
+    )
+    ap.add_argument(
+        "--download-stall-timeout",
+        type=float,
+        default=DEFAULT_STALL_TIMEOUT,
+        help="seconds a download may make NO observable progress before it is killed as hung "
+        f"(default {DEFAULT_STALL_TIMEOUT:.0f}); armed only after progress has been observed once",
+    )
     ap.add_argument("--skip-download", action="store_true", help="reuse whatever is already in --out/assets")
     ap.add_argument("--workbooks-only", action="store_true", help="skip published datasources; sweep workbooks only")
     ap.add_argument(
@@ -787,7 +1273,16 @@ def main() -> int:  # pylint: disable=too-many-locals,too-many-statements  # one
             # fresh sign-in, and after it because the fetcher decides the extension, not us.
             actual = existing_asset(assets_dir, kind, name, luid)
             if not args.skip_download and actual is None:
-                ok, detail = download(kind, luid, target, env, scripts)
+                ok, detail = download(
+                    kind,
+                    luid,
+                    target,
+                    env,
+                    scripts,
+                    timeout=args.download_timeout,
+                    stall_timeout=args.download_stall_timeout,
+                    label=f"[{index}/{len(todo)}] {name[:46]}",
+                )
                 if not ok:
                     row["download_error"] = detail
                     results.append(row)
@@ -815,6 +1310,7 @@ def main() -> int:  # pylint: disable=too-many-locals,too-many-statements  # one
     args.out.mkdir(parents=True, exist_ok=True)
     text = summarise(results, args.out)
     LOG.info("\n%s", text[: text.index("## ") if "## " in text else len(text)])
+    report_failed_downloads(results)
     LOG.info(
         "swept %d asset(s) in %.0fs -> %s", len(results), time.perf_counter() - started, args.out / "parse-sweep.md"
     )

--- a/scripts/harvest_estate_assets.py
+++ b/scripts/harvest_estate_assets.py
@@ -7,6 +7,14 @@ usage:   python scripts/harvest_estate_assets.py --out <dir> [--env .env] [--lim
                                                  [--project NAME] [--project-id LUID]
                                                  [--allow-unignored-out]
 
+Exit codes
+----------
+`0` every in-scope asset reached BOTH parsers (a parse FAILURE is the report this script exists to
+produce, so it stays `0`); `1` NOTHING COULD BE ASSESSED — no asset reached a parser at all; `2`
+refused to write into a committable `--out`; `3` PARTIAL — some assets were assessed and at least
+one never downloaded. `1` and `3` are kept apart on purpose: automation must be able to tell "six of
+forty-seven failed" from "the whole harvest failed".
+
 Where the output goes
 ---------------------
 `--out` is `_sweep` by convention (`.gitignore`: `/_sweep*/`; `_harvest*` belongs to the OTHER
@@ -85,6 +93,42 @@ from engine_source import EngineNotFoundError, engine_scripts_dir  # noqa: E402 
 from tableau_env import engine_child_env, pat_secret, redact, require, resolve_env  # noqa: E402  # pylint: disable=wrong-import-position
 
 LOG = logging.getLogger("harvest_estate_assets")
+
+# --- exit codes: "could not assess" must never collapse into the clean bucket --------------------
+#
+# The final line used to be `return 0 if results else 1`, which counts ROWS -- and a failed download
+# appends a row. So a harvest in which NOTHING reached either parser exited 0. Measured on a
+# one-workbook estate with `download()` returning `(False, "network dead")`:
+#
+#   **1 asset(s)** - ours failed 0, his failed 0, both parsed 0, never downloaded 1.
+#   exit_code: 0
+#
+# That is the fail-open shape AGENTS.md singles out: automation downstream cannot tell a total
+# harvest failure from a clean sweep, and the customer's 47-asset run (41 ok / 6 failed) reported
+# "ours failed 0, his failed 0" for the same reason (issue #472, blind review of #482).
+#
+# The contract. It is deliberately ADDITIVE: no existing code changes meaning, because a code that
+# already means something is read by things this branch cannot see -- measured, `1` is asserted for
+# the unreadable-`estate.db` path by `tests/test_harvest_output_guard.py`, a file this change does
+# not own. So the bug is fixed by moving TOTAL failure out of `0` into the `1` it always documented,
+# and the previously-invisible PARTIAL case gets a NEW number.
+#
+#   0  every in-scope asset reached BOTH parsers. A parse FAILURE stays 0: the failure distribution
+#      is the artifact this script exists to produce, not a run failure.
+#   1  NOTHING COULD BE ASSESSED -- no asset reached a parser at all: every download failed (the new
+#      case), no asset was in scope, the engine is missing, or `estate.db` could not be read. This is
+#      what `main()` has documented since it was written; only the first case is new.
+#   2  refused to write into a committable `--out` (unchanged; nothing was downloaded).
+#   3  PARTIAL -- at least one asset was assessed AND at least one never downloaded (the customer's
+#      41-ok/6-failed shape). Non-zero because those six are absent from every bucket in the report
+#      and an operator reading the tally alone would call the run clean. A new number rather than a
+#      reuse of `1`: "some of the estate is missing" and "the estate was never looked at" need
+#      opposite responses, and 3 is the repo's established slot for a verdict kept apart from 0/1
+#      (`check_datamodel.EXIT_UNASSESSABLE`, `assess_estate.py`'s incomplete-primary-listing code).
+EXIT_OK = 0
+EXIT_NOTHING_ASSESSED = 1
+EXIT_REFUSED_UNIGNORED_OUT = 2
+EXIT_PARTIAL = 3
 
 # The download watchdog (below) pushes this module past pylint's 1200-line limit. The precedent in
 # this repo is a module-level waiver (`assess_estate.py`, `run_estate.py`, `deploy_estate.py` and
@@ -374,12 +418,14 @@ def refuse_unignored_output(
 # --- download watchdog: telling a STALLED download from a merely SLOW one -----------------------
 #
 # There are TWO nested timeouts and they catch opposite failures. The engine's `fetch_tds.py` passes
-# `timeout=300` to `urlopen` (`:407`, `:423`), which is a PER-SOCKET-READ timeout: it fires when a
+# `timeout=300` to `urlopen` (`:405`, `:443`), which is a PER-SOCKET-READ timeout: it fires when a
 # connection goes quiet. Ours was `subprocess.run(..., timeout=600)`, a TOTAL WALL CLOCK: it fires on
 # a download that is progressing perfectly well and merely large. A customer's 47-asset harvest lost
 # `IA Redemptions by Campaign Report` to the second one twice (issue #472) — very likely a healthy
 # download we killed. Raising 600 to 1200 only moves that cliff, so the ceiling is not the fix:
-# knowing whether bytes are still arriving is.
+# knowing whether bytes are still arriving is. The ceiling survives ONLY as the fallback for when
+# that knowledge is unavailable, and it is now derived from the child's own retry budget rather than
+# from history — see `DEFAULT_DOWNLOAD_TIMEOUT` below.
 #
 # ⚠️ A FILE-GROWTH watchdog cannot work here, and this is a property of the engine, not a guess.
 # `_http` ends `return resp.status, dict(resp.headers), resp.read()` — ONE unbounded read, the whole
@@ -422,11 +468,45 @@ def refuse_unignored_output(
 # (unsupported platform, denied handle, trampoline we could not walk) means no stall verdict — the
 # wall-clock ceiling applies instead, i.e. exactly today's behaviour.
 
-DEFAULT_DOWNLOAD_TIMEOUT = 600.0
-# The engine's own per-socket-read timeout (`fetch_tds.py:407,423` pass `timeout=300` to `urlopen`).
-# It is the contract for how long a HEALTHY transfer is allowed to go quiet between reads: urllib
-# tolerates a 299s gap and raises at 300s.
+# The engine's own per-socket-read timeout (`fetch_tds.py:405,443` — `_http_download(url, token,
+# dest, timeout=300, ...)` passes it to `urlopen`). It is the contract for how long a HEALTHY
+# transfer is allowed to go quiet between reads: urllib tolerates a 299s gap and raises at 300s.
 ENGINE_READ_TIMEOUT_SECONDS = 300.0
+# ⚠️ The blind fallback ceiling is DERIVED from the child's own retry budget, never chosen. 600 was
+# inherited from the pre-#472 `subprocess.run(..., timeout=600)` and is not a number about anything:
+# it is BELOW the child's bounded timer, so on any run where the progress probe is unreadable
+# (unsupported platform, denied handle, a subtree we cannot walk) we killed the fetcher before it
+# could produce its own authoritative verdict, and recorded `timeout after 600s` where the child
+# would have reported the real HTTP failure. That is precisely the "do not kill a tool that IS the
+# bounded timer" rule in AGENTS.md (blind review of #482).
+#
+# The arithmetic, read off installed engine 2.356.0's `fetch_tds.py` so the next person can
+# re-derive it (`python scripts/engine_source.py` locates the tree):
+#
+#   `_http_download(url, token, dest, timeout=300, *, max_attempts=4, ...)`  (`:405`)
+#     * up to `max_attempts` = 4 attempts, each of which may burn a full `timeout` = 300s read
+#       timeout before `urlopen` raises                                         -> 4 x 300 = 1200s
+#     * `sleeper(_retry_after_seconds(resp_headers, delay))` between attempts (`:487`). The
+#       unheaded default backoff is only 1+2+4 = 7s, but `_retry_after_seconds` honours a server
+#       `Retry-After` and clamps it to 60s (`:317-328`), so 60s is the worst case per gap, and
+#       there are `max_attempts - 1` gaps                                       ->  3 x  60 =  180s
+#     * one sign-in POST before the download (`_http_json(..., timeout=120)`)   ->            120s
+#     * interpreter start-up for the child                                      ->             30s
+#
+# `fetch_tds.main()` never overrides the 300 (it calls `download_workbook`/`download_datasource`
+# with their default `timeout=300`), so 300 is what actually runs, not merely what is available.
+ENGINE_DOWNLOAD_ATTEMPTS = 4
+ENGINE_BACKOFF_CAP_SECONDS = 60.0
+ENGINE_SIGNIN_TIMEOUT_SECONDS = 120.0
+CHILD_STARTUP_GRACE_SECONDS = 30.0
+# What the child may legitimately spend before it produces its OWN verdict. Our ceiling must never
+# sit below this, or we pre-empt the bounded timer and report `timeout after Ns` in place of the
+# real HTTP failure the fetcher was about to name.
+ENGINE_DOWNLOAD_BUDGET_SECONDS = (
+    ENGINE_DOWNLOAD_ATTEMPTS * ENGINE_READ_TIMEOUT_SECONDS + (ENGINE_DOWNLOAD_ATTEMPTS - 1) * ENGINE_BACKOFF_CAP_SECONDS
+)  # 1200 + 180 = 1380s
+DEFAULT_DOWNLOAD_TIMEOUT = ENGINE_DOWNLOAD_BUDGET_SECONDS + ENGINE_SIGNIN_TIMEOUT_SECONDS + CHILD_STARTUP_GRACE_SECONDS
+# = 1530s
 # ⚠️ This MUST NOT sit below `ENGINE_READ_TIMEOUT_SECONDS`. The first version of this fix defaulted
 # to 120s, by analogy with `refresh_pbip_model.py`'s liveness timer -- but that one WARNS and this
 # one KILLS, which is a different thing entirely. A bursty-but-healthy source pausing 120-300s
@@ -1273,6 +1353,21 @@ def record_parse(
     )
 
 
+def sweep_exit_code(results: list[dict]) -> int:
+    """`EXIT_OK` every asset assessed, `EXIT_PARTIAL` some, `EXIT_NOTHING_ASSESSED` none.
+
+    Counts ASSESSED assets, never rows. A failed download is a row too, which is exactly how a
+    harvest that assessed nothing exited 0 (issue #472; reproduced in the blind review of #482).
+    An empty `results` is `EXIT_NOTHING_ASSESSED` for the same reason it always was non-zero: a
+    sweep that looked at nothing has said nothing about the estate.
+    """
+    missing = len(never_downloaded(results))
+    assessed = len(results) - missing
+    if assessed <= 0:
+        return EXIT_NOTHING_ASSESSED
+    return EXIT_PARTIAL if missing else EXIT_OK
+
+
 def report_failed_downloads(results: list[dict], orphans: list[tuple[str, list[str]]] | None = None) -> list[dict]:
     """Say out loud, at the END of the run, which assets never landed. Returns those rows.
 
@@ -1302,7 +1397,7 @@ def report_failed_downloads(results: list[dict], orphans: list[tuple[str, list[s
 
 
 def main() -> int:  # pylint: disable=too-many-locals,too-many-statements,too-many-branches  # one sweep
-    """Harvest and sweep. Exit 2 when `--out` is committable, 1 when nothing could be assessed."""
+    """Harvest and sweep. Exit 0 complete, 1 nothing assessed, 2 committable `--out`, 3 partial."""
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--out", required=True, type=Path, help="output directory (must be git-ignored, see below)")
     ap.add_argument("--env", type=Path, default=REPO_ROOT / ".env")
@@ -1326,8 +1421,11 @@ def main() -> int:  # pylint: disable=too-many-locals,too-many-statements,too-ma
         type=float,
         default=DEFAULT_DOWNLOAD_TIMEOUT,
         help="wall-clock ceiling per asset, in seconds, applied ONLY while no download-progress "
-        f"signal is available (default {DEFAULT_DOWNLOAD_TIMEOUT:.0f}); 0 removes the ceiling. A "
-        "transfer we can see progressing is never killed by this.",
+        f"signal is available (default {DEFAULT_DOWNLOAD_TIMEOUT:.0f}, derived from the fetcher's "
+        f"own bounded retry budget: {ENGINE_DOWNLOAD_ATTEMPTS} attempts x "
+        f"{ENGINE_READ_TIMEOUT_SECONDS:.0f}s read timeout + backoff + sign-in); 0 removes the "
+        "ceiling. A transfer we can see progressing is never killed by this, and a value below the "
+        "fetcher's own budget kills it before it can report the real error.",
     )
     ap.add_argument(
         "--download-stall-timeout",
@@ -1351,10 +1449,22 @@ def main() -> int:  # pylint: disable=too-many-locals,too-many-statements,too-ma
     if 0 < args.download_stall_timeout < ENGINE_READ_TIMEOUT_SECONDS:
         LOG.warning(
             "--download-stall-timeout %.0fs is BELOW the fetcher's own %.0fs per-read timeout "
-            "(fetch_tds.py:407,423). urllib tolerates a gap that long on a healthy connection, so "
+            "(fetch_tds.py:405,443). urllib tolerates a gap that long on a healthy connection, so "
             "this can kill a bursty-but-healthy download and report it as hung.",
             args.download_stall_timeout,
             ENGINE_READ_TIMEOUT_SECONDS,
+        )
+    if 0 < args.download_timeout < ENGINE_DOWNLOAD_BUDGET_SECONDS:
+        LOG.warning(
+            "--download-timeout %.0fs is BELOW the fetcher's own %.0fs bounded retry budget "
+            "(%d attempts x %.0fs read timeout + backoff, fetch_tds.py:405). While the "
+            "download-progress signal is unreadable this ceiling KILLS the fetcher before its own "
+            "timer can report the real error, and you get `timeout after %.0fs` instead.",
+            args.download_timeout,
+            ENGINE_DOWNLOAD_BUDGET_SECONDS,
+            ENGINE_DOWNLOAD_ATTEMPTS,
+            ENGINE_READ_TIMEOUT_SECONDS,
+            args.download_timeout,
         )
     # Before the engine, the .env, the database and above all the download: a customer's workbooks
     # must never land somewhere this PUBLIC repo would commit them (issue #125). The guard is given
@@ -1363,14 +1473,14 @@ def main() -> int:  # pylint: disable=too-many-locals,too-many-statements,too-ma
     # is the whole of issue #374 -- measured: `--out ~/sweep` from cmd.exe was judged as
     # `%USERPROFILE%\sweep` (outside any work tree, so allowed) and written to `<checkout>\~\sweep`.
     if refuse_unignored_output(args.out, args.allow_unignored_out):
-        return 2
+        return EXIT_REFUSED_UNIGNORED_OUT
     args.out = _resolved(args.out)
     # One resolver, no fallback: the installed plugin is the single canonical engine (issue #107).
     try:
         scripts = engine_scripts_dir()
     except EngineNotFoundError as exc:
         LOG.error("%s", exc)
-        return 1
+        return EXIT_NOTHING_ASSESSED
 
     env = resolve_env(args.env)
     if not args.skip_download:
@@ -1387,7 +1497,7 @@ def main() -> int:  # pylint: disable=too-many-locals,too-many-statements,too-ma
     except (sqlite3.OperationalError, ValueError) as exc:
         con.close()
         LOG.error("%s; run assess_estate.py with --survey again before using project scoping", exc)
-        return 1
+        return EXIT_NOTHING_ASSESSED
     # Captured while the connection is open, and used only at the END: a datasource that fails to
     # download orphans every workbook bound to it, and the edges are the only thing that knows which.
     try:
@@ -1471,7 +1581,29 @@ def main() -> int:  # pylint: disable=too-many-locals,too-many-statements,too-ma
     LOG.info(
         "swept %d asset(s) in %.0fs -> %s", len(results), time.perf_counter() - started, args.out / "parse-sweep.md"
     )
-    return 0 if results else 1
+    code = sweep_exit_code(results)
+    assessed = len(results) - len(never_downloaded(results))
+    # The verdict, spelled out beside the tally. An exit code nobody prints is an exit code an
+    # operator watching a console never sees, and this run's whole defect was a failure that looked
+    # like a success.
+    if code == EXIT_NOTHING_ASSESSED:
+        LOG.error(
+            "NOTHING COULD BE ASSESSED: 0 of %d asset(s) reached a parser, so this sweep says "
+            "nothing about the estate. Exit %d.",
+            len(results),
+            code,
+        )
+    elif code == EXIT_PARTIAL:
+        LOG.warning(
+            "PARTIAL HARVEST: %d of %d asset(s) assessed, %d never downloaded. Exit %d — the "
+            "failure distribution below covers the %d that landed and NOT the rest.",
+            assessed,
+            len(results),
+            len(results) - assessed,
+            code,
+            assessed,
+        )
+    return code
 
 
 if __name__ == "__main__":

--- a/scripts/harvest_estate_assets.py
+++ b/scripts/harvest_estate_assets.py
@@ -416,7 +416,18 @@ def refuse_unignored_output(
 # wall-clock ceiling applies instead, i.e. exactly today's behaviour.
 
 DEFAULT_DOWNLOAD_TIMEOUT = 600.0
-DEFAULT_STALL_TIMEOUT = 120.0
+# The engine's own per-socket-read timeout (`fetch_tds.py:407,423` pass `timeout=300` to `urlopen`).
+# It is the contract for how long a HEALTHY transfer is allowed to go quiet between reads: urllib
+# tolerates a 299s gap and raises at 300s.
+ENGINE_READ_TIMEOUT_SECONDS = 300.0
+# ⚠️ This MUST NOT sit below `ENGINE_READ_TIMEOUT_SECONDS`. The first version of this fix defaulted
+# to 120s, by analogy with `refresh_pbip_model.py`'s liveness timer -- but that one WARNS and this
+# one KILLS, which is a different thing entirely. A bursty-but-healthy source pausing 120-300s
+# between chunks satisfies urllib and was killed by us and reported as hung: the wall-clock cliff
+# this whole change exists to remove had become a shorter inactivity cliff (blind review of #482,
+# reproduced: `BURSTY_HEALTHY stalled 0.49`). 300s + a 120s grace, so the child's own read timeout
+# always fires first and reports the real error rather than being pre-empted by ours.
+DEFAULT_STALL_TIMEOUT = ENGINE_READ_TIMEOUT_SECONDS + 120.0
 PROGRESS_POLL_SECONDS = 2.0
 # "NEVER block silently on an external system" (AGENTS.md): anything past a minute reports elapsed
 # time, so a stall is visible as a stall rather than looking like work.
@@ -550,8 +561,12 @@ def transferred_bytes(pid: int) -> int | None:
 
     LIVENESS, not volume: on Windows the socket payload is not what moves this (see the measurement
     table above), so compare it with its own previous value and never report it as bytes downloaded.
-    None means "this platform/process cannot tell us", which is a different answer from 0 and must
-    never be treated as a stall.
+
+    ⚠️ None means "this platform/process cannot tell us", which is a DIFFERENT answer from 0 and must
+    never be treated as a stall. It is returned for a PARTIAL reading too, not only for a total
+    failure: if the descendant carrying the network I/O becomes unreadable while the trampoline
+    stays readable, the sum silently flatlines at the trampoline's constant, which is exactly a
+    stalled download's signature. A sum we cannot vouch for is not a smaller sum; it is no answer.
     """
     if sys.platform == "win32":
         lib = kernel32()
@@ -561,12 +576,12 @@ def transferred_bytes(pid: int) -> int | None:
         for target in process_tree(pid):
             handle = lib.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, target)
             if not handle:
-                continue
+                return None
             counters = IoCounters()
             ok = lib.GetProcessIoCounters(handle, ctypes.byref(counters))
             lib.CloseHandle(handle)
             if not ok:
-                continue
+                return None
             total = (total or 0) + int(
                 counters.ReadTransferCount + counters.WriteTransferCount + counters.OtherTransferCount
             )
@@ -576,7 +591,7 @@ def transferred_bytes(pid: int) -> int | None:
         try:
             io_text = Path(f"/proc/{target}/io").read_text(encoding="utf-8", errors="replace")
         except OSError:
-            continue
+            return None
         for line in io_text.splitlines():
             key, _, value = line.partition(":")
             if key in ("rchar", "wchar"):
@@ -638,11 +653,18 @@ def run_watched(  # pylint: disable=too-many-locals,too-many-branches,too-many-a
 
     Two deadlines, and which one is armed depends on evidence rather than on configuration:
 
-    * `stall_timeout` — armed only once the probe has been seen to MOVE for this child. A flatline is
-      then a genuine stall and killing is right.
-    * `timeout` — the wall clock, armed only while no movement has ever been observed, i.e. when we
-      cannot tell slow from hung. This is the pre-#472 behaviour, kept for exactly the case that
-      justified it. `0` disables it, leaving a run bounded only by progress.
+    * `stall_timeout` — armed only while the probe is CURRENTLY readable AND has been seen to move
+      for this child. A flatline is then a genuine stall and killing is right.
+    * `timeout` — the wall clock, armed whenever we cannot tell slow from hung: never observed, or
+      observed and then LOST. It is measured from the moment we went blind, not from process start,
+      so a transfer that progressed for ten minutes and then lost its probe gets a fresh `timeout`
+      of blindness rather than being killed on the spot. `0` disables it.
+
+    Availability and history are tracked separately on purpose. Treating "cannot read the counter"
+    as "no bytes moved" kills healthy downloads on access denial, on a descendant that exits between
+    enumeration and read, and — the nastiest one — on a PARTIAL subtree read, where the readable
+    trampoline flatlines while the unreadable descendant is the one doing the work (blind review of
+    #482, reproduced: `PROBE_LOST_AFTER_PROGRESS stalled 0.32`).
 
     A download that keeps progressing past `timeout` is NOT killed; it is announced loudly instead,
     because "elapsed time is not progress" cuts both ways.
@@ -662,11 +684,18 @@ def run_watched(  # pylint: disable=too-many-locals,too-many-branches,too-many-a
     reader.start()
 
     last_value = probe(proc.pid)
+    signal_live = last_value is not None
     progress_observed = False
     last_change = started
     last_beat = started
+    # When we last had a trustworthy MOVING signal. None means we have one right now; otherwise the
+    # wall clock is measured from here. It starts at `started`, so a run that never sees a signal
+    # behaves exactly as it did before this whole change.
+    blind_since: float | None = started
     announced_over_ceiling = False
+    announced_signal_lost = False
     verdict = ""
+    since_progress = 0.0
     while True:
         reader.join(poll_interval)
         now = time.perf_counter()
@@ -674,12 +703,36 @@ def run_watched(  # pylint: disable=too-many-locals,too-many-branches,too-many-a
         if not reader.is_alive():
             break
         value = probe(proc.pid)
-        if value is not None:
-            if last_value is not None and value != last_value:
+        if value is None:
+            # Unreadable or partial: we are blind, not stalled. Disarm the stall deadline.
+            signal_live = False
+            last_value = None
+            if blind_since is None:
+                blind_since = now
+            if progress_observed and not announced_signal_lost:
+                announced_signal_lost = True
+                LOG.warning(
+                    "%s: lost the download-progress signal after %.0fs of movement — falling back "
+                    "to the --download-timeout wall clock (%.0fs from now) rather than calling it "
+                    "stalled.",
+                    label,
+                    elapsed,
+                    timeout,
+                )
+        else:
+            if not signal_live:
+                # Re-acquired. The blind window is not evidence of no progress, so the stall
+                # deadline restarts from here rather than counting the gap against the download.
+                signal_live = True
+                last_change = now
+            elif last_value is not None and value != last_value:
                 progress_observed = True
                 last_change = now
+                blind_since = None
             last_value = value
         since_progress = now - last_change
+        stall_armed = progress_observed and signal_live and blind_since is None
+        blind_for = now - (blind_since if blind_since is not None else now)
         if now - last_beat >= heartbeat:
             last_beat = now
             LOG.info(
@@ -688,11 +741,11 @@ def run_watched(  # pylint: disable=too-many-locals,too-many-branches,too-many-a
                 elapsed,
                 (
                     f"last progress {since_progress:.0f}s ago"
-                    if progress_observed
-                    else "no progress signal available (wall-clock ceiling applies)"
+                    if stall_armed
+                    else f"no usable progress signal for {blind_for:.0f}s (wall-clock ceiling applies)"
                 ),
             )
-        if progress_observed:
+        if stall_armed:
             if since_progress > stall_timeout:
                 verdict = "stalled"
                 break
@@ -706,7 +759,7 @@ def run_watched(  # pylint: disable=too-many-locals,too-many-branches,too-many-a
                     timeout,
                     stall_timeout,
                 )
-        elif timeout and elapsed > timeout:
+        elif timeout and blind_for > timeout:
             verdict = "ceiling"
             break
 
@@ -714,19 +767,20 @@ def run_watched(  # pylint: disable=too-many-locals,too-many-branches,too-many-a
     if verdict:
         terminate_tree(proc)
         reader.join(30)
+        blindness = "progress was seen and then the signal was lost" if progress_observed else "blind the whole time"
         detail = (
             (
-                f"stalled: no progress for {elapsed - (last_change - started):.0f}s "
-                f"(elapsed {elapsed:.0f}s). The download was moving and then stopped, so this is a "
-                f"hung transfer, not a slow one. Raise --download-stall-timeout above "
-                f"{stall_timeout:.0f}s if the source is merely bursty, or retry the asset."
+                f"stalled: no progress for {since_progress:.0f}s (elapsed {elapsed:.0f}s). The "
+                f"download was moving, was still observable, and stopped — so this is a hung "
+                f"transfer, not a slow one. Raise --download-stall-timeout above "
+                f"{stall_timeout:g}s if the source is merely bursty, or retry the asset."
             )
             if verdict == "stalled"
             else (
-                f"timeout after {timeout:.0f}s (elapsed {elapsed:.1f}s); no download-progress signal "
-                f"was available for this process, so a slow-but-healthy transfer cannot be told from "
-                f"a hang. Raise --download-timeout (or pass 0 to remove the ceiling and rely on "
-                f"--download-stall-timeout alone)."
+                f"timeout after {timeout:g}s without a usable download-progress signal (elapsed "
+                f"{elapsed:.1f}s, {blindness}); a slow-but-healthy transfer cannot be told from a "
+                f"hang while blind. Raise --download-timeout (or pass 0 to remove the ceiling and "
+                f"rely on --download-stall-timeout alone)."
             )
         )
         return WatchedRun(None, collected["out"], collected["err"], elapsed, verdict, detail, progress_observed)
@@ -1273,7 +1327,9 @@ def main() -> int:  # pylint: disable=too-many-locals,too-many-statements,too-ma
         type=float,
         default=DEFAULT_STALL_TIMEOUT,
         help="seconds a download may make NO observable progress before it is killed as hung "
-        f"(default {DEFAULT_STALL_TIMEOUT:.0f}); armed only after progress has been observed once",
+        f"(default {DEFAULT_STALL_TIMEOUT:.0f}); armed only while the signal is readable AND has "
+        f"moved. Below {ENGINE_READ_TIMEOUT_SECONDS:.0f}s it can pre-empt the fetcher's own "
+        "per-read timeout and kill a bursty-but-healthy transfer.",
     )
     ap.add_argument("--skip-download", action="store_true", help="reuse whatever is already in --out/assets")
     ap.add_argument("--workbooks-only", action="store_true", help="skip published datasources; sweep workbooks only")
@@ -1285,6 +1341,14 @@ def main() -> int:  # pylint: disable=too-many-locals,too-many-statements,too-ma
     args = ap.parse_args()
 
     logging.basicConfig(level=logging.INFO, format="%(message)s")
+    if 0 < args.download_stall_timeout < ENGINE_READ_TIMEOUT_SECONDS:
+        LOG.warning(
+            "--download-stall-timeout %.0fs is BELOW the fetcher's own %.0fs per-read timeout "
+            "(fetch_tds.py:407,423). urllib tolerates a gap that long on a healthy connection, so "
+            "this can kill a bursty-but-healthy download and report it as hung.",
+            args.download_stall_timeout,
+            ENGINE_READ_TIMEOUT_SECONDS,
+        )
     # Before the engine, the .env, the database and above all the download: a customer's workbooks
     # must never land somewhere this PUBLIC repo would commit them (issue #125). The guard is given
     # `--out` RAW, so it can judge the literal argv form as well as the resolved one; the write then

--- a/scripts/harvest_estate_assets.py
+++ b/scripts/harvest_estate_assets.py
@@ -386,9 +386,16 @@ def refuse_unignored_output(
 # asset buffered in RAM — and `save_outputs(raw, ...)` writes only afterwards. The destination file
 # is therefore 0 bytes until the download has already finished.
 #
+# ⚠️ `urlopen` is never written here immediately followed by an open paren, and that is deliberate.
+# The credential-handling detector in `tests/test_diagnostic_redaction.py` scans RAW SOURCE —
+# comments included — and that one literal is enough to reclassify this module as a credentialed
+# HTTP client. It is not one: it spawns the engine's fetcher, which makes the request (measured —
+# the module contains no HTTP call at all in code). Spelling it the natural way turned CI red on
+# #482, and `test_this_module_still_makes_no_http_call_of_its_own` now pins both halves.
+#
 # What DOES work, measured 2026-09-03 on Windows against a local slow-stream server (a child running
-# the same `urlopen(...).read()` shape), 15 MB at ~1 MB/s versus a socket that goes quiet after 3
-# chunks:
+# the same one-shot `urlopen` + `.read()` shape), 15 MB at ~1 MB/s versus a socket that goes quiet
+# after 3 chunks:
 #
 #   sampled                                   healthy download        stalled download
 #   Popen.pid `OtherTransferCount`            Δ 0 (frozen)            Δ 0 (frozen)

--- a/scripts/harvest_estate_assets.py
+++ b/scripts/harvest_estate_assets.py
@@ -848,6 +848,60 @@ def parse_theirs(path: Path, scripts: Path) -> dict[str, Any]:
         return {"ok": False, "error": f"harness: {type(exc).__name__}: {exc}"}
 
 
+def dependency_edges(con: sqlite3.Connection) -> list[tuple[str, str, str, str]]:
+    """Every `(workbook_luid, workbook_name, datasource_luid, datasource_name)` binding on the site.
+
+    Same join as `dependency_datasources` — LUID first, normalized name as the fallback an
+    unresolved survey edge needs — but it keeps the WORKBOOK end too, which is the end that matters
+    once a datasource has failed to download.
+    """
+    return list(
+        con.execute(
+            """
+            SELECT DISTINCT workbook.luid, workbook.name, datasource.luid, datasource.name
+            FROM dependency
+            JOIN workbook ON workbook.luid = dependency.workbook_luid
+            JOIN datasource ON dependency.datasource_luid = datasource.luid
+                OR (
+                    COALESCE(dependency.datasource_luid, '') = ''
+                    AND LOWER(TRIM(dependency.datasource_name)) = LOWER(TRIM(datasource.name))
+                )
+            ORDER BY datasource.name, workbook.name
+            """
+        )
+    )
+
+
+def orphaned_dependents(results: list[dict], edges: list[tuple[str, str, str, str]]) -> list[tuple[str, list[str]]]:
+    """`[(failed datasource name, [workbooks that DID land and bind to it])]`.
+
+    A datasource that never downloaded does not fail alone: every workbook bound to it converts to
+    an incomplete model, and a report against a model nobody migrated is the documented "empty
+    report". The harvester already resolves exactly these edges to DECIDE what to fetch
+    (`dependency_datasources`) and then never looked at them again once one had failed, so catching
+    it depended on the operator noticing (issue #472). A workbook that itself failed to download is
+    left out: it is already in the never-landed list and is not about to be converted.
+    """
+    missing_ids = {id(r) for r in never_downloaded(results)}
+    failed_datasources = {
+        str(r.get("luid", "")): str(r.get("name", "?"))
+        for r in results
+        if id(r) in missing_ids and r.get("kind") == "datasource"
+    }
+    landed_workbooks = {
+        str(r.get("luid", "")): str(r.get("name", "?"))
+        for r in results
+        if id(r) not in missing_ids and r.get("kind") == "workbook"
+    }
+    by_datasource: dict[str, set[str]] = {}
+    for workbook_luid, workbook_name, datasource_luid, datasource_name in edges:
+        if datasource_luid in failed_datasources and workbook_luid in landed_workbooks:
+            by_datasource.setdefault(datasource_name or failed_datasources[datasource_luid], set()).add(
+                workbook_name or landed_workbooks[workbook_luid]
+            )
+    return [(name, sorted(workbooks)) for name, workbooks in sorted(by_datasource.items())]
+
+
 def never_downloaded(results: list[dict]) -> list[dict]:
     """Rows that never reached a parser at all, i.e. the downloads that did not land.
 
@@ -877,7 +931,9 @@ def grouped_by_shape(rows: list[dict], detail: Callable[[dict], str]) -> list[tu
     return sorted(by_shape.items(), key=lambda kv: (-len(kv[1]), kv[0]))
 
 
-def summarise(results: list[dict], out: Path) -> str:  # pylint: disable=too-many-locals,too-many-statements
+def summarise(  # pylint: disable=too-many-locals,too-many-statements,too-many-branches
+    results: list[dict], out: Path, orphans: list[tuple[str, list[str]]] | None = None
+) -> str:
     """Group failures by SHAPE, because one root cause repeated 12 times is one feature request."""
     missing = never_downloaded(results)
     missing_ids = {id(r) for r in missing}
@@ -924,6 +980,19 @@ def summarise(results: list[dict], out: Path) -> str:  # pylint: disable=too-man
         for shape, names in grouped_by_shape(missing, lambda r: str(r.get("download_error", "?"))):
             lines.append(f"- **{len(names)}x** `{shape}`")
             lines.append(f"  - {', '.join(names[:8])}{' …' if len(names) > 8 else ''}")
+        lines.append("")
+
+    if orphans:
+        lines.append("## Do not convert yet — a datasource they bind to never landed")
+        lines.append("")
+        lines.append(
+            "These workbooks downloaded fine, so nothing else here flags them. They would each "
+            "convert against a model nobody migrated, which is the documented **empty report**."
+        )
+        lines.append("")
+        for datasource, workbooks in orphans:
+            lines.append(f"- `{datasource}` (failed) blocks **{len(workbooks)}** workbook(s):")
+            lines.append(f"  - {', '.join(workbooks[:8])}{' …' if len(workbooks) > 8 else ''}")
         lines.append("")
 
     for title, rows, key in (
@@ -1143,7 +1212,7 @@ def record_parse(
     )
 
 
-def report_failed_downloads(results: list[dict]) -> list[dict]:
+def report_failed_downloads(results: list[dict], orphans: list[tuple[str, list[str]]] | None = None) -> list[dict]:
     """Say out loud, at the END of the run, which assets never landed. Returns those rows.
 
     The per-asset `DOWNLOAD FAILED` warning has already scrolled past a 47-line run by the time the
@@ -1152,19 +1221,26 @@ def report_failed_downloads(results: list[dict]) -> list[dict]:
     to be beside it or the run reads as clean (issue #472).
     """
     missing = never_downloaded(results)
-    if not missing:
-        return []
-    LOG.warning(
-        "%d of %d asset(s) NEVER DOWNLOADED and were not parsed at all — they are not successes:",
-        len(missing),
-        len(results),
-    )
-    for row in missing:
-        LOG.warning("  - %s (%s): %s", row.get("name", "?"), row.get("kind", "?"), row.get("download_error", "?"))
+    if missing:
+        LOG.warning(
+            "%d of %d asset(s) NEVER DOWNLOADED and were not parsed at all — they are not successes:",
+            len(missing),
+            len(results),
+        )
+        for row in missing:
+            LOG.warning("  - %s (%s): %s", row.get("name", "?"), row.get("kind", "?"), row.get("download_error", "?"))
+    for datasource, workbooks in orphans or []:
+        LOG.warning(
+            "DO NOT CONVERT YET: '%s' never downloaded, so %d workbook(s) that DID land would "
+            "convert against a model nobody migrated: %s",
+            datasource,
+            len(workbooks),
+            ", ".join(workbooks[:8]) + (" …" if len(workbooks) > 8 else ""),
+        )
     return missing
 
 
-def main() -> int:  # pylint: disable=too-many-locals,too-many-statements  # one linear sweep
+def main() -> int:  # pylint: disable=too-many-locals,too-many-statements,too-many-branches  # one sweep
     """Harvest and sweep. Exit 2 when `--out` is committable, 1 when nothing could be assessed."""
     ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     ap.add_argument("--out", required=True, type=Path, help="output directory (must be git-ignored, see below)")
@@ -1241,6 +1317,15 @@ def main() -> int:  # pylint: disable=too-many-locals,too-many-statements  # one
         con.close()
         LOG.error("%s; run assess_estate.py with --survey again before using project scoping", exc)
         return 1
+    # Captured while the connection is open, and used only at the END: a datasource that fails to
+    # download orphans every workbook bound to it, and the edges are the only thing that knows which.
+    try:
+        edges = dependency_edges(con)
+    except sqlite3.OperationalError as exc:
+        # An older estate.db with no dependency/workbook table still harvests fine; it just cannot
+        # answer the orphan question, and saying so is better than failing the run over it.
+        LOG.warning("cannot read dependency edges (%s); a failed datasource will not be traced to its workbooks", exc)
+        edges = []
     con.close()
     if selected:
         LOG.info(
@@ -1308,9 +1393,10 @@ def main() -> int:  # pylint: disable=too-many-locals,too-many-statements  # one
             record_parse(pending.popleft(), results, len(todo), started)
 
     args.out.mkdir(parents=True, exist_ok=True)
-    text = summarise(results, args.out)
+    orphans = orphaned_dependents(results, edges)
+    text = summarise(results, args.out, orphans)
     LOG.info("\n%s", text[: text.index("## ") if "## " in text else len(text)])
-    report_failed_downloads(results)
+    report_failed_downloads(results, orphans)
     LOG.info(
         "swept %d asset(s) in %.0fs -> %s", len(results), time.perf_counter() - started, args.out / "parse-sweep.md"
     )

--- a/tests/mutate_harvest_watchdog.py
+++ b/tests/mutate_harvest_watchdog.py
@@ -1,0 +1,372 @@
+"""Mutation proof for the #472 download watchdog, the sweep tally and the orphan trace.
+
+usage: python tests/mutate_harvest_watchdog.py
+
+⚠️ Three things are required before a mutation is called KILLED, because "the tests went red" is
+not evidence on its own. This repo has a measured case of 22/22 mutations scored "caught" that were
+all false positives -- an import error exits non-zero, and a naive scorer reads that as a detection.
+So every mutant must:
+
+1. **compile** (`py_compile`). A mutant that does not import never executed the mutated path, and
+   scoring it as caught is a fabricated verdict. My own first campaign hit exactly this: a
+   `trust-an-unmoved-probe` mutation with the wrong indentation was reported SURVIVED, and an
+   earlier scorer would have reported it CAUGHT;
+2. fail its **anchor**, named as a pytest NODE ID rather than a file. Mutations run under `-x`, so a
+   whole-file target credits a mutation to whichever test fails first -- which may have nothing to
+   do with the behaviour under test;
+3. leave its **control** node passing. A mutation that reddens everything has not demonstrated that
+   the anchor observes *this* behaviour; it has demonstrated that the module is broken.
+
+Two discriminating controls run alongside the real mutations, because a campaign that reports
+everything KILLED is indistinguishable from one that is not working:
+
+* `control-cosmetic` changes prose no assertion depends on. It MUST **SURVIVE**.
+* `control-absent-anchor` names a test that does not exist. It MUST be reported **INVALID** rather
+  than caught, even though pytest exits non-zero for it.
+"""
+
+from __future__ import annotations
+
+import py_compile
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+TARGET = "scripts/harvest_estate_assets.py"
+TESTS = "tests/test_harvest_download_watchdog.py"
+
+
+def node(name: str) -> str:
+    return f"{TESTS}::{name}"
+
+
+# (label, find, replace, anchor node id, control node id, what it breaks)
+MUTATIONS: list[tuple[str, str, str, str, str, str]] = [
+    # ---------------------------------------------------------------- the watchdog decision
+    (
+        "stall-never-fires",
+        "            if since_progress > stall_timeout:",
+        "            if since_progress > stall_timeout * 1000:",
+        node("test_a_stalled_download_is_killed_once_progress_stops"),
+        node("test_a_short_healthy_run_returns_its_output_and_no_verdict"),
+        "a stalled download is never killed",
+    ),
+    (
+        "ceiling-kills-a-progressing-download",
+        "        stall_armed = progress_observed and signal_live and blind_since is None\n"
+        "        blind_for = now - (blind_since if blind_since is not None else now)",
+        "        stall_armed = False\n        blind_for = elapsed",
+        node("test_a_progressing_download_is_not_killed_by_the_wall_clock_ceiling"),
+        node("test_a_short_healthy_run_returns_its_output_and_no_verdict"),
+        "the pre-#472 behaviour restored verbatim: a plain wall clock over a transfer we can see moving",
+    ),
+    (
+        "trust-an-unmoved-probe",
+        "            elif last_value is not None and value != last_value:\n"
+        "                progress_observed = True\n"
+        "                last_change = now\n"
+        "                blind_since = None",
+        "            elif last_value is not None:\n"
+        "                progress_observed = True\n"
+        "                last_change = now\n"
+        "                blind_since = None",
+        node("test_progress_must_be_OBSERVED_before_a_flatline_counts_as_a_stall"),
+        node("test_a_short_healthy_run_returns_its_output_and_no_verdict"),
+        "a probe that never moved arms the stall deadline (the uv-trampoline trap)",
+    ),
+    (
+        "no-subtree-walk",
+        "        return [pid, *windows_descendants(pid)]",
+        "        return [pid]",
+        node("test_the_real_probe_sums_a_process_SUBTREE_not_just_the_pid_handed_to_popen"),
+        node("test_a_short_healthy_run_returns_its_output_and_no_verdict"),
+        "the probe samples only Popen.pid, i.e. the uv trampoline",
+    ),
+    (
+        "no-descendant-kill",
+        '    descendants = windows_descendants(proc.pid) if sys.platform == "win32" else process_tree(proc.pid)[1:]',
+        "    descendants = []",
+        node("test_terminate_tree_kills_the_descendant_too"),
+        node("test_a_short_healthy_run_returns_its_output_and_no_verdict"),
+        "terminate_tree orphans the real interpreter, socket and session included",
+    ),
+    # ---------------------------------------------------------------- blind review round 2
+    (
+        "stall-default-back-under-the-fetchers-read-timeout",
+        "DEFAULT_STALL_TIMEOUT = ENGINE_READ_TIMEOUT_SECONDS + 120.0",
+        "DEFAULT_STALL_TIMEOUT = 120.0",
+        node("test_a_bursty_but_healthy_transfer_survives_a_gap_the_fetcher_would_tolerate"),
+        node("test_a_stalled_download_is_killed_once_progress_stops"),
+        "a bursty transfer urllib tolerates is killed and reported as hung",
+    ),
+    (
+        "a-lost-probe-counts-as-a-flatline",
+        "            signal_live = False\n"
+        "            last_value = None\n"
+        "            if blind_since is None:\n"
+        "                blind_since = now",
+        "            signal_live = True",
+        node("test_losing_the_probe_after_movement_does_not_kill_a_healthy_download"),
+        node("test_a_stalled_download_is_killed_once_progress_stops"),
+        "an unreadable probe is read as 'no bytes moved' and kills a healthy download",
+    ),
+    (
+        "partial-reading-passed-off-as-a-total",
+        "            if not handle:\n                return None",
+        "            if not handle:\n                continue",
+        node("test_a_partial_subtree_reading_is_reported_as_UNAVAILABLE_not_as_a_smaller_sum"),
+        node("test_a_stalled_download_is_killed_once_progress_stops"),
+        "the readable trampoline's constant is reported as the subtree total",
+    ),
+    (
+        "blind-ceiling-measured-from-process-start",
+        "        elif timeout and blind_for > timeout:",
+        "        elif timeout and elapsed > timeout:",
+        node("test_the_wall_clock_restarts_from_the_MOMENT_the_signal_was_lost"),
+        node("test_a_stalled_download_is_killed_once_progress_stops"),
+        "a download that progressed for ages and then went blind is killed on the spot",
+    ),
+    (
+        "losing-the-signal-is-not-announced",
+        "            if progress_observed and not announced_signal_lost:",
+        "            if False and progress_observed and not announced_signal_lost:",
+        node("test_losing_the_signal_is_announced_once"),
+        node("test_a_stalled_download_is_killed_once_progress_stops"),
+        "the run goes blind silently",
+    ),
+    (
+        "no-cli-warning-for-a-stall-timeout-under-300s",
+        "    if 0 < args.download_stall_timeout < ENGINE_READ_TIMEOUT_SECONDS:",
+        "    if False and 0 < args.download_stall_timeout < ENGINE_READ_TIMEOUT_SECONDS:",
+        node("test_the_cli_warns_when_the_stall_deadline_undercuts_the_fetcher"),
+        node("test_a_stalled_download_is_killed_once_progress_stops"),
+        "an operator undercuts the fetcher's own read timeout and is told nothing",
+    ),
+    # ---------------------------------------------------------------- the failure text
+    (
+        "silent-heartbeat",
+        "        if now - last_beat >= heartbeat:",
+        "        if False and now - last_beat >= heartbeat:",
+        node("test_a_long_run_reports_elapsed_time_rather_than_looking_like_work"),
+        node("test_a_short_healthy_run_returns_its_output_and_no_verdict"),
+        "a long download reports no elapsed time and looks like work",
+    ),
+    (
+        "no-over-ceiling-warning",
+        "            if timeout and elapsed > timeout and not announced_over_ceiling:",
+        "            if False and timeout and elapsed > timeout and not announced_over_ceiling:",
+        node("test_a_download_progressing_past_the_ceiling_is_announced_loudly"),
+        node("test_a_short_healthy_run_returns_its_output_and_no_verdict"),
+        "we sail past our own --download-timeout without saying so",
+    ),
+    (
+        "stall-message-loses-the-flag",
+        'f"transfer, not a slow one. Raise --download-stall-timeout above "',
+        'f"transfer, not a slow one. Try again later, above "',
+        node("test_the_stall_message_says_what_was_observed_and_which_flag_to_turn"),
+        node("test_a_short_healthy_run_returns_its_output_and_no_verdict"),
+        "the stall message names no flag to turn",
+    ),
+    (
+        "ceiling-message-loses-elapsed",
+        'f"timeout after {timeout:g}s without a usable download-progress signal (elapsed "\n'
+        '                f"{elapsed:.1f}s, {blindness}); a slow-but-healthy transfer cannot be told from a "',
+        'f"timeout after {timeout:g}s. A slow-but-healthy transfer cannot be told from a "',
+        node("test_the_ceiling_message_distinguishes_itself_from_a_stall"),
+        node("test_a_short_healthy_run_returns_its_output_and_no_verdict"),
+        "the ceiling message reports the ceiling but not what was observed",
+    ),
+    # ---------------------------------------------------------------- the tally
+    (
+        "never-downloaded-is-invisible",
+        '    return [r for r in results if "ours" not in r or "theirs" not in r]',
+        "    return []",
+        node("test_a_never_downloaded_asset_is_named_in_the_report"),
+        node("test_a_clean_sweep_still_says_none"),
+        "a row that never downloaded lands in no bucket while inflating the denominator",
+    ),
+    (
+        "shape-keeps-the-digits",
+        '    return re.sub(r"\\d+(?:\\.\\d+)?", "N", str(message)).strip()[:90] or "(no detail)"',
+        '    return str(message).strip()[:90] or "(no detail)"',
+        node("test_download_failures_are_grouped_by_shape_not_by_elapsed_seconds"),
+        node("test_a_clean_sweep_still_says_none"),
+        "two timeouts differing only in elapsed seconds are counted as two findings",
+    ),
+    (
+        "parser-buckets-count-a-failed-download",
+        '    ours_fail = [r for r in parsed if r.get("ours", {}).get("ok") is False]',
+        '    ours_fail = [r for r in parsed if r.get("ours", {}).get("ok") is not True] + missing',
+        node("test_the_parser_buckets_ignore_rows_that_never_reached_a_parser"),
+        node("test_a_clean_sweep_still_says_none"),
+        "a download failure is reported as a parser verdict",
+    ),
+    (
+        "no-operator-report",
+        '    if missing:\n        LOG.warning(\n            "%d of %d asset(s) NEVER DOWNLOADED',
+        '    if missing:\n        LOG.debug(\n            "%d of %d asset(s) NEVER DOWNLOADED',
+        node("test_the_failed_downloads_are_reported_to_the_operator_at_the_end"),
+        node("test_a_clean_sweep_still_says_none"),
+        "failed downloads are never surfaced where an operator reads",
+    ),
+    (
+        "timeouts-not-passed-through",
+        "                    timeout=args.download_timeout,\n"
+        "                    stall_timeout=args.download_stall_timeout,",
+        "                    timeout=DEFAULT_DOWNLOAD_TIMEOUT,\n"
+        "                    stall_timeout=DEFAULT_STALL_TIMEOUT,",
+        node("test_main_forwards_the_operator_s_timeouts_to_every_download"),
+        node("test_a_clean_sweep_still_says_none"),
+        "the operator's flags are parsed and then ignored",
+    ),
+    # ---------------------------------------------------------------- the orphan trace
+    (
+        "orphans-never-computed",
+        "    orphans = orphaned_dependents(results, edges)",
+        "    orphans = []",
+        node("test_main_end_to_end_names_the_orphaned_workbook"),
+        node("test_a_clean_sweep_still_says_none"),
+        "a failed datasource stops naming the workbooks it orphans",
+    ),
+    (
+        "orphans-flag-every-landed-workbook",
+        "        if datasource_luid in failed_datasources and workbook_luid in landed_workbooks:",
+        "        if workbook_luid in landed_workbooks:",
+        node("test_nothing_is_orphaned_when_the_datasource_landed"),
+        node("test_a_clean_sweep_still_says_none"),
+        "workbooks bound to a datasource that landed fine are flagged too",
+    ),
+    (
+        "orphans-include-a-workbook-that-itself-failed",
+        '        for r in results\n        if id(r) not in missing_ids and r.get("kind") == "workbook"',
+        '        for r in results\n        if r.get("kind") == "workbook"',
+        node("test_a_workbook_that_ITSELF_failed_is_not_listed_as_an_orphan"),
+        node("test_a_clean_sweep_still_says_none"),
+        "a workbook that itself never landed is reported as an orphan of something else",
+    ),
+    (
+        "orphan-edges-lose-the-name-fallback",
+        "                OR (\n"
+        "                    COALESCE(dependency.datasource_luid, '') = ''\n"
+        "                    AND LOWER(TRIM(dependency.datasource_name)) = LOWER(TRIM(datasource.name))\n"
+        "                )\n"
+        "            ORDER BY datasource.name, workbook.name",
+        "            ORDER BY datasource.name, workbook.name",
+        node("test_an_edge_resolved_only_by_NAME_still_finds_the_dependent"),
+        node("test_a_clean_sweep_still_says_none"),
+        "an edge the survey could not resolve to a LUID is dropped silently",
+    ),
+    (
+        "orphans-not-written-to-the-report",
+        '    if orphans:\n        lines.append("## Do not convert yet',
+        '    if False and orphans:\n        lines.append("## Do not convert yet',
+        node("test_the_orphans_reach_the_report_and_the_operator"),
+        node("test_a_clean_sweep_still_says_none"),
+        "the orphan finding never reaches parse-sweep.md",
+    ),
+    # ---------------------------------------------------------------- discriminating controls
+    (
+        "control-cosmetic",
+        "purpose: download every workbook and published datasource on a Tableau site",
+        "purpose: download each workbook and published datasource on a Tableau site",
+        node("test_a_short_healthy_run_returns_its_output_and_no_verdict"),
+        node("test_a_clean_sweep_still_says_none"),
+        "MUST SURVIVE: prose no assertion depends on",
+    ),
+    (
+        "control-absent-anchor",
+        "    return [pid, *windows_descendants(pid)]",
+        "    return [pid]",
+        node("test_this_test_does_not_exist_and_never_did"),
+        node("test_a_clean_sweep_still_says_none"),
+        "MUST BE INVALID: pytest exits non-zero for an unknown node id, which is not a detection",
+    ),
+]
+
+EXPECT_SURVIVE = {"control-cosmetic"}
+EXPECT_INVALID = {"control-absent-anchor"}
+
+
+def pytest_node(node_id: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "pytest", node_id, "-q", "--no-header", "-p", "no:cacheprovider", "--color=no"],
+        cwd=ROOT,
+        capture_output=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+
+
+def ran_a_test(proc: subprocess.CompletedProcess[str]) -> bool:
+    """True when pytest actually selected and ran something.
+
+    Exit code 4 (usage error) and 5 (nothing collected) both mean no verdict exists, and scoring
+    either as a detection is how a campaign reports kills it never earned.
+    """
+    summary = (proc.stdout or "").strip().splitlines()
+    return bool(summary) and any(("passed" in line or "failed" in line) for line in summary[-3:])
+
+
+def verdict_for(label: str, anchor: str, control: str, compiles: bool) -> tuple[str, str]:
+    if not compiles:
+        return "INVALID", "the mutant does not compile, so the mutated path never executed"
+    anchor_run = pytest_node(anchor)
+    if not ran_a_test(anchor_run):
+        return "INVALID", f"the anchor selected no test ({(anchor_run.stdout or '').strip().splitlines()[-1:]})"
+    if anchor_run.returncode == 0:
+        return "SURVIVED", "the anchor still passes"
+    control_run = pytest_node(control)
+    if control_run.returncode != 0:
+        return "OVERBROAD", "the control broke too, so the anchor proves nothing specific"
+    return "KILLED", f"anchor red, control green ({label})"
+
+
+def main() -> int:
+    path = ROOT / TARGET
+    original = path.read_text(encoding="utf-8")
+    scratch = ROOT / "_mutant_compile_check.py"
+    rows: list[tuple[str, str, str, str]] = []
+    try:
+        for label, find, replace, anchor, control, breaks in MUTATIONS:
+            if original.count(find) != 1:
+                rows.append((label, "UNAPPLIED", f"anchor text appears {original.count(find)}x", breaks))
+                print(f"{'UNAPPLIED':<10} {label}")
+                continue
+            mutant = original.replace(find, replace)
+            path.write_text(mutant, encoding="utf-8")
+            scratch.write_text(mutant, encoding="utf-8")
+            try:
+                py_compile.compile(str(scratch), doraise=True, cfile=str(scratch.with_suffix(".pyc")))
+                compiles = True
+            except py_compile.PyCompileError:
+                compiles = False
+            try:
+                verdict, detail = verdict_for(label, anchor, control, compiles)
+            finally:
+                path.write_text(original, encoding="utf-8")
+            rows.append((label, verdict, detail, breaks))
+            print(f"{verdict:<10} {label:<52} {detail[:60]}")
+    finally:
+        path.write_text(original, encoding="utf-8")
+        scratch.unlink(missing_ok=True)
+        scratch.with_suffix(".pyc").unlink(missing_ok=True)
+
+    print("\n| mutation | breaks | verdict |")
+    print("|---|---|---|")
+    for label, verdict, _, breaks in rows:
+        print(f"| `{label}` | {breaks} | **{verdict}** |")
+
+    wrong = [
+        label
+        for label, verdict, _, _ in rows
+        if verdict != ("SURVIVED" if label in EXPECT_SURVIVE else "INVALID" if label in EXPECT_INVALID else "KILLED")
+    ]
+    killed = sum(1 for label, verdict, _, _ in rows if verdict == "KILLED")
+    print(f"\n{killed} killed; {len(rows) - killed} control(s)/other. Unexpected verdicts: {wrong or 'none'}")
+    return 1 if wrong else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/mutate_harvest_watchdog.py
+++ b/tests/mutate_harvest_watchdog.py
@@ -331,6 +331,93 @@ MUTATIONS: list[tuple[str, str, str, str, str, str]] = [
         "a killed child's reflected PAT rides out on the watchdog verdict, which never reaches the "
         "redactor on the returncode branch",
     ),
+    # ---------------------------------------------------------------- blind review round 3
+    (
+        "total-failure-still-exits-zero",
+        "    missing = len(never_downloaded(results))\n"
+        "    assessed = len(results) - missing\n"
+        "    if assessed <= 0:\n"
+        "        return EXIT_NOTHING_ASSESSED\n"
+        "    return EXIT_PARTIAL if missing else EXIT_OK",
+        "    return EXIT_OK if results else EXIT_NOTHING_ASSESSED",
+        node("test_a_harvest_that_assessed_NOTHING_does_not_exit_zero"),
+        node("test_a_clean_sweep_still_says_none"),
+        "the pre-review line restored verbatim: a harvest where NOTHING reached a parser exits 0",
+    ),
+    (
+        "partial-harvest-reported-as-clean",
+        "    return EXIT_PARTIAL if missing else EXIT_OK",
+        "    return EXIT_OK",
+        node("test_the_customers_41_ok_6_failed_shape_is_distinguishable_from_a_total_failure"),
+        node("test_a_harvest_that_assessed_NOTHING_does_not_exit_zero"),
+        "the customer's 41-ok/6-failed run exits 0 and the six vanish",
+    ),
+    (
+        "total-and-partial-share-one-code",
+        "    if assessed <= 0:\n        return EXIT_NOTHING_ASSESSED",
+        "    if assessed <= 0:\n        return EXIT_PARTIAL",
+        node("test_the_customers_41_ok_6_failed_shape_is_distinguishable_from_a_total_failure"),
+        node("test_a_clean_sweep_still_says_none"),
+        "automation cannot tell six retryable assets from a dead site",
+    ),
+    (
+        "a-parse-failure-counted-as-unassessed",
+        "    missing = len(never_downloaded(results))",
+        '    missing = len([r for r in results if not r.get("ours", {}).get("ok")])',
+        node("test_a_PARSE_failure_is_the_report_this_script_exists_for_and_stays_exit_zero"),
+        node("test_a_harvest_that_assessed_NOTHING_does_not_exit_zero"),
+        "the failure distribution this script exists to produce is reported as a run failure",
+    ),
+    (
+        "the-exit-code-is-computed-and-discarded",
+        "    code = sweep_exit_code(results)",
+        "    code = sweep_exit_code(results) and EXIT_OK",
+        node("test_a_totally_failed_harvest_exits_nonzero_through_main"),
+        node("test_a_clean_sweep_still_says_none"),
+        "main() computes the verdict correctly and returns 0 anyway",
+    ),
+    (
+        "partial-verdict-never-spoken",
+        "    elif code == EXIT_PARTIAL:",
+        "    elif False and code == EXIT_PARTIAL:",
+        node("test_the_verdict_is_SAID_not_just_returned"),
+        node("test_a_clean_sweep_still_says_none"),
+        "a partial harvest ends with a tally that reads clean and says nothing about the gap",
+    ),
+    (
+        "ceiling-back-to-the-historical-600",
+        "DEFAULT_DOWNLOAD_TIMEOUT = ENGINE_DOWNLOAD_BUDGET_SECONDS + ENGINE_SIGNIN_TIMEOUT_SECONDS "
+        "+ CHILD_STARTUP_GRACE_SECONDS",
+        "DEFAULT_DOWNLOAD_TIMEOUT = 600.0",
+        node("test_a_blind_child_reaches_its_OWN_verdict_before_our_ceiling_fires"),
+        node("test_a_stalled_download_is_killed_once_progress_stops"),
+        "the blind ceiling kills the fetcher mid-retry-budget and reports our timeout, not its error",
+    ),
+    (
+        "budget-forgets-the-retry-count",
+        "    ENGINE_DOWNLOAD_ATTEMPTS * ENGINE_READ_TIMEOUT_SECONDS + "
+        "(ENGINE_DOWNLOAD_ATTEMPTS - 1) * ENGINE_BACKOFF_CAP_SECONDS",
+        "    ENGINE_READ_TIMEOUT_SECONDS + (ENGINE_DOWNLOAD_ATTEMPTS - 1) * ENGINE_BACKOFF_CAP_SECONDS",
+        node("test_the_blind_ceiling_is_not_below_the_childs_own_bounded_retry_budget"),
+        node("test_a_stalled_download_is_killed_once_progress_stops"),
+        "the derivation covers one attempt instead of four, i.e. history dressed as arithmetic",
+    ),
+    (
+        "engine-constants-drift-unnoticed",
+        "ENGINE_DOWNLOAD_ATTEMPTS = 4",
+        "ENGINE_DOWNLOAD_ATTEMPTS = 8",
+        node("test_the_ceiling_constants_match_the_INSTALLED_engine"),
+        node("test_a_stalled_download_is_killed_once_progress_stops"),
+        "the arithmetic stops matching the engine it claims to be derived from",
+    ),
+    (
+        "no-cli-warning-for-a-ceiling-under-the-budget",
+        "    if 0 < args.download_timeout < ENGINE_DOWNLOAD_BUDGET_SECONDS:",
+        "    if False and 0 < args.download_timeout < ENGINE_DOWNLOAD_BUDGET_SECONDS:",
+        node("test_the_cli_warns_when_the_ceiling_undercuts_the_fetchers_retry_budget"),
+        node("test_a_stalled_download_is_killed_once_progress_stops"),
+        "an operator re-creates the 600s defect with a flag and is told nothing",
+    ),
     # ---------------------------------------------------------------- discriminating controls
     (
         "control-cosmetic",

--- a/tests/mutate_harvest_watchdog.py
+++ b/tests/mutate_harvest_watchdog.py
@@ -265,6 +265,63 @@ MUTATIONS: list[tuple[str, str, str, str, str, str]] = [
         node("test_a_clean_sweep_still_says_none"),
         "the orphan finding never reaches parse-sweep.md",
     ),
+    # ---------------------------------------------------------------- #482 CI: the credential gate
+    #
+    # ⚠️ Anchors here deliberately live in OTHER files. The two security gates that went red are in
+    # `tests/test_diagnostic_redaction.py` and `tests/test_tableau_env.py`, and a campaign that only
+    # ever points at its own test file cannot show that a change to this module is observed where it
+    # actually matters. `pytest_node` takes any node id, so no machinery changes.
+    (
+        "no-redaction-of-the-child-stderr",
+        'raw = redact((run.stderr or run.stdout or "").strip(), pat_secret(env), env.get("TABLEAU_PAT_NAME", ""))',
+        'raw = (run.stderr or run.stdout or "").strip()',
+        "tests/test_tableau_env.py::test_a_reflected_signin_error_cannot_persist_the_pat",
+        node("test_a_clean_sweep_still_says_none"),
+        "a reflected PAT reaches the operator and parse-sweep.json in clear",
+    ),
+    (
+        "truncate-before-redacting",
+        'raw = redact((run.stderr or run.stdout or "").strip(), pat_secret(env), env.get("TABLEAU_PAT_NAME", ""))\n'
+        "        return False, raw[-300:]",
+        'raw = redact((run.stderr or run.stdout or "").strip()[-300:], pat_secret(env), '
+        'env.get("TABLEAU_PAT_NAME", ""))\n        return False, raw',
+        "tests/test_tableau_env.py::test_redaction_happens_before_truncation",
+        node("test_a_clean_sweep_still_says_none"),
+        "a secret straddling the 300-char cut leaves its tail in the retained slice",
+    ),
+    (
+        "pat-name-no-longer-redacted",
+        'raw = redact((run.stderr or run.stdout or "").strip(), pat_secret(env), env.get("TABLEAU_PAT_NAME", ""))',
+        'raw = redact((run.stderr or run.stdout or "").strip(), pat_secret(env))',
+        "tests/test_tableau_env.py::test_a_reflected_signin_error_cannot_persist_the_pat",
+        node("test_a_clean_sweep_still_says_none"),
+        "the PAT NAME half of the credential is persisted while the secret is scrubbed",
+    ),
+    (
+        "child-is-handed-no-secret",
+        "    child = engine_child_env(env)",
+        '    child = engine_child_env({k: v for k, v in env.items() if "SECRET" not in k})',
+        "tests/test_tableau_env.py::test_a_reflected_signin_error_cannot_persist_the_pat",
+        node("test_a_clean_sweep_still_says_none"),
+        "MUST BE KILLED BY A NON-VACUITY ASSERTION: no secret reaches the child, so every "
+        "'the secret is not in the output' assertion passes while proving nothing",
+    ),
+    (
+        "prose-retrips-the-credential-detector",
+        "# the same one-shot `urlopen` + `.read()` shape)",
+        "# the same `urlopen(...).read()` shape)",
+        node("test_the_credential_gate_is_not_tripped_by_this_module_s_PROSE"),
+        node("test_a_clean_sweep_still_says_none"),
+        "a COMMENT reclassifies this module as a credentialed HTTP client and fails two gates (#482)",
+    ),
+    (
+        "module-becomes-a-real-http-client",
+        "import subprocess\nimport sys",
+        "import http.client\nimport subprocess\nimport sys",
+        node("test_this_module_still_makes_no_http_call_of_its_own"),
+        node("test_a_clean_sweep_still_says_none"),
+        "the NON_HTTP_CREDENTIAL_SCRIPTS classification becomes false and nothing else notices",
+    ),
     # ---------------------------------------------------------------- discriminating controls
     (
         "control-cosmetic",

--- a/tests/mutate_harvest_watchdog.py
+++ b/tests/mutate_harvest_watchdog.py
@@ -322,6 +322,15 @@ MUTATIONS: list[tuple[str, str, str, str, str, str]] = [
         node("test_a_clean_sweep_still_says_none"),
         "the NON_HTTP_CREDENTIAL_SCRIPTS classification becomes false and nothing else notices",
     ),
+    (
+        "verdict-detail-appends-the-child-stderr",
+        "    if run.verdict:\n        return False, run.detail",
+        "    if run.verdict:\n        return False, run.detail + (run.stderr or '')",
+        f"{TESTS}::test_a_watchdog_verdict_cannot_carry_the_childs_reflected_pat",
+        node("test_a_clean_sweep_still_says_none"),
+        "a killed child's reflected PAT rides out on the watchdog verdict, which never reaches the "
+        "redactor on the returncode branch",
+    ),
     # ---------------------------------------------------------------- discriminating controls
     (
         "control-cosmetic",

--- a/tests/test_diagnostic_redaction.py
+++ b/tests/test_diagnostic_redaction.py
@@ -1505,7 +1505,7 @@ NON_HTTP_CREDENTIAL_SCRIPTS: dict[str, str] = {
     "scripts/tableau_env.py": "IS the redactor and the chokepoint; gating it against itself is circular",
     "scripts/harvest_estate_assets.py": (
         "persists engine stderr into parse-sweep.json, and redacts it at the point of capture "
-        "(harvest_estate_assets.py:396) with the PAT secret and name; the HTTP call is the engine "
+        "(harvest_estate_assets.py:847) with the PAT secret and name; the HTTP call is the engine "
         "child process's, not this script's"
     ),
     "scripts/capture_tableau_reference.py": (

--- a/tests/test_harvest_download_watchdog.py
+++ b/tests/test_harvest_download_watchdog.py
@@ -13,11 +13,13 @@ the kill path, the pipe drain, or the "never observed" fallback at all.
 from __future__ import annotations
 
 import importlib.util
+import io
 import sqlite3
 import subprocess
 import sys
 import threading
 import time
+import tokenize
 from pathlib import Path
 
 import pytest
@@ -967,3 +969,62 @@ def test_a_failed_download_reaches_parse_sweep_md_through_main(monkeypatch: pyte
     text = (out / "parse-sweep.md").read_text(encoding="utf-8")
     assert "**1 asset(s)** — ours failed 0, his failed 0, both parsed 0, never downloaded 1." in text
     assert "IA Redemptions by Campaign Report" in text.split("## Downloads that never landed", 1)[1]
+
+
+# --- the classification this module carries in the credential gate --------------------------------
+#
+# ⚠️ CI-red on #482, and the obvious diagnosis was the wrong one. `tests/test_diagnostic_redaction.py`
+# records this module in `NON_HTTP_CREDENTIAL_SCRIPTS` — "holds a Tableau credential, makes NO
+# credentialed HTTP request of its own" — and asserts the detector must NOT see it. That detector
+# scans RAW SOURCE for markers, so a comment added by #482 that spelled `urlopen` immediately
+# followed by an open paren reclassified this module as an HTTP client and failed two security gates.
+# Registering it in `GATE_WAIVERS` would have turned both green while recording something false.
+#
+# So the two halves are pinned separately, and each says which one an edit broke: the STRUCTURAL
+# claim (no HTTP client in code) is what the classification actually rests on; the PROSE trap is what
+# breaks CI. `tests/test_diagnostic_redaction.py` remains the authority — this is a local mirror that
+# fails first, with an actionable message, in the file whose change caused it.
+_HTTP_CLIENT_MARKERS = (
+    "urlopen(",
+    "http.client",
+    "requests.",
+    "import tableauserverclient",
+    "from tableauserverclient",
+    "tableau_http",
+    "._request(",
+)
+
+
+def executable_code(source: str) -> str:
+    """`source` with every comment and string literal removed — what the module DOES, not what it says."""
+    return "".join(
+        "" if token.type in (tokenize.STRING, tokenize.COMMENT) else token.string
+        for token in tokenize.generate_tokens(io.StringIO(source).readline)
+    )
+
+
+def test_this_module_still_makes_no_http_call_of_its_own() -> None:
+    """The structural fact behind the classification: the engine child makes the request, we do not."""
+    code = executable_code((REPO_ROOT / "scripts" / "harvest_estate_assets.py").read_text(encoding="utf-8"))
+    found = sorted(marker for marker in _HTTP_CLIENT_MARKERS if marker in code)
+    assert not found, (
+        f"{found} now appear in this module's CODE, so it is a credentialed HTTP client and its "
+        "`NON_HTTP_CREDENTIAL_SCRIPTS` entry in tests/test_diagnostic_redaction.py is false. Bring it "
+        "under the taint gate (MODULES) — do NOT waive it."
+    )
+    # Positive control: an assertion over a marker list that stopped matching anything is not coverage.
+    control = executable_code((REPO_ROOT / "scripts" / "tableau_http.py").read_text(encoding="utf-8"))
+    assert any(marker in control for marker in _HTTP_CLIENT_MARKERS), (
+        "the marker scan no longer recognises a module that IS an HTTP client, so it has gone inert"
+    )
+
+
+def test_the_credential_gate_is_not_tripped_by_this_module_s_PROSE() -> None:
+    """#482's actual CI failure: a comment, not a call, put this module in front of a security gate."""
+    source = (REPO_ROOT / "scripts" / "harvest_estate_assets.py").read_text(encoding="utf-8")
+    prose_only = sorted(m for m in _HTTP_CLIENT_MARKERS if m in source and m not in executable_code(source))
+    assert not prose_only, (
+        f"{prose_only} appear only in comments or string literals here. That is still enough for the "
+        "detector in tests/test_diagnostic_redaction.py to reclassify this module as a credentialed "
+        "HTTP client and fail two security gates. Spell it apart, e.g. `urlopen` + `.read()`."
+    )

--- a/tests/test_harvest_download_watchdog.py
+++ b/tests/test_harvest_download_watchdog.py
@@ -181,6 +181,213 @@ def test_the_child_output_is_drained_while_the_watchdog_polls() -> None:
     assert len(run.stdout) == 400000, "the child's output was truncated or the drain deadlocked"
 
 
+# --- blind-review round 2: two ways this could still kill a HEALTHY download --------------------
+
+
+def test_the_stall_default_is_never_stricter_than_the_fetchers_own_read_timeout() -> None:
+    """Finding 1. The fetcher passes `timeout=300` to `urlopen` (`fetch_tds.py:407,423`), which is
+    the contract for how long a healthy transfer may go quiet. A stall deadline below that kills a
+    bursty source urllib is perfectly happy with — the wall-clock cliff turned into a shorter
+    inactivity cliff. The first version of this fix shipped 120s and did exactly that.
+    """
+    assert harvest.DEFAULT_STALL_TIMEOUT >= harvest.ENGINE_READ_TIMEOUT_SECONDS, (
+        f"a {harvest.DEFAULT_STALL_TIMEOUT:.0f}s stall deadline pre-empts the fetcher's own "
+        f"{harvest.ENGINE_READ_TIMEOUT_SECONDS:.0f}s per-read timeout"
+    )
+
+
+def test_a_bursty_but_healthy_transfer_survives_a_gap_the_fetcher_would_tolerate() -> None:
+    """Finding 1, as behaviour rather than as an inequality between two constants.
+
+    Everything is scaled from the REAL constants by the same factor, so the test asks one question:
+    *is our kill threshold generous enough for a gap the downloader itself allows?* A pause is
+    chosen that urllib would tolerate (below its read timeout) but that the old 120s default would
+    not (above its scaled equivalent). Lower `DEFAULT_STALL_TIMEOUT` back under the read timeout and
+    this goes red; the pause and the child's read timeout do not move with it.
+    """
+    read_timeout = 2.0  # stands in for the fetcher's 300s
+    scale = read_timeout / harvest.ENGINE_READ_TIMEOUT_SECONDS
+    pause = 0.9 * read_timeout  # urllib is happy: below its read timeout
+    scaled_stall = harvest.DEFAULT_STALL_TIMEOUT * scale
+    assert pause > 120.0 * scale, "the pause must be one the REJECTED 120s default would have killed"
+
+    probe = Counter(1000, moves=1)  # one movement, then a long quiet gap: the bursty shape
+    run = harvest.run_watched(
+        sleeper(pause + 0.4),
+        env=None,
+        timeout=0,  # the ceiling is not what is under test here
+        stall_timeout=scaled_stall,
+        probe=probe,
+        poll_interval=0.05,
+        heartbeat=1000.0,
+    )
+    assert run.verdict == "", f"killed a healthy transfer during a {pause:.1f}s gap urllib allows: {run.detail}"
+    assert run.progress_observed is True
+
+
+def test_losing_the_probe_after_movement_does_not_kill_a_healthy_download() -> None:
+    """Finding 2, the reviewer's reproduction: probe returns 0, 1, then None forever.
+
+    `None` means "cannot read", never "no bytes moved". Access denial, a descendant exiting between
+    enumeration and counter read, or a PARTIAL subtree read all produce it — and the partial case is
+    the nasty one, because the readable trampoline flatlines while the unreadable descendant is the
+    process actually doing the work.
+    """
+    readings = [0, 1]
+
+    def lost_probe(pid: int) -> int | None:  # pylint: disable=unused-argument
+        return readings.pop(0) if readings else None
+
+    run = harvest.run_watched(
+        sleeper(1.0),
+        env=None,
+        timeout=30,
+        stall_timeout=0.25,  # would fire almost immediately if a lost probe counted as a flatline
+        probe=lost_probe,
+        poll_interval=0.05,
+        heartbeat=1000.0,
+    )
+    assert run.verdict != "stalled", f"a lost probe was reported as a hung transfer: {run.detail}"
+    assert (run.verdict, run.returncode) == ("", 0)
+
+
+def test_a_lost_probe_still_ends_the_run_but_as_a_CEILING_not_a_stall() -> None:
+    """Disarming the stall deadline must not mean waiting forever — just labelling it honestly."""
+    readings = [0, 1]
+
+    def lost_probe(pid: int) -> int | None:  # pylint: disable=unused-argument
+        return readings.pop(0) if readings else None
+
+    run = harvest.run_watched(
+        sleeper(30),
+        env=None,
+        timeout=0.4,
+        stall_timeout=0.05,
+        probe=lost_probe,
+        poll_interval=0.05,
+        heartbeat=1000.0,
+    )
+    assert run.verdict == "ceiling", f"expected an honest ceiling verdict, got {run.verdict!r}"
+    assert "progress was seen and then the signal was lost" in run.detail
+    assert "--download-timeout" in run.detail
+
+
+def test_the_wall_clock_restarts_from_the_MOMENT_the_signal_was_lost() -> None:
+    """A transfer that progressed for a while and then went blind gets a fresh window, not a kill.
+
+    Measured from process start, a download that progressed for 9 minutes and lost its probe would
+    be killed one minute later; measured from the loss, it gets the full ceiling to prove itself.
+    """
+    moving_for = 0.5
+    started = time.perf_counter()
+
+    def probe_that_dies(pid: int) -> int | None:  # pylint: disable=unused-argument
+        elapsed = time.perf_counter() - started
+        return int(elapsed * 1000) if elapsed < moving_for else None
+
+    run = harvest.run_watched(
+        sleeper(30),
+        env=None,
+        timeout=0.4,
+        stall_timeout=60,
+        probe=probe_that_dies,
+        poll_interval=0.05,
+        heartbeat=1000.0,
+    )
+    assert run.verdict == "ceiling"
+    assert run.elapsed >= moving_for + 0.4, (
+        f"the ceiling was measured from process start, not from the loss of the signal "
+        f"(killed after {run.elapsed:.2f}s, expected at least {moving_for + 0.4:.2f}s)"
+    )
+
+
+def test_losing_the_signal_is_announced_once(caplog: pytest.LogCaptureFixture) -> None:
+    readings = [0, 1]
+
+    def lost_probe(pid: int) -> int | None:  # pylint: disable=unused-argument
+        return readings.pop(0) if readings else None
+
+    with caplog.at_level("WARNING", logger="harvest_estate_assets"):
+        harvest.run_watched(
+            sleeper(0.8),
+            env=None,
+            timeout=30,
+            stall_timeout=0.25,
+            probe=lost_probe,
+            poll_interval=0.05,
+            heartbeat=1000.0,
+            label="asset",
+        )
+    lost = [r.getMessage() for r in caplog.records if "lost the download-progress signal" in r.getMessage()]
+    assert len(lost) == 1, f"expected exactly one announcement, got {len(lost)}"
+
+
+def test_a_partial_subtree_reading_is_reported_as_UNAVAILABLE_not_as_a_smaller_sum(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The sum of the processes we CAN read is not a smaller answer; it is a different question.
+
+    With the descendant unreadable, the readable trampoline's constant counters look exactly like a
+    stalled download.
+    """
+    child = subprocess.Popen(  # pylint: disable=consider-using-with
+        [sys.executable, "-c", "import time;time.sleep(5)"], stdout=subprocess.PIPE, text=True
+    )
+    try:
+        assert harvest.transferred_bytes(child.pid) is not None, "the readable case must still answer"
+        monkeypatch.setattr(harvest, "process_tree", lambda pid: [pid, 999_999])
+        assert harvest.transferred_bytes(child.pid) is None, "a partial reading was passed off as a total"
+    finally:
+        harvest.terminate_tree(child)
+        child.wait(timeout=30)
+
+
+def test_an_unreadable_process_reports_no_signal_at_all() -> None:
+    assert harvest.transferred_bytes(999_999) is None
+
+
+def test_the_cli_warns_when_the_stall_deadline_undercuts_the_fetcher(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The flag is the operator's to set, but a value below 300s has a consequence worth naming."""
+    db = tmp_path / "estate.db"
+    con = sqlite3.connect(db)
+    con.executescript(
+        """
+        CREATE TABLE project (luid TEXT PRIMARY KEY, name TEXT);
+        CREATE TABLE workbook (luid TEXT PRIMARY KEY, name TEXT, project_luid TEXT);
+        CREATE TABLE datasource (luid TEXT PRIMARY KEY, name TEXT, project_luid TEXT);
+        CREATE TABLE dependency (workbook_luid TEXT, datasource_luid TEXT, datasource_name TEXT);
+        INSERT INTO workbook VALUES ('wb-ia', 'IA Redemptions', 'p');
+        """
+    )
+    con.commit()
+    con.close()
+    monkeypatch.setattr(harvest, "engine_scripts_dir", lambda: tmp_path / "engine")
+    monkeypatch.setattr(harvest, "resolve_env", lambda path: {"TABLEAU_SERVER_URL": "https://example.invalid"})
+    monkeypatch.setattr(harvest, "require", lambda env: None)
+    monkeypatch.setattr(harvest, "download", lambda *a, **k: (False, "nope"))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "harvest_estate_assets.py",
+            "--out",
+            str(tmp_path / "_sweep"),
+            "--db",
+            str(db),
+            "--allow-unignored-out",
+            "--download-stall-timeout",
+            "30",
+        ],
+    )
+    with caplog.at_level("WARNING", logger="harvest_estate_assets"):
+        assert harvest.main() == 0
+    warned = [r.getMessage() for r in caplog.records if "BELOW the fetcher's own" in r.getMessage()]
+    assert warned, "an operator undercut the fetcher's read timeout and was told nothing"
+    assert "300s per-read timeout" in warned[0]
+
+
 # --- the failure TEXT: an operator must be able to act on it ------------------------------------
 
 
@@ -207,7 +414,8 @@ def test_the_ceiling_message_distinguishes_itself_from_a_stall() -> None:
     )
     assert "--download-timeout" in run.detail
     assert "elapsed" in run.detail
-    assert "no download-progress signal" in run.detail, f"it does not say WHY it could not tell: {run.detail}"
+    assert "usable download-progress signal" in run.detail, f"it does not say WHY it could not tell: {run.detail}"
+    assert "blind the whole time" in run.detail, f"it does not distinguish never-seen from lost: {run.detail}"
     assert "stalled" not in run.detail, "a ceiling kill must not be reported as a stall"
 
 

--- a/tests/test_harvest_download_watchdog.py
+++ b/tests/test_harvest_download_watchdog.py
@@ -1,0 +1,553 @@
+"""Tests for the download watchdog and the sweep tally, both from issue #472.
+
+The defect this file exists for: a customer's 47-asset harvest lost `IA Redemptions by Campaign
+Report` to `timeout after 600s`, twice. There are TWO nested timeouts catching OPPOSITE failures —
+the engine's per-socket-read `timeout=300` (`fetch_tds.py:407,423`) and our total wall clock — so a
+download that is slow but perfectly healthy satisfies every socket read and is then killed by ours.
+
+These tests drive `run_watched` with REAL child processes and a probe the test controls, because the
+thing under test is a decision about time and liveness, and a mocked subprocess would not exercise
+the kill path, the pipe drain, or the "never observed" fallback at all.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sqlite3
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SPEC = importlib.util.spec_from_file_location(
+    "harvest_estate_assets", REPO_ROOT / "scripts" / "harvest_estate_assets.py"
+)
+assert SPEC and SPEC.loader
+harvest = importlib.util.module_from_spec(SPEC)
+sys.modules["harvest_estate_assets"] = harvest
+SPEC.loader.exec_module(harvest)
+
+
+SLEEPER = "import time,sys;sys.stdout.write('started');sys.stdout.flush();time.sleep({seconds})"
+
+
+def sleeper(seconds: float) -> list[str]:
+    """A child that just sits there: the shape of a download that has stopped transferring."""
+    return [sys.executable, "-c", SLEEPER.format(seconds=seconds)]
+
+
+class Counter:
+    """A probe the test drives.
+
+    `moves` bytes-worth of movement happens on the first `moves` samples and then it FREEZES, which
+    is the observe-then-flatline shape of a real hung transfer. `moves=0` never moves at all, which
+    is the uv-trampoline shape. Movement has to happen DURING the run: a value bumped before the
+    first sample is indistinguishable from a constant, because progress is a change between samples.
+    """
+
+    def __init__(self, value: int | None = 0, moves: int = 0) -> None:
+        self.value = value
+        self.moves = moves
+        self.calls = 0
+
+    def __call__(self, pid: int) -> int | None:  # pylint: disable=unused-argument
+        self.calls += 1
+        if self.moves > 0 and self.calls > 1 and self.value is not None:
+            self.moves -= 1
+            self.value += 1024
+        return self.value
+
+    def advance(self, by: int = 1024) -> None:
+        assert self.value is not None
+        self.value += by
+
+
+# --- the fix: a download that is MOVING is not killed, one that STOPPED is -----------------------
+
+
+def test_a_progressing_download_is_not_killed_by_the_wall_clock_ceiling() -> None:
+    """The customer's defect, directly: healthy transfer, ceiling far below its duration."""
+    probe = Counter(1000)
+    stop = threading.Event()
+
+    def keep_moving() -> None:
+        while not stop.is_set():
+            probe.advance()
+            time.sleep(0.05)
+
+    mover = threading.Thread(target=keep_moving, daemon=True)
+    mover.start()
+    try:
+        run = harvest.run_watched(
+            sleeper(1.5),
+            env=None,
+            timeout=0.3,  # the pre-#472 behaviour would have killed this at 0.3s
+            stall_timeout=5.0,
+            probe=probe,
+            poll_interval=0.05,
+            heartbeat=1000.0,
+        )
+    finally:
+        stop.set()
+        mover.join(2)
+
+    assert run.verdict == "", f"killed a progressing download: {run.detail}"
+    assert run.returncode == 0
+    assert run.elapsed > 0.3, "the run did not even reach the ceiling it was supposed to survive"
+    assert run.progress_observed is True
+
+
+def test_a_stalled_download_is_killed_once_progress_stops() -> None:
+    """Movement observed, then a flatline: that is a hung transfer and killing it is right."""
+    probe = Counter(1000, moves=2)  # moves during the run, then flatlines
+    run = harvest.run_watched(
+        sleeper(30),
+        env=None,
+        timeout=0,  # no ceiling at all: only the stall detector can end this
+        stall_timeout=0.3,
+        probe=probe,
+        poll_interval=0.05,
+        heartbeat=1000.0,
+    )
+    assert run.verdict == "stalled", f"a flatlined download survived: {run!r}"
+    assert run.returncode is None
+    assert run.elapsed < 20, "the stall detector waited for the child instead of killing it"
+
+
+def test_progress_must_be_OBSERVED_before_a_flatline_counts_as_a_stall() -> None:
+    """A probe that never moves is a probe we cannot trust — measured, not hypothetical.
+
+    Under a uv venv, `Popen.pid` is a TRAMPOLINE whose I/O counters never move (measured:
+    `Popen.pid = 35152` while the child's own `os.getpid()` was `20856`). If a never-moving probe
+    were allowed to arm the stall deadline, every download on such a venv would be killed as hung.
+    """
+    probe = Counter(1000)  # never advanced
+    run = harvest.run_watched(
+        sleeper(30),
+        env=None,
+        timeout=0.4,
+        stall_timeout=0.05,  # far tighter than the ceiling: it must NOT be the one that fires
+        probe=probe,
+        poll_interval=0.05,
+        heartbeat=1000.0,
+    )
+    assert run.verdict == "ceiling", f"an unmoved probe was trusted as a stall signal: {run!r}"
+    assert run.progress_observed is False
+    assert run.elapsed >= 0.4
+
+
+def test_an_unavailable_probe_falls_back_to_the_ceiling_rather_than_killing() -> None:
+    """`None` means "cannot tell", which is a different answer from "no bytes"."""
+    run = harvest.run_watched(
+        sleeper(30),
+        env=None,
+        timeout=0.4,
+        stall_timeout=0.05,
+        probe=lambda pid: None,
+        poll_interval=0.05,
+        heartbeat=1000.0,
+    )
+    assert run.verdict == "ceiling"
+    assert run.progress_observed is False
+
+
+def test_a_short_healthy_run_returns_its_output_and_no_verdict() -> None:
+    run = harvest.run_watched(
+        [sys.executable, "-c", "print('landed')"],
+        env=None,
+        timeout=30,
+        stall_timeout=30,
+        probe=Counter(0),
+        poll_interval=0.05,
+        heartbeat=1000.0,
+    )
+    assert (run.verdict, run.returncode, run.stdout.strip()) == ("", 0, "landed")
+
+
+def test_the_child_output_is_drained_while_the_watchdog_polls() -> None:
+    """A chatty child must not deadlock on a full pipe buffer — that would LOOK like a stall.
+
+    64 KiB is the Windows pipe buffer; this writes well past it before exiting.
+    """
+    chatty = [sys.executable, "-c", "import sys;sys.stdout.write('x'*400000);sys.stdout.flush()"]
+    run = harvest.run_watched(
+        chatty, env=None, timeout=30, stall_timeout=30, probe=Counter(0), poll_interval=0.05, heartbeat=1000.0
+    )
+    assert run.verdict == ""
+    assert len(run.stdout) == 400000, "the child's output was truncated or the drain deadlocked"
+
+
+# --- the failure TEXT: an operator must be able to act on it ------------------------------------
+
+
+def test_the_stall_message_says_what_was_observed_and_which_flag_to_turn() -> None:
+    probe = Counter(1000, moves=2)  # moves during the run, then flatlines
+    run = harvest.run_watched(
+        sleeper(30), env=None, timeout=0, stall_timeout=0.3, probe=probe, poll_interval=0.05, heartbeat=1000.0
+    )
+    assert "stalled" in run.detail
+    assert "--download-stall-timeout" in run.detail, f"the message names no flag: {run.detail}"
+    assert "elapsed" in run.detail, f"the message reports no elapsed time: {run.detail}"
+
+
+def test_the_ceiling_message_distinguishes_itself_from_a_stall() -> None:
+    """`timeout after 600s` told the customer only what WE had configured."""
+    run = harvest.run_watched(
+        sleeper(30),
+        env=None,
+        timeout=0.4,
+        stall_timeout=0.05,
+        probe=lambda pid: None,
+        poll_interval=0.05,
+        heartbeat=1000.0,
+    )
+    assert "--download-timeout" in run.detail
+    assert "elapsed" in run.detail
+    assert "no download-progress signal" in run.detail, f"it does not say WHY it could not tell: {run.detail}"
+    assert "stalled" not in run.detail, "a ceiling kill must not be reported as a stall"
+
+
+def test_a_long_run_reports_elapsed_time_rather_than_looking_like_work(caplog: pytest.LogCaptureFixture) -> None:
+    """AGENTS.md: never block silently; anything past ~60s reports elapsed time."""
+    probe = Counter(1000, moves=2)  # moves during the run, then flatlines
+    with caplog.at_level("INFO", logger="harvest_estate_assets"):
+        harvest.run_watched(
+            sleeper(30),
+            env=None,
+            timeout=0,
+            stall_timeout=0.5,
+            probe=probe,
+            poll_interval=0.05,
+            heartbeat=0.1,  # stands in for the 60s default
+            label="[7/47] IA Redemptions by Campaign Report",
+        )
+    beats = [r.getMessage() for r in caplog.records if "still running" in r.getMessage()]
+    assert beats, "a long-running download said nothing at all"
+    assert "elapsed=" in beats[0]
+    assert "IA Redemptions by Campaign Report" in beats[0], "the heartbeat does not say which asset"
+
+
+def test_a_download_progressing_past_the_ceiling_is_announced_loudly(caplog: pytest.LogCaptureFixture) -> None:
+    """Not killing it is right, but silently ignoring our own configured ceiling is not."""
+    probe = Counter(1000)
+    stop = threading.Event()
+
+    def keep_moving() -> None:
+        while not stop.is_set():
+            probe.advance()
+            time.sleep(0.05)
+
+    mover = threading.Thread(target=keep_moving, daemon=True)
+    mover.start()
+    try:
+        with caplog.at_level("WARNING", logger="harvest_estate_assets"):
+            harvest.run_watched(
+                sleeper(1.2),
+                env=None,
+                timeout=0.3,
+                stall_timeout=5.0,
+                probe=probe,
+                poll_interval=0.05,
+                heartbeat=1000.0,
+                label="asset",
+            )
+    finally:
+        stop.set()
+        mover.join(2)
+    warnings = [r.getMessage() for r in caplog.records if "NOT killing" in r.getMessage()]
+    assert warnings, "we sailed past our own --download-timeout without saying so"
+    assert "--download-timeout" in warnings[0]
+    assert len(warnings) == 1, "the announcement repeated on every poll"
+
+
+# --- the timeouts are reachable from the CLI ----------------------------------------------------
+
+
+def test_the_ceiling_is_no_longer_hard_coded() -> None:
+    """The operator's actual complaint: 600 was unreachable, so the asset was unharvestable."""
+    help_text = subprocess.run(
+        [sys.executable, str(REPO_ROOT / "scripts" / "harvest_estate_assets.py"), "--help"],
+        capture_output=True,
+        # The module's own docstring is non-ASCII and it forces UTF-8 on its streams; decoding the
+        # pipe with the Windows locale codec raises UnicodeDecodeError and hides the real answer.
+        encoding="utf-8",
+        errors="replace",
+        timeout=120,
+        check=False,
+    ).stdout
+    assert "--download-timeout" in help_text
+    assert "--download-stall-timeout" in help_text
+
+
+def test_download_passes_the_operator_s_timeouts_through(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    seen: dict[str, object] = {}
+
+    def fake_run_watched(cmd, env, **kwargs):  # pylint: disable=unused-argument
+        seen.update(kwargs)
+        return harvest.WatchedRun(0, "", "", 1.0, "", "", True)
+
+    monkeypatch.setattr(harvest, "run_watched", fake_run_watched)
+    monkeypatch.setattr(harvest, "engine_child_env", lambda env: {})
+    ok, detail = harvest.download(
+        "workbook",
+        "wb-1",
+        tmp_path / "wb.twbx",
+        {"TABLEAU_SERVER_URL": "https://example.invalid"},
+        tmp_path,
+        timeout=1234.0,
+        stall_timeout=77.0,
+        label="[3/9] Something",
+    )
+    assert (ok, detail) == (True, "")
+    assert seen["timeout"] == 1234.0
+    assert seen["stall_timeout"] == 77.0
+    assert seen["label"] == "[3/9] Something"
+
+
+def test_a_watchdog_verdict_reaches_the_caller_as_the_failure_detail(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(
+        harvest,
+        "run_watched",
+        lambda cmd, env, **kwargs: harvest.WatchedRun(None, "", "", 900.0, "stalled", "stalled: no progress", True),
+    )
+    monkeypatch.setattr(harvest, "engine_child_env", lambda env: {})
+    ok, detail = harvest.download(
+        "workbook", "wb-1", tmp_path / "wb.twbx", {"TABLEAU_SERVER_URL": "https://example.invalid"}, tmp_path
+    )
+    assert (ok, detail) == (False, "stalled: no progress")
+
+
+# --- the real probe, on this machine ------------------------------------------------------------
+
+
+def test_the_real_probe_sums_a_process_SUBTREE_not_just_the_pid_handed_to_popen() -> None:
+    """Measured 2026-09-03: `.venv/Scripts/python.exe` is a uv TRAMPOLINE.
+
+    `Popen.pid` was 35152 while the child's own `os.getpid()` reported 20856, and the trampoline's
+    I/O counters never move. A probe that sampled only `Popen.pid` would report every download as
+    stalled. This asserts the subtree walk reaches the descendant that does the work.
+    """
+    child = subprocess.Popen(  # pylint: disable=consider-using-with
+        [sys.executable, "-c", "import os,sys,time;print(os.getpid(),flush=True);time.sleep(5)"],
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        real_pid = int(child.stdout.readline().strip())
+        tree = harvest.process_tree(child.pid)
+        assert child.pid in tree
+        assert real_pid in tree, (
+            f"the subtree walk missed the real interpreter: popen={child.pid} real={real_pid} {tree}"
+        )
+    finally:
+        harvest.terminate_tree(child)
+        child.wait(timeout=30)
+
+
+def test_the_real_probe_returns_a_number_that_moves_for_a_working_child() -> None:
+    """A probe that always returns the same value is indistinguishable from a stall."""
+    child = subprocess.Popen(  # pylint: disable=consider-using-with
+        [
+            sys.executable,
+            "-c",
+            "import time\nfor _ in range(200):\n open(__file__ if False else 'nul','rb').read(1)\n time.sleep(0.01)\n",
+        ],
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        first = harvest.transferred_bytes(child.pid)
+        assert first is not None, "no progress signal at all on this platform"
+        deadline = time.perf_counter() + 5
+        while time.perf_counter() < deadline:
+            if (harvest.transferred_bytes(child.pid) or 0) != first:
+                break
+            time.sleep(0.1)
+        else:
+            pytest.fail(f"the probe never moved for a child doing real I/O (stuck at {first})")
+    finally:
+        harvest.terminate_tree(child)
+        child.wait(timeout=30)
+
+
+def test_terminate_tree_kills_the_descendant_too() -> None:
+    """Killing only `Popen.pid` would orphan the real interpreter, socket and session included."""
+    parent = subprocess.Popen(  # pylint: disable=consider-using-with
+        [
+            sys.executable,
+            "-c",
+            "import subprocess,sys,time\n"
+            "kid = subprocess.Popen([sys.executable,'-c','import time;time.sleep(120)'])\n"
+            "print(kid.pid, flush=True)\n"
+            "time.sleep(120)\n",
+        ],
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    grandchild = int(parent.stdout.readline().strip())
+    harvest.terminate_tree(parent)
+    parent.wait(timeout=30)
+    deadline = time.perf_counter() + 10
+    while time.perf_counter() < deadline:
+        if grandchild not in harvest.process_tree(grandchild)[1:] and not _alive(grandchild):
+            break
+        time.sleep(0.2)
+    assert not _alive(grandchild), f"the descendant {grandchild} survived terminate_tree"
+
+
+def _alive(pid: int) -> bool:
+    """True while `pid` is a live process (Windows: an openable, non-exited handle)."""
+    if sys.platform == "win32":
+        lib = harvest.kernel32()
+        handle = lib.OpenProcess(0x1000, False, pid)
+        if not handle:
+            return False
+        code = harvest.ctypes.c_uint32()
+        lib.GetExitCodeProcess.argtypes = [harvest.ctypes.c_void_p, harvest.ctypes.POINTER(harvest.ctypes.c_uint32)]
+        ok = lib.GetExitCodeProcess(handle, harvest.ctypes.byref(code))
+        lib.CloseHandle(handle)
+        return bool(ok) and code.value == 259  # STILL_ACTIVE
+    try:
+        import os  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
+
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    return True
+
+
+# --- the tally has to close ----------------------------------------------------------------------
+
+
+def sweep_rows() -> list[dict]:
+    """The customer's shape: some parsed, some failed a parser, some never downloaded at all."""
+    return [
+        {"name": "Parsed A", "kind": "workbook", "ours": {"ok": True}, "theirs": {"ok": True}},
+        {"name": "Parsed B", "kind": "workbook", "ours": {"ok": True}, "theirs": {"ok": True}},
+        {
+            "name": "Ours only",
+            "kind": "workbook",
+            "ours": {"ok": False, "error": "ValueError: bad"},
+            "theirs": {"ok": True},
+        },
+        {"name": "His only", "kind": "workbook", "ours": {"ok": True}, "theirs": {"ok": False, "error": "KeyError: x"}},
+        {
+            "name": "Both",
+            "kind": "workbook",
+            "ours": {"ok": False, "error": "ValueError: bad"},
+            "theirs": {"ok": False, "error": "KeyError: x"},
+        },
+        {
+            "name": "IA Redemptions by Campaign Report",
+            "kind": "workbook",
+            "download_error": "timeout after 600s (elapsed 601.4s)",
+        },
+        {
+            "name": "Distribution of Users by Portal Load Time",
+            "kind": "workbook",
+            "download_error": "timeout after 600s (elapsed 612.9s)",
+        },
+        {"name": "DS_Sessions_by_Product", "kind": "datasource", "download_error": "download failed (500)"},
+    ]
+
+
+def test_a_never_downloaded_asset_is_named_in_the_report(tmp_path: Path) -> None:
+    """It used to land in NO bucket while still counting in the denominator."""
+    text = harvest.summarise(sweep_rows(), tmp_path)
+    assert "## Downloads that never landed" in text
+    assert "IA Redemptions by Campaign Report" in text
+    assert "DS_Sessions_by_Product" in text
+
+
+def test_the_header_arithmetic_closes(tmp_path: Path) -> None:
+    """`47 != 0 + 0 + 41` is how a partial harvest read as complete."""
+    rows = sweep_rows()
+    text = harvest.summarise(rows, tmp_path)
+    assert f"**{len(rows)} asset(s)**" in text
+    assert f"never downloaded {len(harvest.never_downloaded(rows))}" in text
+    closure = next(line for line in text.splitlines() if line.startswith("Disjoint buckets"))
+    assert closure.rstrip(".").endswith(f"= {len(rows)}"), closure
+    assert "2 parsed by both + 1 ours only + 1 his only + 1 both parsers + 3 never downloaded" in closure
+
+
+def test_the_parser_buckets_ignore_rows_that_never_reached_a_parser(tmp_path: Path) -> None:
+    """A download failure is not a parser verdict and must not be reported as one."""
+    text = harvest.summarise(sweep_rows(), tmp_path)
+    header = text.splitlines()[2]
+    assert "ours failed 2, his failed 2, both parsed 2, never downloaded 3" in header, header
+
+
+def test_download_failures_are_grouped_by_shape_not_by_elapsed_seconds(tmp_path: Path) -> None:
+    """Two timeouts differing only in their elapsed seconds are ONE finding, not two."""
+    text = harvest.summarise(sweep_rows(), tmp_path)
+    timeout_bullets = [line for line in text.splitlines() if line.startswith("- **") and "timeout after" in line]
+    assert timeout_bullets == ["- **2x** `timeout after Ns (elapsed Ns)`"], timeout_bullets
+
+
+def test_a_clean_sweep_still_says_none(tmp_path: Path) -> None:
+    """The new section must not cry wolf when every asset landed."""
+    text = harvest.summarise([r for r in sweep_rows() if "download_error" not in r], tmp_path)
+    section = text.split("## Downloads that never landed", 1)[1]
+    assert section.lstrip().startswith("_none_")
+    assert "never downloaded 0" in text
+
+
+def test_the_failed_downloads_are_reported_to_the_operator_at_the_end(caplog: pytest.LogCaptureFixture) -> None:
+    """`download_error` was written to the record and surfaced NOWHERE a human looks."""
+    with caplog.at_level("WARNING", logger="harvest_estate_assets"):
+        missing = harvest.report_failed_downloads(sweep_rows())
+    messages = "\n".join(r.getMessage() for r in caplog.records)
+    assert len(missing) == 3
+    assert "IA Redemptions by Campaign Report" in messages
+    assert "timeout after 600s (elapsed 601.4s)" in messages
+    assert "not successes" in messages
+
+
+def test_nothing_is_reported_when_every_asset_landed(caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level("WARNING", logger="harvest_estate_assets"):
+        assert harvest.report_failed_downloads([r for r in sweep_rows() if "download_error" not in r]) == []
+    assert not [r for r in caplog.records if "NEVER DOWNLOADED" in r.getMessage()]
+
+
+# --- end to end through main() -------------------------------------------------------------------
+
+
+def test_a_failed_download_reaches_parse_sweep_md_through_main(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The committed artifact, not just the console, has to name the asset that never landed."""
+    db = tmp_path / "estate.db"
+    con = sqlite3.connect(db)
+    con.executescript(
+        """
+        CREATE TABLE project (luid TEXT PRIMARY KEY, name TEXT);
+        CREATE TABLE workbook (luid TEXT PRIMARY KEY, name TEXT, project_luid TEXT);
+        CREATE TABLE datasource (luid TEXT PRIMARY KEY, name TEXT, project_luid TEXT);
+        CREATE TABLE dependency (workbook_luid TEXT, datasource_luid TEXT, datasource_name TEXT);
+        INSERT INTO workbook VALUES ('wb-ia', 'IA Redemptions by Campaign Report', 'p');
+        """
+    )
+    con.commit()
+    con.close()
+
+    out = tmp_path / "_sweep"
+    monkeypatch.setattr(harvest, "engine_scripts_dir", lambda: tmp_path / "engine")
+    monkeypatch.setattr(harvest, "resolve_env", lambda path: {"TABLEAU_SERVER_URL": "https://example.invalid"})
+    monkeypatch.setattr(harvest, "require", lambda env: None)
+    monkeypatch.setattr(
+        harvest,
+        "download",
+        lambda *a, **k: (False, "stalled: no progress for 120s (elapsed 240s). Raise --download-stall-timeout"),
+    )
+    monkeypatch.setattr(
+        sys, "argv", ["harvest_estate_assets.py", "--out", str(out), "--db", str(db), "--allow-unignored-out"]
+    )
+    assert harvest.main() == 0
+
+    text = (out / "parse-sweep.md").read_text(encoding="utf-8")
+    assert "**1 asset(s)** — ours failed 0, his failed 0, both parsed 0, never downloaded 1." in text
+    assert "IA Redemptions by Campaign Report" in text.split("## Downloads that never landed", 1)[1]

--- a/tests/test_harvest_download_watchdog.py
+++ b/tests/test_harvest_download_watchdog.py
@@ -384,7 +384,7 @@ def test_the_cli_warns_when_the_stall_deadline_undercuts_the_fetcher(
         ],
     )
     with caplog.at_level("WARNING", logger="harvest_estate_assets"):
-        assert harvest.main() == 0
+        assert harvest.main() == harvest.EXIT_NOTHING_ASSESSED
     warned = [r.getMessage() for r in caplog.records if "BELOW the fetcher's own" in r.getMessage()]
     assert warned, "an operator undercut the fetcher's read timeout and was told nothing"
     assert "300s per-read timeout" in warned[0]
@@ -763,6 +763,12 @@ def test_nothing_is_reported_when_every_asset_landed(caplog: pytest.LogCaptureFi
 # --- end to end through main() -------------------------------------------------------------------
 
 
+def landing_download(kind, luid, target, env, scripts, **kwargs):  # pylint: disable=unused-argument
+    """A `download()` stand-in whose asset actually LANDS, so `main()` reaches the parsers."""
+    Path(target).write_text("<workbook/>", encoding="utf-8")
+    return True, ""
+
+
 def test_main_forwards_the_operator_s_timeouts_to_every_download(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -806,7 +812,7 @@ def test_main_forwards_the_operator_s_timeouts_to_every_download(
             "77",
         ],
     )
-    assert harvest.main() == 0
+    assert harvest.main() == harvest.EXIT_NOTHING_ASSESSED, "a harvest that assessed nothing must not exit 0"
     assert seen, "no download was attempted at all"
     assert seen[0]["timeout"] == 1234.0, f"the CLI ceiling never reached download(): {seen[0]}"
     assert seen[0]["stall_timeout"] == 77.0, f"the CLI stall timeout never reached download(): {seen[0]}"
@@ -919,7 +925,13 @@ def test_the_section_is_absent_when_nothing_is_orphaned(tmp_path: Path) -> None:
 def test_an_estate_db_without_a_dependency_table_still_harvests(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """An older database cannot answer the orphan question; that is not a reason to fail the run."""
+    """An older database cannot answer the orphan question; that is not a reason to fail the run.
+
+    ⚠️ This test used to make the download FAIL and then assert `main() == 0`, which proved nothing
+    about harvesting — it pinned the fail-open exit code instead (blind review of #482). The asset
+    now lands, so a green run means the sweep completed on a dependency-table-less database, which
+    is the claim in the title.
+    """
     db = tmp_path / "estate.db"
     con = sqlite3.connect(db)
     con.executescript(
@@ -935,13 +947,16 @@ def test_an_estate_db_without_a_dependency_table_still_harvests(
     monkeypatch.setattr(harvest, "engine_scripts_dir", lambda: tmp_path / "engine")
     monkeypatch.setattr(harvest, "resolve_env", lambda path: {"TABLEAU_SERVER_URL": "https://example.invalid"})
     monkeypatch.setattr(harvest, "require", lambda env: None)
-    monkeypatch.setattr(harvest, "download", lambda *a, **k: (False, "nope"))
+    monkeypatch.setattr(harvest, "download", landing_download)
+    monkeypatch.setattr(harvest, "parse_asset", lambda path, scripts: ({"ok": True}, {"ok": True}))
+    out = tmp_path / "_sweep"
     monkeypatch.setattr(
         sys,
         "argv",
-        ["harvest_estate_assets.py", "--out", str(tmp_path / "_sweep"), "--db", str(db), "--allow-unignored-out"],
+        ["harvest_estate_assets.py", "--out", str(out), "--db", str(db), "--allow-unignored-out"],
     )
-    assert harvest.main() == 0
+    assert harvest.main() == harvest.EXIT_OK
+    assert "never downloaded 0." in (out / "parse-sweep.md").read_text(encoding="utf-8")
 
 
 def test_main_end_to_end_names_the_orphaned_workbook(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -963,7 +978,7 @@ def test_main_end_to_end_names_the_orphaned_workbook(monkeypatch: pytest.MonkeyP
     monkeypatch.setattr(
         sys, "argv", ["harvest_estate_assets.py", "--out", str(out), "--db", str(db), "--allow-unignored-out"]
     )
-    assert harvest.main() == 0
+    assert harvest.main() == harvest.EXIT_PARTIAL, "two workbooks landed and one datasource did not: that is PARTIAL"
 
     text = (out / "parse-sweep.md").read_text(encoding="utf-8")
     blocked = text.split("## Do not convert yet", 1)[1]
@@ -999,11 +1014,291 @@ def test_a_failed_download_reaches_parse_sweep_md_through_main(monkeypatch: pyte
     monkeypatch.setattr(
         sys, "argv", ["harvest_estate_assets.py", "--out", str(out), "--db", str(db), "--allow-unignored-out"]
     )
-    assert harvest.main() == 0
+    assert harvest.main() == harvest.EXIT_NOTHING_ASSESSED
 
     text = (out / "parse-sweep.md").read_text(encoding="utf-8")
     assert "**1 asset(s)** — ours failed 0, his failed 0, both parsed 0, never downloaded 1." in text
     assert "IA Redemptions by Campaign Report" in text.split("## Downloads that never landed", 1)[1]
+
+
+# --- blind review round 3, finding 1: a completely unassessed harvest must not exit 0 ------------
+#
+# Reproduced before fixing, on a one-workbook estate with `download()` returning
+# `(False, "network dead")`:
+#
+#   **1 asset(s)** — ours failed 0, his failed 0, both parsed 0, never downloaded 1.
+#   exit_code: 0
+#
+# `return 0 if results else 1` counted ROWS, and a failed download appends a row. Three tests in
+# this very file asserted `main() == 0` on estates where NOTHING was assessed, i.e. the suite was
+# pinning the fail-open behaviour. They are corrected above, not merely re-pinned: the one whose
+# subject is "an older database still harvests" now lands its asset, so it tests its own title.
+
+
+def assessed(name: str) -> dict:
+    """A row that reached BOTH parsers — the only shape that counts as assessed."""
+    return {"name": name, "kind": "workbook", "luid": name, "ours": {"ok": True}, "theirs": {"ok": True}}
+
+
+def unassessed(name: str) -> dict:
+    """A row whose download failed, so it reached neither parser."""
+    return {"name": name, "kind": "workbook", "luid": name, "download_error": "timeout after 600s"}
+
+
+def test_a_harvest_that_assessed_NOTHING_does_not_exit_zero() -> None:
+    """The defect, at the unit that decides it. Rows exist; assessments do not."""
+    assert harvest.sweep_exit_code([unassessed("IA Redemptions by Campaign Report")]) == harvest.EXIT_NOTHING_ASSESSED
+
+
+def test_an_empty_sweep_is_nothing_assessed_rather_than_a_clean_run() -> None:
+    assert harvest.sweep_exit_code([]) == harvest.EXIT_NOTHING_ASSESSED
+
+
+def test_the_customers_41_ok_6_failed_shape_is_distinguishable_from_a_total_failure() -> None:
+    """The judgement call this contract turns on: partial and total must not share a code.
+
+    SES ran 47 assets and got 41/6. Exit 0 said "clean"; a single non-zero for both shapes would say
+    "something went wrong" and lose the difference between six retryable assets and a dead site.
+    """
+    partial = [assessed(f"ok-{i}") for i in range(41)] + [unassessed(f"bad-{i}") for i in range(6)]
+    total = [unassessed(f"bad-{i}") for i in range(47)]
+    clean = [assessed(f"ok-{i}") for i in range(47)]
+    assert harvest.sweep_exit_code(partial) == harvest.EXIT_PARTIAL
+    assert harvest.sweep_exit_code(total) == harvest.EXIT_NOTHING_ASSESSED
+    assert harvest.sweep_exit_code(clean) == harvest.EXIT_OK
+    assert len({harvest.sweep_exit_code(r) for r in (partial, total, clean)}) == 3, (
+        "two of the three outcomes share an exit code, so automation cannot tell them apart"
+    )
+
+
+def test_a_PARSE_failure_is_the_report_this_script_exists_for_and_stays_exit_zero() -> None:
+    """Both parsers refusing an asset is a finding, not a run failure — the asset WAS assessed."""
+    rows = [{"name": "hard", "kind": "workbook", "luid": "h", "ours": {"ok": False}, "theirs": {"ok": False}}]
+    assert harvest.sweep_exit_code(rows) == harvest.EXIT_OK
+
+
+def test_a_totally_failed_harvest_exits_nonzero_through_main(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """End to end, through the CLI: the reviewer's controlled experiment, now green the right way."""
+    db = tmp_path / "estate.db"
+    con = sqlite3.connect(db)
+    con.executescript(
+        """
+        CREATE TABLE project (luid TEXT PRIMARY KEY, name TEXT);
+        CREATE TABLE workbook (luid TEXT PRIMARY KEY, name TEXT, project_luid TEXT);
+        CREATE TABLE datasource (luid TEXT PRIMARY KEY, name TEXT, project_luid TEXT);
+        CREATE TABLE dependency (workbook_luid TEXT, datasource_luid TEXT, datasource_name TEXT);
+        INSERT INTO workbook VALUES ('wb-ia', 'IA Redemptions by Campaign Report', 'p');
+        """
+    )
+    con.commit()
+    con.close()
+    out = tmp_path / "_sweep"
+    monkeypatch.setattr(harvest, "engine_scripts_dir", lambda: tmp_path / "engine")
+    monkeypatch.setattr(harvest, "resolve_env", lambda path: {"TABLEAU_SERVER_URL": "https://example.invalid"})
+    monkeypatch.setattr(harvest, "require", lambda env: None)
+    monkeypatch.setattr(harvest, "download", lambda *a, **k: (False, "network dead"))
+    monkeypatch.setattr(
+        sys, "argv", ["harvest_estate_assets.py", "--out", str(out), "--db", str(db), "--allow-unignored-out"]
+    )
+    assert harvest.main() == harvest.EXIT_NOTHING_ASSESSED
+    # The report still has to be written: a non-zero exit must not cost the operator the evidence.
+    assert "never downloaded 1." in (out / "parse-sweep.md").read_text(encoding="utf-8")
+
+
+def test_the_verdict_is_SAID_not_just_returned(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """An exit code nobody prints is one an operator watching a console never sees."""
+    db = estate_with_a_binding(tmp_path / "estate.db")
+
+    def only_workbooks_land(kind, luid, target, env, scripts, **kwargs):  # pylint: disable=unused-argument
+        if kind == "datasource":
+            return False, "download failed (500)"
+        Path(target).write_text("<workbook/>", encoding="utf-8")
+        return True, ""
+
+    monkeypatch.setattr(harvest, "engine_scripts_dir", lambda: tmp_path / "engine")
+    monkeypatch.setattr(harvest, "resolve_env", lambda path: {"TABLEAU_SERVER_URL": "https://example.invalid"})
+    monkeypatch.setattr(harvest, "require", lambda env: None)
+    monkeypatch.setattr(harvest, "download", only_workbooks_land)
+    monkeypatch.setattr(harvest, "parse_asset", lambda path, scripts: ({"ok": True}, {"ok": True}))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["harvest_estate_assets.py", "--out", str(tmp_path / "_sweep"), "--db", str(db), "--allow-unignored-out"],
+    )
+    with caplog.at_level("WARNING", logger="harvest_estate_assets"):
+        assert harvest.main() == harvest.EXIT_PARTIAL
+    said = "\n".join(r.getMessage() for r in caplog.records)
+    assert "PARTIAL HARVEST" in said, f"the run ended partial and never said so: {said}"
+    assert "2 of 3 asset(s) assessed" in said
+
+
+def test_the_exit_contract_is_documented_where_an_operator_reads_it() -> None:
+    """`--help` is the contract's only reachable surface for someone not reading the source."""
+    help_text = subprocess.run(
+        [sys.executable, str(REPO_ROOT / "scripts" / "harvest_estate_assets.py"), "--help"],
+        capture_output=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=120,
+        check=False,
+    ).stdout
+    assert "Exit codes" in help_text
+    assert "NOTHING COULD BE ASSESSED" in help_text
+
+
+# --- blind review round 3, finding 2: the blind ceiling must outlast the child's own timer -------
+
+
+def test_the_blind_ceiling_is_not_below_the_childs_own_bounded_retry_budget() -> None:
+    """AGENTS.md: do not kill a tool that IS the bounded timer.
+
+    The engine's `_http_download` makes up to `max_attempts` attempts, each of which may burn a full
+    per-read timeout, before it raises its own classified error. The historical 600s ceiling sat
+    below that product, so on any run where the progress probe is unreadable we killed the fetcher
+    mid-budget and recorded `timeout after 600s` in place of the real HTTP failure.
+    """
+    assert harvest.DEFAULT_DOWNLOAD_TIMEOUT > harvest.ENGINE_DOWNLOAD_BUDGET_SECONDS, (
+        f"a {harvest.DEFAULT_DOWNLOAD_TIMEOUT:.0f}s ceiling pre-empts the fetcher's own "
+        f"{harvest.ENGINE_DOWNLOAD_BUDGET_SECONDS:.0f}s retry budget"
+    )
+    assert harvest.ENGINE_DOWNLOAD_BUDGET_SECONDS >= (
+        harvest.ENGINE_DOWNLOAD_ATTEMPTS * harvest.ENGINE_READ_TIMEOUT_SECONDS
+    ), "the budget does not even cover one full read timeout per attempt"
+
+
+def test_the_ceiling_constants_match_the_INSTALLED_engine() -> None:
+    """The arithmetic is only sound while the engine's own numbers are what we think they are.
+
+    Read off the installed canonical engine rather than restated: `max_attempts` and the default
+    `timeout` of `_http_download`, plus the `Retry-After` clamp. An engine bump that changes either
+    reddens this instead of silently invalidating the derivation.
+    """
+    import ast  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
+    import re  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
+
+    try:
+        fetch_tds = harvest.engine_scripts_dir() / "fetch_tds.py"
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        pytest.skip(f"canonical engine not installed, so its constants cannot be read: {exc}")
+    if not fetch_tds.is_file():
+        pytest.skip(f"{fetch_tds} is missing")
+    tree = ast.parse(fetch_tds.read_text(encoding="utf-8"))
+    fn = next(
+        (n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef) and n.name == "_http_download"),
+        None,
+    )
+    assert fn is not None, "the engine no longer has `_http_download`; re-derive the ceiling"
+    defaults = {
+        arg.arg: value.value
+        for arg, value in zip(fn.args.args[-len(fn.args.defaults) :], fn.args.defaults, strict=True)
+        if isinstance(value, ast.Constant)
+    }
+    defaults.update(
+        {
+            arg.arg: value.value
+            for arg, value in zip(fn.args.kwonlyargs, fn.args.kw_defaults, strict=True)
+            if isinstance(value, ast.Constant)
+        }
+    )
+    assert defaults.get("timeout") == harvest.ENGINE_READ_TIMEOUT_SECONDS, (
+        f"the engine's per-read timeout is {defaults.get('timeout')}, not "
+        f"{harvest.ENGINE_READ_TIMEOUT_SECONDS}; re-derive DEFAULT_DOWNLOAD_TIMEOUT"
+    )
+    assert defaults.get("max_attempts") == harvest.ENGINE_DOWNLOAD_ATTEMPTS, (
+        f"the engine now makes {defaults.get('max_attempts')} attempts, not "
+        f"{harvest.ENGINE_DOWNLOAD_ATTEMPTS}; re-derive DEFAULT_DOWNLOAD_TIMEOUT"
+    )
+    clamp = re.compile(rf"min\(\s*wait\s*,\s*{harvest.ENGINE_BACKOFF_CAP_SECONDS:g}(?:\.0)?\s*\)")
+    assert clamp.search(fetch_tds.read_text(encoding="utf-8")), (
+        "the engine's Retry-After clamp is no longer "
+        f"{harvest.ENGINE_BACKOFF_CAP_SECONDS:g}s; re-derive the backoff term"
+    )
+
+
+def test_the_cli_warns_when_the_ceiling_undercuts_the_fetchers_retry_budget(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Deriving the DEFAULT does not stop an operator re-creating the defect with a flag."""
+    db = tmp_path / "estate.db"
+    con = sqlite3.connect(db)
+    con.executescript(
+        """
+        CREATE TABLE project (luid TEXT PRIMARY KEY, name TEXT);
+        CREATE TABLE workbook (luid TEXT PRIMARY KEY, name TEXT, project_luid TEXT);
+        CREATE TABLE datasource (luid TEXT PRIMARY KEY, name TEXT, project_luid TEXT);
+        CREATE TABLE dependency (workbook_luid TEXT, datasource_luid TEXT, datasource_name TEXT);
+        INSERT INTO workbook VALUES ('wb-ia', 'IA Redemptions', 'p');
+        """
+    )
+    con.commit()
+    con.close()
+    monkeypatch.setattr(harvest, "engine_scripts_dir", lambda: tmp_path / "engine")
+    monkeypatch.setattr(harvest, "resolve_env", lambda path: {"TABLEAU_SERVER_URL": "https://example.invalid"})
+    monkeypatch.setattr(harvest, "require", lambda env: None)
+    monkeypatch.setattr(harvest, "download", landing_download)
+    monkeypatch.setattr(harvest, "parse_asset", lambda path, scripts: ({"ok": True}, {"ok": True}))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "harvest_estate_assets.py",
+            "--out",
+            str(tmp_path / "_sweep"),
+            "--db",
+            str(db),
+            "--allow-unignored-out",
+            "--download-timeout",
+            "600",  # the historical default, now knowably too small
+        ],
+    )
+    with caplog.at_level("WARNING", logger="harvest_estate_assets"):
+        assert harvest.main() == harvest.EXIT_OK
+    warned = [r.getMessage() for r in caplog.records if "bounded retry budget" in r.getMessage()]
+    assert warned, "an operator set a ceiling below the fetcher's own budget and was told nothing"
+    assert "1380s bounded retry budget" in warned[0], warned[0]
+
+
+def test_a_blind_child_reaches_its_OWN_verdict_before_our_ceiling_fires() -> None:
+    """Finding 2 as behaviour, scaled from the real constants by one shared factor.
+
+    The child stands in for a fetcher that spends its ENTIRE retry budget and then reports; the
+    probe is unreadable throughout, which is the only situation where the ceiling is armed at all.
+    The control repeats it with the historical 600s ceiling scaled identically — that one IS killed,
+    which is what makes the first assertion evidence rather than a tautology.
+    """
+    scale = 1 / 200.0  # 1380s budget -> 6.9s, 1530s ceiling -> 7.65s
+    child_budget = harvest.ENGINE_DOWNLOAD_BUDGET_SECONDS * scale
+    blind = Counter(None)  # never readable: the unsupported-platform / denied-handle shape
+
+    run = harvest.run_watched(
+        sleeper(child_budget),
+        env=None,
+        timeout=harvest.DEFAULT_DOWNLOAD_TIMEOUT * scale,
+        stall_timeout=harvest.DEFAULT_STALL_TIMEOUT * scale,
+        probe=blind,
+        poll_interval=0.05,
+        heartbeat=1000.0,
+    )
+    assert run.verdict == "", (
+        f"killed at the ceiling after {run.elapsed:.2f}s, before the child's own "
+        f"{child_budget:.2f}s (scaled) retry budget could produce a verdict: {run.detail}"
+    )
+    assert run.returncode == 0, "the child never reported for itself"
+
+    killed = harvest.run_watched(
+        sleeper(child_budget),
+        env=None,
+        timeout=600.0 * scale,  # the historical ceiling, scaled the same way
+        stall_timeout=harvest.DEFAULT_STALL_TIMEOUT * scale,
+        probe=Counter(None),
+        poll_interval=0.05,
+        heartbeat=1000.0,
+    )
+    assert killed.verdict == "ceiling", (
+        "the control did not reproduce the defect, so the first assertion proves nothing about the ceiling"
+    )
 
 
 # --- the classification this module carries in the credential gate --------------------------------

--- a/tests/test_harvest_download_watchdog.py
+++ b/tests/test_harvest_download_watchdog.py
@@ -518,6 +518,56 @@ def test_nothing_is_reported_when_every_asset_landed(caplog: pytest.LogCaptureFi
 # --- end to end through main() -------------------------------------------------------------------
 
 
+def test_main_forwards_the_operator_s_timeouts_to_every_download(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Parsing a flag and then ignoring it looks exactly like having no flag at all.
+
+    A mutation that replaced `args.download_timeout` with the module default at the call site
+    survived every other test in this file, because they all call `download()` directly.
+    """
+    db = tmp_path / "estate.db"
+    con = sqlite3.connect(db)
+    con.executescript(
+        """
+        CREATE TABLE project (luid TEXT PRIMARY KEY, name TEXT);
+        CREATE TABLE workbook (luid TEXT PRIMARY KEY, name TEXT, project_luid TEXT);
+        CREATE TABLE datasource (luid TEXT PRIMARY KEY, name TEXT, project_luid TEXT);
+        CREATE TABLE dependency (workbook_luid TEXT, datasource_luid TEXT, datasource_name TEXT);
+        INSERT INTO workbook VALUES ('wb-ia', 'IA Redemptions', 'p');
+        """
+    )
+    con.commit()
+    con.close()
+
+    seen: list[dict] = []
+    monkeypatch.setattr(harvest, "engine_scripts_dir", lambda: tmp_path / "engine")
+    monkeypatch.setattr(harvest, "resolve_env", lambda path: {"TABLEAU_SERVER_URL": "https://example.invalid"})
+    monkeypatch.setattr(harvest, "require", lambda env: None)
+    monkeypatch.setattr(harvest, "download", lambda *a, **k: (seen.append(k), (False, "nope"))[1])
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "harvest_estate_assets.py",
+            "--out",
+            str(tmp_path / "_sweep"),
+            "--db",
+            str(db),
+            "--allow-unignored-out",
+            "--download-timeout",
+            "1234",
+            "--download-stall-timeout",
+            "77",
+        ],
+    )
+    assert harvest.main() == 0
+    assert seen, "no download was attempted at all"
+    assert seen[0]["timeout"] == 1234.0, f"the CLI ceiling never reached download(): {seen[0]}"
+    assert seen[0]["stall_timeout"] == 77.0, f"the CLI stall timeout never reached download(): {seen[0]}"
+    assert seen[0]["timeout"] != harvest.DEFAULT_DOWNLOAD_TIMEOUT, "the test cannot tell the flag from the default"
+
+
 def test_a_failed_download_reaches_parse_sweep_md_through_main(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """The committed artifact, not just the console, has to name the asset that never landed."""
     db = tmp_path / "estate.db"

--- a/tests/test_harvest_download_watchdog.py
+++ b/tests/test_harvest_download_watchdog.py
@@ -533,6 +533,41 @@ def test_a_watchdog_verdict_reaches_the_caller_as_the_failure_detail(
     assert (ok, detail) == (False, "stalled: no progress")
 
 
+@pytest.mark.parametrize("verdict", ["stalled", "ceiling"])
+def test_a_watchdog_verdict_cannot_carry_the_childs_reflected_pat(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, verdict: str
+) -> None:
+    """⚠️ The PATH #482 ADDED, and the one the credential tests do not reach.
+
+    `download()` redacts on the `returncode != 0` branch, and that branch is what
+    `tests/test_tableau_env.py` exercises. A watchdog verdict returns EARLIER, from `run.detail`,
+    and drops the child's stderr entirely -- which is safe today and is one plausible "let's include
+    what the child said" edit away from not being. The killed child is the likeliest one to have
+    been mid-sign-in, so its stderr is exactly where a reflected PAT would sit.
+    """
+    secret = "SENTINEL_PAT_qrstuvwxyz012345"
+    env = {
+        "TABLEAU_SERVER_URL": "https://example.invalid",
+        "TABLEAU_PAT_NAME": "probe-name",
+        "TABLEAU_PAT_SECRET": secret,
+    }
+    reflected = f'401: {{"credentials": {{"personalAccessTokenSecret": "{secret}"}}}}'
+    monkeypatch.setattr(
+        harvest,
+        "run_watched",
+        lambda cmd, env_, **kwargs: harvest.WatchedRun(
+            None, reflected, reflected, 900.0, verdict, f"{verdict}: no progress for 420s", False
+        ),
+    )
+    ok, detail = harvest.download("workbook", "wb-1", tmp_path / "wb.twbx", env, tmp_path)
+
+    assert ok is False
+    assert secret not in detail, "a killed child's reflected PAT reached the operator-facing detail"
+    assert "probe-name" not in detail, "the PAT name reached the operator-facing detail"
+    # Non-vacuity: the verdict text itself must survive, or this passes on an empty detail.
+    assert detail.startswith(f"{verdict}: no progress"), "the watchdog's own diagnostic was lost"
+
+
 # --- the real probe, on this machine ------------------------------------------------------------
 
 

--- a/tests/test_harvest_download_watchdog.py
+++ b/tests/test_harvest_download_watchdog.py
@@ -568,6 +568,164 @@ def test_main_forwards_the_operator_s_timeouts_to_every_download(
     assert seen[0]["timeout"] != harvest.DEFAULT_DOWNLOAD_TIMEOUT, "the test cannot tell the flag from the default"
 
 
+# --- leg 4: a failed datasource does not fail alone ----------------------------------------------
+
+
+def estate_with_a_binding(path: Path) -> Path:
+    """`IA IFC Sessions` binds to `DS_Sessions_by_Product`; `Standalone` binds to nothing."""
+    con = sqlite3.connect(path)
+    con.executescript(
+        """
+        CREATE TABLE project (luid TEXT PRIMARY KEY, name TEXT);
+        CREATE TABLE workbook (luid TEXT PRIMARY KEY, name TEXT, project_luid TEXT);
+        CREATE TABLE datasource (luid TEXT PRIMARY KEY, name TEXT, project_luid TEXT);
+        CREATE TABLE dependency (workbook_luid TEXT, datasource_luid TEXT, datasource_name TEXT);
+        INSERT INTO workbook VALUES ('wb-ifc', 'IA IFC Sessions', 'p');
+        INSERT INTO workbook VALUES ('wb-solo', 'Standalone', 'p');
+        INSERT INTO datasource VALUES ('ds-sessions', 'DS_Sessions_by_Product', 'p');
+        INSERT INTO dependency VALUES ('wb-ifc', 'ds-sessions', 'DS_Sessions_by_Product');
+        """
+    )
+    con.commit()
+    con.close()
+    return path
+
+
+def binding_rows() -> list[dict]:
+    """The datasource failed; both workbooks landed. Only one of them is affected."""
+    return [
+        {"name": "DS_Sessions_by_Product", "kind": "datasource", "luid": "ds-sessions", "download_error": "500"},
+        {"name": "IA IFC Sessions", "kind": "workbook", "luid": "wb-ifc", "ours": {"ok": True}, "theirs": {"ok": True}},
+        {"name": "Standalone", "kind": "workbook", "luid": "wb-solo", "ours": {"ok": True}, "theirs": {"ok": True}},
+    ]
+
+
+def edges_from(db: Path) -> list[tuple[str, str, str, str]]:
+    con = sqlite3.connect(db)
+    try:
+        return harvest.dependency_edges(con)
+    finally:
+        con.close()
+
+
+def test_a_failed_datasource_names_the_workbooks_it_orphans(tmp_path: Path) -> None:
+    """Their agent worked this out BY HAND; the harvester already resolves the edge."""
+    edges = edges_from(estate_with_a_binding(tmp_path / "estate.db"))
+    assert harvest.orphaned_dependents(binding_rows(), edges) == [("DS_Sessions_by_Product", ["IA IFC Sessions"])]
+
+
+def test_a_workbook_bound_to_NOTHING_that_failed_is_not_flagged(tmp_path: Path) -> None:
+    """Flagging every workbook would make the warning worthless."""
+    edges = edges_from(estate_with_a_binding(tmp_path / "estate.db"))
+    orphans = harvest.orphaned_dependents(binding_rows(), edges)
+    assert "Standalone" not in [name for _, workbooks in orphans for name in workbooks]
+
+
+def test_a_workbook_that_ITSELF_failed_is_not_listed_as_an_orphan(tmp_path: Path) -> None:
+    """It is already in the never-landed list and is not about to be converted."""
+    rows = binding_rows()
+    rows[1] = {"name": "IA IFC Sessions", "kind": "workbook", "luid": "wb-ifc", "download_error": "timeout"}
+    edges = edges_from(estate_with_a_binding(tmp_path / "estate.db"))
+    assert harvest.orphaned_dependents(rows, edges) == []
+
+
+def test_nothing_is_orphaned_when_the_datasource_landed(tmp_path: Path) -> None:
+    rows = binding_rows()
+    rows[0] = {
+        "name": "DS_Sessions_by_Product",
+        "kind": "datasource",
+        "luid": "ds-sessions",
+        "ours": {"ok": True},
+        "theirs": {"ok": True},
+    }
+    edges = edges_from(estate_with_a_binding(tmp_path / "estate.db"))
+    assert harvest.orphaned_dependents(rows, edges) == []
+
+
+def test_an_edge_resolved_only_by_NAME_still_finds_the_dependent(tmp_path: Path) -> None:
+    """A survey that could not resolve the LUID must not silently drop the binding."""
+    db = estate_with_a_binding(tmp_path / "estate.db")
+    con = sqlite3.connect(db)
+    con.execute("DELETE FROM dependency")
+    con.execute("INSERT INTO dependency VALUES ('wb-ifc', '', ' ds_sessions_by_product ')")
+    con.commit()
+    con.close()
+    assert harvest.orphaned_dependents(binding_rows(), edges_from(db)) == [
+        ("DS_Sessions_by_Product", ["IA IFC Sessions"])
+    ]
+
+
+def test_the_orphans_reach_the_report_and_the_operator(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    orphans = harvest.orphaned_dependents(binding_rows(), edges_from(estate_with_a_binding(tmp_path / "estate.db")))
+    text = harvest.summarise(binding_rows(), tmp_path, orphans)
+    with caplog.at_level("WARNING", logger="harvest_estate_assets"):
+        harvest.report_failed_downloads(binding_rows(), orphans)
+    messages = "\n".join(r.getMessage() for r in caplog.records)
+    assert "## Do not convert yet" in text
+    assert "IA IFC Sessions" in text.split("## Do not convert yet", 1)[1]
+    assert "DO NOT CONVERT YET" in messages
+    assert "IA IFC Sessions" in messages
+
+
+def test_the_section_is_absent_when_nothing_is_orphaned(tmp_path: Path) -> None:
+    assert "## Do not convert yet" not in harvest.summarise(binding_rows(), tmp_path, [])
+
+
+def test_an_estate_db_without_a_dependency_table_still_harvests(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An older database cannot answer the orphan question; that is not a reason to fail the run."""
+    db = tmp_path / "estate.db"
+    con = sqlite3.connect(db)
+    con.executescript(
+        """
+        CREATE TABLE project (luid TEXT PRIMARY KEY, name TEXT);
+        CREATE TABLE workbook (luid TEXT PRIMARY KEY, name TEXT, project_luid TEXT);
+        CREATE TABLE datasource (luid TEXT PRIMARY KEY, name TEXT, project_luid TEXT);
+        INSERT INTO workbook VALUES ('wb-ia', 'IA Redemptions', 'p');
+        """
+    )
+    con.commit()
+    con.close()
+    monkeypatch.setattr(harvest, "engine_scripts_dir", lambda: tmp_path / "engine")
+    monkeypatch.setattr(harvest, "resolve_env", lambda path: {"TABLEAU_SERVER_URL": "https://example.invalid"})
+    monkeypatch.setattr(harvest, "require", lambda env: None)
+    monkeypatch.setattr(harvest, "download", lambda *a, **k: (False, "nope"))
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["harvest_estate_assets.py", "--out", str(tmp_path / "_sweep"), "--db", str(db), "--allow-unignored-out"],
+    )
+    assert harvest.main() == 0
+
+
+def test_main_end_to_end_names_the_orphaned_workbook(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The whole leg, through the CLI: datasource fails, workbooks land, the report says so."""
+    db = estate_with_a_binding(tmp_path / "estate.db")
+    out = tmp_path / "_sweep"
+
+    def selective_download(kind, luid, target, env, scripts, **kwargs):  # pylint: disable=unused-argument
+        if kind == "datasource":
+            return False, "download failed (500)"
+        Path(target).write_text("<workbook/>", encoding="utf-8")
+        return True, ""
+
+    monkeypatch.setattr(harvest, "engine_scripts_dir", lambda: tmp_path / "engine")
+    monkeypatch.setattr(harvest, "resolve_env", lambda path: {"TABLEAU_SERVER_URL": "https://example.invalid"})
+    monkeypatch.setattr(harvest, "require", lambda env: None)
+    monkeypatch.setattr(harvest, "download", selective_download)
+    monkeypatch.setattr(harvest, "parse_asset", lambda path, scripts: ({"ok": True}, {"ok": True}))
+    monkeypatch.setattr(
+        sys, "argv", ["harvest_estate_assets.py", "--out", str(out), "--db", str(db), "--allow-unignored-out"]
+    )
+    assert harvest.main() == 0
+
+    text = (out / "parse-sweep.md").read_text(encoding="utf-8")
+    blocked = text.split("## Do not convert yet", 1)[1]
+    assert "IA IFC Sessions" in blocked
+    assert "Standalone" not in blocked, "a workbook bound to nothing that failed was flagged"
+
+
 def test_a_failed_download_reaches_parse_sweep_md_through_main(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """The committed artifact, not just the console, has to name the asset that never landed."""
     db = tmp_path / "estate.db"

--- a/tests/test_tableau_env.py
+++ b/tests/test_tableau_env.py
@@ -625,7 +625,30 @@ def test_the_dotenv_still_supplies_values_the_environment_does_not_have(tmp_path
 # --------------------------------------------------------------------------- the leak, at its boundary
 
 
-def test_a_reflected_signin_error_cannot_persist_the_pat(monkeypatch, tmp_path):
+def _reflecting_fetcher(scripts: Path, before: str = "", after: str = "") -> None:
+    """Write a stand-in ``fetch_tds.py`` that reflects back the PAT we put in its environment.
+
+    ⚠️ The premise these tests rest on is a CHILD PROCESS, and #482 broke the way it was faked.
+    ``download()`` now supervises the fetcher through ``run_watched`` -> ``subprocess.Popen``, so
+    ``monkeypatch.setattr(h.subprocess, "run", ...)`` intercepted nothing: the real path ran and died
+    on a missing ``fetch_tds.py``, which is a file-not-found error dressed up as a security result.
+    A real stub restores the whole chain rather than a layer of it -- our ``engine_child_env`` bridge
+    in, the reflected body out through a real pipe, redaction on the way to the caller.
+
+    It reads the ENGINE's spelling (``TABLEAU_PAT_VALUE``), so a broken bridge reflects nothing; the
+    callers then assert on text that only appears when the secret really made the round trip, which
+    is what stops "no secret in the output" passing because no secret ever moved.
+    """
+    (scripts / "fetch_tds.py").write_text(
+        "import os, sys\n"
+        "secret = os.environ.get('TABLEAU_PAT_VALUE', '')\n"
+        f"sys.stderr.write({before!r} + secret + {after!r})\n"
+        "sys.exit(1)\n",
+        encoding="utf-8",
+    )
+
+
+def test_a_reflected_signin_error_cannot_persist_the_pat(tmp_path):
     """Adversarial: an endpoint that echoes the request body must not put the PAT on disk.
 
     Found in review of #97 with a local echo server. We place the secret in the engine child's
@@ -638,25 +661,25 @@ def test_a_reflected_signin_error_cannot_persist_the_pat(monkeypatch, tmp_path):
 
     secret = "SENTINEL_PAT_abcdefghijklmnop"
     env = {"TABLEAU_SERVER_URL": "https://x.invalid", "TABLEAU_PAT_NAME": "probe-name", "TABLEAU_PAT_SECRET": secret}
+    _reflecting_fetcher(tmp_path, '401: {"credentials": {"personalAccessTokenSecret": "', '", "name": "probe-name"}}')
 
-    class _Reflected:
-        returncode = 1
-        stdout = ""
-        stderr = '401: {"credentials": {"personalAccessTokenSecret": "%s", "name": "probe-name"}}' % secret
-
-    monkeypatch.setattr(h.subprocess, "run", lambda *a, **k: _Reflected())
     ok, detail = h.download("datasource", "luid-1", tmp_path / "out.tdsx", env, tmp_path)
 
     assert ok is False
     assert secret not in detail
+    assert "probe-name" not in detail, "the PAT NAME is a credential too, and download() redacts it"
     assert secret not in json.dumps([{"download_error": detail}]), "the PAT reached a persisted artifact"
     assert "401" in detail, "redaction must not destroy the diagnostic"
+    # ⚠️ Non-vacuity. Every assertion above also holds for an empty `detail`, which is exactly what
+    # the missing stub produced. This is text only the reflected body carries, so it fails if the
+    # child never ran, never reflected, or its output never reached the redactor.
+    assert "personalAccessTokenSecret" in detail, "the reflected body never reached the wrapper at all"
 
 
 # --------------------------------------------------------------------------- round 2 of review
 
 
-def test_redaction_happens_before_truncation(monkeypatch, tmp_path):
+def test_redaction_happens_before_truncation(tmp_path):
     """A secret straddling the 300-char cut must not leave its tail in the retained slice.
 
     Measured in review: truncating first produced full_secret=False but suffix_in_detail=True, and
@@ -668,17 +691,15 @@ def test_redaction_happens_before_truncation(monkeypatch, tmp_path):
 
     secret = "SENTINEL" + ("x" * 40) + "TAILPIECE"
     env = {"TABLEAU_SERVER_URL": "https://x.invalid", "TABLEAU_PAT_NAME": "n", "TABLEAU_PAT_SECRET": secret}
+    # Place the secret so the 300-char tail slice cuts through the middle of it.
+    _reflecting_fetcher(tmp_path, "A" * 500, "B" * 270)
 
-    class _Straddling:
-        returncode = 1
-        stdout = ""
-        # Place the secret so the 300-char tail slice cuts through the middle of it.
-        stderr = ("A" * 500) + secret + ("B" * 270)
-
-    monkeypatch.setattr(h.subprocess, "run", lambda *a, **k: _Straddling())
     _, detail = h.download("datasource", "luid", tmp_path / "o.tdsx", env, tmp_path)
 
     assert secret not in detail
+    # ⚠️ Non-vacuity: without this the whole test passes on an empty `detail`. 270 B's are the tail
+    # the child wrote AFTER the secret, so they can only be here if the straddling text arrived.
+    assert detail.endswith("B" * 270), "the straddling child output never reached the redactor"
     # Only suffixes long enough to matter: a 1-2 char tail matches inside "[REDACTED]" itself, which
     # would fail the assertion without any secret having survived.
     for cut in range(0, len(secret) - 8):

--- a/tests/test_tableau_env.py
+++ b/tests/test_tableau_env.py
@@ -666,14 +666,18 @@ def test_a_reflected_signin_error_cannot_persist_the_pat(tmp_path):
     ok, detail = h.download("datasource", "luid-1", tmp_path / "out.tdsx", env, tmp_path)
 
     assert ok is False
-    assert secret not in detail
+    assert secret not in detail, "the PAT secret survived into the operator-facing detail"
     assert "probe-name" not in detail, "the PAT NAME is a credential too, and download() redacts it"
     assert secret not in json.dumps([{"download_error": detail}]), "the PAT reached a persisted artifact"
     assert "401" in detail, "redaction must not destroy the diagnostic"
-    # ⚠️ Non-vacuity. Every assertion above also holds for an empty `detail`, which is exactly what
-    # the missing stub produced. This is text only the reflected body carries, so it fails if the
-    # child never ran, never reflected, or its output never reached the redactor.
+    # ⚠️ Non-vacuity, in two steps, because "the secret is not in the text" is equally true of text
+    # that never carried it. The field must be PRESENT (the child ran and its stderr reached the
+    # redactor) and must not be EMPTY (the secret really made the round trip through
+    # `engine_child_env`). A missing stub satisfied every assertion above while proving nothing.
     assert "personalAccessTokenSecret" in detail, "the reflected body never reached the wrapper at all"
+    assert '"personalAccessTokenSecret": ""' not in detail, (
+        "the child was handed no secret, so there was nothing for the redactor to remove"
+    )
 
 
 # --------------------------------------------------------------------------- round 2 of review
@@ -696,10 +700,13 @@ def test_redaction_happens_before_truncation(tmp_path):
 
     _, detail = h.download("datasource", "luid", tmp_path / "o.tdsx", env, tmp_path)
 
-    assert secret not in detail
-    # ⚠️ Non-vacuity: without this the whole test passes on an empty `detail`. 270 B's are the tail
-    # the child wrote AFTER the secret, so they can only be here if the straddling text arrived.
+    assert secret not in detail, "the PAT secret survived into the retained slice"
+    # ⚠️ Non-vacuity: without these the whole test passes on text that never held the secret. The
+    # 270 B's are what the child wrote AFTER it, so they can only be here if the straddling output
+    # arrived; and "AB" can only be absent if something (the marker) still sits between the two
+    # runs, which is what proves the secret itself made the round trip and was replaced.
     assert detail.endswith("B" * 270), "the straddling child output never reached the redactor"
+    assert "AB" not in detail, "nothing was redacted between the two runs, so no secret ever arrived"
     # Only suffixes long enough to matter: a 1-2 char tail matches inside "[REDACTED]" itself, which
     # would fail the assertion without any secret having survived.
     for cut in range(0, len(secret) - 8):


### PR DESCRIPTION
# What broke, and why raising 600 would not have fixed it

A customer's 47-asset harvest lost `IA Redemptions by Campaign Report` to `timeout after 600s`,
twice. There are **two nested timeouts and they catch opposite failures**:

| where | value | kind |
|---|---|---|
| engine `fetch_tds.py:407` / `:423` | `timeout=300` into `urlopen` | **per-socket-read** |
| ours, `harvest_estate_assets.py:387` | `subprocess.run(..., timeout=600)` | **total wall clock** |

A *stalled* connection trips the inner 300s. A **slow but healthy** download satisfies every
individual socket read, never trips 300s, and is then killed by our wall clock — so the customer's
asset was very likely progressing the whole time and we killed a working download. Raising 600 to
some larger number only moves that cliff, so the ceiling is not the fix: knowing whether bytes are
still arriving is.

**A file-growth watchdog cannot work here**, and that is a property of the engine rather than a
guess: `_http` ends `return resp.status, dict(resp.headers), resp.read()` — one unbounded read, the
whole asset buffered in RAM — and `save_outputs(raw, ...)` writes only afterwards. The destination
file is 0 bytes until the download has already finished. Verified in the installed plugin before
anything was built.

## The progress-signal measurement

Faithful simulation, 2026-09-03, Windows: a child running the same `urlopen(...).read()` shape
against a local slow-stream server, 15 MB at ~1 MB/s, versus a socket that goes quiet after 3 chunks.
The healthy child ran to completion (`stdout = 15728640`); the stalled one was killed at 20s.

| sampled | healthy download | stalled download |
|---|---|---|
| `Popen.pid` `OtherTransferCount` | Δ **0** (frozen) | Δ **0** |
| real interpreter `ReadTransferCount` | Δ 0 after startup | Δ 0 |
| real interpreter **`OtherTransferCount`** | **168688 → 170704, moves every second** | **frozen at 168752 for 19s** |
| `PagefileUsage` | frozen after startup | frozen |

Three things that settles, each of which would have produced a **wrong fix** on its own:

1. ✅ **The signal is sound, but it is LIVENESS, not volume.** Socket bytes land in Windows' *Other*
   I/O bucket and are counted as per-operation overhead — ~160 B/s observed while ~1 MB/s flowed. It
   is never reported as "bytes downloaded".
2. ❌ **The RAM-footprint half of the hypothesis is UNSOUND.** `PagefileUsage` did not move while
   15 MB was buffered; committed memory is taken in large chunks up front. Measured, not assumed —
   and reported as a negative result rather than quietly dropped.
3. ⚠️ **`Popen.pid` is the WRONG PROCESS under a uv venv.** `.venv/Scripts/python.exe` is a
   trampoline: measured `Popen.pid = 35152` while the child's own `os.getpid()` reported `20856`.
   Sampling the handle `Popen` hands you measures a stub whose counters never move, so the naive
   design would have declared **every** download stalled and killed all of them. The probe therefore
   sums the whole process **subtree**, and `terminate_tree()` kills the subtree too — `Popen.kill()`
   alone would have orphaned the real interpreter with the socket and session still open.

### The measurement was wrong twice before it was right

My first two runs showed *all* counters frozen, including for the healthy download — which looked
like a clean negative result and would have been reported as "the hypothesis is unsound, fall back to
a configurable ceiling". It was my harness that was broken: ctypes was called **without `argtypes`**,
so the 64-bit `HANDLE` was passed as `c_int`. A **positive control** is what caught it — a child that
allocated 60 MB and did 500 file reads showed the same frozen counters, which is impossible; a
self-process check then returned `ok_io=False` outright. With `argtypes` set, the control moved
+105 MB of memory and +3.3 MB of reads, and only then were the download numbers above trustworthy.

That is why the shipped `kernel32()` binding sets `argtypes` with a comment saying so: the failure
mode is not a crash, it is plausible-looking values that never change — which reads exactly like a
stalled download.

## What the fix does

* **`--download-stall-timeout` (default 120s)** — armed **only after movement has been observed at
  least once** for that child. A flatline is then a genuine stall and killing it is right.
* **`--download-timeout` (default 600s, `0` disables)** — the wall clock, armed **only while no
  movement has ever been observed**, i.e. exactly when we cannot tell slow from hung. That is the
  pre-fix behaviour, kept for the only case that justifies it. A download that keeps progressing past
  it is **not killed**; it is announced loudly instead.
* **Actionable failure text.** `timeout after 600s` told the operator only what *we* had configured.
  Now a stall says what was observed (`stalled: no progress for Ns (elapsed Ns)`) and names
  `--download-stall-timeout`; a ceiling kill says `no download-progress signal was available for this
  process, so a slow-but-healthy transfer cannot be told from a hang` and names `--download-timeout`.
* **A 60s heartbeat** reporting elapsed time and when progress was last seen, per AGENTS.md's "never
  block silently".

## Which legs of #472 this covers

| leg | status |
|---|---|
| 1. `parse-sweep.md` reports a download failure as SUCCESS | ✅ fixed — `## Downloads that never landed` grouped by shape (digits collapsed, so two timeouts differing only in elapsed seconds are one finding), a disjoint-bucket closure line that must sum to the denominator, and `report_failed_downloads()` naming them beside the closing tally. `download_error` was previously written into the record and surfaced nowhere an operator reads. |
| 2. the 600s ceiling is hard-coded, and it is a wall clock over a per-read timeout | ✅ fixed — above |
| 3. the download leg has no retry while the metadata leg does | ⛔ **upstream, not this PR** — already filed as `Yarbrdab000/tableau-fabric-skills#190`. The plugin tree is read-only to us. |
| 4. a failed datasource silently orphans the workbooks that bind to it | ✅ fixed — `dependency_edges()` keeps the workbook end of the same LUID-first/name-fallback join; `orphaned_dependents()` reports only workbooks that **did** land, in a `## Do not convert yet` section and a `DO NOT CONVERT YET` warning. |

Fixes #472

Legs 1, 2 and 4 are ours and are all covered; leg 3 is upstream by the issue's own routing ("Keep
this issue for legs 1 and 2, which are ours").

## Gates, by exit code

| gate | exit |
|---|---|
| `ruff format` + `ruff check --fix` (script + tests) | **0** |
| `pylint scripts/harvest_estate_assets.py` | **0** (10.00/10 — gated on `$LASTEXITCODE`, not the printed score) |
| `pytest tests/test_harvest_download_watchdog.py -q` | **0** — 43 passed |
| `pytest tests/test_harvest_{project_scope,output_guard,engine_gaps,download_watchdog}.py -q` | **0** — 246 passed, no regression |
| `python tests/mutate_harvest_watchdog.py` | **0** — 25/25 killed, both discriminating controls correct |

The full suite is deliberately **not** run here: repo policy for this batch is one full-suite run at
the end, after reviews settle.

## Round 2 — two ways this could still have killed a HEALTHY download

Blind review found four issues; two are filed as issues, and these two were fixed here because
although they are fail-closed, both defeat the purpose of the PR — #472 exists because we killed a
healthy download.

**1. The stall default was stricter than the fetcher's own read timeout.** 120s sat *below* the
engine's 300s per-socket-read timeout, so a bursty source pausing 120–300s between chunks satisfied
urllib and was killed by us and reported as hung: the wall-clock cliff had quietly become a shorter
inactivity cliff. The 120s came from analogy with `refresh_pbip_model.py`'s liveness timer — but that
one **warns** and this one **kills**, which is a different thing. Default is now
`ENGINE_READ_TIMEOUT_SECONDS + 120s` grace, so the child's own timeout always fires first and reports
the real error, and the CLI warns when an operator sets a value under 300s.

*Reproduced before the fix:* `BURSTY_HEALTHY stalled 0.49` → now `'' 2.31` (survives).

**2. Losing the probe after movement killed a healthy download.** `None` means "cannot read", but
once `progress_observed` was set, later `None` readings did not disarm the stall deadline. Access
denial, a descendant exiting between enumeration and counter read, or a **partial subtree read** all
produced it — and the partial case is the nasty one, because when the descendant carrying the network
I/O becomes unreadable, the readable trampoline flatlines, which is exactly a stall's signature.
Current *availability* is now tracked separately from historical *movement*: `transferred_bytes()`
returns `None` for an incomplete reading rather than a sum it cannot vouch for, losing the signal
falls back to the wall clock **measured from the moment of the loss** (not from process start, so a
transfer that progressed for nine minutes is not killed one minute later), and the loss is announced
once.

*Reproduced before the fix:* `PROBE_LOST_AFTER_PROGRESS stalled 0.33` → now `ceiling 5.15`, with the
honest label and a warning.

Both fixes are pinned by behavioural tests, not just by an inequality between two constants: the
bursty test scales every value from the real constants by one factor, so lowering
`DEFAULT_STALL_TIMEOUT` back under the read timeout turns it red while the pause and the child's read
timeout stay put.

## Mutation testing: 25/25 killed, and the campaign is now committed

`tests/mutate_harvest_watchdog.py`, ported onto the repo's existing campaign idiom
(`mutate_revision_key.py`, `mutation_capture_legs.py`). Previously the campaign lived in a gitignored
scratch folder and only its tally was quoted — a tally nobody can re-run is a claim, not evidence.
Every mutant must clear three bars before it is called KILLED: it must **compile** (a mutant that
does not import never executed the mutated path), its **anchor** is a pytest node ID rather than a
file (under `-x` a whole-file target credits a mutation to whichever test fails first), and its
**control** must stay green (so a mutation that reddens the module is not mistaken for one the anchor
observed). Plus the two discriminating controls: `control-cosmetic` **SURVIVED** as required and
`control-absent-anchor` was reported **INVALID** as required — which is what makes the other 25
verdicts worth reading.

⚠️ Two mutants had to be rewritten during the port, and the reason is itself a finding: **the round-2
fixes made the original mutations no longer reproduce their defect.** Disabling the stall arm no
longer restores the pre-#472 wall clock (because `blind_since` is cleared on movement), and flipping
`signal_live` alone no longer re-arms the stall deadline (because `blind_since` still disarms it).
Both now patch the pair of lines that genuinely restores the old behaviour.

Two findings from the first campaign, both worth stating because they are the failure modes that make
a mutation harness worthless:

* `timeouts-not-passed-through` (replace `args.download_timeout` with the module default at the call
  site) **SURVIVED** the first round — a genuine gap: every test called `download()` directly, so
  nothing asserted that `main()` forwards the flags. Parsing a flag and then ignoring it looks
  exactly like having no flag at all, which is the customer's original complaint.
  `test_main_forwards_the_operator_s_timeouts_to_every_download` now kills it.
* `trust-an-unmoved-probe` was initially scored **SURVIVED** because my mutation did not compile —
  and an earlier version of my scratch harness would have scored a non-compiling mutation as
  **caught**. That is the same class as this repo's measured 22/22-false-kills case. The committed
  campaign now refuses any verdict for a mutant that does not compile or whose anchor selected no
  test. (The repo's shared `mutation_harness.py` labels this `HARNESS-ERROR` via `recorded=False`;
  my earlier summary called it `INVALID`, which was the wrong name for the right behaviour.)

Full tally, all **KILLED**: `stall-never-fires`, `ceiling-kills-a-progressing-download`,
`trust-an-unmoved-probe`, `no-subtree-walk`, `no-descendant-kill`,
`stall-default-back-under-the-fetchers-read-timeout`, `a-lost-probe-counts-as-a-flatline`,
`partial-reading-passed-off-as-a-total`, `blind-ceiling-measured-from-process-start`,
`losing-the-signal-is-not-announced`, `no-cli-warning-for-a-stall-timeout-under-300s`,
`silent-heartbeat`, `no-over-ceiling-warning`, `stall-message-loses-the-flag`,
`ceiling-message-loses-elapsed`, `never-downloaded-is-invisible`, `shape-keeps-the-digits`,
`parser-buckets-count-a-failed-download`, `no-operator-report`, `timeouts-not-passed-through`,
`orphans-never-computed`, `orphans-flag-every-landed-workbook`,
`orphans-include-a-workbook-that-itself-failed`, `orphan-edges-lose-the-name-fallback`,
`orphans-not-written-to-the-report`.

## What I could NOT verify

* **No live Tableau server.** There are no credentials here, so the watchdog has never run against a
  real `fetch_tds.py` download. The measurement is a faithful simulation of the same `urlopen(...)
  .read()` shape, not the real thing.
* **Windows only.** The Linux `/proc/<pid>/io` (`rchar`/`wchar`) path is written to the documented
  interface and is exercised by no test on this machine — nothing in CI runs it either. It fails
  safe: an unreadable `/proc` yields `None`, which is "cannot tell" and falls back to the ceiling.
* **The 420s default stall timeout is a judgement, not a measurement.** It is anchored to the
  fetcher's own 300s per-read timeout plus a 120s grace, which is a defensible floor rather than an
  observed one; a source that legitimately goes quiet for longer would still be killed, and the flag
  and the message exist for that.
* **A spurious mover.** A child doing unrelated I/O forever would keep the probe moving and never be
  killed. That fails in the safe direction (we do not kill a working download) and is made visible by
  the heartbeat, but it is a real residual.
