### PR TITLE
Slim root AGENTS.md to 44,691 chars and tighten the generated shared block

### DIFF
--- a/.github/agents/dry-run-operator.agent.md
+++ b/.github/agents/dry-run-operator.agent.md
@@ -16,69 +16,70 @@ whole run in its own context.
 
 ## Shared agent conventions (all agents inherit these)
 
-- **Cite your source — and say WHOSE.** Every capability claim, mapping decision, or numeric result
+- **Cite your source — and say WHOSE.** Every capability claim, mapping decision or numeric result
   names its evidence: a `migration-spec.json` field, a TMDL/PBIR path + line, a live `EVALUATE`
   result, or a doc URL. "It renders / it returned a number" is not verification; "it matches the
-  Tableau value" is. **A number also names the estate it was measured on** — ours (the reference
-  bundle) or the customer's. Never present ours as theirs: measured 2026-08-21, five did in one day.
+  Tableau value" is. **A number also names the estate it was measured on** — ours or the customer's;
+  never present ours as theirs.
 - **Use confidence markers** — ✅ verified / ⚠️ inferred, needs check / ❌ known gap — on any fidelity,
-  mapping, or capability statement.
+  mapping or capability statement.
 - **Own your layer; don't cross it.** `pbi-semantic-builder` owns TMDL/DAX, `pbi-report-builder` owns
   PBIR/visuals, `pbi-migration-validator` is read-only and never edits. A subagent never "just fixes"
   a finding another agent owns — it reports; the orchestrator routes.
-- **Three locations, one direction: engine truth → working copy → deliverable. Never edit upstream of
-  where you are.**
+- **Three stages, one direction: pristine baseline → working/shipped pass → deliverable. Never edit
+  upstream of where you are.**
   | stage | location | rule |
   |---|---|---|
-  | engine truth | `<bundle>/reports/`; `<bundle>/semantic_models/` (if emitted) | **NEVER edit an existing baseline** |
-  | working copy | `<bundle>/pbip/`, or `<package>/fabric/` when you were handed a PACKAGE | agents edit **here**; whichever tree you were handed is CANONICAL. `declare_generated_edit.py` / `--tamper` cover BUNDLE work only (#460) |
-  | deliverable | `migrations/{workbooks,datasources}/<slug>/fabric/` | **COPIED at sign-off**, so the bundle survives as evidence |
+  | pristine baseline | `<bundle>/reports/` (the model-unbound report pass); `<bundle>/semantic_models/` when emitted | **NEVER edit.** Evidence for the engine-gap diff only — and an absent baseline is BASELINE UNAVAILABLE, never "no changes" |
+  | working copy | `<bundle>/pbip/` (the model-bound working/shipped pass), or `<package>/fabric/` when you were handed a PACKAGE | agents edit **here**; whichever tree you were handed is CANONICAL. `declare_generated_edit.py` / `--tamper` cover BUNDLE work only (#460) |
+  | deliverable | `migrations/{workbooks,datasources}/<slug>/fabric/` | promoted at sign-off (`promote_unit.py`), so the bundle survives as evidence |
 
   A bundle may contain `<bundle>/{pbip,reports,semantic_models,handover,data}` — **no `out/` level**;
-  `<bundle>/semantic_models/` is conditional (absent for 8/12 workbooks), and absent baseline ≠ no
-  changes — see `AGENTS.md`.
+  `<bundle>/semantic_models/` is conditional (absent for 8 of 12 workbooks in one audited estate).
 
-  ⚠️ **The copy must keep
-  `definition.pbir`'s `byPath` resolving** — plain copy for a per-workbook model, path rewrite for a
-  shared datasource; never ship `<bundle>/reports/` (reference-only: no model beside it) and never
-  edit it - keep it pristine and diff it with git. Mechanics: `powerbi-report-gotchas` §3.
+  ⚠️ **The two report passes can diverge by design, so neither is fidelity proof.**
+  `shipped_tree_divergence` discloses a difference to inspect, not a faithful pass;
+  `viz_fidelity.status: "rebuilt"` is a claim about what the engine did, not render or
+  shipped-artifact proof. **Judge fidelity on the shipped bytes** — the `pbip/` or package tree —
+  against the Tableau evidence.
+
+  ⚠️ Promotion must keep `definition.pbir`'s `byPath` resolving: plain copy for a per-workbook model,
+  path rewrite for a shared datasource. Never ship `<bundle>/reports/` (reference-only: no model
+  beside it). Mechanics: `powerbi-report-gotchas` §3.
 
 - **Structural validation is necessary, not sufficient.** A clean parse/validate proves shape, not
   correctness: TMDL deserialization and `powerbi-report-author validate` both pass defects that only
-  surface in Desktop **with data**. Never declare something done on a green validator alone. (The
-  PBIR and TMDL specifics live in the `powerbi-report-gotchas` and `powerbi-semantic-model-gotchas`
-  skills, which the owning agents invoke.)
-- **Keep `limitations_encountered` alive** through the whole build **and** fix phase; every bug found
-  and fixed later is itself worth recording. Regenerate it from the final artifacts before sign-off so
-  stale entries don't mislead the validator.
+  surface in Desktop **with data**. Never declare something done on a green validator alone. PBIR and
+  TMDL specifics: the `powerbi-report-gotchas` / `powerbi-semantic-model-gotchas` skills.
+- **Keep `limitations_encountered` alive** through the whole build **and** fix phase. Regenerate it
+  from the final artifacts before sign-off so stale entries don't mislead the validator.
 - **Declare generated edits.** TMDL/PBIR/`.pbip`: file/change/why + replay script + hash record.
 - **Surface complexity mismatches proactively.** If the parsed workbook implies more effort than the
   user assumes (many LOD/table-calc fields, extract-only data with no upstream, >20 floating-layout
-  worksheets), say so before building rather than discovering it mid-migration.
-- **NEVER block silently on an external system — time-box it, then ASK.** Measured, from a real user
-  report: an agent sat on "Testing live Snowflake connectivity" for **129 minutes / 298 tool calls**,
-  retrying without ever surfacing the problem, until the user intervened. Waiting is not progress.
-  - **Cap it: ~2 minutes or 3 attempts, whichever comes first** — for any unresponsive external
-    system (database/warehouse/gateway, MCP server, XMLA refresh, the Power BI Desktop bridge). Cap
-    *relaunches* at 2 as well; "kill it and retry" is otherwise an unbounded loop.
-  - **Unless the tool tells you it IS the timer** — some of our scripts self-bound and announce their
-    own deadline. Measured: an agent applied this 2-minute cap to a script that was already the
-    bounded timer, killed it at 120 s, and so recorded **no verdict at all** — strictly worse than
-    waiting. Read the tool's own output before you decide it has hung.
-  - **A MISSING CREDENTIAL is not transient — try ONCE.** The cap above is for *flaky* systems. A
-    refusal naming authentication, permissions or a sign-in prompt is a **final answer**; only a
-    plainly transient timeout (a serverless warehouse cold-starting) earns one retry.
+  worksheets), say so before building rather than mid-migration.
+- **NEVER block silently on an external system — time-box it, then ASK.** Measured: an agent sat on
+  live-Snowflake connectivity for **129 minutes / 298 tool calls** without ever surfacing the
+  problem. Waiting is not progress.
+  - **Cap it: ~2 minutes or 3 attempts, whichever comes first** — any unresponsive external system
+    (database/warehouse/gateway, MCP server, XMLA refresh, the Desktop bridge). Cap *relaunches* at 2
+    as well; "kill it and retry" is otherwise an unbounded loop.
+  - **Unless the tool tells you it IS the timer** — some scripts self-bound and announce their own
+    deadline. Measured: an agent applied the cap to such a script, killed it at 120 s and recorded
+    **no verdict at all** — worse than waiting. Read the tool's own output first.
+  - **A MISSING CREDENTIAL is not transient — try ONCE.** The cap is for *flaky* systems. A refusal
+    naming authentication, permissions or a sign-in prompt is a **final answer**; only a plainly
+    transient timeout (a serverless warehouse cold-starting) earns one retry.
   - **AUTOPILOT / auto-approve DOES NOT override a credential stop.** "Decide, don't ask" applies to
     *choices*; this is a physical dependency on a human — the credential sits behind a **modal
     sign-in dialog no automation can fill**. Stop and ask **even in an unattended run**, and end the
-    turn. A clear question costs minutes; a confidently built, unvalidated model costs the whole run.
+    turn.
   - On hitting the cap, **STOP and ask a specific, actionable question** — name the system, what you
     tried, and the concrete options. Never re-run the same call hoping for a different result. Ask in
     your normal reply — there is no `ask_user` tool.
   - **Report elapsed time** whenever an operation exceeds ~60 s, so a stall is visible rather than
     looking like work.
 - **End every message with a clear next step or an explicit verdict** — never a vague "looks fine."
-- **Durable learnings go in committed files** (the agent `Gotchas` sections and
+- **Durable learnings go in committed files** (agent `Gotchas`, the skills,
   `docs/tableau-dax-translation-guide.md`), never in a git-ignored scratch folder — that is how each
   real migration permanently improves the toolkit.
 - **Power BI Desktop cleanup is PID-scoped.** Concurrent instances are fine; never sweep by name.
@@ -87,11 +88,11 @@ whole run in its own context.
   leaks are enforced by `check_unit.py`'s `desktop-orphans` gate. Remove scratch/temp files you
   created; keep only committed deliverables plus re-runnable `_build/` scripts, and confirm nothing
   scratch leaked into git before reporting done. ⚠️ **Never `git add -A` after a gapped pull** —
-  measured: a merge staged **111** untracked scratch paths (a whole engine bundle, loose `_tmp_*.py`)
-  because `-A` cannot tell "files this merge introduces" from "files that happened to be lying
-  around". Stage from `git diff --name-status <old-HEAD> origin/master`. If you must undo one,
-  `reset --soft HEAD~1` **clears `MERGE_HEAD` even on a merge commit**, so recreate it or the next
-  commit is silently single-parent and the ancestry breaks.
+  measured: a merge staged **111** untracked scratch paths, because `-A` cannot tell files the merge
+  introduces from files merely lying around. Stage from
+  `git diff --name-status <old-HEAD> origin/master`. If you must undo one, `reset --soft HEAD~1`
+  **clears `MERGE_HEAD` even on a merge commit** — recreate it, or the next commit is silently
+  single-parent and the ancestry breaks.
 <!-- END:shared-conventions -->
 
 ## What you own, and what you must never do

--- a/.github/agents/pbi-migration-validator.agent.md
+++ b/.github/agents/pbi-migration-validator.agent.md
@@ -31,69 +31,70 @@ never the builder's reasoning or self-reported success.
 
 ## Shared agent conventions (all agents inherit these)
 
-- **Cite your source — and say WHOSE.** Every capability claim, mapping decision, or numeric result
+- **Cite your source — and say WHOSE.** Every capability claim, mapping decision or numeric result
   names its evidence: a `migration-spec.json` field, a TMDL/PBIR path + line, a live `EVALUATE`
   result, or a doc URL. "It renders / it returned a number" is not verification; "it matches the
-  Tableau value" is. **A number also names the estate it was measured on** — ours (the reference
-  bundle) or the customer's. Never present ours as theirs: measured 2026-08-21, five did in one day.
+  Tableau value" is. **A number also names the estate it was measured on** — ours or the customer's;
+  never present ours as theirs.
 - **Use confidence markers** — ✅ verified / ⚠️ inferred, needs check / ❌ known gap — on any fidelity,
-  mapping, or capability statement.
+  mapping or capability statement.
 - **Own your layer; don't cross it.** `pbi-semantic-builder` owns TMDL/DAX, `pbi-report-builder` owns
   PBIR/visuals, `pbi-migration-validator` is read-only and never edits. A subagent never "just fixes"
   a finding another agent owns — it reports; the orchestrator routes.
-- **Three locations, one direction: engine truth → working copy → deliverable. Never edit upstream of
-  where you are.**
+- **Three stages, one direction: pristine baseline → working/shipped pass → deliverable. Never edit
+  upstream of where you are.**
   | stage | location | rule |
   |---|---|---|
-  | engine truth | `<bundle>/reports/`; `<bundle>/semantic_models/` (if emitted) | **NEVER edit an existing baseline** |
-  | working copy | `<bundle>/pbip/`, or `<package>/fabric/` when you were handed a PACKAGE | agents edit **here**; whichever tree you were handed is CANONICAL. `declare_generated_edit.py` / `--tamper` cover BUNDLE work only (#460) |
-  | deliverable | `migrations/{workbooks,datasources}/<slug>/fabric/` | **COPIED at sign-off**, so the bundle survives as evidence |
+  | pristine baseline | `<bundle>/reports/` (the model-unbound report pass); `<bundle>/semantic_models/` when emitted | **NEVER edit.** Evidence for the engine-gap diff only — and an absent baseline is BASELINE UNAVAILABLE, never "no changes" |
+  | working copy | `<bundle>/pbip/` (the model-bound working/shipped pass), or `<package>/fabric/` when you were handed a PACKAGE | agents edit **here**; whichever tree you were handed is CANONICAL. `declare_generated_edit.py` / `--tamper` cover BUNDLE work only (#460) |
+  | deliverable | `migrations/{workbooks,datasources}/<slug>/fabric/` | promoted at sign-off (`promote_unit.py`), so the bundle survives as evidence |
 
   A bundle may contain `<bundle>/{pbip,reports,semantic_models,handover,data}` — **no `out/` level**;
-  `<bundle>/semantic_models/` is conditional (absent for 8/12 workbooks), and absent baseline ≠ no
-  changes — see `AGENTS.md`.
+  `<bundle>/semantic_models/` is conditional (absent for 8 of 12 workbooks in one audited estate).
 
-  ⚠️ **The copy must keep
-  `definition.pbir`'s `byPath` resolving** — plain copy for a per-workbook model, path rewrite for a
-  shared datasource; never ship `<bundle>/reports/` (reference-only: no model beside it) and never
-  edit it - keep it pristine and diff it with git. Mechanics: `powerbi-report-gotchas` §3.
+  ⚠️ **The two report passes can diverge by design, so neither is fidelity proof.**
+  `shipped_tree_divergence` discloses a difference to inspect, not a faithful pass;
+  `viz_fidelity.status: "rebuilt"` is a claim about what the engine did, not render or
+  shipped-artifact proof. **Judge fidelity on the shipped bytes** — the `pbip/` or package tree —
+  against the Tableau evidence.
+
+  ⚠️ Promotion must keep `definition.pbir`'s `byPath` resolving: plain copy for a per-workbook model,
+  path rewrite for a shared datasource. Never ship `<bundle>/reports/` (reference-only: no model
+  beside it). Mechanics: `powerbi-report-gotchas` §3.
 
 - **Structural validation is necessary, not sufficient.** A clean parse/validate proves shape, not
   correctness: TMDL deserialization and `powerbi-report-author validate` both pass defects that only
-  surface in Desktop **with data**. Never declare something done on a green validator alone. (The
-  PBIR and TMDL specifics live in the `powerbi-report-gotchas` and `powerbi-semantic-model-gotchas`
-  skills, which the owning agents invoke.)
-- **Keep `limitations_encountered` alive** through the whole build **and** fix phase; every bug found
-  and fixed later is itself worth recording. Regenerate it from the final artifacts before sign-off so
-  stale entries don't mislead the validator.
+  surface in Desktop **with data**. Never declare something done on a green validator alone. PBIR and
+  TMDL specifics: the `powerbi-report-gotchas` / `powerbi-semantic-model-gotchas` skills.
+- **Keep `limitations_encountered` alive** through the whole build **and** fix phase. Regenerate it
+  from the final artifacts before sign-off so stale entries don't mislead the validator.
 - **Declare generated edits.** TMDL/PBIR/`.pbip`: file/change/why + replay script + hash record.
 - **Surface complexity mismatches proactively.** If the parsed workbook implies more effort than the
   user assumes (many LOD/table-calc fields, extract-only data with no upstream, >20 floating-layout
-  worksheets), say so before building rather than discovering it mid-migration.
-- **NEVER block silently on an external system — time-box it, then ASK.** Measured, from a real user
-  report: an agent sat on "Testing live Snowflake connectivity" for **129 minutes / 298 tool calls**,
-  retrying without ever surfacing the problem, until the user intervened. Waiting is not progress.
-  - **Cap it: ~2 minutes or 3 attempts, whichever comes first** — for any unresponsive external
-    system (database/warehouse/gateway, MCP server, XMLA refresh, the Power BI Desktop bridge). Cap
-    *relaunches* at 2 as well; "kill it and retry" is otherwise an unbounded loop.
-  - **Unless the tool tells you it IS the timer** — some of our scripts self-bound and announce their
-    own deadline. Measured: an agent applied this 2-minute cap to a script that was already the
-    bounded timer, killed it at 120 s, and so recorded **no verdict at all** — strictly worse than
-    waiting. Read the tool's own output before you decide it has hung.
-  - **A MISSING CREDENTIAL is not transient — try ONCE.** The cap above is for *flaky* systems. A
-    refusal naming authentication, permissions or a sign-in prompt is a **final answer**; only a
-    plainly transient timeout (a serverless warehouse cold-starting) earns one retry.
+  worksheets), say so before building rather than mid-migration.
+- **NEVER block silently on an external system — time-box it, then ASK.** Measured: an agent sat on
+  live-Snowflake connectivity for **129 minutes / 298 tool calls** without ever surfacing the
+  problem. Waiting is not progress.
+  - **Cap it: ~2 minutes or 3 attempts, whichever comes first** — any unresponsive external system
+    (database/warehouse/gateway, MCP server, XMLA refresh, the Desktop bridge). Cap *relaunches* at 2
+    as well; "kill it and retry" is otherwise an unbounded loop.
+  - **Unless the tool tells you it IS the timer** — some scripts self-bound and announce their own
+    deadline. Measured: an agent applied the cap to such a script, killed it at 120 s and recorded
+    **no verdict at all** — worse than waiting. Read the tool's own output first.
+  - **A MISSING CREDENTIAL is not transient — try ONCE.** The cap is for *flaky* systems. A refusal
+    naming authentication, permissions or a sign-in prompt is a **final answer**; only a plainly
+    transient timeout (a serverless warehouse cold-starting) earns one retry.
   - **AUTOPILOT / auto-approve DOES NOT override a credential stop.** "Decide, don't ask" applies to
     *choices*; this is a physical dependency on a human — the credential sits behind a **modal
     sign-in dialog no automation can fill**. Stop and ask **even in an unattended run**, and end the
-    turn. A clear question costs minutes; a confidently built, unvalidated model costs the whole run.
+    turn.
   - On hitting the cap, **STOP and ask a specific, actionable question** — name the system, what you
     tried, and the concrete options. Never re-run the same call hoping for a different result. Ask in
     your normal reply — there is no `ask_user` tool.
   - **Report elapsed time** whenever an operation exceeds ~60 s, so a stall is visible rather than
     looking like work.
 - **End every message with a clear next step or an explicit verdict** — never a vague "looks fine."
-- **Durable learnings go in committed files** (the agent `Gotchas` sections and
+- **Durable learnings go in committed files** (agent `Gotchas`, the skills,
   `docs/tableau-dax-translation-guide.md`), never in a git-ignored scratch folder — that is how each
   real migration permanently improves the toolkit.
 - **Power BI Desktop cleanup is PID-scoped.** Concurrent instances are fine; never sweep by name.
@@ -102,11 +103,11 @@ never the builder's reasoning or self-reported success.
   leaks are enforced by `check_unit.py`'s `desktop-orphans` gate. Remove scratch/temp files you
   created; keep only committed deliverables plus re-runnable `_build/` scripts, and confirm nothing
   scratch leaked into git before reporting done. ⚠️ **Never `git add -A` after a gapped pull** —
-  measured: a merge staged **111** untracked scratch paths (a whole engine bundle, loose `_tmp_*.py`)
-  because `-A` cannot tell "files this merge introduces" from "files that happened to be lying
-  around". Stage from `git diff --name-status <old-HEAD> origin/master`. If you must undo one,
-  `reset --soft HEAD~1` **clears `MERGE_HEAD` even on a merge commit**, so recreate it or the next
-  commit is silently single-parent and the ancestry breaks.
+  measured: a merge staged **111** untracked scratch paths, because `-A` cannot tell files the merge
+  introduces from files merely lying around. Stage from
+  `git diff --name-status <old-HEAD> origin/master`. If you must undo one, `reset --soft HEAD~1`
+  **clears `MERGE_HEAD` even on a merge commit** — recreate it, or the next commit is silently
+  single-parent and the ancestry breaks.
 <!-- END:shared-conventions -->
 
 ## Inputs you require from the orchestrator

--- a/.github/agents/pbi-report-builder.agent.md
+++ b/.github/agents/pbi-report-builder.agent.md
@@ -16,69 +16,70 @@ You repair and finish the PBIR report the deterministic tier already emitted and
 
 ## Shared agent conventions (all agents inherit these)
 
-- **Cite your source — and say WHOSE.** Every capability claim, mapping decision, or numeric result
+- **Cite your source — and say WHOSE.** Every capability claim, mapping decision or numeric result
   names its evidence: a `migration-spec.json` field, a TMDL/PBIR path + line, a live `EVALUATE`
   result, or a doc URL. "It renders / it returned a number" is not verification; "it matches the
-  Tableau value" is. **A number also names the estate it was measured on** — ours (the reference
-  bundle) or the customer's. Never present ours as theirs: measured 2026-08-21, five did in one day.
+  Tableau value" is. **A number also names the estate it was measured on** — ours or the customer's;
+  never present ours as theirs.
 - **Use confidence markers** — ✅ verified / ⚠️ inferred, needs check / ❌ known gap — on any fidelity,
-  mapping, or capability statement.
+  mapping or capability statement.
 - **Own your layer; don't cross it.** `pbi-semantic-builder` owns TMDL/DAX, `pbi-report-builder` owns
   PBIR/visuals, `pbi-migration-validator` is read-only and never edits. A subagent never "just fixes"
   a finding another agent owns — it reports; the orchestrator routes.
-- **Three locations, one direction: engine truth → working copy → deliverable. Never edit upstream of
-  where you are.**
+- **Three stages, one direction: pristine baseline → working/shipped pass → deliverable. Never edit
+  upstream of where you are.**
   | stage | location | rule |
   |---|---|---|
-  | engine truth | `<bundle>/reports/`; `<bundle>/semantic_models/` (if emitted) | **NEVER edit an existing baseline** |
-  | working copy | `<bundle>/pbip/`, or `<package>/fabric/` when you were handed a PACKAGE | agents edit **here**; whichever tree you were handed is CANONICAL. `declare_generated_edit.py` / `--tamper` cover BUNDLE work only (#460) |
-  | deliverable | `migrations/{workbooks,datasources}/<slug>/fabric/` | **COPIED at sign-off**, so the bundle survives as evidence |
+  | pristine baseline | `<bundle>/reports/` (the model-unbound report pass); `<bundle>/semantic_models/` when emitted | **NEVER edit.** Evidence for the engine-gap diff only — and an absent baseline is BASELINE UNAVAILABLE, never "no changes" |
+  | working copy | `<bundle>/pbip/` (the model-bound working/shipped pass), or `<package>/fabric/` when you were handed a PACKAGE | agents edit **here**; whichever tree you were handed is CANONICAL. `declare_generated_edit.py` / `--tamper` cover BUNDLE work only (#460) |
+  | deliverable | `migrations/{workbooks,datasources}/<slug>/fabric/` | promoted at sign-off (`promote_unit.py`), so the bundle survives as evidence |
 
   A bundle may contain `<bundle>/{pbip,reports,semantic_models,handover,data}` — **no `out/` level**;
-  `<bundle>/semantic_models/` is conditional (absent for 8/12 workbooks), and absent baseline ≠ no
-  changes — see `AGENTS.md`.
+  `<bundle>/semantic_models/` is conditional (absent for 8 of 12 workbooks in one audited estate).
 
-  ⚠️ **The copy must keep
-  `definition.pbir`'s `byPath` resolving** — plain copy for a per-workbook model, path rewrite for a
-  shared datasource; never ship `<bundle>/reports/` (reference-only: no model beside it) and never
-  edit it - keep it pristine and diff it with git. Mechanics: `powerbi-report-gotchas` §3.
+  ⚠️ **The two report passes can diverge by design, so neither is fidelity proof.**
+  `shipped_tree_divergence` discloses a difference to inspect, not a faithful pass;
+  `viz_fidelity.status: "rebuilt"` is a claim about what the engine did, not render or
+  shipped-artifact proof. **Judge fidelity on the shipped bytes** — the `pbip/` or package tree —
+  against the Tableau evidence.
+
+  ⚠️ Promotion must keep `definition.pbir`'s `byPath` resolving: plain copy for a per-workbook model,
+  path rewrite for a shared datasource. Never ship `<bundle>/reports/` (reference-only: no model
+  beside it). Mechanics: `powerbi-report-gotchas` §3.
 
 - **Structural validation is necessary, not sufficient.** A clean parse/validate proves shape, not
   correctness: TMDL deserialization and `powerbi-report-author validate` both pass defects that only
-  surface in Desktop **with data**. Never declare something done on a green validator alone. (The
-  PBIR and TMDL specifics live in the `powerbi-report-gotchas` and `powerbi-semantic-model-gotchas`
-  skills, which the owning agents invoke.)
-- **Keep `limitations_encountered` alive** through the whole build **and** fix phase; every bug found
-  and fixed later is itself worth recording. Regenerate it from the final artifacts before sign-off so
-  stale entries don't mislead the validator.
+  surface in Desktop **with data**. Never declare something done on a green validator alone. PBIR and
+  TMDL specifics: the `powerbi-report-gotchas` / `powerbi-semantic-model-gotchas` skills.
+- **Keep `limitations_encountered` alive** through the whole build **and** fix phase. Regenerate it
+  from the final artifacts before sign-off so stale entries don't mislead the validator.
 - **Declare generated edits.** TMDL/PBIR/`.pbip`: file/change/why + replay script + hash record.
 - **Surface complexity mismatches proactively.** If the parsed workbook implies more effort than the
   user assumes (many LOD/table-calc fields, extract-only data with no upstream, >20 floating-layout
-  worksheets), say so before building rather than discovering it mid-migration.
-- **NEVER block silently on an external system — time-box it, then ASK.** Measured, from a real user
-  report: an agent sat on "Testing live Snowflake connectivity" for **129 minutes / 298 tool calls**,
-  retrying without ever surfacing the problem, until the user intervened. Waiting is not progress.
-  - **Cap it: ~2 minutes or 3 attempts, whichever comes first** — for any unresponsive external
-    system (database/warehouse/gateway, MCP server, XMLA refresh, the Power BI Desktop bridge). Cap
-    *relaunches* at 2 as well; "kill it and retry" is otherwise an unbounded loop.
-  - **Unless the tool tells you it IS the timer** — some of our scripts self-bound and announce their
-    own deadline. Measured: an agent applied this 2-minute cap to a script that was already the
-    bounded timer, killed it at 120 s, and so recorded **no verdict at all** — strictly worse than
-    waiting. Read the tool's own output before you decide it has hung.
-  - **A MISSING CREDENTIAL is not transient — try ONCE.** The cap above is for *flaky* systems. A
-    refusal naming authentication, permissions or a sign-in prompt is a **final answer**; only a
-    plainly transient timeout (a serverless warehouse cold-starting) earns one retry.
+  worksheets), say so before building rather than mid-migration.
+- **NEVER block silently on an external system — time-box it, then ASK.** Measured: an agent sat on
+  live-Snowflake connectivity for **129 minutes / 298 tool calls** without ever surfacing the
+  problem. Waiting is not progress.
+  - **Cap it: ~2 minutes or 3 attempts, whichever comes first** — any unresponsive external system
+    (database/warehouse/gateway, MCP server, XMLA refresh, the Desktop bridge). Cap *relaunches* at 2
+    as well; "kill it and retry" is otherwise an unbounded loop.
+  - **Unless the tool tells you it IS the timer** — some scripts self-bound and announce their own
+    deadline. Measured: an agent applied the cap to such a script, killed it at 120 s and recorded
+    **no verdict at all** — worse than waiting. Read the tool's own output first.
+  - **A MISSING CREDENTIAL is not transient — try ONCE.** The cap is for *flaky* systems. A refusal
+    naming authentication, permissions or a sign-in prompt is a **final answer**; only a plainly
+    transient timeout (a serverless warehouse cold-starting) earns one retry.
   - **AUTOPILOT / auto-approve DOES NOT override a credential stop.** "Decide, don't ask" applies to
     *choices*; this is a physical dependency on a human — the credential sits behind a **modal
     sign-in dialog no automation can fill**. Stop and ask **even in an unattended run**, and end the
-    turn. A clear question costs minutes; a confidently built, unvalidated model costs the whole run.
+    turn.
   - On hitting the cap, **STOP and ask a specific, actionable question** — name the system, what you
     tried, and the concrete options. Never re-run the same call hoping for a different result. Ask in
     your normal reply — there is no `ask_user` tool.
   - **Report elapsed time** whenever an operation exceeds ~60 s, so a stall is visible rather than
     looking like work.
 - **End every message with a clear next step or an explicit verdict** — never a vague "looks fine."
-- **Durable learnings go in committed files** (the agent `Gotchas` sections and
+- **Durable learnings go in committed files** (agent `Gotchas`, the skills,
   `docs/tableau-dax-translation-guide.md`), never in a git-ignored scratch folder — that is how each
   real migration permanently improves the toolkit.
 - **Power BI Desktop cleanup is PID-scoped.** Concurrent instances are fine; never sweep by name.
@@ -87,11 +88,11 @@ You repair and finish the PBIR report the deterministic tier already emitted and
   leaks are enforced by `check_unit.py`'s `desktop-orphans` gate. Remove scratch/temp files you
   created; keep only committed deliverables plus re-runnable `_build/` scripts, and confirm nothing
   scratch leaked into git before reporting done. ⚠️ **Never `git add -A` after a gapped pull** —
-  measured: a merge staged **111** untracked scratch paths (a whole engine bundle, loose `_tmp_*.py`)
-  because `-A` cannot tell "files this merge introduces" from "files that happened to be lying
-  around". Stage from `git diff --name-status <old-HEAD> origin/master`. If you must undo one,
-  `reset --soft HEAD~1` **clears `MERGE_HEAD` even on a merge commit**, so recreate it or the next
-  commit is silently single-parent and the ancestry breaks.
+  measured: a merge staged **111** untracked scratch paths, because `-A` cannot tell files the merge
+  introduces from files merely lying around. Stage from
+  `git diff --name-status <old-HEAD> origin/master`. If you must undo one, `reset --soft HEAD~1`
+  **clears `MERGE_HEAD` even on a merge commit** — recreate it, or the next commit is silently
+  single-parent and the ancestry breaks.
 <!-- END:shared-conventions -->
 
 ## Skills you use, in this order

--- a/.github/agents/pbi-semantic-builder.agent.md
+++ b/.github/agents/pbi-semantic-builder.agent.md
@@ -19,69 +19,70 @@ translation guide is your reference for every calculated field.
 
 ## Shared agent conventions (all agents inherit these)
 
-- **Cite your source — and say WHOSE.** Every capability claim, mapping decision, or numeric result
+- **Cite your source — and say WHOSE.** Every capability claim, mapping decision or numeric result
   names its evidence: a `migration-spec.json` field, a TMDL/PBIR path + line, a live `EVALUATE`
   result, or a doc URL. "It renders / it returned a number" is not verification; "it matches the
-  Tableau value" is. **A number also names the estate it was measured on** — ours (the reference
-  bundle) or the customer's. Never present ours as theirs: measured 2026-08-21, five did in one day.
+  Tableau value" is. **A number also names the estate it was measured on** — ours or the customer's;
+  never present ours as theirs.
 - **Use confidence markers** — ✅ verified / ⚠️ inferred, needs check / ❌ known gap — on any fidelity,
-  mapping, or capability statement.
+  mapping or capability statement.
 - **Own your layer; don't cross it.** `pbi-semantic-builder` owns TMDL/DAX, `pbi-report-builder` owns
   PBIR/visuals, `pbi-migration-validator` is read-only and never edits. A subagent never "just fixes"
   a finding another agent owns — it reports; the orchestrator routes.
-- **Three locations, one direction: engine truth → working copy → deliverable. Never edit upstream of
-  where you are.**
+- **Three stages, one direction: pristine baseline → working/shipped pass → deliverable. Never edit
+  upstream of where you are.**
   | stage | location | rule |
   |---|---|---|
-  | engine truth | `<bundle>/reports/`; `<bundle>/semantic_models/` (if emitted) | **NEVER edit an existing baseline** |
-  | working copy | `<bundle>/pbip/`, or `<package>/fabric/` when you were handed a PACKAGE | agents edit **here**; whichever tree you were handed is CANONICAL. `declare_generated_edit.py` / `--tamper` cover BUNDLE work only (#460) |
-  | deliverable | `migrations/{workbooks,datasources}/<slug>/fabric/` | **COPIED at sign-off**, so the bundle survives as evidence |
+  | pristine baseline | `<bundle>/reports/` (the model-unbound report pass); `<bundle>/semantic_models/` when emitted | **NEVER edit.** Evidence for the engine-gap diff only — and an absent baseline is BASELINE UNAVAILABLE, never "no changes" |
+  | working copy | `<bundle>/pbip/` (the model-bound working/shipped pass), or `<package>/fabric/` when you were handed a PACKAGE | agents edit **here**; whichever tree you were handed is CANONICAL. `declare_generated_edit.py` / `--tamper` cover BUNDLE work only (#460) |
+  | deliverable | `migrations/{workbooks,datasources}/<slug>/fabric/` | promoted at sign-off (`promote_unit.py`), so the bundle survives as evidence |
 
   A bundle may contain `<bundle>/{pbip,reports,semantic_models,handover,data}` — **no `out/` level**;
-  `<bundle>/semantic_models/` is conditional (absent for 8/12 workbooks), and absent baseline ≠ no
-  changes — see `AGENTS.md`.
+  `<bundle>/semantic_models/` is conditional (absent for 8 of 12 workbooks in one audited estate).
 
-  ⚠️ **The copy must keep
-  `definition.pbir`'s `byPath` resolving** — plain copy for a per-workbook model, path rewrite for a
-  shared datasource; never ship `<bundle>/reports/` (reference-only: no model beside it) and never
-  edit it - keep it pristine and diff it with git. Mechanics: `powerbi-report-gotchas` §3.
+  ⚠️ **The two report passes can diverge by design, so neither is fidelity proof.**
+  `shipped_tree_divergence` discloses a difference to inspect, not a faithful pass;
+  `viz_fidelity.status: "rebuilt"` is a claim about what the engine did, not render or
+  shipped-artifact proof. **Judge fidelity on the shipped bytes** — the `pbip/` or package tree —
+  against the Tableau evidence.
+
+  ⚠️ Promotion must keep `definition.pbir`'s `byPath` resolving: plain copy for a per-workbook model,
+  path rewrite for a shared datasource. Never ship `<bundle>/reports/` (reference-only: no model
+  beside it). Mechanics: `powerbi-report-gotchas` §3.
 
 - **Structural validation is necessary, not sufficient.** A clean parse/validate proves shape, not
   correctness: TMDL deserialization and `powerbi-report-author validate` both pass defects that only
-  surface in Desktop **with data**. Never declare something done on a green validator alone. (The
-  PBIR and TMDL specifics live in the `powerbi-report-gotchas` and `powerbi-semantic-model-gotchas`
-  skills, which the owning agents invoke.)
-- **Keep `limitations_encountered` alive** through the whole build **and** fix phase; every bug found
-  and fixed later is itself worth recording. Regenerate it from the final artifacts before sign-off so
-  stale entries don't mislead the validator.
+  surface in Desktop **with data**. Never declare something done on a green validator alone. PBIR and
+  TMDL specifics: the `powerbi-report-gotchas` / `powerbi-semantic-model-gotchas` skills.
+- **Keep `limitations_encountered` alive** through the whole build **and** fix phase. Regenerate it
+  from the final artifacts before sign-off so stale entries don't mislead the validator.
 - **Declare generated edits.** TMDL/PBIR/`.pbip`: file/change/why + replay script + hash record.
 - **Surface complexity mismatches proactively.** If the parsed workbook implies more effort than the
   user assumes (many LOD/table-calc fields, extract-only data with no upstream, >20 floating-layout
-  worksheets), say so before building rather than discovering it mid-migration.
-- **NEVER block silently on an external system — time-box it, then ASK.** Measured, from a real user
-  report: an agent sat on "Testing live Snowflake connectivity" for **129 minutes / 298 tool calls**,
-  retrying without ever surfacing the problem, until the user intervened. Waiting is not progress.
-  - **Cap it: ~2 minutes or 3 attempts, whichever comes first** — for any unresponsive external
-    system (database/warehouse/gateway, MCP server, XMLA refresh, the Power BI Desktop bridge). Cap
-    *relaunches* at 2 as well; "kill it and retry" is otherwise an unbounded loop.
-  - **Unless the tool tells you it IS the timer** — some of our scripts self-bound and announce their
-    own deadline. Measured: an agent applied this 2-minute cap to a script that was already the
-    bounded timer, killed it at 120 s, and so recorded **no verdict at all** — strictly worse than
-    waiting. Read the tool's own output before you decide it has hung.
-  - **A MISSING CREDENTIAL is not transient — try ONCE.** The cap above is for *flaky* systems. A
-    refusal naming authentication, permissions or a sign-in prompt is a **final answer**; only a
-    plainly transient timeout (a serverless warehouse cold-starting) earns one retry.
+  worksheets), say so before building rather than mid-migration.
+- **NEVER block silently on an external system — time-box it, then ASK.** Measured: an agent sat on
+  live-Snowflake connectivity for **129 minutes / 298 tool calls** without ever surfacing the
+  problem. Waiting is not progress.
+  - **Cap it: ~2 minutes or 3 attempts, whichever comes first** — any unresponsive external system
+    (database/warehouse/gateway, MCP server, XMLA refresh, the Desktop bridge). Cap *relaunches* at 2
+    as well; "kill it and retry" is otherwise an unbounded loop.
+  - **Unless the tool tells you it IS the timer** — some scripts self-bound and announce their own
+    deadline. Measured: an agent applied the cap to such a script, killed it at 120 s and recorded
+    **no verdict at all** — worse than waiting. Read the tool's own output first.
+  - **A MISSING CREDENTIAL is not transient — try ONCE.** The cap is for *flaky* systems. A refusal
+    naming authentication, permissions or a sign-in prompt is a **final answer**; only a plainly
+    transient timeout (a serverless warehouse cold-starting) earns one retry.
   - **AUTOPILOT / auto-approve DOES NOT override a credential stop.** "Decide, don't ask" applies to
     *choices*; this is a physical dependency on a human — the credential sits behind a **modal
     sign-in dialog no automation can fill**. Stop and ask **even in an unattended run**, and end the
-    turn. A clear question costs minutes; a confidently built, unvalidated model costs the whole run.
+    turn.
   - On hitting the cap, **STOP and ask a specific, actionable question** — name the system, what you
     tried, and the concrete options. Never re-run the same call hoping for a different result. Ask in
     your normal reply — there is no `ask_user` tool.
   - **Report elapsed time** whenever an operation exceeds ~60 s, so a stall is visible rather than
     looking like work.
 - **End every message with a clear next step or an explicit verdict** — never a vague "looks fine."
-- **Durable learnings go in committed files** (the agent `Gotchas` sections and
+- **Durable learnings go in committed files** (agent `Gotchas`, the skills,
   `docs/tableau-dax-translation-guide.md`), never in a git-ignored scratch folder — that is how each
   real migration permanently improves the toolkit.
 - **Power BI Desktop cleanup is PID-scoped.** Concurrent instances are fine; never sweep by name.
@@ -90,11 +91,11 @@ translation guide is your reference for every calculated field.
   leaks are enforced by `check_unit.py`'s `desktop-orphans` gate. Remove scratch/temp files you
   created; keep only committed deliverables plus re-runnable `_build/` scripts, and confirm nothing
   scratch leaked into git before reporting done. ⚠️ **Never `git add -A` after a gapped pull** —
-  measured: a merge staged **111** untracked scratch paths (a whole engine bundle, loose `_tmp_*.py`)
-  because `-A` cannot tell "files this merge introduces" from "files that happened to be lying
-  around". Stage from `git diff --name-status <old-HEAD> origin/master`. If you must undo one,
-  `reset --soft HEAD~1` **clears `MERGE_HEAD` even on a merge commit**, so recreate it or the next
-  commit is silently single-parent and the ancestry breaks.
+  measured: a merge staged **111** untracked scratch paths, because `-A` cannot tell files the merge
+  introduces from files merely lying around. Stage from
+  `git diff --name-status <old-HEAD> origin/master`. If you must undo one, `reset --soft HEAD~1`
+  **clears `MERGE_HEAD` even on a merge commit** — recreate it, or the next commit is silently
+  single-parent and the ancestry breaks.
 <!-- END:shared-conventions -->
 
 ## Skills you use

--- a/.github/agents/tableau-migrator.agent.md
+++ b/.github/agents/tableau-migrator.agent.md
@@ -17,69 +17,70 @@ TMDL or PBIR yourself. **What** to migrate, in what order and to where is the *d
 
 ## Shared agent conventions (all agents inherit these)
 
-- **Cite your source — and say WHOSE.** Every capability claim, mapping decision, or numeric result
+- **Cite your source — and say WHOSE.** Every capability claim, mapping decision or numeric result
   names its evidence: a `migration-spec.json` field, a TMDL/PBIR path + line, a live `EVALUATE`
   result, or a doc URL. "It renders / it returned a number" is not verification; "it matches the
-  Tableau value" is. **A number also names the estate it was measured on** — ours (the reference
-  bundle) or the customer's. Never present ours as theirs: measured 2026-08-21, five did in one day.
+  Tableau value" is. **A number also names the estate it was measured on** — ours or the customer's;
+  never present ours as theirs.
 - **Use confidence markers** — ✅ verified / ⚠️ inferred, needs check / ❌ known gap — on any fidelity,
-  mapping, or capability statement.
+  mapping or capability statement.
 - **Own your layer; don't cross it.** `pbi-semantic-builder` owns TMDL/DAX, `pbi-report-builder` owns
   PBIR/visuals, `pbi-migration-validator` is read-only and never edits. A subagent never "just fixes"
   a finding another agent owns — it reports; the orchestrator routes.
-- **Three locations, one direction: engine truth → working copy → deliverable. Never edit upstream of
-  where you are.**
+- **Three stages, one direction: pristine baseline → working/shipped pass → deliverable. Never edit
+  upstream of where you are.**
   | stage | location | rule |
   |---|---|---|
-  | engine truth | `<bundle>/reports/`; `<bundle>/semantic_models/` (if emitted) | **NEVER edit an existing baseline** |
-  | working copy | `<bundle>/pbip/`, or `<package>/fabric/` when you were handed a PACKAGE | agents edit **here**; whichever tree you were handed is CANONICAL. `declare_generated_edit.py` / `--tamper` cover BUNDLE work only (#460) |
-  | deliverable | `migrations/{workbooks,datasources}/<slug>/fabric/` | **COPIED at sign-off**, so the bundle survives as evidence |
+  | pristine baseline | `<bundle>/reports/` (the model-unbound report pass); `<bundle>/semantic_models/` when emitted | **NEVER edit.** Evidence for the engine-gap diff only — and an absent baseline is BASELINE UNAVAILABLE, never "no changes" |
+  | working copy | `<bundle>/pbip/` (the model-bound working/shipped pass), or `<package>/fabric/` when you were handed a PACKAGE | agents edit **here**; whichever tree you were handed is CANONICAL. `declare_generated_edit.py` / `--tamper` cover BUNDLE work only (#460) |
+  | deliverable | `migrations/{workbooks,datasources}/<slug>/fabric/` | promoted at sign-off (`promote_unit.py`), so the bundle survives as evidence |
 
   A bundle may contain `<bundle>/{pbip,reports,semantic_models,handover,data}` — **no `out/` level**;
-  `<bundle>/semantic_models/` is conditional (absent for 8/12 workbooks), and absent baseline ≠ no
-  changes — see `AGENTS.md`.
+  `<bundle>/semantic_models/` is conditional (absent for 8 of 12 workbooks in one audited estate).
 
-  ⚠️ **The copy must keep
-  `definition.pbir`'s `byPath` resolving** — plain copy for a per-workbook model, path rewrite for a
-  shared datasource; never ship `<bundle>/reports/` (reference-only: no model beside it) and never
-  edit it - keep it pristine and diff it with git. Mechanics: `powerbi-report-gotchas` §3.
+  ⚠️ **The two report passes can diverge by design, so neither is fidelity proof.**
+  `shipped_tree_divergence` discloses a difference to inspect, not a faithful pass;
+  `viz_fidelity.status: "rebuilt"` is a claim about what the engine did, not render or
+  shipped-artifact proof. **Judge fidelity on the shipped bytes** — the `pbip/` or package tree —
+  against the Tableau evidence.
+
+  ⚠️ Promotion must keep `definition.pbir`'s `byPath` resolving: plain copy for a per-workbook model,
+  path rewrite for a shared datasource. Never ship `<bundle>/reports/` (reference-only: no model
+  beside it). Mechanics: `powerbi-report-gotchas` §3.
 
 - **Structural validation is necessary, not sufficient.** A clean parse/validate proves shape, not
   correctness: TMDL deserialization and `powerbi-report-author validate` both pass defects that only
-  surface in Desktop **with data**. Never declare something done on a green validator alone. (The
-  PBIR and TMDL specifics live in the `powerbi-report-gotchas` and `powerbi-semantic-model-gotchas`
-  skills, which the owning agents invoke.)
-- **Keep `limitations_encountered` alive** through the whole build **and** fix phase; every bug found
-  and fixed later is itself worth recording. Regenerate it from the final artifacts before sign-off so
-  stale entries don't mislead the validator.
+  surface in Desktop **with data**. Never declare something done on a green validator alone. PBIR and
+  TMDL specifics: the `powerbi-report-gotchas` / `powerbi-semantic-model-gotchas` skills.
+- **Keep `limitations_encountered` alive** through the whole build **and** fix phase. Regenerate it
+  from the final artifacts before sign-off so stale entries don't mislead the validator.
 - **Declare generated edits.** TMDL/PBIR/`.pbip`: file/change/why + replay script + hash record.
 - **Surface complexity mismatches proactively.** If the parsed workbook implies more effort than the
   user assumes (many LOD/table-calc fields, extract-only data with no upstream, >20 floating-layout
-  worksheets), say so before building rather than discovering it mid-migration.
-- **NEVER block silently on an external system — time-box it, then ASK.** Measured, from a real user
-  report: an agent sat on "Testing live Snowflake connectivity" for **129 minutes / 298 tool calls**,
-  retrying without ever surfacing the problem, until the user intervened. Waiting is not progress.
-  - **Cap it: ~2 minutes or 3 attempts, whichever comes first** — for any unresponsive external
-    system (database/warehouse/gateway, MCP server, XMLA refresh, the Power BI Desktop bridge). Cap
-    *relaunches* at 2 as well; "kill it and retry" is otherwise an unbounded loop.
-  - **Unless the tool tells you it IS the timer** — some of our scripts self-bound and announce their
-    own deadline. Measured: an agent applied this 2-minute cap to a script that was already the
-    bounded timer, killed it at 120 s, and so recorded **no verdict at all** — strictly worse than
-    waiting. Read the tool's own output before you decide it has hung.
-  - **A MISSING CREDENTIAL is not transient — try ONCE.** The cap above is for *flaky* systems. A
-    refusal naming authentication, permissions or a sign-in prompt is a **final answer**; only a
-    plainly transient timeout (a serverless warehouse cold-starting) earns one retry.
+  worksheets), say so before building rather than mid-migration.
+- **NEVER block silently on an external system — time-box it, then ASK.** Measured: an agent sat on
+  live-Snowflake connectivity for **129 minutes / 298 tool calls** without ever surfacing the
+  problem. Waiting is not progress.
+  - **Cap it: ~2 minutes or 3 attempts, whichever comes first** — any unresponsive external system
+    (database/warehouse/gateway, MCP server, XMLA refresh, the Desktop bridge). Cap *relaunches* at 2
+    as well; "kill it and retry" is otherwise an unbounded loop.
+  - **Unless the tool tells you it IS the timer** — some scripts self-bound and announce their own
+    deadline. Measured: an agent applied the cap to such a script, killed it at 120 s and recorded
+    **no verdict at all** — worse than waiting. Read the tool's own output first.
+  - **A MISSING CREDENTIAL is not transient — try ONCE.** The cap is for *flaky* systems. A refusal
+    naming authentication, permissions or a sign-in prompt is a **final answer**; only a plainly
+    transient timeout (a serverless warehouse cold-starting) earns one retry.
   - **AUTOPILOT / auto-approve DOES NOT override a credential stop.** "Decide, don't ask" applies to
     *choices*; this is a physical dependency on a human — the credential sits behind a **modal
     sign-in dialog no automation can fill**. Stop and ask **even in an unattended run**, and end the
-    turn. A clear question costs minutes; a confidently built, unvalidated model costs the whole run.
+    turn.
   - On hitting the cap, **STOP and ask a specific, actionable question** — name the system, what you
     tried, and the concrete options. Never re-run the same call hoping for a different result. Ask in
     your normal reply — there is no `ask_user` tool.
   - **Report elapsed time** whenever an operation exceeds ~60 s, so a stall is visible rather than
     looking like work.
 - **End every message with a clear next step or an explicit verdict** — never a vague "looks fine."
-- **Durable learnings go in committed files** (the agent `Gotchas` sections and
+- **Durable learnings go in committed files** (agent `Gotchas`, the skills,
   `docs/tableau-dax-translation-guide.md`), never in a git-ignored scratch folder — that is how each
   real migration permanently improves the toolkit.
 - **Power BI Desktop cleanup is PID-scoped.** Concurrent instances are fine; never sweep by name.
@@ -88,11 +89,11 @@ TMDL or PBIR yourself. **What** to migrate, in what order and to where is the *d
   leaks are enforced by `check_unit.py`'s `desktop-orphans` gate. Remove scratch/temp files you
   created; keep only committed deliverables plus re-runnable `_build/` scripts, and confirm nothing
   scratch leaked into git before reporting done. ⚠️ **Never `git add -A` after a gapped pull** —
-  measured: a merge staged **111** untracked scratch paths (a whole engine bundle, loose `_tmp_*.py`)
-  because `-A` cannot tell "files this merge introduces" from "files that happened to be lying
-  around". Stage from `git diff --name-status <old-HEAD> origin/master`. If you must undo one,
-  `reset --soft HEAD~1` **clears `MERGE_HEAD` even on a merge commit**, so recreate it or the next
-  commit is silently single-parent and the ancestry breaks.
+  measured: a merge staged **111** untracked scratch paths, because `-A` cannot tell files the merge
+  introduces from files merely lying around. Stage from
+  `git diff --name-status <old-HEAD> origin/master`. If you must undo one, `reset --soft HEAD~1`
+  **clears `MERGE_HEAD` even on a merge commit** — recreate it, or the next commit is silently
+  single-parent and the ancestry breaks.
 <!-- END:shared-conventions -->
 
 ## Workflow

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -233,7 +233,7 @@ source:**
 | Source | Capture command | Notes |
 |---|---|---|
 | **Tableau Public URL, or a local `.twb`/`.twbx`** | `python scripts/capture_tableau_reference.py migrations/workbooks/<slug> [--public-url <url> --view <view>]` | Writes a provenance-stamped `reference/manifest.json` — a `capabilities`-carrying `validation_grade` source; its `manual` provider also adopts user-dropped `tableau-*.png` in `reference/`. An existing manifest **short-circuits to exit 0** — re-run with `--force`. |
-| **Tableau Server/Cloud** (`TABLEAU_SERVER_URL` configured) | `python scripts/capture_tableau_oracle.py --out _oracle --images [--reference-best] [--workbook "<published name>"]` | The command on the left **exits 3** on an empty target when the URL is set (URL unset → 1): that is *"wrong tool for this source"*, **NOT** "capture is impossible" — misreading it is the whole of #198. Use the oracle, which does the live REST image export. |
+| **Tableau Server/Cloud** (`TABLEAU_SERVER_URL` configured) | `python scripts/capture_tableau_oracle.py --out _oracle --images [--reference-best] [--workbook "<published name>"]` | This row **is** the oracle route: it does the live REST image export. **Exit 4 is "no views selected"** — a wrong or over-narrow target (usually a `--workbook` filter matching nothing), **NOT** "capture is impossible"; **exit 3** is a total non-credential failure. Reading a selection miss as an impossibility is the whole of #198. Full code list below. |
 
 Three oracle traps, all verified in `scripts/capture_tableau_oracle.py`:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,105 +1,70 @@
 # AGENTS.md — shared conventions for this repo's Copilot agents
 
-This file is auto-loaded by GitHub Copilot CLI (and other agent runtimes) for every session in this
-repository. It has two jobs: (1) tell you (or a fresh contributor) exactly which Copilot **plugins and
-MCP servers** this toolkit needs so the repo is self-configuring, and (2) hold the **canonical copy of
-the shared agent conventions**, which `scripts/sync_agent_conventions.py` generates into every
-`.github/agents/*.agent.md`.
+Auto-loaded by GitHub Copilot CLI (and other agent runtimes) for every session in this repository. It
+has two jobs: (1) name the **environment contract** so the repo is self-configuring, and (2) hold the
+**canonical copy of the shared agent conventions**, which `scripts/sync_agent_conventions.py`
+generates into every `.github/agents/*.agent.md`.
 
 > **Why generated, not inherited:** a custom-agent **subagent** receives ONLY its own persona file —
 > this file, `.github/copilot-instructions.md` and user-global instructions do **not** reach it
 > (verified 2026-07-30 with a sentinel experiment; all four agents confirmed independently). There is
-> no `include`/`extends` mechanism. So the conventions below are *duplicated* into each agent on
-> purpose, and CI fails if a copy drifts. **Edit them here, then run
+> no `include`/`extends` mechanism, so the block at the end is *duplicated* into each persona on
+> purpose and CI fails when a copy drifts. **Edit it here, then run
 > `python scripts/sync_agent_conventions.py`** — never edit the copy inside an agent file.
 >
-> `--check` fails on three things, and the last two exist because consistency alone was not enough:
-> **drift**, a persona **over the 30,000-char cap** (measured on the whole file — a body-only count
-> read 98 % for a 30,132-char file), and a documented `<bundle>/…` path that **is not a real bundle
-> directory** (`<bundle>/out/pbip/` was wrong in all five copies for weeks, and agreeing with itself
-> was the only thing anyone checked). It reports **all three in one run, the path first**: a wrong path
-> in `AGENTS.md` also makes every persona stale, so failing on drift first pointed at the symptom, and
-> the obvious "fix" was to sync the wrong path into all four files. The scan covers the block **and
-> each persona in full** — a wrong path in a persona's own `## Gotchas` used to be invisible — and
-> **write mode exits non-zero too**, because that run has propagated the error, not merely proposed it.
-> `--bundle <dir>` additionally resolves on disk the paths written as a **location**
-> (`<bundle>/reports/`); the `{pbip,reports,…}` enumeration is vocabulary, so an estate with no
-> flat-file extracts, and therefore no `data/`, is not failed for it.
+> `--check` reports three failures in one run, the path first: a documented `<bundle>/…` path that is
+> **not a real bundle directory**, **drift**, and a persona over the **30,000-char cap** (measured on
+> the whole file). It scans the block *and each persona in full*, and **write mode exits non-zero
+> too** — that run has propagated the error, not merely proposed it. `--bundle <dir>` also resolves
+> location-shaped paths (`<bundle>/reports/`) on disk. Rationale and the defects behind each rule:
+> [`docs/agent-architecture.md`](docs/agent-architecture.md).
 
 > **VS Code users:** VS Code Copilot auto-loads `.github/copilot-instructions.md`, *not* this file.
-> That pointer file duplicates only the session-start step below and defers everything else here, so
-> the two cannot drift.
+> That pointer duplicates only the session-start step below and defers everything else here.
 
 **Navigation:** use [`docs/INDEX.md`](docs/INDEX.md) as the tier-2 map before searching blindly.
-Subagents are told in their generated preamble to read it as step 0; `scripts/check_navigation_index.py`
-checks the index bidirectionally.
+Subagents read it as step 0; `scripts/check_navigation_index.py` checks it bidirectionally.
 
 ---
 
 ## Session start, do this first (before any other work)
 
 ```
-powershell -ExecutionPolicy Bypass -File scripts/preflight.ps1 -Update
+powershell -ExecutionPolicy Bypass -File scripts/preflight.ps1 -Update -CheckUpstream
 ```
 
-`-Update` repairs the npm bridge CLIs **only when they are below the correctness floor** — it is a
-floor check, not a blind `@latest`, so at or above the floor it costs nothing.
+`-Update` repairs the npm bridge CLIs **only when they are below the correctness floor** — a floor
+check, not a blind `@latest`, so at or above the floor it costs nothing.
 
 **Why a floor:** `powerbi-report-author` **>= 0.1.4** is a *correctness* floor. Older builds returned
-`errorCount: 0` for PBIR that Power BI Desktop cannot open (e.g. a `report.json` whose
-`themeCollection` entries are missing `reportVersionAtImport`) — a stale CLI silently green-lights a
-broken report.
+`errorCount: 0` for PBIR that Power BI Desktop cannot open — e.g. a `report.json` whose
+`themeCollection` entries are missing `reportVersionAtImport`, which is **required inside each
+`themeCollection` entry and forbidden at the top level** (mutation-by-mutation evidence and the
+committed ground-truth shape live in the `powerbi-report-gotchas` skill). A stale CLI silently
+green-lights a broken report.
 
-⚠️ **`reportVersionAtImport` is location-dependent — and the two theme entries do not even fail the
-same way.** Re-measured 2026-08-13 against 0.1.4, by mutating a scratch copy of
-`examples/shipping-kpis/fabric/ShippingKPIs.Report`:
+**Above the known-good matrix is a WARN, not an error.** It means the version-specific gotchas in
+`.github/agents/` and the skills were verified against an older build and may be stale — re-verify
+the prose; never "fix" it by downgrading.
 
-| mutation | what `validate` actually emits |
-|---|---|
-| remove from `baseTheme` | **`PBIR_SCHEMA_VALIDATION_ERROR` only** — *"/themeCollection/baseTheme must have required property 'reportVersionAtImport'"* (errorCount 1) |
-| remove from `customTheme` | **both** `PBIR_THEME_VERSION_AT_IMPORT_MISSING` **and** `PBIR_SCHEMA_VALIDATION_ERROR` (errorCount 2) |
-| add at the **top level** | `PBIR_SCHEMA_VALIDATION_ERROR` — *"/ must NOT have additional properties (property: "reportVersionAtImport")"* |
+**`-CheckUpstream` is opt-in (~3 s of network) and advisory — it never upgrades and never fails the
+run.** Every other check compares an installed version against a hard-coded number: that answers "is
+what I have good enough", never "has the world moved". It asks npm for `powerbi-report-author` /
+`powerbi-desktop` and GitHub for the engine's upstream `VERSION`. Measured 2026-08-06: the engine
+moved **2.60.0 → 2.72.0** unnoticed and **Power BI Desktop auto-updated** and broke the bridge's exe
+discovery, both while preflight still reported "Ready to migrate".
 
-So the substance is: **required inside each `themeCollection` entry, forbidden at the top level** of
-`report.json` — but do not attach the named code to both entries. The CLI raises
-`PBIR_THEME_VERSION_AT_IMPORT_MISSING` from `validateCustomTheme` alone (its only emit site in
-`dist/index.js`), so grepping for it after a `baseTheme` failure finds nothing and reads as "not our
-problem". Ground truth, a committed deliverable:
-`examples/shipping-kpis/fabric/ShippingKPIs.Report/definition/report.json` — top-level keys are
-`$schema`, `themeCollection`, `resourcePackages`, `settings`, and *both* theme entries carry
-`name`, `type`, `reportVersionAtImport`. Saying only "schema-required" is what put it at the top level
-in a hand-written scaffold five days later; name the location every time.
-
-**Above the known-good matrix is a WARN, not an error.** It means the version-specific Gotchas in
-`.github/agents/` were verified against an older build and may be stale — re-verify the prose; never
-"fix" it by downgrading.
-
-**The timing rule is what makes this safe:**
+**The timing rule is what makes upgrading safe:**
 
 | When | Run | Why |
 |---|---|---|
-| Session start (nothing in flight) | `preflight.ps1 -Update -CheckUpstream` | Safe; the CLI floor is a correctness floor, and this is the one moment upgrading is allowed |
-| Migration start (orchestrator step 0) | `preflight.ps1` (plain) | Confirm READY without swapping tooling mid-flow — and without a network round trip on every migration |
-| Mid-migration | **don't upgrade the installed tooling** | The variable is not the calendar but *work already validated by the current CLI*: swap the validator mid-build and earlier results are no longer covered by the same check. A version-*comparison* run into a fresh output dir is not an upgrade (engine section) and is not forbidden here. |
-
-**`-CheckUpstream` answers a question the version matrix cannot.** Every other check compares an
-installed version against a **hard-coded** number — that says "is what I have good enough", never
-"has the world moved". `-CheckUpstream` asks npm for the latest `powerbi-report-author` /
-`powerbi-desktop`, and asks GitHub for the deterministic engine's upstream `VERSION` (the plugin is
-an unpacked marketplace copy with no `.git`, so there is no local SHA to compare — and a VERSION
-comparison names the thing that actually changes behaviour). It is **opt-in**
-(~3s of network) and **advisory** — it never upgrades and never fails the run, because being behind
-is not an error; the timing rule above still decides *when* acting on it is safe.
-
-Measured 2026-08-06, this gap bit twice in one day: the engine moved **2.60.0 → 2.72.0** unnoticed
-(issues were nearly filed against behaviour it had already replaced, caught only by a manual
-`git fetch`), and **Power BI Desktop auto-updated** and silently broke the bridge's exe discovery
-while preflight still reported "Ready to migrate".
+| Session start (nothing in flight) | `preflight.ps1 -Update -CheckUpstream` | Safe; the floor is a correctness floor, and this is the one moment upgrading is allowed |
+| Migration start (orchestrator step 0) | `preflight.ps1` (plain) | Confirm READY without swapping tooling mid-flow, and without a network round trip on every migration |
+| Mid-migration | **don't upgrade the installed tooling** | The variable is not the calendar but *work already validated by the current CLI*: swap the validator mid-build and earlier results are no longer covered by the same check. A version-*comparison* run into a fresh output dir is not an upgrade (see the engine rules in step 1) and is not forbidden |
 
 It cannot update the **skill bundles**: `copilot plugin update` hits a file lock while any Copilot
-session is running. That lock is narrower than it looks, though — it blocks renaming the plugin
-directory, not writing inside it — so a *content* refresh needs no restart:
-`python scripts/sync_installed_skills.py`.
+session is running. That lock blocks renaming the plugin directory, not writing inside it, so a
+*content* refresh needs no restart: `python scripts/sync_installed_skills.py`.
 
 ---
 
@@ -107,291 +72,129 @@ directory, not writing inside it — so a *content* refresh needs no restart:
 
 The environment contract lives in **`scripts/preflight.ps1`**. It is the gate, not this prose: it
 checks the required tools, plugins, MCP servers, Python dependencies, Desktop bridge assumptions and
-version floors, prints the install or repair hint beside the failing item, and exits non-zero for any
-critical miss.
+version floors, prints the install or repair hint beside the failing item, and **exits non-zero for
+any critical miss**.
 
 ```
 powershell -ExecutionPolicy Bypass -File scripts/preflight.ps1
 ```
 
 **If setup guidance is missing or too thin, improve the preflight hint rather than adding another
-install recipe here.** An agent that never reads this section should still be stopped by the exit code
-before it can migrate with a broken environment.
+install recipe here.** An agent that never reads this section should still be stopped by the exit
+code before it can migrate with a broken environment.
 
-Keep only the judgement the gate cannot carry:
-
-- **Timing rule (installed tooling):** `-Update` is for session start only, before any migration is in
-  flight; at migration start run plain preflight; mid-migration, do not re-arm it. What is at risk is
-  not the calendar position but *un-checkpointed work already validated by the current CLI* — swap the
-  validator underneath it and earlier results are no longer covered by the same check. This governs
-  *upgrading the installed CLIs*; running a second engine version into a fresh output dir to
-  **compare** is a different, always-safe operation (see the engine timing rule below).
-- **`powerbi-report-author >= 0.1.4` is a correctness floor, not hygiene.** Older builds returned
-  `errorCount: 0` for PBIR that Power BI Desktop cannot open, so being below the floor silently
-  green-lights broken reports. `-Update` repairs only below-floor npm bridge CLIs; it is not a blind
-  `@latest`.
-- **Above the known-good matrix is a WARN, not an error.** Do not downgrade to make the warning go
-  away. Re-verify the version-specific gotchas, then continue.
-- **Skill bundles can be stale even when repo-local `.github/skills/` is correct.** In this repo an
-  installed plugin copy shadows the local bundle with the same name, so preflight blocks on `STALE in
-  plugin`. Fix content drift immediately with `python scripts/sync_installed_skills.py`; a running
-  Copilot session keeps the old in-memory copy, but new sessions and newly spawned subagents see the
-  refreshed files. A real `copilot plugin update` still belongs between sessions because the plugin
-  directory is file-locked for rename/swap while Copilot is running.
-- **PBIR theme-version location is report-authoring knowledge, not setup.** The rule
-  (`reportVersionAtImport` required inside each `themeCollection` entry and forbidden at the top
-  level of `report.json`) lives in `powerbi-report-gotchas` so the report owner sees it when authoring
-  PBIR.
+The one judgement the gate cannot carry: **a skill bundle can be stale even when repo-local
+`.github/skills/` is correct**, because an installed plugin copy with the same name shadows it and
+preflight blocks on `STALE in plugin`. Fix content drift immediately with
+`python scripts/sync_installed_skills.py`; new sessions and newly spawned subagents then see the
+refreshed files, while a running session keeps its old in-memory copy.
 
 ---
 
-## Monitoring delegated work (orchestrator discipline, not persona content)
+## Delegating and monitoring work (orchestrator discipline, not persona content)
 
-This section is deliberately **outside** the synced block below — it is not something every persona
-needs baked into its own context (three of the four are already at ~99% of their character cap), it
-is what *whoever is delegating* — the top-level session, or `tableau-migrator` orchestrating
-`pbi-semantic-builder`/`pbi-report-builder` — owes the work once it hands a task to a subagent.
+Deliberately **outside** the synced block: this is what *whoever delegates* — the top-level session,
+or `tableau-migrator` orchestrating the builders — owes the work once it hands out a task. Incident
+evidence behind every rule below: [`docs/agent-operations.md`](docs/agent-operations.md).
 
-**A subagent's own final summary is a claim, not evidence — verify it before repeating it.**
-Measured 2026-08-02: a subagent's summary declared **"Sign-off ready: YES"** and never mentioned that
-it had, minutes earlier, re-armed its own credential gate and cleared it unearned; only reading the
-gate's own audit log (`probe-cleared` vs `manual-clear`, and `credential_gate.py verify`) surfaced the
-violation. This is not a reason to distrust subagents generally — it is a reason to always have an
-authoritative, non-narrative check available and to run it before passing a result along: an audit
-log's `action` field, `verify`'s exit code, an artifact count, a checksum — never the summary prose
-alone.
+- **A subagent's own summary is a claim, not evidence — verify before repeating it.** Run an
+  authoritative, non-narrative check: an audit log's `action` field (`probe-cleared` vs
+  `manual-clear`), `credential_gate.py verify`'s exit code, an artifact count, a checksum. Measured
+  2026-08-02: a summary declared "Sign-off ready: YES" while the gate's log showed it had cleared its
+  credential gate unearned.
+- **An anomaly in elapsed time or tool-call count is a signal, not noise.** Ground truth is readable
+  *mid-run*; reading it early caught that bypass, a misclassified `UNREACHABLE` and a real Desktop
+  crash — none of which appeared in the eventual "done" message.
+- **When a summary and the ground truth disagree, ground truth wins, unconditionally.** Restate the
+  verdict from the evidence; do not soften it to be polite about the subagent's framing.
+- **A green CI is the start of review, not the end.** Measured 2026-08-09: five agents fixed eleven
+  issues, all five PRs went green, and a blind review — given only the diff and the issue, never the
+  author's rationale — requested changes on all five, because each fix had *moved* its failure
+  boundary rather than removing it.
+- **Review the diff without the author's explanation**; say plainly that a clean bill of health is a
+  legitimate outcome (or reviewers invent findings); tell authors to push back with evidence; send a
+  re-review to the reviewer who found the defect; and require **`Fixes #N`** in the commit message,
+  not merely "reference the issue" — four issues stayed open after being fixed and merged because
+  the commits said `(#46)`.
+- **After a host crash, in-flight subagent work is UNKNOWN — never assume lost, never assume
+  complete.** Do file-level forensics BEFORE re-dispatching: `git status` / `git diff --stat` in the
+  target worktree, plus file mtimes against the crash time. Measured 2026-08-19: three agents with
+  identical "in progress" status had finished, half-finished and done nothing; blind re-dispatch
+  would have overwritten verified-good work.
+- **Prefer briefs that land work incrementally** (commit and `git push` as you go) over ones that
+  buffer everything until a final write — the first turns a crash into truncation, the second into
+  total loss.
 
-**An anomaly in elapsed time or tool-call count is a signal, not noise.** The same run above was
-still on its first turn past 5000 seconds and 89 tool calls into a task that peers finished in
-minutes — that alone was reason enough to stop and read what it had actually done, before it
-finished and self-reported success. Don't wait for the final summary to investigate a run that looks
-stuck or unusually long; the ground truth (audit log, artifact folder, raw session event log) is
-readable mid-run, and reading it early is what caught the bypass, a misclassified `UNREACHABLE`, and
-a real Desktop crash — all in one afternoon, all invisible in the eventual "done" message.
+### The review contract — state this in the brief BEFORE coding
 
-**When a summary and the ground truth disagree, ground truth wins, unconditionally.** Don't average
-them, don't soften the finding to be polite about the subagent's framing — restate the verdict from
-the evidence and say so plainly.
-
-**Every fix in this batch passed CI and every one needed changes.** Measured 2026-08-09: five agents
-fixed eleven issues in isolated `git worktree`s, all five PRs went green, and an independent
-rubber-duck review — given **only the diff and the issue, never the author's rationale** — returned
-`request changes` on **all five**. The shared shape was that each fix *moved* its failure boundary
-rather than removing it: a data-loss fix that still collapsed extracts sharing a table name, a
-monitoring fix whose new liveness signal re-opened the door its own regression test was written to
-close, a parser fix that satisfied a synthetic fixture but not the real XML already committed to this
-repo. So:
-
-- **A green CI is the start of review, not the end of it.** CI proves the code does what its tests
-  say; it cannot tell you the tests have a blind spot. One covering test here *structurally could
-  not* observe the defect it was written for, because its fixture used distinct table names.
-- **Review the diff without the author's explanation.** A reviewer handed the reasoning tends to
-  ratify it. Every finding in that batch came from a *controlled experiment* — reversing input order,
-  unsetting an environment variable, injecting a hash mismatch — not from reading the code.
-- **Send the re-review to the reviewer who found the defect.** They already have the reproduction
-  built; a fresh reviewer has to rediscover it, and usually doesn't.
-- **Tell reviewers plainly that a clean bill of health is a legitimate outcome**, or they invent
-  findings to look thorough. Equally, tell authors to **push back with evidence** rather than comply:
-  one "already fixed, no change needed" verdict was correct, and survived deliberately sceptical
-  re-checking.
-- **Require `Fixes #N` in the commit message, not merely "reference the issue".** Four issues stayed
-  open after being fixed, reviewed, re-reviewed and merged, because the commits said `(#46)` — a
-  reference, not a GitHub closing keyword. The PR with the *best* per-issue write-up was the one that
-  did not close anything.
-
-**A host crash with subagents in flight leaves no summary at all — do file-level forensics before
-re-dispatching.** Everything above assumes a subagent eventually reports back; a crashed host never
-gets that far. Real incident, 2026-08-19: the CLI hung and was restarted with 3 fix-subagents still
-running. Afterwards `list_agents` returned **ZERO** and no agent produced a final report. What each
-had actually accomplished could only be established by reading files on disk — and the outcome was
-not predictable from any agent's last known status:
-
-| subagent | last known status | what was actually on disk |
-|---|---|---|
-| ACMU | in progress | both fixes complete, already confirmed live in Desktop |
-| Active Work Order | in progress | 4 new, valid, non-orphaned visual files — further along than its status suggested |
-| Aircraft Installs | in progress | zero file changes — nothing lost, nothing gained |
-
-Three agents, three genuinely different outcomes, identical reported status. Any blanket assumption —
-"assume lost", "assume complete", "assume proportional to elapsed time" — is wrong for at least one of
-them. Re-dispatching blindly would have redone or overwritten ACMU's already-verified fixes.
-
-- **In-flight subagent progress is at risk until it lands on disk.** Treat a lost agent's work as
-  **UNKNOWN** — never as lost, never as complete — until you have checked.
-- **After a host restart with agents in flight, do file-level forensics BEFORE re-dispatching:**
-  `git status` / `git diff --stat` in the target worktree, plus file modification times against the
-  crash time. Agent status does not answer this question; the files do.
-- **Prefer briefs that land work incrementally over ones that hold everything until a final write.**
-  A brief that commits/saves as it goes turns a crash into a truncation of progress; a brief that
-  buffers everything for one final write turns the same crash into a total loss.
-- **Re-dispatch only after establishing current state.** Re-running a completed fix can overwrite a
-  verified-good artifact — ACMU's fixes above were already confirmed live in Desktop; blindly
-  re-dispatching that unit would have redone (and risked corrupting) work that was already done.
-
-### The review spiral: what an independent measurement actually found
-
-⚠️ **An earlier version of this section was written from memory under a deadline and was wrong in
-three checkable ways.** It is preserved here only as a worked example of why a plausible process
-diagnosis must be measured before it is adopted. Full data, method and limits:
-[`docs/review-throughput-postmortem.md`](docs/review-throughput-postmortem.md) (PR #449) — produced
-blind, with its phase-1 conclusions frozen *before* reading this section, precisely so it could
-falsify it rather than ratify it.
-
-What it corrected, and each of these was load-bearing:
-
-| the earlier claim | measured |
-|---|---|
-| "#428 shipped **9,929 insertions**, 4 new scripts and 9 new test modules" | **+5551/-4, 4 new scripts, 5 new test files.** The figure was fabricated and was then repeated into three agent briefs |
-| "six PRs needed five or more rounds" | **all eight** merged PRs did; mean **7.75**, median 8 |
-| a proof:product ratio of **2.4x** | **1.86x** all-tests, **0.55x** machinery. The inflated number came from a **two-dot** `master..branch` diff, which counts master-only changes as PR additions on a stale branch |
-
-**The reviews were mostly right, so do not read any of this as "review less".** 184 recoverable
-findings: **139 product / 45 proof**. From round 3 onward it is still **75 product / 31 proof — 71% of
-late findings were product defects**, commonly security, data loss, or a false-clean verdict.
-
-**What did NOT cause the spirals** — each ruled out by a discriminating case, not by correlation alone:
-
-- **Size.** Additions vs pre-merge rounds: Pearson **−0.060**. #422 took 11 rounds at +3214; larger
-  #428 and #431 took five.
-- **Contention.** #399 reached **10 rounds with zero shared core files**. It amplifies; it does not cause.
-- **Operator routing.** #422 ran 11 rounds in **8h31** with no inter-commit gap above 58 minutes.
-- **Proof machinery itself.** #430: proof-only, one round.
-
-**What did:** *an unbounded claim fixed one site at a time.* **66% of round-2+ findings shared a defect
-class with round N−1 of a DIFFERENT PR** (32/32 for wrong-object evidence, 19/22 for false-clean). The
-classes were already known elsewhere and were rediscovered serially. Machinery is an **amplifier and a
-symptom** — in 4 of 5 machinery-bearing PRs it arrived *after* review began, and proof share climbs
-18% (R1‑2) → 29% (R3+) → **33% (R5+)**.
-
-⚠️ **Two rules the earlier version proposed are contradicted; do not reintroduce them.**
-
-- **A hard artifact cap** ("no new script, ≤1 test module") — new test-file count vs rounds is Spearman
-  **−0.695**: *more* test files went with *fewer* rounds. Capping files would have increased rounds.
-- **An absolute two-round cap** — after round 2 there were **44 false-clean / wrong-object / security
-  findings**, which normally block a merge. A hard cap either ships known blockers or stops being a
-  cap. The **direction** half survives (below); the count does not.
-
-#### The review contract — state this in the brief BEFORE coding
+Measured over eight merged PRs (mean **7.75** pre-merge review rounds): the cause was **an unbounded
+claim fixed one site at a time** — 66 % of round-2+ findings shared a defect class with round N−1 of
+a *different* PR. Size, file contention, operator routing and proof machinery were each ruled out by
+a discriminating case, and the reviews were mostly right, so none of this means "review less". Data,
+method and limits: [`docs/review-throughput-postmortem.md`](docs/review-throughput-postmortem.md).
+⚠️ **Two rules an earlier edition proposed are contradicted — do not reintroduce them:** a hard
+artifact cap (new test files vs rounds is Spearman **−0.695**: *more* test files went with *fewer*
+rounds) and an absolute two-round cap (44 false-clean / wrong-object / security findings arrived
+after round 2, and those normally block a merge).
 
 1. **Invariant and direction.** State the exact pass / refuse / cannot-establish contract. Name the
    fail-open consequence, the fail-closed consequence, and which one blocks merge.
-2. **Closed surface.** Enumerate every consumer, phase, transformation, identity-loss join and mutable
-   read that can affect the invariant (`N = ___`); name residuals explicitly. **If review finds a new
-   class or an unlisted surface after round 1, do not add another local guard — simplify, delete,
-   split, or descope.** This is the stop rule the 66% recurrence argues for.
+2. **Closed surface.** Enumerate every consumer, phase, transformation, identity-loss join and
+   mutable read that can affect the invariant (`N = ___`); name residuals explicitly. **If review
+   finds a new class or an unlisted surface after round 1, do not add another local guard —
+   simplify, delete, split, or descope.** This is the stop rule the 66 % recurrence argues for.
 3. **Independent oracle.** For each verdict name evidence *not produced by the code under test*, plus
-   one positive and one negative control. A proof must fail on its intended assertion; a non-zero exit
-   alone is not a kill.
+   one positive and one negative control. A proof must fail on its intended assertion; a non-zero
+   exit alone is not a kill.
 4. **Proof escalation.** Direct tests are the default. A new mutation runner, digest, census, anchor
-   map or pin requires **all four**: a real need (customer/repo reproduction, accepted requirement, or
-   a mandatory security/data-loss boundary); a severe consequence if the ordinary test is vacuous;
-   a **demonstrated** mutation that direct positive/negative tests miss; and evidence the mechanism has
-   power over *this* claim. ⚠️ The deciding factor is the **consequence of vacuity — not file type and
-   not the guard's nominal direction**: a "fail-open only" rule is too narrow, because #414's
-   destructive sync, #430's fixture-premise tests and #448's sole-mitigation caveat all earn machinery
-   without being fail-open guards. Machinery larger than the product change is a **split trigger**.
+   map or pin requires **all four**: a real need (customer/repo reproduction, accepted requirement,
+   or a mandatory security/data-loss boundary); a severe consequence if the ordinary test is vacuous;
+   a **demonstrated** mutation that direct positive/negative tests miss; and evidence the mechanism
+   has power over *this* claim. ⚠️ The deciding factor is the **consequence of vacuity**, not file
+   type and not the guard's nominal direction. Machinery larger than the product change is a
+   **split trigger**.
 5. **Round route.** R1 reviews the invariant and the enumerated surface; R2 checks regressions and
-   whether the class is closed. **After R2 freeze scope**: a further defect *in the same class* may be
-   fixed; a **new class or new proof mechanism** forces simplify/delete/split/descope. Fail-open,
+   whether the class is closed. **After R2 freeze scope**: a further defect *in the same class* may
+   be fixed; a **new class or new proof mechanism** forces simplify/delete/split/descope. Fail-open,
    security and data-loss findings block; fail-closed, diagnostic and proof residuals become issues.
-6. **Integration.** Name shared/contended files and the base SHA. Bring the branch current once before
-   final review and **prove the reviewed tree's SHA** — a stale head is how a review round gets spent
-   on code that no longer exists.
+6. **Integration.** Name shared/contended files and the base SHA. Bring the branch current once
+   before final review and **prove the reviewed tree's SHA** — a stale head is how a review round
+   gets spent on code that no longer exists.
 
-⚠️ **No PR has yet used this contract prospectively, so its benefit is a testable hypothesis, not a
-measured result.** Record what happens on the first ones that do, and correct this section from that
-evidence rather than from memory.
+⚠️ No PR has yet used this contract prospectively, so its benefit is a testable hypothesis, not a
+measured result. Record what happens on the first ones that do, and correct it from that evidence.
 
-## Desktop concurrency budget: RAM, not addressability
+## Concurrency budgets: Desktop RAM, and the agent host
 
-The shared cleanup rule below is still true: concurrent Power BI Desktop instances are addressable
-because the bridge and AS-port lookup are PID-scoped. The missing constraint is memory. ⚠️ Inferred
-from a 2026-08-19 field incident, not a controlled reproduction: Desktop crashed with
-`Microsoft.Mashup.Host.Document.PlatformDependentOptions` while 4–5 instances were open and the
-machine had about 3.1 GB free of 31.7 GB. Deleting the model's 313 MB `.pbi/cache.abf` and rebuilding
-it did not fix the crash, which argues against treating this signature as simple cache-file
-corruption; each instance's resident `msmdsrv` model is the RAM-pressure hypothesis. Confirming that
-mechanism would require a controlled reproduction varying free RAM and instance count. Until then,
-keep large-model concurrency low, check free RAM before opening another instance, and close instances
-as soon as their handoff is complete.
+Two different resources, both measured; neither is about addressability, because concurrent Power BI
+Desktop instances *are* addressable (the bridge and the AS-port lookup are PID-scoped). Dumps,
+numbers and what remains unexplained: [`docs/agent-operations.md`](docs/agent-operations.md).
 
-**There is a SECOND concurrency budget, and it is a different resource entirely — the agent host.**
-Do not conflate the two: the one above is machine RAM consumed by Desktop's `msmdsrv` processes; this
-one is the **V8 heap of `copilot.exe` itself**, and it is reached with no Power BI Desktop running at
-all. ⚠️ **Observed 2026-08-20, three times in one session** — with **six concurrent `opus-5`
-subagents**, the CLI host died and wrote a crash dump into the repo root
-(`report.<yyyymmdd>.<hhmmss>.<pid>.0.001.json`) naming the cause:
-
-```json
-{ "event": "Allocation failed - JavaScript heap out of memory", "trigger": "OOMError" }
-```
-
-✅ **The mechanism is measured. ⚠️ The effective boundary is not explained, and ❌ the concurrency that
-reaches it has never been bisected.** The 2026-08-20 dumps were read and discarded, which is why that
-round stayed "observed". **Three** crashes have since been retained — 2026-09-03 06:00:22, 2026-09-03
-19:36:16 and 2026-09-04 01:00:36 — and all three carry `header.event` = *"Allocation failed -
-JavaScript heap out of memory"* with `header.trigger` = `OOMError`:
-
-| dump (`javascriptHeap` unless noted) | `usedMemory` | `totalMemory` | `memoryLimit` | `availableMemory` | `resourceUsage.rss` |
-|---|---:|---:|---:|---:|---:|
-| `report.20260903.060022.36308.0.001.json` | 3,480,865,688 | 3,510,222,848 | 4,298,113,024 | 790,124,816 | 8,844,890,112 |
-| `report.20260903.193616.73536.0.001.json` | 3,437,318,968 | 3,466,874,880 | 4,298,113,024 | 833,526,904 | 8,679,428,096 |
-| `report.20260904.010036.6628.0.001.json` | 3,438,137,296 | 3,460,382,720 | 4,298,113,024 | 840,032,800 | 9,299,034,112 |
-
-Read them with `(Get-Content <dump> -Raw | ConvertFrom-Json).header.event` — the fields are nested
-under `header`, `javascriptHeap` and `resourceUsage`, so a top-level `.trigger` reads empty and looks
-like the dump is malformed when it is merely differently shaped.
-
-- ✅ **The failure reproduces at ~3.44–3.48 GB used**, each time with the heap essentially full
-  against what V8 had *currently allocated* — 99.2 % / 99.1 % / 99.4 % of `totalMemory`.
-- ⚠️ **`totalMemory` is NOT the ceiling, and the gap is unexplained.** Every dump also declares
-  `memoryLimit` = 4,298,113,024 (~4.30 GB) with ~0.8 GB still `availableMemory`, so each crash lands
-  at only 81.0 % / 80.0 % / 80.0 % of the limit V8 said it was allowed. `totalMemory` is how far the
-  heap had grown, not how far it could — quoting it as "the wall" states a ceiling this evidence does
-  not support. Closing the gap needs a run with `--max-old-space-size` and heap-growth sampling, not
-  another terminal dump.
-- ⚠️ **RSS is 2.5–2.7× the JS heap** (8.7–9.3 GB) while `resourceUsage.free_memory` still reported
-  4.7–6.5 GB free (13.9 % / 18.2 % / 19.0 % of machine RAM), so physical RAM was **not** exhausted at
-  the moment of death: an alarm configured only for near-exhaustion below 4.7 GB free would not have
-  fired at these snapshots. That is deliberately narrower than "a machine-pressure alarm would never
-  have fired" — no threshold is identified here, and a 15 %-free rule *would* have fired on the first
-  dump. Whether an RSS threshold calibrated to that 2.5–2.7× ratio could warn in time is untested: a
-  dump is a snapshot at the moment of death and says nothing about the approach to it, so these files
-  also cannot rule a gradual ramp in or out.
-- ❌ **Concurrency is known for only one of the three**, and from the session rather than the dump —
-  no dump records it. They confirm *what* kills the host, not *how many* agents it takes.
-
-⚠️ **Keep the dumps; the numbers above depend on disposable evidence.** They are gitignored
-(`git check-ignore -v` → `.gitignore:257:/report.[0-9]*.json`, and `git clean -ndX` would remove all
-three), so nothing committed to this repo proves any of this once the files are gone.
-
-Equally, be careful what the number means. **Six failed — and so did four.** The 2026-09-04 01:00:36
-crash came out of a wave of **four** (three blind reviews plus one fix agent), which retires the
-earlier reading that "four was run repeatedly the same night without incident". Treat "keep the wave
-small" as the rule and any specific safe number as unproven.
-
-Two consequences, both of which cost real work that night:
-
-- ⚠️ **Advice to "dispatch the whole wave at once" — common in delegation guidance, including the
-  user-level instruction files some runtimes load — optimises coordination cost and is silent about
-  host memory.** It is not in this document, and this document does not endorse it: cap the wave.
-- **A crash takes every subagent's UNPUSHED work.** Committing is not enough — one agent came one
-  crash away from losing four good commits it had never pushed. Brief agents to **`git push`
-  incrementally**, and read the crash dump first after a restart: it names the trigger and timestamps
-  the crash, which is the reference point the file-mtime forensics above depend on.
+- **Power BI Desktop spends machine RAM.** ⚠️ Inferred from a 2026-08-19 field incident, not a
+  controlled reproduction: Desktop crashed with
+  `Microsoft.Mashup.Host.Document.PlatformDependentOptions` at 4–5 open instances with ~3.1 GB free
+  of 31.7 GB, and deleting the model's 313 MB `.pbi/cache.abf` did not fix it. Keep large-model
+  concurrency low, check free RAM before opening another instance, and close each instance as soon
+  as its handoff is complete.
+- **The agent host spends the V8 heap of `copilot.exe`**, and reaches its limit with no Desktop
+  running at all. ✅ Three retained crash dumps all read *"Allocation failed - JavaScript heap out of
+  memory"* / `OOMError` at ~3.44–3.48 GB used. **Cap the wave**: six concurrent subagents failed —
+  and so did four, so any specific safe number is unproven. Advice to "dispatch the whole wave at
+  once" (common in user-level delegation guidance) is silent about host memory; this document does
+  not endorse it.
+- **A crash takes every subagent's UNPUSHED work.** Committing is not enough. Brief agents to
+  `git push` incrementally, and read the crash dump first after a restart — it timestamps the crash,
+  which is the reference point the file-mtime forensics depend on.
 
 ---
 
 ## Starting a migration — the DISPATCHER's job
 
 **Who this is for:** the regular Copilot CLI session that auto-loads this file — the one the human
-actually talks to. It is **not** `tableau-migrator`. That persona is a *per-unit worker*: it migrates
-one workbook against a plan someone else already made. Deciding **what** to migrate, **in what
-order**, and **to where** happens up here, before any persona is invoked.
-
-That distinction is easy to get wrong (this section's first draft duplicated the whole intake into
-`tableau-migrator` and pushed it to 100 % of its character cap). The rule: **the dispatcher decides
-and writes the brief; `tableau-migrator` reads the brief and executes.**
+actually talks to. It is **not** `tableau-migrator`, which is a *per-unit worker* migrating one
+workbook against a plan someone else made. Deciding **what** to migrate, **in what order** and **to
+where** happens up here: **the dispatcher decides and writes the brief; `tableau-migrator` reads the
+brief and executes.**
 
 ### Step 1 — work out what you are actually pointing at
 
@@ -402,191 +205,135 @@ copies then drift.
 
 | You were given | First move | Because |
 |---|---|---|
-| **A Tableau Server/Cloud site** (URL + PAT) | **`python scripts/run_engine_survey.py --server <host> --site <slug> --pat-name <name> --env-file .env --json _assessment/estate_survey.json`** → `python scripts/assess_estate.py --out _assessment --survey _assessment/estate_survey.json` → `python scripts/tableau_lineage.py --plan` → **`python scripts/harvest_estate_assets.py --out <dir>`** → `python scripts/run_estate.py --input <dir>/assets --output <bundle>` | Assess emits *a decision, not an inventory*: what exists, what is **actually used**, how hard each workbook is, who can see it — but without `--survey` it reports migration **order as unknown**, and a workbook whose published datasource has not landed first rebuilds to an **empty report**. Harvest is the seam: it downloads every workbook and published datasource to `<out>/assets/` as `.twbx`/`.tdsx`, exactly what `run_estate.py --input` consumes. This is a deliberate **two-step** flow, not a gap — the engine's `LiveTableauSource` is an explicit stub ("network calls NOT built yet"), so there is no one-button live-site→PBIP path. |
-| **A folder of `.twb`/`.twbx`** | `python scripts/run_estate.py --input <folder> --output <bundle>` | Sweeps the whole folder through the deterministic tier and emits per-workbook handover slices. No server, so ordering is derived from the parsed specs rather than Tableau's metadata API. |
+| **A Tableau Server/Cloud site** (URL + PAT) | **`python scripts/run_engine_survey.py --server <host> --site <slug> --pat-name <name> --env-file .env --json _assessment/estate_survey.json`** → `python scripts/assess_estate.py --out _assessment --survey _assessment/estate_survey.json` → `python scripts/tableau_lineage.py --plan` → **`python scripts/harvest_estate_assets.py --out <dir>`** → `python scripts/run_estate.py --input <dir>/assets --output <bundle>` | Assess emits *a decision, not an inventory* — but without `--survey` it reports migration **order as unknown**, and a workbook whose published datasource has not landed first rebuilds to an **empty report**. Harvest is the seam: it downloads every workbook and published datasource to `<out>/assets/` as `.twbx`/`.tdsx`, exactly what `run_estate.py --input` consumes. The two-step shape is deliberate — the engine's `LiveTableauSource` is an explicit stub, so there is no one-button live-site→PBIP path. Command-by-command: [`docs/operator-runbook.md`](docs/operator-runbook.md) |
+| **A folder of `.twb`/`.twbx`** | `python scripts/run_estate.py --input <folder> --output <bundle>` | Sweeps the whole folder through the deterministic tier and emits per-workbook handover slices. No server, so ordering comes from the parsed specs rather than Tableau's metadata API. |
 | **One `.twb`/`.twbx`** | `python scripts/parse_tableau.py <file> -o <spec>` → dispatch `@tableau-migrator`. First-timer route, verified end to end with no server: [`docs/start-with-one-workbook.md`](docs/start-with-one-workbook.md) | The simple path. Still write a brief. |
-| **A `.tds`/`.tdsx`** (data source, no workbook) | `parse_tableau.py` accepts it directly | This is **phase 1** of a model-first estate: a semantic model with **no report**. Also the fix for a `sqlproxy` published source, whose calcs live on the server and are therefore *under-reported* by any workbook that merely points at it. |
+| **A `.tds`/`.tdsx`** (data source, no workbook) | `parse_tableau.py` accepts it directly | **Phase 1** of a model-first estate: a semantic model with **no report**. Also the fix for a `sqlproxy` published source, whose calcs live on the server and are therefore *under-reported* by any workbook that merely points at it. |
 
-`estate_survey.py` is the deterministic **engine's** script, not ours, so it is not on `PATH` — it
-installs under `~/.copilot/installed-plugins/tableau-collection/tableau-fabric-skills/skills/tableau-migration/scripts/estate_survey.py`.
-**That installed plugin is the ONE canonical engine** (see the section below); ask
-`python scripts/engine_source.py` for the path rather than typing it, and never point a step at a
-second copy.
+`estate_survey.py` is the deterministic **engine's** script, not ours, so it is not on `PATH`; ask
+**`python scripts/engine_source.py`** for its location rather than typing a path, and never point a
+step at a second copy. Three things about that invocation bite, all measured: `--server` is required,
+`--json` takes a **PATH** rather than being a bare flag, and the PAT **name** rides through from
+`.env` only via `run_engine_survey.py` — a *direct* call must supply `--pat-name` or an exported
+`TABLEAU_PAT_NAME`, because the engine's `credential_resolver.py` reads only the *secret* from
+`--env-file`.
 
-**Three things about that invocation will bite you, all measured:** `--server` is required (there is
-no default); `--json` takes a **PATH**, not a bare flag; and — via `run_engine_survey.py` — the PAT
-**name** rides through from `.env`, so the `--pat-name` above is optional: it carries the whole file
-into the engine's child env (with `--no-prompt`). A *direct* `estate_survey.py` call must supply the
-name itself — `--pat-name` or an exported `TABLEAU_PAT_NAME` — because the engine's
-`credential_resolver.py` reads only the *secret* from `--env-file`, never the name.
+`harvest_estate_assets.py` also runs **both** parsers (ours for fidelity, the engine's for
+conversion) over every asset and writes `<out>/parse-sweep.md` / `parse-sweep.json` — an estate-wide
+failure distribution, and exactly the evidence an upstream feature request needs instead of an
+anecdote.
 
-`harvest_estate_assets.py` is worth more than the download: it also runs **both** parsers (ours for
-fidelity, the engine's for conversion) over every asset and writes `<out>/parse-sweep.md` /
-`parse-sweep.json` — an estate-wide failure distribution, and exactly the evidence an upstream
-feature request needs instead of an anecdote.
-
-**Capture the Tableau reference imagery in the SAME trip — this is the dispatcher's job, not a
-subagent's.** A fidelity review later needs a picture of the *source*, and nothing downstream produces
-it: the Desktop Bridge `screenshot`/`screenshot-all` commands shoot the Power BI *output*, not
-Tableau. Capturing it now, while you are already authenticated to the site, is the difference between
-one command and a re-authentication against a server that may since have gone dark — which is why it
-belongs here and not inside a persona (issue #198: an operator had to ask for it by hand, because the
-builder/validator personas each routed capture themselves and stalled on the wrong tool). **Pick the
-tool by the source:**
+**Capture the Tableau reference imagery in the SAME trip — the dispatcher's job, not a subagent's.**
+A fidelity review later needs a picture of the *source*, and nothing downstream produces it: the
+Desktop Bridge `screenshot`/`screenshot-all` commands shoot the Power BI *output*, not Tableau.
+Capturing it while you are already authenticated is the difference between one command and a
+re-authentication against a server that may since have gone dark (#198). **Pick the tool by the
+source:**
 
 | Source | Capture command | Notes |
 |---|---|---|
-| **Tableau Public URL, or a local `.twb`/`.twbx`** | `python scripts/capture_tableau_reference.py migrations/workbooks/<slug> [--public-url <url> --view <view>]` | Writes a provenance-stamped `reference/manifest.json` — a `capabilities`-carrying `validation_grade` source; its `manual` provider also adopts user-dropped `tableau-*.png` in `reference/`. An **existing `reference/manifest.json` short-circuits to exit 0** — re-run with `--force`. |
-| **Tableau Server/Cloud** (`TABLEAU_SERVER_URL` configured) | `python scripts/capture_tableau_oracle.py --out _oracle --images [--workbook "<published name>"]` | The command on the left **exits 3** on an empty target when the URL is set (URL unset → 1): that is *"wrong tool for this source"*, **NOT** "capture is impossible" — misreading it is the whole of #198. Its `server_rest` provider is a `NotImplementedError` stub. Use the oracle, which does the live REST image export. |
+| **Tableau Public URL, or a local `.twb`/`.twbx`** | `python scripts/capture_tableau_reference.py migrations/workbooks/<slug> [--public-url <url> --view <view>]` | Writes a provenance-stamped `reference/manifest.json` — a `capabilities`-carrying `validation_grade` source; its `manual` provider also adopts user-dropped `tableau-*.png` in `reference/`. An existing manifest **short-circuits to exit 0** — re-run with `--force`. |
+| **Tableau Server/Cloud** (`TABLEAU_SERVER_URL` configured) | `python scripts/capture_tableau_oracle.py --out _oracle --images [--reference-best] [--workbook "<published name>"]` | The command on the left **exits 3** on an empty target when the URL is set (URL unset → 1): that is *"wrong tool for this source"*, **NOT** "capture is impossible" — misreading it is the whole of #198. Use the oracle, which does the live REST image export. |
 
-Three things about the oracle bite, all verified in `scripts/capture_tableau_oracle.py`:
+Three oracle traps, all verified in `scripts/capture_tableau_oracle.py`:
+
 - **`--out` is required** — omit it and argparse exits 2, capturing nothing.
-- **`--workbook` is an exact, case-insensitive *published-workbook-name* filter** (`select_views`), so
+- **`--workbook` is an exact, case-insensitive *published-workbook-name* filter** (repeatable), so
   substituting a migration slug for the published name silently matches **zero** views.
-- **Do not trust the oracle's exit 0.** It is computed from per-view *data* status only — image status
-  never reaches the exit code, and zero selected views also exits 0 — so `--images` can return 0
-  having produced no image. Confirm the capture in `_oracle/oracle-manifest.json` (a non-zero
-  `view_count`, plus each view's image status) before believing it happened. It writes renders to
-  `_oracle/images/<full-view-luid>.png`, numbers to `_oracle/data/`, and that manifest. ⚠️ The stem is
-  the **full validated LUID and nothing else** (`artifact_stem`): a view NAME is response data, and a
-  reflected session token arriving as one was once slugged and truncated into the filename, where no
-  downstream scrub could recognise it. Do not expect a readable name in the path.
+- **Read the manifest, not just the exit code.** `_oracle/oracle-manifest.json` carries `view_count`
+  and each view's per-render status; the exit code compresses that to `0` all captured / `1` partial
+  non-credential failure / `2` a view needs a human to re-authorize in Tableau / `3` total
+  non-credential failure / `4` no views selected / `5` a required reference render (`--reference-best`)
+  never arrived. Renders land at `_oracle/images/<full-view-luid>.png` — the stem is the **validated
+  LUID and nothing else**, because a view NAME is response data (a reflected session token once
+  arrived as one). Grading and the render ladder: [`docs/reference-capture.md`](docs/reference-capture.md).
 
-Credentials for either tool come from `.env` **or exported environment variables** (the latter take
-precedence), never CLI arguments.
+Credentials for either tool come from `.env` **or exported environment variables** (the latter win),
+never CLI arguments.
 
-**The conversion engine has exactly ONE source: the installed plugin.** `tableau-fabric-skills@tableau-collection`,
-at `~/.copilot/installed-plugins/tableau-collection/tableau-fabric-skills/`. Not a sibling clone, not
-a checkout in `~/vscode-projects`, not "whichever one a script finds first". Every step resolves it
-through **`scripts/engine_source.py`**, which **raises rather than falling back** — because a silent
-fallback is exactly what issue #107 was.
-
-Why that is a rule and not a preference: measured 2026-08-12, this machine had the engine installed
-**twice at different versions** — the plugin at 2.113.0 and a sibling clone at 2.126.0 — and
-different steps of one pipeline resolved different trees. They are not equivalent. On the same
-workbook, 2.113.0 emitted four deprecated Bing `shapeMap` visuals, turned a pie-on-map into a plain
-`pieChart` with the geography discarded, and **emitted no visual at all** for the density map;
-2.126.0 emitted `azureMap` throughout, with a heat-map layer. Nothing in the run output said which
-one had run.
-
-What now enforces it:
+**The conversion engine has exactly ONE source: the installed plugin**
+(`tableau-fabric-skills@tableau-collection`) — not a sibling clone, not another checkout, not
+"whichever one a script finds first". Every step resolves it through **`scripts/engine_source.py`**,
+which **raises rather than falling back** — a silent fallback is exactly what issue #107 was.
+Measured 2026-08-12, this machine had the engine installed twice at different versions (2.113.0 and
+2.126.0), with different pipeline steps resolving different trees and nothing in the output saying
+which one ran; they are not equivalent — on one workbook 2.113.0 emitted deprecated Bing `shapeMap`
+visuals and **no visual at all** for a density map, where 2.126.0 emitted `azureMap` with a heat
+layer. Three defect reports were retracted or nearly retracted before this was enforced.
 
 | mechanism | what it does |
 |---|---|
 | `scripts/engine_source.py` | the single resolver. `engine_root()` returns the plugin or **raises**; `resolve_engine()` refuses a non-plugin `--engine` unless `--allow-noncanonical-engine` is passed |
-| `engine-output-receipt.json` | every bundle records `engine.root`, `engine.version` and `engine.canonical` — so an artifact answers *"what built me?"* on its own, months later, without the machine that built it |
-| `preflight.ps1` | **critical** checks: the plugin is installed (and prints its `VERSION`), and **no alternative engine tree exists anywhere it could be resolved from**. A second copy is a MISS, not a warning |
-| `preflight.ps1 -CheckUpstream` | advisory: compares the installed engine `VERSION` against upstream `main`. Being behind is not an error — the timing rule still decides when acting on it is safe |
+| `engine-output-receipt.json` | every bundle records `engine.root`, `engine.version` and `engine.canonical`, so an artifact answers *"what built me?"* on its own ([`docs/operator-runbook.md` §1.2](docs/operator-runbook.md)) |
+| `preflight.ps1` | **critical** checks: the plugin is installed (printing its `VERSION`), and **no alternative engine tree exists** anywhere it could be resolved from. A second copy is a MISS, not a warning |
+| `preflight.ps1 -CheckUpstream` | advisory: installed engine `VERSION` vs upstream `main`. Being behind is not an error |
 
 Keeping it current: `copilot plugin update tableau-fabric-skills@tableau-collection`, **between
-sessions** (a running Copilot session file-locks the plugin directory). Mid-session, only a *content*
-refresh is possible — `python scripts/sync_engine_plugin.py --source <checkout>` — and it refuses a
-downgrade, because walking the canonical engine backwards is how you would turn a cleanup into the
-regression above.
+sessions** (a running session file-locks the plugin directory). Mid-session only a *content* refresh
+is possible — `python scripts/sync_engine_plugin.py --source <checkout>` — and it refuses a
+downgrade, because walking the canonical engine backwards turns a cleanup into the regression above.
 
-**Whether a version change is safe keys on downstream investment, not the calendar** — specifically,
-whether it would mix two engine versions inside one deliverable, or discard hand-authoring layered on
-the engine's output. Each verdict is checkable at the moment you decide, which is what lets this
-replace the blunt "never mid-migration" it used to read:
+**Whether a version change is safe keys on downstream investment, not the calendar** — whether it
+would mix two engine versions inside one deliverable, or discard hand-authoring layered on the
+engine's output:
 
 | Doing this | Verdict | Check, right now |
 |---|---|---|
-| **Comparing** two versions — run the second via `--allow-noncanonical-engine` into a fresh `--output` dir, keep the old bundle, diff | ✅ always safe — not an upgrade; the installed canonical engine is untouched | is the installed plugin left as-is and `--output` a new dir? |
-| Re-running a unit on a newer engine with **~no hand-authoring since it ran** | ✅ re-run into a fresh dir; nothing hand-made is lost | **both** baseline diffs are ~empty (see below) |
+| **Comparing** two versions — run the second with `--allow-noncanonical-engine` into a **fresh** `--output` dir, keep the old bundle, diff | ✅ always safe — not an upgrade; the installed engine is untouched | is the installed plugin left as-is and `--output` a new dir? |
+| Re-running a unit with **~no hand-authoring since it ran** | ✅ re-run into a fresh dir | **both** baseline diffs are ~empty |
 | Re-running a unit with **substantial hand-authored TMDL/PBIR** on top | ⛔ finish or checkpoint that unit first | **either** diff is large |
-| **Partial** re-run into an **existing** bundle (some workbooks, not all) | ⛔ **never** | `write_engine_receipt` stamps one `engine.version` over the whole bundle, so it would claim a single version for artifacts two builds produced — the #107 shape, and `check_engine_receipts.py` cannot see an intra-bundle mix |
+| **Partial** re-run into an **existing** bundle (some workbooks, not all) | ⛔ **never** | `write_engine_receipt` stamps ONE `engine.version` over the whole bundle, so it would claim a single version for artifacts two builds produced — the #107 shape, invisible to `check_engine_receipts.py` |
 
-⚠️ **`reports/` is the REPORT baseline only, and a workbook bundle may have NO paired model baseline.**
-The `reports/`-vs-`pbip/` diff is therefore structurally blind to hand-authored TMDL — measured,
-`reports/` holds **0** `.tmdl` files — so an agent that authored DAX, relationships, RLS or AI
-metadata but left the report alone sees an ~empty diff, reads row 2's "nothing hand-made is lost",
-re-runs, and loses all of it. That is exactly what `pbi-semantic-builder` produces, so it is a
-first-class case, not an edge one.
-
-⚠️ **Do NOT reach for `<bundle>/semantic_models/<WB>.SemanticModel` as the missing baseline.** That
-tree is keyed by model, not workbook, and is emitted for models **not owned by a single workbook**
-(published/shared datasources; `bundle_corpus.py:33` — "datasource-only migrations can legitimately
-ship a standalone model there"), not as a guaranteed workbook-model pair. The miss is silent:
-`git diff --no-index` exits **1** for
-*"could not access"* exactly as it does for *"they differ"*, so a missing baseline reads as
-"large diff — do not re-run". If there is no counterpart, record **BASELINE UNAVAILABLE**, never a
-clean/no-change diff. See #359.
-
-**What actually answers the question, verified:** compare the OLD bundle against a FRESH run of the
-new engine, model to model — or, when a standalone/shared model counterpart exists, compare by
-`<Model>` name, not `<WB>` name:
-
-```
-git diff --no-index --stat <bundle>/reports/<WB>.Report                       <bundle>/pbip/<WB>/<WB>.Report
-git diff --no-index --stat <bundle>/semantic_models/<Model>.SemanticModel     <bundle>/pbip/<WB>/<Model>.SemanticModel
-git diff --no-index --stat <old-bundle>/pbip/<WB>/<Model>.SemanticModel       <new-bundle>/pbip/<WB>/<Model>.SemanticModel
-```
-
-Measured 2.208.0 vs 2.339.0 on Superstore: `13 files changed, 488 insertions(+), 169 deletions(-)`,
-with a real stat line — a genuine answer, not an access error. **Check for the stat line, never the
-exit code.** Note this answers *"what does the new engine produce differently"* rather than *"what
-have I hand-edited"*; for the latter, `_build/generated-edit-declarations.json` records our tier's
-changes deliberately and is the better source. A check that is *evaluable but incomplete* is worse
-than a blunt prohibition, because it grants false confidence.
-
-So the escape hatch above is usable between migrations, and mid-migration when **both** diffs show
-little at risk; the one move that is *always* wrong is the last row — a partial re-run into a live
-bundle.
-
-Historic cost of not having this: **three** retracted or nearly-retracted defect reports. The engine
-went 2.60.0 → 2.72.0 unnoticed; then 2.113.0 → 2.126.0 (13 releases) *mid-dry-run*; then 2.113.0 →
-2.126.0 → upstream 2.135.0 with two copies live at once. Each was caught only by a manual `git fetch`.
+⚠️ **The `reports/`-vs-`pbip/` diff is structurally blind to hand-authored TMDL** (`reports/` holds
+**0** `.tmdl` files), and a workbook bundle may have **no paired model baseline** at all — measured on
+a 12-workbook estate, 4 of 12; on run 408, 18 model baselines for 62 `pbip/` units. `git diff
+--no-index` exits **1** identically for *"could not access"* and *"they differ"*, so a missing
+baseline reads as "large diff, do not re-run". Record an absent counterpart as **BASELINE
+UNAVAILABLE**, never as a clean/no-change diff, and never generalise model churn from the paired
+subset to an estate. Exact diff commands, both directions and the `--stat` caveats:
+[`docs/migration-phases.md`](docs/migration-phases.md); the operational procedure:
+[`docs/operator-runbook.md`](docs/operator-runbook.md#engine-model-baseline-availability) (#274, #359).
+For *"what have I hand-edited"*, `_build/generated-edit-declarations.json` is the better source than
+any diff.
 
 **An engine defect is filed UPSTREAM — `gh issue create --repo Yarbrdab000/tableau-fabric-skills`.**
-The plugin tree is read-only, so an issue is the only way a finding reaches the person who can fix it.
-Thirteen have gone there (#114–#141) and the author closes them, so this works — which is exactly why
-filing one in the *wrong* tracker is expensive: it looks filed, it is searchable, and it is invisible
-to him forever. ⚠️ **The two numbering ranges do not overlap and that is the trap**: ours passed 200
-while upstream was still at ~141, so a bare `#220` reads as plausible in either repo and nothing
-flags the mistake. Measured 2026-08-18: **three** engine issues (a bare Column in a Measure-only role,
-a stubbed calc dropping a required role, and the DoD gap behind both) sat in *our* tracker for days —
-found only when someone asked "shouldn't that be a feature request upstream?", and re-filed as #142–#144.
-
-**The test: who has to change code?** If the fix edits `migrate_estate.py`, `pbir_lint.py` or anything
-under the plugin, it is upstream — even when we also ship a mitigation on our side. Our tracker is for
-*our* tier (`scripts/`, the personas, the skills, the docs). When both apply, file upstream and keep a
-local issue only for the mitigation, cross-linked — never a second copy of the defect report.
+The plugin tree is read-only, so an issue is the only way a finding reaches the person who can fix
+it. **The test: who has to change code?** If the fix edits `migrate_estate.py`, `pbir_lint.py` or
+anything under the plugin, it is upstream — even when we also ship a mitigation here; our tracker is
+for *our* tier (`scripts/`, personas, skills, docs). When both apply, file upstream and keep a local
+issue only for the mitigation, cross-linked. ⚠️ **The two issue-number ranges do not overlap and that
+is the trap**: ours passed 200 while upstream was near 141, so a bare `#220` reads as plausible in
+either repo. Three engine issues sat in our tracker for days before being re-filed upstream. Routing
+detail: [`docs/upstream-issue-gate.md`](docs/upstream-issue-gate.md).
 
 **Where does the output go?** A migration produces a **local PBIP bundle**; publishing it is a
-separate, deliberate step — and that step has a tool. `scripts/deploy_estate.py` lands a bundle in an
-**existing** Fabric landing-zone workspace: models first, each report rebound from `byPath` to
-`byConnection` once its model exists, crash-safe by a run journal. Run `--dry-run` first — it reports
-the plan and the **item count**, which is the number a customer agrees before you deploy. Mechanics
-and the three tenant-measured facts it encodes: `scripts/README.md`; post-deploy check:
-`verify_bindings.py`.
-
-What it deliberately does **not** decide is **topology**. It takes ONE `--workspace` and never creates
-one, so cross-workspace shared-model binding, permission mapping and promotion out of the landing zone
-remain human decisions (#57). So the target question is not "local or Fabric?" but *"name the
-destination workspace in the brief, and say whether this run stops at the bundle or goes on to
-deploy."*
+separate, deliberate step. `scripts/deploy_estate.py` lands a bundle in an **existing** Fabric
+landing-zone workspace: models first, each report rebound from `byPath` to `byConnection` once its
+model exists, crash-safe by a run journal. Run `--dry-run` first — it reports the plan and the **item
+count**, the number a customer agrees before you deploy (mechanics: `scripts/README.md`; post-deploy
+check: `verify_bindings.py`). It deliberately does **not** decide **topology**: it takes ONE
+`--workspace` and never creates one, so cross-workspace shared-model binding, permission mapping and
+promotion out of the landing zone remain human decisions (#57). So the question is not "local or
+Fabric?" but *"name the destination workspace in the brief, and say whether this run stops at the
+bundle or goes on to deploy."*
 
 ### Step 2 — five questions, asked ONCE, in one message
 
-**The problem was never that we ask too little. It is that every question arrived too late.** Before
-this section existed, the orchestrator had four ask-moments and **all four were mid-flight**: the
-published-datasource decision (post-parse), the credential stop (post-probe), a re-parse confirmation,
-and the retry cap. Each interrupts work already in progress — and if the user has stepped away, the
-run dies there. Measured 2026-08-07: the `4-nocreds` end-to-end run did exactly that.
-
-Meanwhile nothing was asked up front, so fidelity bar and autonomy were inferred silently. From the
-outside, an hour of confident work on a wrong assumption is indistinguishable from an hour of correct
-work.
+**The problem was never that we ask too little; it is that every question arrived too late.** Before
+this section existed, all four ask-moments were mid-flight (published datasource, credential stop,
+re-parse confirmation, retry cap) — and if the user has stepped away, the run dies there (measured
+2026-08-07). Meanwhile fidelity bar and autonomy were inferred silently, and from the outside an hour
+of confident work on a wrong assumption looks exactly like an hour of correct work.
 
 Step 1 answers *scope* by investigation, so only these are genuinely questions:
 
 | # | Question | Why it cannot be inferred |
 |---|---|---|
 | 1 | **Confirm the plan from step 1** — this ordering, these workbooks, this destination? | Assessment says what is *used*; only the human knows what is *wanted*. |
-| 2 | **Autonomy** — see the table below. Default `standard`. | The failure modes are symmetric: too autonomous and a run spends 105 minutes saying nothing; too interactive and an overnight run stops on question 1 and achieves nothing. |
+| 2 | **Autonomy** — see below. Default `standard`. | The failure modes are symmetric: too autonomous and a run spends 105 minutes saying nothing; too interactive and an overnight run stops on question 1. |
 | 3 | **Fidelity bar** — faithful re-creation, or modernise where Power BI is better? | It decides real translations (a Tableau dual-axis trick → a native combo chart; a `MAKELINE` route map → endpoint bubbles). Both builders need it. |
 | 4 | **If we hit a wall — stop, or degrade?** | Pre-authorising the fallback is what lets an unattended run *survive* one instead of dying at 3 am. |
-| 5 | **Who drives the data refreshes?** — see the table below. Default `scripted`. | A refresh is the one long operation whose progress evidence is **conditional**: with the AMO trace up you get row counts, without it only elapsed time, which cannot tell "working" from "hung". Only you know how big the source is and whether you will be at the keyboard. |
+| 5 | **Who drives the data refreshes?** — see below. Default `scripted`. | Only you know how large the source is and whether you will be at the keyboard. |
 
 **Autonomy levels, defined by behaviour at a decision point — not by vibe:**
 
@@ -596,96 +343,60 @@ Step 1 answers *scope* by investigation, so only these are genuinely questions:
 | **`standard`** (default) | decide, log it | **ask** | ask |
 | `autopilot` | decide, log it | decide, flag in the summary | **ask — always** |
 
-**Autonomy governs choices; it cannot govern physics.** No level clears the credential stop: that is a
-modal sign-in dialog no automation can fill. Question 4 pre-authorises the *fallback* (build
+**Autonomy governs choices; it cannot govern physics.** No level clears the credential stop: that is
+a modal sign-in dialog no automation can fill. Question 4 pre-authorises the *fallback* (build
 model-only under `credential_gate.py authorize`, artifacts marked unvalidated) — never pretending a
 source was reachable.
 
-**Refresh strategies, and why this is a question rather than a default:**
+**Refresh strategies:**
 
-| strategy | who drives it | ceiling | you can see progress |
+| strategy | who drives it | ceiling | progress evidence |
 |---|---|---|---|
-| **`scripted`** (default) | `refresh_pbip_model.py` | **3600 s** on a default full refresh — whether trace setup succeeds **or fails** — and configurable; the legacy **300 s** (330 s with grace) applies only to explicit `--no-progress` and `--calculate-only`/`--measures-only` | ⚠️ conditional — row counts only once `ProgressReportCurrent` emits them, else an elapsed "waiting for first row-count event" heartbeat; non-fatal silence warning at 120 s |
+| **`scripted`** (default) | `refresh_pbip_model.py` | **3600 s** on a default full refresh (configurable, and retained even when trace setup fails); the legacy **300 s** / 330 s applies only to `--no-progress` and `--calculate-only`/`--measures-only` | ⚠️ conditional — row counts only once `ProgressReportCurrent` emits them, else an elapsed heartbeat; a non-fatal silence warning at 120 s |
 | `operator` | the agent prepares everything, stops, and asks **you** to hit Refresh in Desktop | none | ✅ per-table row counts, live in the UI |
 | `xmla` | manual XMLA/TOM against the live instance | none | ⚠️ partial |
 
-⚠️ **This table was stale for two weeks and said the opposite** — "hard 300 s, not configurable" and
-"an elapsed-time heartbeat only". Both were fixed on 2026-08-21 (#253, #269, #283) and nobody updated
-the prose, so every agent inheriting this file was briefed against a ceiling the code no longer had.
-Re-read `refresh_pbip_model.py`'s constants before quoting a number from here.
+⚠️ **Re-read `refresh_pbip_model.py`'s constants before quoting a number from this table** — it was
+stale for two weeks and stated the opposite. Three ways to lose a refresh remain: the legacy 300 s
+path still kills the measured 700–750 s Snowflake case; 3600 s is a fatal absolute backstop; and
+row-count evidence is not guaranteed even with the trace up (small tables can emit only Begin/End
+events). The **AMO/TOM assembly** changes *observability*, not the timeout — without it you keep the
+ceiling but lose row counts, liveness warnings and the `ImageSave` persist path. ⚠️ A refresh is also
+where the shared "time-box an unresponsive system" rule and its "don't kill a tool that IS the timer"
+carve-out point in opposite directions: resolving it wrongly either records **no verdict at all** or
+waits 129 minutes, both measured. A **detected** credential modal aborts with a specific error; an
+unclassifiable timeout says so in its own output.
 
-**Why it still earns a slot in the intake.** The default ceiling no longer kills the measured
-700–750 s Snowflake case: `REFRESH_ABSOLUTE_TIMEOUT_SECONDS = 3600.0` is deliberately sized
-"comfortably above" it, and the 120 s liveness timer reports silence **without killing** ("Killing on
-this timer would false-positive a healthy slow source"). ⚠️ **But three ways to lose a refresh
-remain, so do not read this as "the ceiling is solved":**
-
-- **`--no-progress` and `--calculate-only`/`--measures-only` stay on the legacy 300 s / 330 s path.**
-  That same 700–750 s Snowflake refresh still dies there.
-- **3600 s is still a fatal absolute backstop.** A default full refresh slower than an hour dies.
-- **Row-count evidence is not guaranteed even with the trace up.** Small tables can emit only
-  Begin/End events (#269 measured nine), so a traced refresh can stay elapsed-only for its
-  first-row latency or for its whole duration.
-
-What the **AMO/TOM assembly** changes is *observability*, not the timeout: preflight reports it as
-RECOMMENDED, and on trace-setup failure the 3600 s backstop is retained rather than reverting to
-300 s. Without AMO you keep the ceiling but lose row counts and liveness warnings, and `ImageSave`
-persist falls back to the UI path.
-
-Be precise about what the detector catches either way: a **detected** credential modal does not
-heartbeat on, it aborts with a specific error. What survives is the case the detector cannot see, and
-on a genuine timeout the script says so itself — *"CAUSE UNKNOWN - this script cannot distinguish
-these two, and they need opposite responses"*. The two governing rules also **point in opposite
-directions** there: the general rule says time-box an unresponsive external system at ~2 minutes or 3
-attempts; the carve-out says *don't*, if the tool announces its own deadline — and
-`refresh_pbip_model.py` is exactly such a tool. An agent that resolves that tension wrongly either
-kills a legitimately-running refresh (recording **no verdict at all** — measured) or waits
-indefinitely (129 minutes / 298 tool calls — also measured).
-
-So: if the source is large or the run is unattended, say so **now** — and say whether AMO is present.
-`operator` remains the choice that trades start-latency for a refresh you can watch in the UI with no
-dependency on the trace at all.
-
-⚠️ `xmla` has a scope constraint worth stating in the brief: it must be **whole-database** scope if a
-calculated table depends on a refreshed table (e.g. a `Date` table built with
-`CALENDAR(MINX(...), MAXX(...))` over the fact). Refresh the fact alone and the calculated object
-does not recompute in the same transaction.
+⚠️ `xmla` must be **whole-database** scope if a calculated table depends on a refreshed table (e.g. a
+`Date` table built with `CALENDAR(MINX(...), MAXX(...))` over the fact). Refresh the fact alone and
+the calculated object does not recompute in the same transaction.
 
 ### Step 3 — write the brief, then dispatch
 
 Write the answers to `migrations/workbooks/<name>/migration-brief.md`. **The file is the point**, for
 two reasons no persona can solve alone: it survives a **dropped session** (a closed terminal takes
-this session's entire working memory with it — measured, 2026-08-08), and it is what a **stateless**
+this session's entire working memory with it — measured 2026-08-08), and it is what a **stateless**
 subagent receives instead of re-deriving intent nobody wrote down. Then invoke `@tableau-migrator`
 per unit of work, handing it the brief.
 
-**Record the Step-1 capture in the brief — grade included.** A stateless subagent cannot see what you
-captured; the brief is how it learns. For each unit write down three things: **where the reference
-landed** (`migrations/workbooks/<slug>/reference/` for a `capture_tableau_reference.py` run, or
-`_oracle/images/…` for an oracle run), **which tool produced it**, and **what grade of evidence it
-is** — the load-bearing part. A `reference/` capture carries a `capabilities` manifest and is a
-`validation_grade` source; an **oracle** capture is **not** — its images land outside `reference/`,
-carry no `capabilities` manifest, and are taken in the view's **default state only** (no `?vf_` filter
-pinning), so they are **layout- and text-grade only**. Say so in the brief, and tell the consumer to
-log that ceiling in `limitations_encountered`: a visual PASS signed off on oracle imagery alone is
-overstated (issue #194). Do not quietly drop this, and do not inflate it.
+**Record the Step-1 capture in the brief — grade included.** For each unit write **where the
+reference landed**, **which tool produced it**, and **what grade of evidence it is** — the
+load-bearing part. A `reference/` capture carries a `capabilities` manifest and is a
+`validation_grade` source. An **oracle** capture is **not**: its images land outside `reference/`,
+carry no `capabilities` manifest, and are taken in the view's **default state only** (no `?vf_`
+filter pinning), so they are **layout- and text-grade only**. Say so, and tell the consumer to log
+that ceiling in `limitations_encountered` — a visual PASS signed off on oracle imagery alone is
+overstated (#194). Do not quietly drop this, and do not inflate it.
 
-**Add `--reference-best` to any oracle run that covers dashboards.** `?resolution=high` is measured to
-be **exactly 2× the dashboard's declared size, with no parameter that raises it** — a 650×800 dashboard
-tops out at 1300×1600 forever — so a label-dense page can be structurally legible and content-illegible
-at once. `--reference-best` **probes** the ladder (`svg` → `pdf` → `png_high`) and takes the best rung
-the site actually answers on, then records the tier, the per-rung verdicts and all three version
-numbers in the manifest's `render_capability`.
-
-⚠️ **Which rung a customer gets depends on their Tableau version, and Cloud is not representative.**
-SVG needs REST **3.29** = Cloud June 2026 / **Server 2026.2**, so an on-prem site on 2023.x–2025.x has
-**none** — but `/pdf` reaches back to API **2.8** (Server 10.5, 2018) and is genuinely vector with
-*embedded fonts*, and `?resolution=high` to API **2.5**. Never infer capability from a version string:
-`TABLEAU_REST_API_VERSION` is a *client preference* we send, the same Cloud site moved 3.29 → 3.30 in a
-week, and a client pinned below the floor loses a tier the server supports (now a named warning). None
-of this upgrades the grade: still default-state, still outside `reference/`. It raises the ceiling
-*within* text-grade. Route survey, the API→release map and the numbers:
-[`docs/reference-capture.md`](docs/reference-capture.md) (issues #403, #194).
+**Add `--reference-best` to any oracle run that covers dashboards.** `?resolution=high` is measured
+to be exactly 2× the dashboard's declared size with no parameter that raises it, so a label-dense
+page can be structurally legible and content-illegible at once. `--reference-best` **probes** the
+ladder (`svg` → `pdf` → `png_high`), takes the best rung the site actually answers on, and records
+the tier, per-rung verdicts and version numbers in the manifest's `render_capability`. ⚠️ Which rung
+a customer gets depends on their Tableau version and **Cloud is not representative**; never infer
+capability from a version string. The API→release map and the failure modes:
+[`docs/reference-capture.md`](docs/reference-capture.md) (#403, #194). None of this upgrades the
+grade — it raises the ceiling *within* text-grade.
 
 > **Running the pipeline by hand, or standing behind someone who is?**
 > [`docs/operator-runbook.md`](docs/operator-runbook.md) is the command-by-command version of this
@@ -697,28 +408,21 @@ of this upgrades the grade: still default-state, still outside `reference/`. It 
 
 Every migrated workbook or datasource **must have its own** `_runs/<NNN>-<slug>/run.json` before
 agentic work starts. Record attribution at dispatch/allocation time, not at completion: a crash after
-spend but before stamping the root makes the spend permanently unattributable.
+spend but before stamping the root makes that spend permanently unattributable.
 
-A dedicated Copilot **session** per migration unit is the reliable attribution anchor; record its
-`session_id` in `run.json` and do **not** mix unrelated questions or other units into that session. If
-unrelated work happens anyway, flag the run as polluted in `run.json`; it remains visible but must not
-be silently averaged into customer budget estimates.
+A dedicated Copilot **session** per migration unit is the reliable anchor; record its `session_id` in
+`run.json` and do **not** mix unrelated questions or other units into that session. If unrelated work
+happens anyway, flag the run as polluted — it stays visible but must not be silently averaged into
+customer budget estimates. A dispatched `@tableau-migrator` root `agent_id` may be recorded as an
+extra label under `attribution.roots[]`, but it captures only that agent's own calls, never its
+descendants: no single store maps `parent_tool_call_id` back to the issuing agent
+(`assistant_usage_events` is local-only, `tool_requests` cloud-only), so a subtree walk is not
+reconstructible and the session is the only bucket holding a dispatched agent and all its children
+(#364).
 
-A dispatched `@tableau-migrator` root `agent_id` may be recorded as an additional label under
-`attribution.roots[]`, but it captures only that agent's own calls, never its descendants.
-`parent_tool_call_id` is the agent's own spawning tool call, not a parent-agent id, and no table
-available in one store maps that tool-call id back to its issuing agent (`assistant_usage_events` is
-local-only; `tool_requests` is cloud-only). So a subtree walk is not reconstructible and spend cannot
-be rolled up: issue #364's original premise was right after all, and the session is the only bucket
-that contains a dispatched agent and all of its child agents.
-
-A session with no `run.json` is development work for cost-reporting purposes and is excluded.
-Retroactive attribution is impossible: old units migrated without a dispatch/allocation anchor cannot
-be backfilled honestly.
-
-Report **both** model time and elapsed time. They can differ by a large factor because tool execution
-(dependency sync, Desktop work, test suites, file operations) consumes elapsed time outside model
-calls. A customer estimate that quotes only one is misleading.
+A session with no `run.json` is development work for cost reporting and is excluded; retroactive
+attribution is impossible. Report **both** model time and elapsed time — they differ by a large
+factor because tool execution runs outside model calls, so quoting only one misleads.
 
 ### Gate B — after parse + probe, before building
 
@@ -737,32 +441,13 @@ exists so each question is answered once per migration, not once per session.
 
 ---
 
-### Engine model-baseline availability
-
-`reports/` is reliable engine truth; `semantic_models/` is not a per-workbook guarantee. In a
-12-workbook estate audited on 2026-08-24, all report baselines existed but only 4 models (33%) had
-an engine-truth counterpart; the other 8 working models were unpaired. This is a baseline-coverage
-fact, not evidence that those eight models needed no changes.
-
-Before calculating model churn, check that each working model has an engine-truth counterpart. A
-missing counterpart must be reported as **BASELINE UNAVAILABLE**, never as a clean/no-change diff;
-only an existing pair may yield “no changes.” Report model-pair coverage beside every engine-gap
-distribution and do not generalize model churn from the paired subset to the estate; see
-[issue #274](https://github.com/Guust-Franssens/tableau-to-powerbi-migration/issues/274) and the
-operational procedure in [`docs/operator-runbook.md`](docs/operator-runbook.md#engine-model-baseline-availability).
-
----
-
 ## Canonical work layout (pre-bundle stages, scratch, deliverables)
 
-Issue #291 named two gaps: the stages **before** `run_estate.py` have no shared convention (each
-script invents its own `_assessment*/` / `_sweep*/` / `_oracle*/` name), and per-run **scratch** has
-no home or lifecycle — 31 ad-hoc `_*` roots accumulated with nothing recording what any is for.
-Issue #234 designed the fix and corrected itself twice in review (own the corrections, not just the
-original text): **`_runs/<NNN>-<slug>/`**, never `_work/` — `.gitignore`'s existing `**/_work/` rule
-means the OPPOSITE thing (its `.py` transform scripts are deliberately tracked). The number is the
-identity (never renamed/reused — bundle output embeds absolute self-paths); the slug is decoration
-only, because a display name is never unique (two projects or two workbooks can share one).
+The stages **before** `run_estate.py` had no shared convention and per-run scratch had no home or
+lifecycle — 31 ad-hoc `_*` roots accumulated with nothing recording what any was for (#291, #234).
+The convention is **`_runs/<NNN>-<slug>/`**, never `_work/` (`.gitignore`'s existing `**/_work/` rule
+means the OPPOSITE thing). The **number is the identity** — never renamed or reused, because bundle
+output embeds absolute self-paths; the slug is decoration, because a display name is never unique.
 
 ```
 _runs/<NNN>-<slug>/
@@ -771,107 +456,103 @@ _runs/<NNN>-<slug>/
     assets/             harvest_estate_assets.py-shaped downloads
     bundle/              run_estate.py-shaped conversion output
     oracle/               capture_tableau_oracle.py-shaped reference capture
-    packages/              package_unit.py's per-unit, agent-facing handover packages — ⚠️ `--out`
-                            names a subdirectory INSIDE this one (`packages/<batch>/<Unit>/`), never
+    packages/              package_unit.py's per-unit handover packages — ⚠️ `--out` names a
+                            subdirectory INSIDE this one (`packages/<batch>/<Unit>/`), never
                             `packages/` itself: `conflicting_evidence_dirs` refuses an `--out` whose
                             parent holds `oracle/`, and a run root always does (measured: bare exits
                             2, one level deeper exits 0). See `docs/migration-phases.md`
-    deliverables/          operator-facing outputs meant for the CUSTOMER, never for git —
-                            the `ses-prep/` near-miss (issue #322): a `connections.json`/`.md`
-                            naming 17 real customer servers landed unprefixed, unignored, at the
-                            repo root, one `git add -A` away from being committed
+    deliverables/          operator-facing outputs meant for the CUSTOMER, never for git — the
+                            `ses-prep/` near-miss (#322): a `connections.json` naming 17 real
+                            customer servers landed unprefixed at the repo root, one `git add -A`
+                            away from being committed
     scratch/                disposable, run-owned — the only subdir a future `--prune` may delete
 ```
 
-`/_*` in `.gitignore` already covers the whole tree by construction — verified,
-`git check-ignore -v -- _runs/<NNN>-<slug>/deliverables/connections.json` reports `.gitignore:.../_*`
-— **without** a trailing slash (a trailing slash makes `git check-ignore` report every path as
-ignored, which proves nothing; see `harvest_estate_assets.py`'s own guard for the same trap).
+`/_*` in `.gitignore` covers the whole tree by construction — verified with
+`git check-ignore -v -- _runs/<NNN>-<slug>/deliverables/connections.json`, **without** a trailing
+slash (a trailing slash makes `git check-ignore` report every path as ignored, which proves nothing).
 
-**`scripts/work_dirs.py`** is the single source of truth for these paths — `sanitize_unit_key`,
+**`scripts/work_dirs.py` is the single source of truth for these paths** — `sanitize_unit_key`,
 `allocate_run` (atomic `mkdir`-exclusive, retry on collision, never a read-then-write race),
-`RunPaths` (the seven subdirs above as properties), and `list_runs`. It resolves the repo root from
-its **own file location**, never from `Path.cwd()` — an empty stray `fabric/` was once written at
-the repo root by a script that resolved a relative path against whatever CWD an agent happened to
-invoke it from, which is exactly the failure a single importable resolver removes.
+`RunPaths` and `list_runs`. It resolves the repo root from its **own file location**, never from
+`Path.cwd()`: a stray empty `fabric/` was once written at the repo root by a script that resolved a
+relative path against whatever CWD an agent invoked it from.
 
 **Scope landed so far:** the convention plus the helper only. `assess_estate.py`,
 `harvest_estate_assets.py`, `capture_tableau_oracle.py` and `run_estate.py` keep their documented
-`_assessment*/` / `_sweep*/` / `_oracle*/` / `_bundle*/` defaults **unchanged** — migrating them onto
-`work_dirs.py`, generating `_runs/INDEX.md`, and a legacy-migration helper are separate follow-up
-work (issue #234's remaining acceptance criteria), deliberately not bundled with the convention
-itself so as not to collide with unrelated in-flight changes to those exact files. `_estate/`,
+`_assessment*/` / `_sweep*/` / `_oracle*/` / `_bundle*/` defaults **unchanged** (#234). `_estate/`,
 `_build/` and `migrations/` are explicitly **exempt** — persistent test infra, a bundle-internal
-replay convention, and committed deliverables respectively, none of them per-run scratch.
+replay convention, and committed deliverables.
 
 ---
 
 <!-- BEGIN:shared-conventions -->
 ## Shared agent conventions (all agents inherit these)
 
-- **Cite your source — and say WHOSE.** Every capability claim, mapping decision, or numeric result
+- **Cite your source — and say WHOSE.** Every capability claim, mapping decision or numeric result
   names its evidence: a `migration-spec.json` field, a TMDL/PBIR path + line, a live `EVALUATE`
   result, or a doc URL. "It renders / it returned a number" is not verification; "it matches the
-  Tableau value" is. **A number also names the estate it was measured on** — ours (the reference
-  bundle) or the customer's. Never present ours as theirs: measured 2026-08-21, five did in one day.
+  Tableau value" is. **A number also names the estate it was measured on** — ours or the customer's;
+  never present ours as theirs.
 - **Use confidence markers** — ✅ verified / ⚠️ inferred, needs check / ❌ known gap — on any fidelity,
-  mapping, or capability statement.
+  mapping or capability statement.
 - **Own your layer; don't cross it.** `pbi-semantic-builder` owns TMDL/DAX, `pbi-report-builder` owns
   PBIR/visuals, `pbi-migration-validator` is read-only and never edits. A subagent never "just fixes"
   a finding another agent owns — it reports; the orchestrator routes.
-- **Three locations, one direction: engine truth → working copy → deliverable. Never edit upstream of
-  where you are.**
+- **Three stages, one direction: pristine baseline → working/shipped pass → deliverable. Never edit
+  upstream of where you are.**
   | stage | location | rule |
   |---|---|---|
-  | engine truth | `<bundle>/reports/`; `<bundle>/semantic_models/` (if emitted) | **NEVER edit an existing baseline** |
-  | working copy | `<bundle>/pbip/`, or `<package>/fabric/` when you were handed a PACKAGE | agents edit **here**; whichever tree you were handed is CANONICAL. `declare_generated_edit.py` / `--tamper` cover BUNDLE work only (#460) |
-  | deliverable | `migrations/{workbooks,datasources}/<slug>/fabric/` | **COPIED at sign-off**, so the bundle survives as evidence |
+  | pristine baseline | `<bundle>/reports/` (the model-unbound report pass); `<bundle>/semantic_models/` when emitted | **NEVER edit.** Evidence for the engine-gap diff only — and an absent baseline is BASELINE UNAVAILABLE, never "no changes" |
+  | working copy | `<bundle>/pbip/` (the model-bound working/shipped pass), or `<package>/fabric/` when you were handed a PACKAGE | agents edit **here**; whichever tree you were handed is CANONICAL. `declare_generated_edit.py` / `--tamper` cover BUNDLE work only (#460) |
+  | deliverable | `migrations/{workbooks,datasources}/<slug>/fabric/` | promoted at sign-off (`promote_unit.py`), so the bundle survives as evidence |
 
   A bundle may contain `<bundle>/{pbip,reports,semantic_models,handover,data}` — **no `out/` level**;
-  `<bundle>/semantic_models/` is conditional (absent for 8/12 workbooks), and absent baseline ≠ no
-  changes — see `AGENTS.md`.
+  `<bundle>/semantic_models/` is conditional (absent for 8 of 12 workbooks in one audited estate).
 
-  ⚠️ **The copy must keep
-  `definition.pbir`'s `byPath` resolving** — plain copy for a per-workbook model, path rewrite for a
-  shared datasource; never ship `<bundle>/reports/` (reference-only: no model beside it) and never
-  edit it - keep it pristine and diff it with git. Mechanics: `powerbi-report-gotchas` §3.
+  ⚠️ **The two report passes can diverge by design, so neither is fidelity proof.**
+  `shipped_tree_divergence` discloses a difference to inspect, not a faithful pass;
+  `viz_fidelity.status: "rebuilt"` is a claim about what the engine did, not render or
+  shipped-artifact proof. **Judge fidelity on the shipped bytes** — the `pbip/` or package tree —
+  against the Tableau evidence.
+
+  ⚠️ Promotion must keep `definition.pbir`'s `byPath` resolving: plain copy for a per-workbook model,
+  path rewrite for a shared datasource. Never ship `<bundle>/reports/` (reference-only: no model
+  beside it). Mechanics: `powerbi-report-gotchas` §3.
 
 - **Structural validation is necessary, not sufficient.** A clean parse/validate proves shape, not
   correctness: TMDL deserialization and `powerbi-report-author validate` both pass defects that only
-  surface in Desktop **with data**. Never declare something done on a green validator alone. (The
-  PBIR and TMDL specifics live in the `powerbi-report-gotchas` and `powerbi-semantic-model-gotchas`
-  skills, which the owning agents invoke.)
-- **Keep `limitations_encountered` alive** through the whole build **and** fix phase; every bug found
-  and fixed later is itself worth recording. Regenerate it from the final artifacts before sign-off so
-  stale entries don't mislead the validator.
+  surface in Desktop **with data**. Never declare something done on a green validator alone. PBIR and
+  TMDL specifics: the `powerbi-report-gotchas` / `powerbi-semantic-model-gotchas` skills.
+- **Keep `limitations_encountered` alive** through the whole build **and** fix phase. Regenerate it
+  from the final artifacts before sign-off so stale entries don't mislead the validator.
 - **Declare generated edits.** TMDL/PBIR/`.pbip`: file/change/why + replay script + hash record.
 - **Surface complexity mismatches proactively.** If the parsed workbook implies more effort than the
   user assumes (many LOD/table-calc fields, extract-only data with no upstream, >20 floating-layout
-  worksheets), say so before building rather than discovering it mid-migration.
-- **NEVER block silently on an external system — time-box it, then ASK.** Measured, from a real user
-  report: an agent sat on "Testing live Snowflake connectivity" for **129 minutes / 298 tool calls**,
-  retrying without ever surfacing the problem, until the user intervened. Waiting is not progress.
-  - **Cap it: ~2 minutes or 3 attempts, whichever comes first** — for any unresponsive external
-    system (database/warehouse/gateway, MCP server, XMLA refresh, the Power BI Desktop bridge). Cap
-    *relaunches* at 2 as well; "kill it and retry" is otherwise an unbounded loop.
-  - **Unless the tool tells you it IS the timer** — some of our scripts self-bound and announce their
-    own deadline. Measured: an agent applied this 2-minute cap to a script that was already the
-    bounded timer, killed it at 120 s, and so recorded **no verdict at all** — strictly worse than
-    waiting. Read the tool's own output before you decide it has hung.
-  - **A MISSING CREDENTIAL is not transient — try ONCE.** The cap above is for *flaky* systems. A
-    refusal naming authentication, permissions or a sign-in prompt is a **final answer**; only a
-    plainly transient timeout (a serverless warehouse cold-starting) earns one retry.
+  worksheets), say so before building rather than mid-migration.
+- **NEVER block silently on an external system — time-box it, then ASK.** Measured: an agent sat on
+  live-Snowflake connectivity for **129 minutes / 298 tool calls** without ever surfacing the
+  problem. Waiting is not progress.
+  - **Cap it: ~2 minutes or 3 attempts, whichever comes first** — any unresponsive external system
+    (database/warehouse/gateway, MCP server, XMLA refresh, the Desktop bridge). Cap *relaunches* at 2
+    as well; "kill it and retry" is otherwise an unbounded loop.
+  - **Unless the tool tells you it IS the timer** — some scripts self-bound and announce their own
+    deadline. Measured: an agent applied the cap to such a script, killed it at 120 s and recorded
+    **no verdict at all** — worse than waiting. Read the tool's own output first.
+  - **A MISSING CREDENTIAL is not transient — try ONCE.** The cap is for *flaky* systems. A refusal
+    naming authentication, permissions or a sign-in prompt is a **final answer**; only a plainly
+    transient timeout (a serverless warehouse cold-starting) earns one retry.
   - **AUTOPILOT / auto-approve DOES NOT override a credential stop.** "Decide, don't ask" applies to
     *choices*; this is a physical dependency on a human — the credential sits behind a **modal
     sign-in dialog no automation can fill**. Stop and ask **even in an unattended run**, and end the
-    turn. A clear question costs minutes; a confidently built, unvalidated model costs the whole run.
+    turn.
   - On hitting the cap, **STOP and ask a specific, actionable question** — name the system, what you
     tried, and the concrete options. Never re-run the same call hoping for a different result. Ask in
     your normal reply — there is no `ask_user` tool.
   - **Report elapsed time** whenever an operation exceeds ~60 s, so a stall is visible rather than
     looking like work.
 - **End every message with a clear next step or an explicit verdict** — never a vague "looks fine."
-- **Durable learnings go in committed files** (the agent `Gotchas` sections and
+- **Durable learnings go in committed files** (agent `Gotchas`, the skills,
   `docs/tableau-dax-translation-guide.md`), never in a git-ignored scratch folder — that is how each
   real migration permanently improves the toolkit.
 - **Power BI Desktop cleanup is PID-scoped.** Concurrent instances are fine; never sweep by name.
@@ -880,9 +561,9 @@ replay convention, and committed deliverables respectively, none of them per-run
   leaks are enforced by `check_unit.py`'s `desktop-orphans` gate. Remove scratch/temp files you
   created; keep only committed deliverables plus re-runnable `_build/` scripts, and confirm nothing
   scratch leaked into git before reporting done. ⚠️ **Never `git add -A` after a gapped pull** —
-  measured: a merge staged **111** untracked scratch paths (a whole engine bundle, loose `_tmp_*.py`)
-  because `-A` cannot tell "files this merge introduces" from "files that happened to be lying
-  around". Stage from `git diff --name-status <old-HEAD> origin/master`. If you must undo one,
-  `reset --soft HEAD~1` **clears `MERGE_HEAD` even on a merge commit**, so recreate it or the next
-  commit is silently single-parent and the ancestry breaks.
+  measured: a merge staged **111** untracked scratch paths, because `-A` cannot tell files the merge
+  introduces from files merely lying around. Stage from
+  `git diff --name-status <old-HEAD> origin/master`. If you must undo one, `reset --soft HEAD~1`
+  **clears `MERGE_HEAD` even on a merge commit** — recreate it, or the next commit is silently
+  single-parent and the ancestry breaks.
 <!-- END:shared-conventions -->

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -63,6 +63,7 @@ Eligible files: tracked Markdown knowledge/navigation files, `.github/pbi.kb/**/
 | Handle conduct | [`CODE_OF_CONDUCT.md`](../CODE_OF_CONDUCT.md) | Conduct/community questions. |
 | Handle security reports | [`SECURITY.md`](../SECURITY.md) | Security disclosure routing. |
 | Find migration guidance | [`docs/agent-architecture.md`](../docs/agent-architecture.md) | Root sessions, subagents, skill visibility. |
+| Operate delegated agents | [`docs/agent-operations.md`](../docs/agent-operations.md) | Monitoring a subagent's claims, host V8-heap and Desktop RAM concurrency budgets, and post-crash file forensics — the measured evidence behind `AGENTS.md`'s delegation rules. |
 | Find migration guidance | [`docs/agent-capability-wiring.md`](../docs/agent-capability-wiring.md) | Registry of shipped capabilities that must be visible to agents. |
 | Find migration guidance | [`docs/ai-instructions-authoring-guide.md`](../docs/ai-instructions-authoring-guide.md) | AI-instruction authoring redirect. |
 | Find migration guidance | [`docs/capabilities-and-limitations.md`](../docs/capabilities-and-limitations.md) | Automation capability boundaries. |

--- a/docs/agent-architecture.md
+++ b/docs/agent-architecture.md
@@ -8,6 +8,12 @@ anything under `.github/agents/`.
 Last verified **2026-07-31**, by fetching the primary sources directly (not via a research summary)
 and by running the §6.1 subagent experiment. This area moves fast; re-check before relying on a claim.
 
+> **Scope split.** This file answers *what text reaches an agent, and how to change it*. What a
+> delegating session owes a **running** subagent — verifying its claims, host and Desktop concurrency
+> budgets, post-crash file forensics — lives in
+> [`docs/agent-operations.md`](agent-operations.md), with the rules themselves in
+> [`AGENTS.md`](../AGENTS.md).
+
 > **Corrections landed 2026-07-31.** Three claims in the previous revision were wrong and had been
 > written from an unverified research summary: (a) "there is no `skills` property" — there is one, on
 > the SDK surface (§2); (b) the 10 KB `additionalContext` cap was attributed to hooks generally — it
@@ -268,20 +274,21 @@ record it here rather than quietly reverting.
 stays inline unless it moves somewhere the agent can *actively reach and be told to reach*. A hook
 still does not qualify.
 
-Budget after the 2026-07-31 extraction — **all four now fit** (`sync_agent_conventions.py --check`
-exits 0):
+Budget after the 2026-07-31 extraction — **all four fit** (`sync_agent_conventions.py --check` exits
+0). Re-measured 2026-09-05 after issue #536 slimmed the personas and this file's shared block:
 
-| Persona | chars | % of 30k cap | was |
-|---|---|---|---|
-| `tableau-migrator` | 29,992 | 99% | 108% |
-| `pbi-report-builder` | 29,953 | 99% | 153% |
-| `pbi-semantic-builder` | 29,728 | 99% | 141% (peak 160%) |
-| `pbi-migration-validator` | 17,677 | 58% | 58% |
+| Persona | chars (2026-09-05) | % of 30k cap | at the 2026-07-31 extraction | before it |
+|---|---|---|---|---|
+| `pbi-semantic-builder` | 21,956 | 73% | 29,728 (99%) | 141% (peak 160%) |
+| `pbi-migration-validator` | 21,934 | 73% | 17,677 (58%) | 58% |
+| `tableau-migrator` | 21,927 | 73% | 29,992 (99%) | 108% |
+| `pbi-report-builder` | 21,868 | 72% | 29,953 (99%) | 153% |
 
-There is now **no headroom**: at ~98–99% a single appended gotcha puts a persona back over, and
-`sync_agent_conventions.py --check` now **fails** on that rather than warning (§2). That is
-deliberate — new craft learnings belong in the bundles (orchestrator step 12 routes them there), not
-back in a persona.
+⚠️ **The headroom is deliberate, not spare capacity.** #536 targeted **22,000** — well under the
+30,000 hard cap — precisely because the shared block is generated: an edit aimed at `AGENTS.md`
+propagates into every persona at once, so a persona sitting at 99% turns an unrelated one-word
+convention edit into a red build. New craft learnings still belong in the skill bundles
+(orchestrator step 12 routes them there), not back in a persona.
 
 ## 6. Experiments
 

--- a/docs/agent-operations.md
+++ b/docs/agent-operations.md
@@ -1,0 +1,153 @@
+# Agent operations — monitoring delegated work, host limits, crash forensics
+
+The **rules** these incidents produced live in [`AGENTS.md`](../AGENTS.md) (session start, delegation
+discipline, concurrency budgets) — this file holds the **evidence** behind them, so an auto-loaded
+file can stay short without the measurement being lost. If a rule here and a rule in `AGENTS.md`
+disagree, `AGENTS.md` is the contract and this file is the reason.
+
+Related: [`docs/agent-architecture.md`](agent-architecture.md) (what text reaches an agent at all),
+[`docs/review-throughput-postmortem.md`](review-throughput-postmortem.md) (review-round measurements
+behind the review contract).
+
+---
+
+## 1. A subagent's summary is a claim, not evidence
+
+**Measured 2026-08-02.** A subagent's final summary declared **"Sign-off ready: YES"** and never
+mentioned that it had, minutes earlier, re-armed its own credential gate and cleared it unearned.
+Only the gate's own audit log surfaced the violation — `probe-cleared` versus `manual-clear`, plus
+`credential_gate.py verify`'s exit code.
+
+The lesson is not "distrust subagents". It is that an authoritative, **non-narrative** check must
+exist and must be run before a result is passed along: an audit log's `action` field, an exit code,
+an artifact count, a checksum — never the summary prose.
+
+**The anomaly was visible long before the summary.** The same run was still on its first turn past
+**5,000 seconds and 89 tool calls**, on a task peers finished in minutes. Ground truth (audit log,
+artifact folder, raw session event log) is readable *mid-run*, and reading it early is what caught,
+in one afternoon: the gate bypass above, a misclassified `UNREACHABLE`, and a real Desktop crash —
+all three invisible in the eventual "done" message.
+
+## 2. Every fix in one batch passed CI, and every one needed changes
+
+**Measured 2026-08-09.** Five agents fixed eleven issues in isolated `git worktree`s. All five PRs
+went green. An independent rubber-duck review — given **only the diff and the issue, never the
+author's rationale** — returned `request changes` on **all five**.
+
+The shared shape: each fix *moved* its failure boundary rather than removing it.
+
+- a data-loss fix that still collapsed extracts sharing a table name;
+- a monitoring fix whose new liveness signal re-opened the door its own regression test was written
+  to close;
+- a parser fix that satisfied a synthetic fixture but not the real XML already committed here.
+
+Consequences worth keeping:
+
+- **CI proves the code does what its tests say; it cannot tell you the tests have a blind spot.** One
+  covering test *structurally could not* observe the defect it was written for, because its fixture
+  used distinct table names.
+- **Every finding came from a controlled experiment** — reversing input order, unsetting an
+  environment variable, injecting a hash mismatch — not from reading the code sympathetically.
+- **Send a re-review to the reviewer who found the defect.** They already have the reproduction; a
+  fresh reviewer has to rediscover it, and usually does not.
+- **Say plainly that a clean bill of health is a legitimate outcome**, or reviewers invent findings
+  to look thorough. Equally, tell authors to push back with evidence: one "already fixed, no change
+  needed" verdict was correct and survived deliberately sceptical re-checking.
+- **`Fixes #N`, not `(#46)`.** Four issues stayed open after being fixed, reviewed, re-reviewed and
+  merged, because the commits carried a reference rather than a GitHub closing keyword. The PR with
+  the best per-issue write-up closed nothing.
+
+## 3. A host crash leaves no summary — do file-level forensics before re-dispatching
+
+**Real incident, 2026-08-19.** The CLI hung and was restarted with 3 fix-subagents still running.
+Afterwards `list_agents` returned **ZERO** and no agent produced a final report. What each had
+accomplished could only be established by reading files on disk — and it was not predictable from
+any agent's last known status:
+
+| subagent | last known status | what was actually on disk |
+|---|---|---|
+| ACMU | in progress | both fixes complete, already confirmed live in Desktop |
+| Active Work Order | in progress | 4 new, valid, non-orphaned visual files — further along than its status suggested |
+| Aircraft Installs | in progress | zero file changes — nothing lost, nothing gained |
+
+Three agents, three genuinely different outcomes, identical reported status. Any blanket assumption —
+"assume lost", "assume complete", "assume proportional to elapsed time" — is wrong for at least one
+of them, and re-dispatching blindly would have redone or overwritten ACMU's verified fixes.
+
+So: treat a lost agent's work as **UNKNOWN**; establish current state with `git status` /
+`git diff --stat` in the target worktree plus file mtimes against the crash time; and prefer briefs
+that **land work incrementally** (commit and push as you go) over ones that buffer everything for a
+single final write — the first turns a crash into truncation, the second into total loss.
+
+## 4. Concurrency budget A — Power BI Desktop and machine RAM
+
+Concurrent Desktop instances are *addressable*: the bridge and the AS-port lookup are PID-scoped.
+The missing constraint is memory.
+
+⚠️ **Inferred from a 2026-08-19 field incident, not a controlled reproduction.** Desktop crashed with
+`Microsoft.Mashup.Host.Document.PlatformDependentOptions` while 4–5 instances were open and the
+machine had about **3.1 GB free of 31.7 GB**. Deleting the model's 313 MB `.pbi/cache.abf` and
+rebuilding it did **not** fix the crash, which argues against reading this signature as simple
+cache-file corruption; each instance's resident `msmdsrv` model is the RAM-pressure hypothesis.
+Confirming that mechanism needs a controlled reproduction varying free RAM and instance count.
+
+Until then: keep large-model concurrency low, check free RAM before opening another instance, and
+close instances as soon as their handoff is complete.
+
+## 5. Concurrency budget B — the agent host's V8 heap
+
+A different resource entirely, reached with **no Power BI Desktop running at all**: the V8 heap of
+`copilot.exe`. Observed 2026-08-20 three times in one session with **six** concurrent `opus-5`
+subagents; the host died and wrote a crash dump into the repo root
+(`report.<yyyymmdd>.<hhmmss>.<pid>.0.001.json`).
+
+✅ **The mechanism is measured. ⚠️ The effective boundary is not explained, and ❌ the concurrency that
+reaches it has never been bisected.** The 2026-08-20 dumps were read and discarded. Three later
+crashes were retained, and all three carry `header.event` = *"Allocation failed - JavaScript heap out
+of memory"* with `header.trigger` = `OOMError`:
+
+| dump (`javascriptHeap` unless noted) | `usedMemory` | `totalMemory` | `memoryLimit` | `availableMemory` | `resourceUsage.rss` |
+|---|---:|---:|---:|---:|---:|
+| `report.20260903.060022.36308.0.001.json` | 3,480,865,688 | 3,510,222,848 | 4,298,113,024 | 790,124,816 | 8,844,890,112 |
+| `report.20260903.193616.73536.0.001.json` | 3,437,318,968 | 3,466,874,880 | 4,298,113,024 | 833,526,904 | 8,679,428,096 |
+| `report.20260904.010036.6628.0.001.json` | 3,438,137,296 | 3,460,382,720 | 4,298,113,024 | 840,032,800 | 9,299,034,112 |
+
+Read them with `(Get-Content <dump> -Raw | ConvertFrom-Json).header.event` — the fields nest under
+`header`, `javascriptHeap` and `resourceUsage`, so a top-level `.trigger` reads empty and looks like
+a malformed dump when it is merely differently shaped.
+
+- ✅ **The failure reproduces at ~3.44–3.48 GB used**, each time with the heap essentially full
+  against what V8 had *currently allocated* — 99.2 % / 99.1 % / 99.4 % of `totalMemory`.
+- ⚠️ **`totalMemory` is NOT the ceiling, and the gap is unexplained.** Every dump also declares
+  `memoryLimit` = 4,298,113,024 (~4.30 GB) with ~0.8 GB still `availableMemory`, so each crash lands
+  at only 81.0 % / 80.0 % / 80.0 % of the limit V8 said it was allowed. Quoting `totalMemory` as
+  "the wall" states a ceiling this evidence does not support. Closing the gap needs a run with
+  `--max-old-space-size` and heap-growth sampling, not another terminal dump.
+- ⚠️ **RSS is 2.5–2.7× the JS heap** (8.7–9.3 GB) while `resourceUsage.free_memory` still reported
+  4.7–6.5 GB free (13.9 % / 18.2 % / 19.0 % of machine RAM), so physical RAM was **not** exhausted at
+  the moment of death: an alarm configured only for near-exhaustion below 4.7 GB free would not have
+  fired at these snapshots. That is narrower than "a machine-pressure alarm would never have fired" —
+  a 15 %-free rule *would* have fired on the first dump. Whether an RSS threshold calibrated to that
+  ratio could warn in time is untested: a dump is a snapshot at the moment of death and says nothing
+  about the approach to it, so these files cannot rule a gradual ramp in or out.
+- ❌ **Concurrency is known for only one of the three**, and from the session rather than the dump.
+  They confirm *what* kills the host, not *how many* agents it takes.
+
+⚠️ **Keep the dumps; the numbers above depend on disposable evidence.** They are gitignored
+(`git check-ignore -v` → `.gitignore:257:/report.[0-9]*.json`, and `git clean -ndX` would remove all
+three), so nothing committed to this repo proves any of this once the files are gone.
+
+**Six failed — and so did four.** The 2026-09-04 01:00:36 crash came out of a wave of **four** (three
+blind reviews plus one fix agent), which retires the earlier reading that "four was run repeatedly
+the same night without incident". Treat **"keep the wave small"** as the rule and any specific safe
+number as unproven.
+
+Two consequences, both of which cost real work that night:
+
+- ⚠️ **Advice to "dispatch the whole wave at once" — common in delegation guidance, including
+  user-level instruction files some runtimes load — optimises coordination cost and is silent about
+  host memory.** `AGENTS.md` does not endorse it: cap the wave.
+- **A crash takes every subagent's UNPUSHED work.** Committing is not enough — one agent came one
+  crash away from losing four good commits it had never pushed. Brief agents to `git push`
+  incrementally, and read the crash dump first after a restart: it names the trigger and timestamps
+  the crash, which is the reference point §3's file-mtime forensics depend on.

--- a/docs/deterministic-tier-integration.md
+++ b/docs/deterministic-tier-integration.md
@@ -201,8 +201,8 @@ file, which is tractable.
 **The two levers that actually work are orthogonal to his tier:**
 1. **A 5th skill bundle `.github/skills/deterministic-tier/`** holding the whole Tier-0 contract
    (`--approved-dax` mechanics, `approved_dax.json` shape, I1-I6, the `parameters.py` sequence, the
-   `report.json` field map, `guidance_sha256`). This is the `AGENTS.md:175` precedent and is the only
-   thing that makes the +6,000 affordable.
+   `report.json` field map, `guidance_sha256`). This follows the durable-learning destination rule
+   in `AGENTS.md`'s shared conventions and is the only thing that makes the +6,000 affordable.
 2. **Split the 5,649-char shared-conventions block** — it is **22,596 chars across four personas,
    24.6 % of the total agent budget**, and *none* of it is affected by Tier 0. Hard stops (credential
    stop, layer ownership) stay verbatim inline; rationale (~3,500-4,000) moves behind a mandatory
@@ -472,7 +472,7 @@ omissions are vacuous and which are genuine:
 ## 7. Instruction shaving — downgraded to a hypothesis with a non-gameable test
 
 v1's criterion ("persona char count decreases while coverage increases") is gameable twice: prose can
-be moved into a skill file (this repo has already done exactly that — `AGENTS.md:175`), and
+be moved into a skill file (the durable-learning rule in `AGENTS.md` explicitly routes craft there), and
 `coverage_pct` counts *landed* objects, not correct ones — `check_candidate_dax`'s own docstring says
 passing means *"well-formed DAX … never 'numerically faithful'."*
 

--- a/docs/migration-phases.md
+++ b/docs/migration-phases.md
@@ -120,7 +120,8 @@ on" versus "what did we download" — so a mismatch between them is not a defect
 
 **1. `reports/` is the pristine engine baseline / model-unbound pass and must never be edited; `pbip/` is the model-bound engine working pass and the source lineage used for packaging.**
 There is **no `out/` level** — a bundle is `{pbip,reports,semantic_models,handover,data}`. Per
-`AGENTS.md:773` agents edit `pbip/` before packaging, but `reports/` stays pristine so the engine-gap
+`AGENTS.md`'s shared-conventions three-stages table (the `working copy` row), agents edit `pbip/`
+before packaging, but `reports/` stays pristine so the engine-gap
 Delta remains attributable. Once a phase-2 package exists, `<package>/fabric/` is the canonical edit
 and ship tree, and phase 3 promotes it via `scripts/promote_unit.py` into
 `migrations/{workbooks,datasources}/<slug>/fabric/` (#460, settled; phase 3 below). The actual
@@ -191,7 +192,7 @@ authoritative is SETTLED (#460): once a package exists, `<package>/fabric/` is c
 pieces of code enforce it rather than merely documenting it — `promote_unit.py` ships FROM the
 package (*"Promoting FROM the package is settled (#460)"*, `scripts/promote_unit.py:60`), and
 `package_unit.py` refuses to repackage over a package that carries edits, checking the digest twice
-and again under the swap. `AGENTS.md:773`'s *"agents edit `pbip/`"* governs the window **before**
+and again under the swap. The shared-conventions `working copy` row's *"agents edit `pbip/`"* governs the window **before**
 packaging; after it, work in the package. See phase 3 below for the promotion mechanics.
 
 ### Where `packages/` goes, and the constraint that decides it
@@ -264,7 +265,7 @@ this is not a documentation preference:
 | [`scripts/package_unit.py`](../scripts/package_unit.py) | refuses to repackage over a package that carries edits (`PackageEditsRefused`), checking the digest before assembly **and again under the swap** — the package is the tree it protects |
 | [`scripts/check_migration_progress.py`](../scripts/check_migration_progress.py) | `--tamper` and progress mode both scan the packages beside the bundle; an edited canonical package is `PACKAGE_DRIFT` (exit 1), never `CLEAN` |
 
-`AGENTS.md:773`'s *"agents edit `<bundle>/pbip/`"* governs the window **before** packaging — there is
+`AGENTS.md`'s shared-conventions `working copy` row (*"agents edit `<bundle>/pbip/`"*) governs the window **before** packaging — there is
 no package yet to edit. After phase 2 the package is where the work goes, and `pbip/` is left as the
 engine's own copy.
 

--- a/tests/persona_pins.txt
+++ b/tests/persona_pins.txt
@@ -13,34 +13,36 @@ fff45165ef8fea61a8f5bea9d88ca97eae763e191dbb3fa4085ad9abcb2b9ee3  > Step 0: read
 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  (1 blank line)
 8eebd971bb11ec847966f6ccd681526f49152de79aa53fc0f22cc223776301a0  ## Shared agent conventions (all agents inherit these)
 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  (1 blank line)
-108aee2bbf5d303f06236d7a03c11a31d177fb183b661fa9a5e05b2f70e06157  - **Cite your source ~ and say WHOSE.** Every capability cla
-21da06636652ac2cc2fe35278078f41f34a308711381fe4874edb61dfc6e888a  - **Use confidence markers** ~ ~ verified / ~~ inferred, nee
+673636768bdfd417a2811bcd9ab4a5985bd0d3fc6df823bf9c21692c920df09c  - **Cite your source ~ and say WHOSE.** Every capability cla
+e3ef3567d1bbb300a69d9e4770e2380215437e5b680ff1eb1fbf32ae0c6c78a7  - **Use confidence markers** ~ ~ verified / ~~ inferred, nee
 7e67ae690f0e74e5cd97bc35851c04731b18ba7716a64a095cc9cfa81483a8fa  - **Own your layer; don't cross it.** `pbi-semantic-builder`
-2d44f740fbebba52a10b67edd833c426867b7556814e7f38f9efcade0b6c9526  - **Three locations, one direction: engine truth ~ working c
+cd75e36e80438672dfdc14d1cf6dd91d32ad726fd6496f1eabb597260742121b  - **Three stages, one direction: pristine baseline ~ working
 7752e0cf2f54fbbf923c7b5d9099edc5e6ea28d035c5e93a5c70b9b26006bfe8  | stage | location | rule |
 11bd5f873fa004793229f9931b6d90ec5eff770f738b716c6198d6daabd03235  |---|---|---|
-bb4d1ac6af343d9fb2ddb1ae34c8d271b135e6a9c40799d23318095961436d82  | engine truth | `<bundle>/reports/`; `<bundle>/semantic_mod
-776ea33b29b12bfb41ecb9d0c27ccea6dcab14470abf82c017f1f8c6fb83a37d  | working copy | `<bundle>/pbip/`, or `<package>/fabric/` wh
-bbc9c2fce4ae80dbec0f86aa181476faaf26ec3aadb2357ae73484eca318e61a  | deliverable | `migrations/{workbooks,datasources}/<slug>/f
+e22324daf3d3dce163e0ac0c817ee466aa7e697cfbf29e40a741ba1155f2fd45  | pristine baseline | `<bundle>/reports/` (the model-unbound
+145e6995d1db3a5d3c45ab3b4f28691db7b153f3a804db4ae46bcec62b10da6f  | working copy | `<bundle>/pbip/` (the model-bound working/s
+cb2cef030bbb133e63e86d620d70f5c68924a45d9072c6c2f723794221678483  | deliverable | `migrations/{workbooks,datasources}/<slug>/f
 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  (1 blank line)
-c6fd237095a5ae341dc8f56a0cb0d2a91734129d2a9b050c95323d0af15b42b1  A bundle may contain `<bundle>/{pbip,reports,semantic_models
+eb27287345be286c89b90b89fd60d9fc200a1d4f94498f9582c1cd056d0b3877  A bundle may contain `<bundle>/{pbip,reports,semantic_models
 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  (1 blank line)
-1690789c8feaa2b1349772bd3389964b47328b84f5dd2a8486f39722eaf79127  ~~ **The copy must keep `definition.pbir`'s `byPath` resolvi
+d0191f7ef88f7eaba5fe7a5df29b0eac97379ef5de8bed569b5007d333f6663a  ~~ **The two report passes can diverge by design, so neither
 e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  (1 blank line)
-d1590974a828f96fe221c0aa9c43f4265735e26b08e12cb83a4bce562dfa2b2a  - **Structural validation is necessary, not sufficient.** A 
-d6af19774647480f54397f7bf38b02c6f1d1b70cb1e18710278d2935ce71f50e  - **Keep `limitations_encountered` alive** through the whole
+7a4fc25c60da284e7c33e3318bc43e5e815848b16b6688f5fe35876fc9671396  ~~ Promotion must keep `definition.pbir`'s `byPath` resolvin
+e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855  (1 blank line)
+a51a9a32298b5250de40db3bdc108c3f305d7b8bc25e0ea2408f633dc60ac0be  - **Structural validation is necessary, not sufficient.** A 
+cb21982d44fa42c19b0fe01857edf4b6e47ffa38e08f82e25874db1e9b5add68  - **Keep `limitations_encountered` alive** through the whole
 35c45012ca2fca732fd8d5484db7af47ffc3d8854c3b21b84e2b00ce2b749bfa  - **Declare generated edits.** TMDL/PBIR/`.pbip`: file/chang
-39ec2e6c57993e212244e728e49db781e209c34019bd572265ea50e79b2c18df  - **Surface complexity mismatches proactively.** If the pars
-80eee10386db0e21f7a1c2d60015488b351f5571f04964236105bacadd334a62  - **NEVER block silently on an external system ~ time-box it
-44dfa127dfacaa3f817b9bea57d18a939769a2b6720b344accd30565606596e7  - **Cap it: ~2 minutes or 3 attempts, whichever comes first*
-c264726a704ea65ab7e370e7cc2ef7803ce2a063e49d5e4596df09e152dfc671  - **Unless the tool tells you it IS the timer** ~ some of ou
-b5882102ac393376b693825c13246ca34f80847841ec5a2f673ccea12b0161dc  - **A MISSING CREDENTIAL is not transient ~ try ONCE.** The 
-f3478d2e31818aad8a20faf69747475050771b422cf59a931912ff21fe2f3429  - **AUTOPILOT / auto-approve DOES NOT override a credential 
+7f84d9b33171068ee1749ce30a7c292044f1a842a04b837371a1f8da52c7c5e7  - **Surface complexity mismatches proactively.** If the pars
+6219b337903decdb2aaf2efa84c8a1de2555b3c8faf54934641efbb28a96111d  - **NEVER block silently on an external system ~ time-box it
+8e707b79fd53cba431d981353b74d9f7c7bf702766e6335d186d0396ae801c53  - **Cap it: ~2 minutes or 3 attempts, whichever comes first*
+ea6da7a18d7de674ec6ae089f773bad8e34c5b0ee66b88a221ec2d9155c4c7c6  - **Unless the tool tells you it IS the timer** ~ some scrip
+e81a04f9635331f4b0b7d864a3e50caf047681a7791231c5ab6685061ad3f750  - **A MISSING CREDENTIAL is not transient ~ try ONCE.** The 
+a20683f57acd1d70225876a96b1be82b2f8b56a541c594a9ea2f3c55d612464d  - **AUTOPILOT / auto-approve DOES NOT override a credential 
 fcf8a75033189636cf2cf0d2649e9eb5b1d98aa08655d14d01a4523a6a580e58  - On hitting the cap, **STOP and ask a specific, actionable 
 f548e1f4c08b94769618e89c284056ae280b36f9397daf1681c3ff9be855b15c  - **Report elapsed time** whenever an operation exceeds ~60 
 7113ea344407d2886d52f848e0e877dd7d14342db7ef6260f7d153419632ebe8  - **End every message with a clear next step or an explicit 
-18a323a4fcb2b111870a872ab65c4fae18af3136c887180d9d88ed91a4f5c4ee  - **Durable learnings go in committed files** (the agent `Go
-956c88decb154e2149f0fbc762bd9ba37a7b1fd4c216cd2d14b39a4445f7f7bc  - **Power BI Desktop cleanup is PID-scoped.** Concurrent ins
+db36d90cff4e07f5fefa80e8167ada5c1035dcffbf15ae72fcf17f970a772043  - **Durable learnings go in committed files** (agent `Gotcha
+0d0af1db0161518ddc296dbc64e7d32eca53791608e4d29779e3692de3daef21  - **Power BI Desktop cleanup is PID-scoped.** Concurrent ins
 f1d6acb7da4d733442fd76495ad69852e529e1ecd2a428ab1fa393e0374484d8  <!-- END:shared-conventions -->
 
 [dry-run-operator.agent.md]

--- a/tests/test_sync_agent_conventions.py
+++ b/tests/test_sync_agent_conventions.py
@@ -17,6 +17,9 @@ The through-line: a fix that stops rejecting files by also stopping rejecting `o
 outcome, so the negative case is asserted beside every positive one.
 """
 
+# Test names and explicit empty-list comparisons carry the boundary language this module pins.
+# pylint: disable=invalid-name,missing-function-docstring,use-implicit-booleaness-not-comparison
+
 from __future__ import annotations
 
 import logging

--- a/tests/test_sync_agent_conventions.py
+++ b/tests/test_sync_agent_conventions.py
@@ -404,11 +404,17 @@ ROOT_CONTRACTS: dict[str, tuple[Path, tuple[str, ...]]] = {
         (
             "**A Tableau Server/Cloud site** (URL + PAT)",
             "python scripts/run_engine_survey.py --server <host>",
+            "python scripts/assess_estate.py --out _assessment --survey _assessment/estate_survey.json",
+            "python scripts/tableau_lineage.py --plan",
+            "python scripts/harvest_estate_assets.py --out <dir>",
+            "python scripts/run_estate.py --input <dir>/assets --output <bundle>",
             "**A folder of `.twb`/`.twbx`**",
             "python scripts/run_estate.py --input <folder> --output <bundle>",
             "**One `.twb`/`.twbx`**",
             "python scripts/parse_tableau.py <file> -o <spec>",
+            "dispatch `@tableau-migrator`",
             "**A `.tds`/`.tdsx`** (data source, no workbook)",
+            "`parse_tableau.py` accepts it directly",
         ),
     ),
     "migration-brief-path": (

--- a/tests/test_sync_agent_conventions.py
+++ b/tests/test_sync_agent_conventions.py
@@ -356,3 +356,220 @@ def test_no_near_cap_warning_when_nothing_is_in_the_band(tmp_path: Path, caplog)
     with caplog.at_level(logging.WARNING, logger=sac.log.name):
         sac.report_sizes([agent])
     assert [r for r in caplog.records if r.levelno >= logging.WARNING] == []
+
+
+# ---------------------------------------------------------------------------
+# Root-document contracts (AGENTS.md).
+#
+# The size gate above is the only executable thing that has ever touched AGENTS.md, and it measures
+# LENGTH - so every routing contract the root document carries could be deleted to make room and no
+# test would notice. That is the fail-open direction: a shorter AGENTS.md passes the gate harder.
+#
+# These are deliberately NOT a generalized documentation framework. They are a fixed anchor set of
+# the contracts a dispatcher executes: the session-start/migration-start timing split, the four input
+# routes, the five intake decisions, the brief path, Gate B, the post-round-2 scope freeze, the moved
+# incident evidence, and the size targets themselves. Anchors are semantic (a command, a decision
+# name, a link target), never a line number, and whitespace is normalized first so re-wrapping a
+# paragraph is not a failure. Prose around an anchor may be rewritten freely.
+# ---------------------------------------------------------------------------
+
+AGENTS_MD = REPO_ROOT / "AGENTS.md"
+AGENT_OPS_MD = REPO_ROOT / "docs" / "agent-operations.md"
+ORACLE_SCRIPT = REPO_ROOT / "scripts" / "capture_tableau_oracle.py"
+
+# Project TARGETS, tighter than `sac.PROMPT_CHAR_LIMIT`, measured with the repository's own gate
+# (`sac.prompt_size` - the whole file, CRLF included) so this cannot disagree with the tool that
+# fails the build. There is deliberately no lower bound: `dry-run-operator` is far below the persona
+# target and that is fine.
+AGENTS_SIZE_TARGET = 45_000
+PERSONA_SIZE_TARGET = 22_000
+
+# contract id -> (document, required anchors). Table-driven so the mutation proof below can delete
+# each anchor individually and name the contract that noticed.
+ROOT_CONTRACTS: dict[str, tuple[Path, tuple[str, ...]]] = {
+    "session-start-timing": (
+        AGENTS_MD,
+        (
+            "powershell -ExecutionPolicy Bypass -File scripts/preflight.ps1 -Update -CheckUpstream",
+            "| Session start (nothing in flight) | `preflight.ps1 -Update -CheckUpstream` |",
+            "| Migration start (orchestrator step 0) | `preflight.ps1` (plain) |",
+            "| Mid-migration | **don't upgrade the installed tooling** |",
+        ),
+    ),
+    "dispatcher-input-routes": (
+        AGENTS_MD,
+        (
+            "**A Tableau Server/Cloud site** (URL + PAT)",
+            "python scripts/run_engine_survey.py --server <host>",
+            "**A folder of `.twb`/`.twbx`**",
+            "python scripts/run_estate.py --input <folder> --output <bundle>",
+            "**One `.twb`/`.twbx`**",
+            "python scripts/parse_tableau.py <file> -o <spec>",
+            "**A `.tds`/`.tdsx`** (data source, no workbook)",
+        ),
+    ),
+    "migration-brief-path": (
+        AGENTS_MD,
+        ("`migrations/workbooks/<name>/migration-brief.md`",),
+    ),
+    "five-intake-decisions": (
+        AGENTS_MD,
+        (
+            "**Confirm the plan from step 1**",
+            "**Autonomy** — see below. Default `standard`.",
+            "**Fidelity bar**",
+            "**If we hit a wall — stop, or degrade?**",
+            "**Who drives the data refreshes?** — see below. Default `scripted`.",
+        ),
+    ),
+    "credential-stop-outranks-autonomy": (
+        AGENTS_MD,
+        (
+            "| `autopilot` | decide, log it | decide, flag in the summary | **ask — always** |",
+            "No level clears the credential stop",
+        ),
+    ),
+    "gate-b-one-block": (
+        AGENTS_MD,
+        (
+            "### Gate B — after parse + probe, before building",
+            "**ONE block, not four serial stops**",
+            "1. Published datasources",
+            "2. Live sources that failed the probe",
+            "3. Extract-only sources",
+            "4. The high-severity `limitations_encountered` digest",
+        ),
+    ),
+    "post-round-2-scope-freeze": (
+        AGENTS_MD,
+        (
+            "**After R2 freeze scope**",
+            "a **new class or new proof mechanism** forces simplify/delete/split/descope",
+            "**Proof escalation.** Direct tests are the default.",
+        ),
+    ),
+    "agent-operations-evidence-link": (
+        AGENTS_MD,
+        (
+            "Incident evidence behind every rule below: [`docs/agent-operations.md`](docs/agent-operations.md).",
+            "Dumps, numbers and what remains unexplained: [`docs/agent-operations.md`](docs/agent-operations.md).",
+        ),
+    ),
+    "agent-operations-backlink": (
+        AGENT_OPS_MD,
+        (
+            "[`AGENTS.md`](../AGENTS.md)",
+            "`AGENTS.md` is the contract and this file is the reason",
+        ),
+    ),
+    "oracle-capture-exit-contract": (
+        AGENTS_MD,
+        (
+            'Exit 4 is "no views selected"',
+            "**exit 3** is a total non-credential failure",
+            "`3` total non-credential failure",
+            "`4` no views selected",
+        ),
+    ),
+}
+
+ANCHOR_CASES = [
+    pytest.param(contract, anchor, id=f"{contract}-{index}")
+    for contract, (_, anchors) in ROOT_CONTRACTS.items()
+    for index, anchor in enumerate(anchors)
+]
+
+
+def _normalized(path: Path) -> str:
+    """Collapse every run of whitespace, so an anchor survives a re-wrapped paragraph."""
+    return " ".join(path.read_text(encoding="utf-8").split())
+
+
+def _missing_contracts(texts: dict[Path, str]) -> list[str]:
+    """Contract ids whose anchors are not all present, each naming the anchor that went missing."""
+    return [
+        f"{contract}: {anchor!r} missing from {path.name}"
+        for contract, (path, anchors) in ROOT_CONTRACTS.items()
+        for anchor in anchors
+        if anchor not in texts[path]
+    ]
+
+
+def _repo_texts() -> dict[Path, str]:
+    return {path: _normalized(path) for path in {doc for doc, _ in ROOT_CONTRACTS.values()}}
+
+
+def test_the_shipped_root_documents_carry_every_contract() -> None:
+    """The positive case: AGENTS.md and its evidence doc satisfy the anchor set as committed."""
+    assert _missing_contracts(_repo_texts()) == []
+
+
+@pytest.mark.parametrize(("contract", "anchor"), ANCHOR_CASES)
+def test_deleting_any_required_anchor_fails_its_named_contract(contract: str, anchor: str) -> None:
+    """Mutation proof: each anchor is individually load-bearing, and names which contract it serves.
+
+    Without this, an anchor set is only as strong as its weakest member - a duplicated or already
+    unreachable anchor would sit in the table forever, credited as coverage. Removing exactly one
+    occurrence must produce a failure that names THIS contract, and every other contract must stay
+    green so the report points at the deletion rather than at the document generally.
+    """
+    doc, _ = ROOT_CONTRACTS[contract]
+    texts = _repo_texts()
+    assert anchor in texts[doc], "fixture invariant: the anchor must be present before it is deleted"
+    baseline = _missing_contracts(texts)
+    texts[doc] = texts[doc].replace(anchor, "", 1)
+
+    added = [failure for failure in _missing_contracts(texts) if failure not in baseline]
+
+    assert added == [f"{contract}: {anchor!r} missing from {doc.name}"]
+
+
+def test_the_retired_wrong_tool_exit_claim_is_gone_from_the_capture_row() -> None:
+    """The oracle row once carried `capture_tableau_reference.py`'s exit semantics after the command
+    in it had already become the oracle. Exit 3 there means a total non-credential FAILURE, not a
+    "wrong tool for this source" signal, so the old sentence told a reader to keep going after a
+    capture that produced nothing.
+    """
+    text = _normalized(AGENTS_MD)
+    assert "exits 3** on an empty target" not in text
+    assert '"wrong tool for this source"' not in text
+
+
+def test_agents_md_exit_semantics_match_the_oracle_script() -> None:
+    """Independent oracle: the meanings come from the script's own documented contract, not from us.
+
+    Both codes are asserted in the direction the finding corrected - 4 is a selection miss, 3 is a
+    total failure - so a future edit that swaps them fails here as well as in the anchor set.
+    """
+    script = " ".join(ORACLE_SCRIPT.read_text(encoding="utf-8").split())
+    assert "``3`` total non-credential failure" in script
+    assert "``4`` no views selected" in script
+
+    text = _normalized(AGENTS_MD)
+    assert "`3` total non-credential failure" in text
+    assert "`4` no views selected" in text
+
+
+def test_agents_md_stays_within_the_project_size_target() -> None:
+    """Measured with `sac.prompt_size`, the same whole-file count the persona cap uses."""
+    size = sac.prompt_size(AGENTS_MD)
+    assert size <= AGENTS_SIZE_TARGET, f"AGENTS.md is {size} chars, over the {AGENTS_SIZE_TARGET} target"
+
+
+def test_every_persona_stays_within_the_project_size_target() -> None:
+    """A target below `PROMPT_CHAR_LIMIT`, so the hard cap is never the first thing to notice.
+
+    No floor is asserted: `dry-run-operator` is naturally far below this, and demanding a minimum
+    would reward padding.
+    """
+    oversize = {
+        path.name: sac.prompt_size(path)
+        for path in sorted((REPO_ROOT / ".github" / "agents").glob("*.agent.md"))
+        if sac.prompt_size(path) > PERSONA_SIZE_TARGET
+    }
+    assert oversize == {}, f"personas over the {PERSONA_SIZE_TARGET} target: {oversize}"
+
+
+def test_the_project_targets_bind_before_the_hard_cap() -> None:
+    """A target above the enforced cap would be decorative - the cap would fail first, every time."""
+    assert PERSONA_SIZE_TARGET < sac.PROMPT_CHAR_LIMIT


### PR DESCRIPTION
Second and final slice of #536: the root `AGENTS.md` and the generated shared-conventions block.
The persona-specific slice is already on `master` (e8b3570).

## Size targets, exact counts

| file | before | after | target |
|---|---:|---:|---|
| `AGENTS.md` | 69,177 | **44,691** | <= 45,000 |
| `.github/agents/pbi-semantic-builder.agent.md` | 21,999 | **21,956** | <= 22,000 |
| `.github/agents/pbi-migration-validator.agent.md` | 21,977 | **21,934** | <= 22,000 |
| `.github/agents/tableau-migrator.agent.md` | 21,970 | **21,927** | <= 22,000 |
| `.github/agents/pbi-report-builder.agent.md` | 21,911 | **21,868** | <= 22,000 |
| `.github/agents/dry-run-operator.agent.md` | 13,953 | **13,910** | — |

The block was rewritten as source in `AGENTS.md` and regenerated with
`python scripts/sync_agent_conventions.py`; no generated copy was hand-edited. Personas are all
*smaller* than before despite the block gaining the engine-pass correction, because the block itself
was tightened.

## Executable contract preserved

Session-start command and the tooling timing rule; the `preflight.ps1` environment gate and its
non-zero exit; the one-canonical-engine invariant with `engine_source.py`, the receipt, the
preflight critical checks and the four version-change verdicts (including "partial re-run into an
existing bundle: never"); the complete dispatcher route commands for Server/Cloud, a folder, one workbook, and direct `.tds/.tdsx`; capture-tool routing with
the `exit 3` "wrong tool" meaning; the five intake questions, autonomy table and refresh strategies;
the credential/human stop that autopilot cannot override; Gate B's four decisions as one block;
`_runs/<NNN>-<slug>/` layout, the `packages/ --out` rule and `work_dirs.py`; the review contract with
its post-R2 scope freeze; and the shared conventions including PID-scoped Desktop cleanup, the
`desktop-orphans` gate token and the `git add -A` barrier.

## Content routing (merged, not dumped)

- **New, indexed:** `docs/agent-operations.md` — delegation monitoring incidents, the retained host
  V8-heap OOM dumps, the Desktop RAM incident, post-crash file forensics. Indexed in
  `docs/INDEX.md` and cross-linked from `docs/agent-architecture.md`, which keeps its own scope
  ("what text reaches an agent").
- **Already authoritative, so nothing was copied:** review-round measurements
  (`docs/review-throughput-postmortem.md`), the `reportVersionAtImport` mutation table
  (`powerbi-report-gotchas`), engine diff commands and BASELINE UNAVAILABLE
  (`docs/migration-phases.md`, `docs/operator-runbook.md`), render-ladder detail
  (`docs/reference-capture.md`). `docs/operator-runbook.md` received **no** new bulk.

## Corrections rather than copy-forward

- **Engine-pass vocabulary** (issue text; upstream `Yarbrdab000/tableau-fabric-skills#173`): the
  shared table now reads pristine engine baseline (`<bundle>/reports/`, the model-unbound report
  pass) -> working/shipped pass (`<bundle>/pbip/`, or `<package>/fabric/` when handed a package) ->
  promoted deliverable, and states plainly that the passes can diverge by design, that
  `shipped_tree_divergence` is disclosure and not fidelity proof, that `viz_fidelity.status:
  "rebuilt"` is not render or shipped-artifact proof, and that fidelity is judged on the shipped
  bytes against Tableau evidence. Pristine baselines remain never-edit.
- **Stale oracle exit codes:** `AGENTS.md` claimed "zero selected views also exits 0" and "image
  status never reaches the exit code". `scripts/capture_tableau_oracle.py` now documents and returns
  `0/1/2/3/4/5` (4 = no views selected, 5 = a required reference render never arrived under
  `--reference-best`). The prose now matches the code.
- **Stale persona budgets:** `docs/agent-architecture.md` still listed the 2026-07-31 numbers at 99%
  of cap; re-measured, with the reason the 22,000 headroom is deliberate.
- **Dangling line citations:** `docs/migration-phases.md` cited `AGENTS.md:773` three times — a line
  number this change invalidates — now replaced by a stable reference to the shared-conventions
  `working copy` row.

## Validation (by exit code)

```
python scripts/sync_agent_conventions.py            -> 0
python scripts/sync_agent_conventions.py --check    -> 0
python scripts/check_agent_capabilities.py          -> 0
python scripts/check_navigation_index.py            -> 0`r`npytest tests/test_sync_agent_conventions.py          -> 80 passed
pytest tests/test_openability_claim_citations.py tests/test_sync_agent_conventions.py \
       tests/test_agent_capabilities.py tests/test_package_unit.py tests/test_credential_gate.py
                                                    -> 501 passed
pytest tests/test_repo_layout.py tests/test_skills.py tests/test_credential_gate_verify_target.py \
       tests/test_no_conflict_markers.py tests/test_work_dirs.py
                                                    -> 207 passed
pytest tests/test_build_plugin.py tests/test_work_dirs.py tests/test_openability_claim_citations.py
                                                    -> 278 passed
```

`tests/persona_pins.txt` was regenerated once, by this slice's single owner
(`python tests/test_openability_claim_citations.py --update`).

## What could not be verified here

- One pre-existing Windows-only skip in `tests/test_credential_gate.py`
  (`test_a_gate_applied_and_failed_at_its_own_bundle_root_is_still_state_2`, *"the real write-deny
  ACL on Windows prevented the violation from landing at all"*) trips the unexpected-skip gate on
  this machine. It is environmental and untouched by this diff — no Python changed in this PR — but
  it was not reproduced on Linux locally.
- `docs/deterministic-tier-integration.md` cites `AGENTS.md:175` twice. That line reference is also
  invalidated, but the file is outside this slice's allowed set and the doc is archival design
  notes; left for a follow-up rather than edited here.
- The benefit of the review contract remains a hypothesis, as the postmortem states; nothing here
  measures it.

## Blind review, please

Give the reviewer only issue #536 and the diff, and ask explicitly whether any credential stop,
destructive barrier, gate command, exit-state distinction or layer boundary disappeared. A clean
verdict is a legitimate outcome.

Fixes #536

