### PR TITLE
fix: preserve backslashes in work-dirs help

### DIFF
--- a/scripts/work_dirs.py
+++ b/scripts/work_dirs.py
@@ -19,7 +19,7 @@ already projects over Desktop's UTF-16 ceiling (`run_estate.py`'s pre-engine pat
 and needs one supported short EXTERNAL root - not a second, hand-maintained tree. The two flags are
 mutually exclusive and both feed the same `repo_root=` parameter `runs_root()`/`allocate_run()`
 already take: `runs_root(repo_root) == (repo_root or REPO_ROOT) / "_runs"` never cared whether
-`repo_root` was a git checkout, so an arbitrary short directory such as `C:\tfmig` needs no new
+`repo_root` was a git checkout, so an arbitrary short directory such as `C:\\t2p` needs no new
 allocation logic, no junction, no symlink and no drive mapping - it allocates the identical
 `_runs/<NNN>-<slug>/{assessment,assets,bundle,...}/` tree, with the identical `run.json`,
 `allocated_abs_path` and `--verify` semantics, just rooted somewhere with more path budget to spare.

--- a/tests/test_work_dirs.py
+++ b/tests/test_work_dirs.py
@@ -1626,3 +1626,76 @@ def test_the_invariant_is_stated_in_work_dirs_itself() -> None:
 
     assert "THE ONE INVARIANT" in source
     assert "only ever returned on positive proof" in source
+
+
+# --------------------------------------------------------------------------------------
+# Issue #479 follow-up - the runtime HELP text must render a Windows path, not an escape
+#
+# The short-EXTERNAL-root example lives in the module docstring, which argparse prints verbatim as
+# the CLI description. The docstring is not raw, so `C:\t2p` written with a single backslash was
+# compiled to `C:` + TAB + `2p` and shipped to the operator as a path they cannot type.
+# --------------------------------------------------------------------------------------
+
+
+SHORT_ROOT_EXAMPLE = "C:" + chr(92) + "t2p"  # built from chr(92) so this test cannot repeat the bug
+
+
+def _run_help_cli() -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(REPO_ROOT / "scripts" / "work_dirs.py"), "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_help_renders_the_short_root_example_with_a_literal_backslash() -> None:
+    """Production CLI, judged on the bytes an operator actually sees.
+
+    Measured on the merged pre-fix source: `python scripts/work_dirs.py --help` printed
+    `an arbitrary short directory such as ``C:<TAB>fmig``` - a tab where the backslash belonged,
+    and a root name no operator could copy. Both halves are asserted: the literal example is
+    present, AND the line carrying it contains no control character that an escape would have
+    substituted."""
+    result = _run_help_cli()
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert SHORT_ROOT_EXAMPLE in result.stdout, (
+        "the short EXTERNAL root example is missing or mangled - a non-raw docstring escape is how "
+        f"it stops rendering as {SHORT_ROOT_EXAMPLE!r}"
+    )
+
+    example_lines = [line for line in result.stdout.splitlines() if "short directory such as" in line]
+    assert example_lines, "the short-root sentence disappeared from the runtime help"
+    for line in example_lines:
+        assert SHORT_ROOT_EXAMPLE in line
+        substituted = {c for c in line if c in "\t\r\x08\x0c\x0b\x07\x00"}
+        assert not substituted, (
+            f"the short-root help line contains control characters {sorted(hex(ord(c)) for c in substituted)} - "
+            "a Windows path example was escape-interpreted instead of printed literally"
+        )
+
+
+def test_no_runtime_string_in_work_dirs_carries_a_substituted_escape() -> None:
+    """Negative control for the fix, and the answer to "is this the only site?".
+
+    Every string constant in the module is parsed out and checked for the control characters a
+    stray `\\t` / `\\r` / `\\b` / `\\f` / `\\v` / `\\a` / `\\0` in a Windows path example would
+    produce. Newlines are excluded - they are legitimate and deliberate here (`json.dumps(...) +
+    "\\n"`). Measured on the merged pre-fix source this failed on exactly one constant: the module
+    docstring. It is a pin, not a general help-text linter: it says nothing about docs, other
+    scripts, or comments."""
+    source = _work_dirs_source()
+    tree = ast.parse(source)
+
+    offenders = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            bad = sorted({c for c in node.value if c in "\t\r\x08\x0c\x0b\x07\x00"})
+            if bad:
+                offenders.append((node.lineno, [hex(ord(c)) for c in bad]))
+
+    assert not offenders, (
+        f"runtime string constants carry substituted escapes at {offenders} - a Windows path "
+        "example needs a doubled backslash in this non-raw source"
+    )


### PR DESCRIPTION
## The regression

`--runs-parent` (#479) documented a short EXTERNAL root in `scripts/work_dirs.py`'s module
docstring, and argparse prints that docstring verbatim as the CLI description. The docstring is not
raw, so the single-backslash Windows path was compiled to a control character before an operator
ever saw it.

Measured on the merged source (586867b), `python scripts/work_dirs.py --help`:

```
`repo_root` was a git checkout, so an arbitrary short directory such as `C:	fmig` needs no new
```

That is `C:` + TAB + `fmig` — a path no operator can type, in the one flag that exists to be typed by
an operator under path pressure.

After this change:

```
`repo_root` was a git checkout, so an arbitrary short directory such as `C:\t2p` needs no new
```

`C:\t2p` is the repo's canonical short root — the same value `dry-run-operator.agent.md` documents
and `tests/test_sync_agent_conventions.py` pins.

## The correction is one character wide

The docstring is deliberately left **non-raw**. Making it raw would change the meaning of every
escape in a 100-line string to fix one defect; doubling the backslash at the single offending site
does not. Requirement 1's "do not make the whole docstring raw unless you prove it is consequence-free"
is honoured by not needing the proof.

## Requirement 3 — is there another escape? No.

Audited every string constant in the module by AST for the control characters a stray `\t` / `\r` /
`\b` / `\f` / `\v` / `\a` / `\0` would produce. **Exactly one** offender: the module docstring
(`0x9`). The other backslash sites are all safe, and each for a different reason:

| site | why it is not a defect |
|---|---|
| `'\\_runs\\001-acme'`, `_review477_round2_attacks\\...` (docstring of `_is_interpreter_independent_abs`) | already doubled — renders as a single backslash |
| `json.dumps(manifest, ...) + "\n"` | a deliberate newline, not a path |
| `\_runs\001-acme` at lines 178/179, 457, 502 | `#` comments — never escape-processed |
| `C:001-acme` | intentionally drive-relative; that is the shape under test |

**Finding: no second runtime escape exists.** No generalized help-text lint was added.

## The regressions, mutation-tested

Both new tests were run against the merged pre-fix source and **both fail**:

```
FAILED tests/test_work_dirs.py::test_help_renders_the_short_root_example_with_a_literal_backslash
FAILED tests/test_work_dirs.py::test_no_runtime_string_in_work_dirs_carries_a_substituted_escape
2 failed, 132 deselected
```

1. **`test_help_renders_the_short_root_example_with_a_literal_backslash`** — executes the production
   CLI (`sys.executable scripts/work_dirs.py --help`), asserts exit 0, asserts the literal `C:\t2p`
   is in stdout, and asserts the short-root line carries no substituted control character. The
   expected value is built as `"C:" + chr(92) + "t2p"` so the test source cannot repeat the very bug
   it checks for.
2. **`test_no_runtime_string_in_work_dirs_carries_a_substituted_escape`** — an AST pin over every
   string constant in the module (newline excluded, it is legitimate here), so the *next* Windows
   path example added to a runtime string cannot ship escape-interpreted. Scoped to this module
   only.

## Verification

| check | result |
|---|---|
| `ruff format` / `ruff check --fix` (both files) | clean |
| `pylint scripts/work_dirs.py` | **10.00/10** |
| `pylint tests/test_work_dirs.py` | 9.74/10, up from 9.73 — residual findings are pre-existing legacy debt (missing test docstrings); no new one |
| `pytest -q tests/test_work_dirs.py` | **134 passed** |
| `pytest -q tests/test_sync_agent_conventions.py` | 104 passed (pins the `C:\t2p` spelling) |
| `python scripts/work_dirs.py --help` | renders `C:\t2p` with a backslash |

Allocator behavior is untouched — the production diff is one line inside a docstring.

## Scope

Only `scripts/work_dirs.py` and `tests/test_work_dirs.py`. `AGENTS.md`, the personas, `run_estate.py`,
docs and other tests are deliberately not touched. A stale `C:\tfmig` comment survives in
`tests/test_promote_unit.py:1831` — it is a comment in a file this PR does not own, and it is inert.

Refs #479
