### PR TITLE
test: pin datasource and workbook path-envelope shapes

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -125,7 +125,7 @@ jobs:
           test "$(cat "$HOME/.copilot/installed-plugins/tableau-collection/tableau-fabric-skills/skills/tableau-migration/VERSION")" = "$EXPECTED_ENGINE_VERSION"
 
       - name: Tests (engine-dependent, pinned engine)
-        run: T2P_REQUIRE_ENGINE_TESTS=1 uv run pytest -q tests/test_issue_424_chart_type_pin.py tests/test_dax_oracle_server.py tests/test_upstream_repro_pins.py tests/test_harvest_download_watchdog.py::test_the_ceiling_constants_match_the_INSTALLED_engine
+        run: T2P_REQUIRE_ENGINE_TESTS=1 uv run pytest -q tests/test_issue_424_chart_type_pin.py tests/test_datasource_path_envelope.py tests/test_dax_oracle_server.py tests/test_upstream_repro_pins.py tests/test_harvest_download_watchdog.py::test_the_ceiling_constants_match_the_INSTALLED_engine
 
   engine-drift:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
@@ -154,7 +154,7 @@ jobs:
           echo "Current engine version: $(cat "$HOME/.copilot/installed-plugins/tableau-collection/tableau-fabric-skills/skills/tableau-migration/VERSION")"
 
       - name: Tests (engine-dependent, latest engine drift signal)
-        run: T2P_REQUIRE_ENGINE_TESTS=1 uv run pytest -q tests/test_issue_424_chart_type_pin.py tests/test_dax_oracle_server.py tests/test_upstream_repro_pins.py tests/test_harvest_download_watchdog.py::test_the_ceiling_constants_match_the_INSTALLED_engine
+        run: T2P_REQUIRE_ENGINE_TESTS=1 uv run pytest -q tests/test_issue_424_chart_type_pin.py tests/test_datasource_path_envelope.py tests/test_dax_oracle_server.py tests/test_upstream_repro_pins.py tests/test_harvest_download_watchdog.py::test_the_ceiling_constants_match_the_INSTALLED_engine
 
   # The main checks job runs on Linux. The pbip-model-refresh bundle does not: `SKILL.md` line 8 says
   # "Windows only." That mismatch is not cosmetic - it makes the Linux job STRUCTURALLY incapable of

--- a/conftest.py
+++ b/conftest.py
@@ -121,8 +121,26 @@ EXPECTED_ENGINE_SKIP_REASONS_BY_NODEID: dict[str, str] = {
     "tests/test_datasource_path_envelope.py::test_a_visual_free_datasource_envelope_would_be_fail_open": (
         "deterministic tier not installed"
     ),
+    "tests/test_datasource_path_envelope.py::test_each_shape_envelope_covers_its_tail_and_one_unit_less_would_not["
+    "CustomSQL_Parameter_And_Doubled_Operators]": "deterministic tier not installed",
+    "tests/test_datasource_path_envelope.py::test_each_shape_envelope_covers_its_tail_and_one_unit_less_would_not["
+    "Swap_Datasource_With_Field_Parameters]": "deterministic tier not installed",
+    "tests/test_datasource_path_envelope.py::test_each_shape_envelope_covers_its_tail_and_one_unit_less_would_not["
+    "issue-424-d-explicit-bar-mark]": "deterministic tier not installed",
+    "tests/test_datasource_path_envelope.py::test_the_engine_itself_resolves_both_declared_swap_controllers": (
+        "deterministic tier not installed"
+    ),
     "tests/test_datasource_path_envelope.py::"
     "test_the_projector_is_blind_to_unit_kind_and_over_projects_this_datasource": ("deterministic tier not installed"),
+    "tests/test_datasource_path_envelope.py::test_the_three_source_shapes_emit_their_documented_reports["
+    "CustomSQL_Parameter_And_Doubled_Operators-page1-False]": "deterministic tier not installed",
+    "tests/test_datasource_path_envelope.py::test_the_three_source_shapes_emit_their_documented_reports["
+    "Swap_Datasource_With_Field_Parameters-pageSelfService-True]": "deterministic tier not installed",
+    "tests/test_datasource_path_envelope.py::test_the_three_source_shapes_emit_their_documented_reports["
+    "issue-424-d-explicit-bar-mark-None-True]": "deterministic tier not installed",
+    "tests/test_datasource_path_envelope.py::test_two_concurrent_pytest_processes_do_not_collide": (
+        "deterministic tier not installed"
+    ),
     "tests/test_dax_oracle_server.py::test_extract_scalar_reads_our_row_shape": "deterministic tier not installed",
     "tests/test_dax_oracle_server.py::test_our_oracle_conforms_to_the_engines_own_contract": (
         "deterministic tier not installed"

--- a/conftest.py
+++ b/conftest.py
@@ -121,15 +121,23 @@ EXPECTED_ENGINE_SKIP_REASONS_BY_NODEID: dict[str, str] = {
     "tests/test_datasource_path_envelope.py::test_a_visual_free_datasource_envelope_would_be_fail_open": (
         "deterministic tier not installed"
     ),
-    "tests/test_datasource_path_envelope.py::test_each_shape_envelope_covers_its_tail_and_one_unit_less_would_not["
-    "CustomSQL_Parameter_And_Doubled_Operators]": "deterministic tier not installed",
-    "tests/test_datasource_path_envelope.py::test_each_shape_envelope_covers_its_tail_and_one_unit_less_would_not["
-    "Swap_Datasource_With_Field_Parameters]": "deterministic tier not installed",
-    "tests/test_datasource_path_envelope.py::test_each_shape_envelope_covers_its_tail_and_one_unit_less_would_not["
-    "issue-424-d-explicit-bar-mark]": "deterministic tier not installed",
     "tests/test_datasource_path_envelope.py::test_the_engine_itself_resolves_both_declared_swap_controllers": (
         "deterministic tier not installed"
     ),
+    "tests/test_datasource_path_envelope.py::test_the_production_identifier_envelope_stays_above_the_engines_"
+    "measured_cap": "deterministic tier not installed",
+    "tests/test_datasource_path_envelope.py::test_the_production_projection_refuses_each_emitted_shape_at_its_own_"
+    "boundary[CustomSQL_Parameter_And_Doubled_Operators-directory]": "deterministic tier not installed",
+    "tests/test_datasource_path_envelope.py::test_the_production_projection_refuses_each_emitted_shape_at_its_own_"
+    "boundary[CustomSQL_Parameter_And_Doubled_Operators-file]": "deterministic tier not installed",
+    "tests/test_datasource_path_envelope.py::test_the_production_projection_refuses_each_emitted_shape_at_its_own_"
+    "boundary[Swap_Datasource_With_Field_Parameters-directory]": "deterministic tier not installed",
+    "tests/test_datasource_path_envelope.py::test_the_production_projection_refuses_each_emitted_shape_at_its_own_"
+    "boundary[Swap_Datasource_With_Field_Parameters-file]": "deterministic tier not installed",
+    "tests/test_datasource_path_envelope.py::test_the_production_projection_refuses_each_emitted_shape_at_its_own_"
+    "boundary[issue-424-d-explicit-bar-mark-directory]": "deterministic tier not installed",
+    "tests/test_datasource_path_envelope.py::test_the_production_projection_refuses_each_emitted_shape_at_its_own_"
+    "boundary[issue-424-d-explicit-bar-mark-file]": "deterministic tier not installed",
     "tests/test_datasource_path_envelope.py::"
     "test_the_projector_is_blind_to_unit_kind_and_over_projects_this_datasource": ("deterministic tier not installed"),
     "tests/test_datasource_path_envelope.py::test_the_three_source_shapes_emit_their_documented_reports["

--- a/conftest.py
+++ b/conftest.py
@@ -115,6 +115,14 @@ ENGINE_SKIP_REASONS: tuple[str, ...] = (
     "canonical engine not installed, so its constants cannot be read",
 )
 EXPECTED_ENGINE_SKIP_REASONS_BY_NODEID: dict[str, str] = {
+    "tests/test_datasource_path_envelope.py::test_a_standalone_datasource_emits_a_self_service_page_with_visuals": (
+        "deterministic tier not installed"
+    ),
+    "tests/test_datasource_path_envelope.py::test_a_visual_free_datasource_envelope_would_be_fail_open": (
+        "deterministic tier not installed"
+    ),
+    "tests/test_datasource_path_envelope.py::"
+    "test_the_projector_is_blind_to_unit_kind_and_over_projects_this_datasource": ("deterministic tier not installed"),
     "tests/test_dax_oracle_server.py::test_extract_scalar_reads_our_row_shape": "deterministic tier not installed",
     "tests/test_dax_oracle_server.py::test_our_oracle_conforms_to_the_engines_own_contract": (
         "deterministic tier not installed"

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -98,6 +98,7 @@ Eligible files: tracked Markdown knowledge/navigation files, `.github/pbi.kb/**/
 | Use fixture | [`fixtures/large-refresh/README.md`](../fixtures/large-refresh/README.md) | Large refresh/cache behavior fixture. |
 | Use fixture | [`tests/fixtures/check-gates-dirty/README.md`](../tests/fixtures/check-gates-dirty/README.md) | Dirty gate golden-output fixture. |
 | Use fixture | [`tests/fixtures/connection-fidelity/README.md`](../tests/fixtures/connection-fidelity/README.md) | Silent live-source-to-flat-file downgrade fixture (issue #328). |
+| Use fixture | [`tests/fixtures/datasource-field-parameter-page/README.md`](../tests/fixtures/datasource-field-parameter-page/README.md) | A standalone datasource that emits a real self-service page with visuals — the fail-open control for any kind-aware PBIP path-ceiling envelope. |
 
 ## Explicit exclusions
 | Task | Path | Exclusion reason |

--- a/tests/fixtures/datasource-field-parameter-page/README.md
+++ b/tests/fixtures/datasource-field-parameter-page/README.md
@@ -40,16 +40,51 @@ tree fitted only because that particular datasource had **no** field-swap calcs,
 ## Provenance
 
 Derived from the committed `tests/fixtures/CustomSQL_Parameter_And_Doubled_Operators.tds` (which
-alone emits a thin `page1` shell), with exactly two calculated columns appended:
+alone emits a thin `page1` shell), with two calculated columns **and the two parameters they
+control** appended:
 
 ```
 Metric Swap    (measure)   CASE [Parameters].[Metric]   WHEN "Sales" THEN [Sales] WHEN "Profit" THEN [Profit] END
 Grouping Swap  (dimension) CASE [Parameters].[Grouping] WHEN "Order" THEN [Order ID] WHEN "Customer" THEN [Customer Name] END
 ```
 
-Both shapes are what `parameters.detect_field_swap` accepts: a `[Parameters].[X]`-driven `CASE`
-whose every branch is a **bare** field reference, with at least two branches. One measure-role and
-one dimension-role swap, so the emitted page carries the field-parameter table **and** one
-`listSlicer` per parameter — the slicer count is what scales with the source, the id length is not.
+⚠️ **The parameters are declared, not merely referenced.** `parameters.detect_field_swap` matches
+only the *formula*, so a fixture can reach the self-service branch while its controller exists
+nowhere — which would make this a test of the engine's regex tolerance rather than of a real Tableau
+shape. Round-1 review caught exactly that. `<datasource-dependencies datasource='Parameters'>` now
+declares both controllers as `param-domain-type='list'` columns whose `<members>` are the swap's own
+branch labels and whose `value` default is one of them:
+
+| parameter | domain | default | members |
+|---|---|---|---|
+| `Metric` | `list` | `Sales` | `Sales`, `Profit` |
+| `Grouping` | `list` | `Order` | `Order`, `Customer` |
+
+Verified with the engine's own parser (canonical 2.368.0):
+
+```
+Min Profit Threshold | any  | default 100.    | members []
+Metric               | list | default "Sales" | members ['Sales', 'Profit']    | aliases {'"Sales"': 'Sales', '"Profit"': 'Profit'}
+Grouping             | list | default "Order" | members ['Order', 'Customer']  | aliases {'"Order"': 'Order', '"Customer"': 'Customer'}
+```
+
+Both shapes are what `detect_field_swap` accepts: a `[Parameters].[X]`-driven `CASE` whose every
+branch is a **bare** field reference, with at least two branches. One measure-role and one
+dimension-role swap, so the emitted page carries the field-parameter table **and** one `listSlicer`
+per parameter — the slicer count is what scales with the source, the identifier length is not.
+
+## The three-shape matrix this fixture completes
+
+`tests/test_datasource_path_envelope.py` runs the canonical engine **once** over three committed
+sources and pins each emitted shape, so no conclusion rests on a single artifact:
+
+| source | unit | emitted page | visuals | deepest report tail |
+|---|---|---|---:|---:|
+| `tests/fixtures/CustomSQL_Parameter_And_Doubled_Operators.tds` | ordinary datasource | `page1` | 0 | 32 |
+| this fixture | swap datasource | `pageSelfService` | 3 @ 24 units | 77 |
+| `fixtures/upstream-repros/issue-424-automatic-mark-discrete-date/issue-424-d-explicit-bar-mark.twb` | workbook | `page-Detail8fea6fd9` | 1 @ 24 units | 81 |
+
+The workbook arm is **borrowed**, not newly authored: long-name path arithmetic is already owned by
+`tests/test_run_estate.py`, and duplicating it here would be redundant proof.
 
 Pinned by `tests/test_datasource_path_envelope.py`.

--- a/tests/fixtures/datasource-field-parameter-page/README.md
+++ b/tests/fixtures/datasource-field-parameter-page/README.md
@@ -1,0 +1,55 @@
+# `datasource-field-parameter-page` — a standalone datasource that is NOT a thin shell
+
+**What it exists to refute:** *"a `.tds`/`.tdsx` unit emits only a one-page report shell, so the
+PBIP path-ceiling projection can give datasource units a visual-free envelope."* That belief is
+false, and a projection built on it would be **fail-open** — it would pass a tree Power BI Desktop
+cannot open.
+
+## The measurement
+
+Run 409's pre-conversion refusal (`run_estate.project_estate_path_ceiling`, file 275 / dir 263 at a
+92-character output root) was driven **entirely** by the longest unit name,
+`Meridian_Calc_Gauntlet__Live_Snowflake_` — a standalone datasource. Rebasing the 437 paths that
+canonical engine 2.368.0 actually emitted from the same three inputs onto that same root gives
+**max file 237 / max dir 225, 0 offenders**: the tree would have fitted. The projector over-projected
+that one unit by **+48 file / +54 dir**, while both workbook units were projected accurate to +4.
+
+The tempting conclusion — *give a datasource unit a thin, visual-free envelope* — is wrong.
+`migrate_estate.py` passes `swap_specs` into `write_local_pbip` on the **datasource** branch, so
+`assemble_model.build_swap_report_parts` → `twb_to_pbir.build_field_parameter_page` emits a real
+self-service page whenever the datasource carries field-swap calcs.
+
+Measured on canonical engine **2.368.0** from this fixture:
+
+| | emitted |
+|---|---|
+| page directory | `pageSelfService` (15 UTF-16 units, a constant in `build_field_parameter_page`) |
+| visuals | `fptable-pageSelf51410740`, `fpslicer-pageSel24d4262c`, `fpslicer-pageSel3815a7d3` — **24 units each** |
+| deepest report tail | `definition/pages/pageSelfService/visuals/<24>/visual.json` = **77** |
+| a visual-free tail | `definition/pages/page1/page.json` = **32** |
+| **understatement** | **45 characters** |
+
+A datasource unit is therefore only **13** characters cheaper than a workbook unit
+(page 15 vs 24, same 24-unit visual cap from `twb_to_pbir._sanitize`), not 45+.
+
+⚠️ And a *sound* kind-aware envelope still does not rescue run 409: at that root, the datasource
+projects **262 / 250** with `pageSelfService` + a 24-unit visual — still over 259 / 247. The real
+tree fitted only because that particular datasource had **no** field-swap calcs, which is a
+**data**-dependent property, not a **kind**-dependent one.
+
+## Provenance
+
+Derived from the committed `tests/fixtures/CustomSQL_Parameter_And_Doubled_Operators.tds` (which
+alone emits a thin `page1` shell), with exactly two calculated columns appended:
+
+```
+Metric Swap    (measure)   CASE [Parameters].[Metric]   WHEN "Sales" THEN [Sales] WHEN "Profit" THEN [Profit] END
+Grouping Swap  (dimension) CASE [Parameters].[Grouping] WHEN "Order" THEN [Order ID] WHEN "Customer" THEN [Customer Name] END
+```
+
+Both shapes are what `parameters.detect_field_swap` accepts: a `[Parameters].[X]`-driven `CASE`
+whose every branch is a **bare** field reference, with at least two branches. One measure-role and
+one dimension-role swap, so the emitted page carries the field-parameter table **and** one
+`listSlicer` per parameter — the slicer count is what scales with the source, the id length is not.
+
+Pinned by `tests/test_datasource_path_envelope.py`.

--- a/tests/fixtures/datasource-field-parameter-page/Swap_Datasource_With_Field_Parameters.tds
+++ b/tests/fixtures/datasource-field-parameter-page/Swap_Datasource_With_Field_Parameters.tds
@@ -1,0 +1,273 @@
+<?xml version='1.0' encoding='utf-8' ?>
+
+<!-- build 20262.26.0623.1517                               -->
+<datasource formatted-name='Complex Custom SQL example' inline='true' source-platform='linux' version='18.1' xml:base='http://10ay.online.tableau.com' xmlns:user='http://www.tableausoftware.com/xml/user'>
+  <document-format-change-manifest>
+    <DatabricksCatalog />
+    <ObjectModelEncapsulateLegacy />
+    <ObjectModelTableType />
+    <SchemaViewerObjectModel />
+  </document-format-change-manifest>
+  <repository-location derived-from='/datasources/CustomSQLParametertest?rev=1.0' id='CustomSQLParametertest' path='/t/fabricmigration-cc8fc056b6/datasources' revision='1.1' site='fabricmigration-cc8fc056b6' />
+  <connection class='federated'>
+    <named-connections>
+      <named-connection caption='adb-000000000000000.0.azuredatabricks.net' name='databricks.1m8fiiq0gddv4d17k40wf0ptqxg4'>
+        <connection authentication='oauth' authentication-type='' class='databricks' dbname='fixture_catalog' instanceurl='https://adb-000000000000000.0.azuredatabricks.net/oidc' oauth-config-id='default' odbc-connect-string-extras='' one-time-sql='' schema='default' server='adb-000000000000000.0.azuredatabricks.net' server-oauth='server-custom' username='fixture-user@example.invalid' usesPrivateConnect='' v-auth-scope='' v-http-path='/sql/1.0/warehouses/240f0d0d01d9e8dd' v-oidc-discovery-endpoint='' v-query-tags='' workgroup-auth-mode=''>
+          <connection-customization class='databricks' enabled='false' version='18.1'>
+            <vendor name='databricks' />
+            <driver name='databricks' />
+            <customizations>
+              <customization name='CAP_AUTH_DB_IMPERSONATE' value='no' />
+              <customization name='CAP_AUTH_KERBEROS_IMPERSONATE' value='yes' />
+              <customization name='CAP_COLLECT_TABLE_STATISTICS' value='no' />
+              <customization name='CAP_CONNECT_STORED_PROCEDURE' value='no' />
+              <customization name='CAP_CREATE_TEMP_TABLES' value='no' />
+              <customization name='CAP_DATASERVER_MAGIC_NUMBER' value='no' />
+              <customization name='CAP_DEFERS_CONNECTION_VERIFICATION' value='no' />
+              <customization name='CAP_DISABLE_EXTRACT_TABLE_INDEXING' value='no' />
+              <customization name='CAP_EQUALITY_JOINS_ONLY' value='no' />
+              <customization name='CAP_EQUIJOINS_ONLY' value='no' />
+              <customization name='CAP_FAST_METADATA' value='no' />
+              <customization name='CAP_FORCE_COUNT_FOR_NUMBEROFRECORDS' value='no' />
+              <customization name='CAP_GREENPLUM_TRUST_METADATA_CONTAINSNULL' value='no' />
+              <customization name='CAP_HIVE_FIX_METADATA_NAMES' value='no' />
+              <customization name='CAP_INCLUDE_OTHER_CATALOG_NAME' value='no' />
+              <customization name='CAP_INDEX_TEMP_TABLES' value='no' />
+              <customization name='CAP_INSERT_TEMP_EXEC_STORED_PROCEDURE' value='no' />
+              <customization name='CAP_JDBC_QUERY_USE_PREPARE_PARAMETER_MARKER' value='no' />
+              <customization name='CAP_LOCAL_ALIASES_CASE_INSENSITIVE' value='no' />
+              <customization name='CAP_METADATA_SHOW_OTHER_CATALOGS' value='no' />
+              <customization name='CAP_OAUTH_FEDERATE_ACCCESS_TOKEN' value='no' />
+              <customization name='CAP_OAUTH_FEDERATE_ID_TOKEN' value='no' />
+              <customization name='CAP_OAUTH_VALIDATE_ALWAYS' value='no' />
+              <customization name='CAP_ODBC_ALWAYS_THROW_CONNECT_ERRORS' value='no' />
+              <customization name='CAP_ODBC_BIND_FORCE_DATETIME_AS_CHAR' value='no' />
+              <customization name='CAP_ODBC_BIND_FORCE_DATE_AS_CHAR' value='no' />
+              <customization name='CAP_ODBC_BIND_FORCE_MAX_STRING_BUFFERS' value='no' />
+              <customization name='CAP_ODBC_BIND_FORCE_MEDIUM_STRING_BUFFERS' value='no' />
+              <customization name='CAP_ODBC_BIND_FORCE_SIGNED' value='no' />
+              <customization name='CAP_ODBC_BIND_FORCE_SMALL_STRING_BUFFERS' value='no' />
+              <customization name='CAP_ODBC_BIND_SUPPRESS_INT64' value='no' />
+              <customization name='CAP_ODBC_BIND_SUPPRESS_PREFERRED_TYPES' value='no' />
+              <customization name='CAP_ODBC_BIND_SUPPRESS_WIDE_CHAR' value='no' />
+              <customization name='CAP_ODBC_CURSOR_DYNAMIC' value='no' />
+              <customization name='CAP_ODBC_CURSOR_FORWARD_ONLY' value='yes' />
+              <customization name='CAP_ODBC_CURSOR_KEYSET_DRIVEN' value='no' />
+              <customization name='CAP_ODBC_CURSOR_STATIC' value='no' />
+              <customization name='CAP_ODBC_DRIVER_HIVE_ASSUME_LATEST' value='no' />
+              <customization name='CAP_ODBC_ERROR_IGNORE_FALSE_ALARM' value='no' />
+              <customization name='CAP_ODBC_FETCH_BUFFERS_RESIZABLE' value='no' />
+              <customization name='CAP_ODBC_FETCH_BUFFERS_SIZE_MASSIVE' value='no' />
+              <customization name='CAP_ODBC_FETCH_CONTINUE_ON_ERROR' value='no' />
+              <customization name='CAP_ODBC_FETCH_FORCE_VERIFY_TRUNCATE_BY_CELLSTATUS' value='no' />
+              <customization name='CAP_ODBC_FETCH_INT_TRUNCATION_AS_ERROR' value='yes' />
+              <customization name='CAP_ODBC_FORCE_SINGLE_ROW_BINDING' value='no' />
+              <customization name='CAP_ODBC_IMPORT_GETDATA_BUFFER_LARGE' value='no' />
+              <customization name='CAP_ODBC_METADATA_STRING_LENGTH_UNKNOWN' value='no' />
+              <customization name='CAP_ODBC_METADATA_SUPPRESS_SQLCOLUMNS_API' value='no' />
+              <customization name='CAP_ODBC_METADATA_SUPPRESS_SQLFOREIGNKEYS_API' value='no' />
+              <customization name='CAP_ODBC_METADATA_SUPPRESS_SQLPRIMARYKEYS_API' value='no' />
+              <customization name='CAP_ODBC_METADATA_SUPPRESS_SQLSTATISTICS_API' value='yes' />
+              <customization name='CAP_ODBC_QUERY_USE_PREPARE_PARAMETER_MARKER' value='no' />
+              <customization name='CAP_ODBC_REBIND_SKIP_UNBIND' value='no' />
+              <customization name='CAP_ODBC_SCHEMAS_OPTIONAL' value='no' />
+              <customization name='CAP_ODBC_TRIM_VARCHAR_PADDING' value='no' />
+              <customization name='CAP_ODBC_UNBIND_AUTO' value='no' />
+              <customization name='CAP_ODBC_UNBIND_BATCH' value='no' />
+              <customization name='CAP_ODBC_UNBIND_EACH' value='yes' />
+              <customization name='CAP_ODBC_USE_NATIVE_PROTOCOL' value='yes' />
+              <customization name='CAP_PADDED_SEMANTICS_NCHAR_NVARCHAR' value='no' />
+              <customization name='CAP_PERSIST_SQL_RELATION_ON_LEAF_CONNECTION' value='no' />
+              <customization name='CAP_QUERY_ALLOW_JOIN_REORDER' value='yes' />
+              <customization name='CAP_QUERY_ALLOW_PARTIAL_AGGREGATION' value='yes' />
+              <customization name='CAP_QUERY_ALWAYS_USE_AQ_CACHE' value='no' />
+              <customization name='CAP_QUERY_AVOID_EXPRESSION_INLINING' value='no' />
+              <customization name='CAP_QUERY_BLENDING_ALWAYS_USE_LOCAL_MAPPING_TABLES' value='no' />
+              <customization name='CAP_QUERY_BLENDING_PREFER_LOCAL_MAPPING_TABLES' value='yes' />
+              <customization name='CAP_QUERY_BLENDING_REMOTE_MAPPING_TABLES' value='yes' />
+              <customization name='CAP_QUERY_BOOLEXPR_TO_INTEXPR' value='no' />
+              <customization name='CAP_QUERY_BOOL_IDENTIFIER_TO_LOGICAL' value='no' />
+              <customization name='CAP_QUERY_CAST_MONEY_AS_NUMERIC' value='no' />
+              <customization name='CAP_QUERY_CONVERT_DATETIMES_TO_DATES' value='no' />
+              <customization name='CAP_QUERY_EMPTY_DOMAIN_TOP' value='no' />
+              <customization name='CAP_QUERY_FORCE_AGGREGATE_MEASURES' value='no' />
+              <customization name='CAP_QUERY_GROUP_BY_ALIAS' value='yes' />
+              <customization name='CAP_QUERY_GROUP_BY_DEGREE' value='yes' />
+              <customization name='CAP_QUERY_HAVING_REQUIRES_GROUP_BY' value='yes' />
+              <customization name='CAP_QUERY_HAVING_UNSUPPORTED' value='no' />
+              <customization name='CAP_QUERY_IGNORE_HINT_CHECK_NOT_NULL' value='no' />
+              <customization name='CAP_QUERY_IGNORE_HINT_MAKE_DOMAIN_PREDICATE' value='no' />
+              <customization name='CAP_QUERY_INLINE_COMPLEX_GROUPBYS_IN_SELECTS' value='yes' />
+              <customization name='CAP_QUERY_JOIN_ACROSS_SCHEMAS' value='yes' />
+              <customization name='CAP_QUERY_JOIN_ASSUME_CONSTRAINED' value='no' />
+              <customization name='CAP_QUERY_JOIN_PUSH_DOWN_CONDITION_EXPRESSIONS' value='no' />
+              <customization name='CAP_QUERY_JOIN_REQUIRES_SCOPE' value='no' />
+              <customization name='CAP_QUERY_JOIN_REQUIRES_SUBQUERY' value='no' />
+              <customization name='CAP_QUERY_MINMAX_FORCE_GROUPBYS' value='no' />
+              <customization name='CAP_QUERY_NULL_REQUIRES_CAST' value='yes' />
+              <customization name='CAP_QUERY_OUTER_JOIN_CONDITION_NO_TRIVIAL' value='no' />
+              <customization name='CAP_QUERY_RECOMPILE_FAILED_QUERY' value='no' />
+              <customization name='CAP_QUERY_SELECT_ALIASES_SORTED' value='no' />
+              <customization name='CAP_QUERY_SORT_BY' value='yes' />
+              <customization name='CAP_QUERY_SORT_BY_DEGREE' value='no' />
+              <customization name='CAP_QUERY_SUBQUERIES' value='yes' />
+              <customization name='CAP_QUERY_SUBQUERIES_WITH_TOP' value='yes' />
+              <customization name='CAP_QUERY_SUBQUERIES_WITH_TOP_ALTERNATIVE' value='no' />
+              <customization name='CAP_QUERY_SUBQUERY_QUERY_CONTEXT' value='yes' />
+              <customization name='CAP_QUERY_SUPPORTS_LODJOINS' value='yes' />
+              <customization name='CAP_QUERY_SUPPORT_ANALYTIC_FUNCTIONS' value='yes' />
+              <customization name='CAP_QUERY_SUPPORT_EMPTY_GROUPBY' value='no' />
+              <customization name='CAP_QUERY_SUPPRESS_CHECK_DOMAIN_LITERALS_THRESHOLD' value='no' />
+              <customization name='CAP_QUERY_SUPPRESS_NULL_CHECK_QUERIES' value='no' />
+              <customization name='CAP_QUERY_TAGS_IN_SQL_TEXT' value='no' />
+              <customization name='CAP_QUERY_TIME_REQUIRES_CAST' value='no' />
+              <customization name='CAP_QUERY_TOPSTYLE_LIMIT' value='no' />
+              <customization name='CAP_QUERY_TOPSTYLE_ROWNUM' value='no' />
+              <customization name='CAP_QUERY_TOPSTYLE_TOP' value='no' />
+              <customization name='CAP_QUERY_TOP_0_METADATA' value='yes' />
+              <customization name='CAP_QUERY_TOP_N' value='yes' />
+              <customization name='CAP_QUERY_USE_DOMAIN_EXCEPT_OPTIMIZATION' value='no' />
+              <customization name='CAP_QUERY_USE_DOMAIN_RANGES_OPTIMIZATION' value='yes' />
+              <customization name='CAP_QUERY_USE_DOMAIN_RANGES_OPTIMIZATION_STRINGS' value='no' />
+              <customization name='CAP_QUERY_USE_QUERY_FUSION' value='yes' />
+              <customization name='CAP_QUERY_USE_STRCMP_WITH_WHERE_EXISTS' value='no' />
+              <customization name='CAP_QUERY_WHERE_FALSE_METADATA' value='no' />
+              <customization name='CAP_RELDATEFILT_CASTTODATE' value='no' />
+              <customization name='CAP_RENAME_TABLE_USE_LEAF_CONNECTION_DIALECT' value='no' />
+              <customization name='CAP_SDK_SUPPORTS_PREP_WRITE_TO_DB' value='no' />
+              <customization name='CAP_SELECT_INTO' value='no' />
+              <customization name='CAP_SELECT_TOP_INTO' value='no' />
+              <customization name='CAP_STORED_PROCEDURE_PREFER_TEMP_TABLE' value='no' />
+              <customization name='CAP_STORED_PROCEDURE_REPAIR_TEMP_TABLE_STRINGS' value='no' />
+              <customization name='CAP_STORED_PROCEDURE_TEMP_TABLE_FROM_BUFFER' value='no' />
+              <customization name='CAP_STORED_PROCEDURE_TEMP_TABLE_FROM_NEW_PROTOCOL' value='no' />
+              <customization name='CAP_SUPPORTS_METRICS_ONLY' value='no' />
+              <customization name='CAP_SUPPRESS_CONNECTION_POOLING' value='yes' />
+              <customization name='CAP_SUPPRESS_DISCOVERY_QUERIES' value='no' />
+              <customization name='CAP_SUPPRESS_ENUMERATE_SCHEMAS_VIA_SQL' value='yes' />
+              <customization name='CAP_SUPPRESS_ENUMERATE_TABLES_VIA_SQL' value='yes' />
+              <customization name='CAP_SUPPRESS_GET_SERVER_TIME' value='yes' />
+              <customization name='CAP_SUPPRESS_QUICK_FILTER_ACCELERATION_VIEWS' value='no' />
+              <customization name='CAP_SUPPRESS_TEMP_TABLE_CHECKS' value='no' />
+            </customizations>
+          </connection-customization>
+        </connection>
+      </named-connection>
+    </named-connections>
+    <relation connection='databricks.1m8fiiq0gddv4d17k40wf0ptqxg4' name='Custom SQL Query' type='text'><![CDATA[SELECT
+    o.`Order ID`,
+    o.`Customer Name`,
+    o.Profit,
+    o.Sales
+FROM fixture_catalog.default.orders AS o
+WHERE o.Profit >> <[Parameters].[Parameter 0014036665946123]>   -- parameter
+  AND o.Sales  << 5000                                   -- literal control]]></relation>
+    <metadata-records>
+      <metadata-record class='column'>
+        <remote-name>Order ID</remote-name>
+        <remote-type>129</remote-type>
+        <local-name>[Order ID]</local-name>
+        <parent-name>[Custom SQL Query]</parent-name>
+        <remote-alias>Order ID</remote-alias>
+        <ordinal>1</ordinal>
+        <local-type>string</local-type>
+        <aggregation>Count</aggregation>
+        <width>255</width>
+        <contains-null>true</contains-null>
+        <collation flag='0' name='binary' />
+        <attributes>
+          <attribute datatype='string' name='DebugRemoteType'>&quot;SQL_VARCHAR&quot;</attribute>
+          <attribute datatype='string' name='DebugWireType'>&quot;SQL_C_CHAR&quot;</attribute>
+          <attribute datatype='string' name='TypeIsVarchar'>&quot;true&quot;</attribute>
+        </attributes>
+        <object-id>[_45B6D75ECD4D4E19AD476AA7331DF17A]</object-id>
+      </metadata-record>
+      <metadata-record class='column'>
+        <remote-name>Customer Name</remote-name>
+        <remote-type>129</remote-type>
+        <local-name>[Customer Name]</local-name>
+        <parent-name>[Custom SQL Query]</parent-name>
+        <remote-alias>Customer Name</remote-alias>
+        <ordinal>2</ordinal>
+        <local-type>string</local-type>
+        <aggregation>Count</aggregation>
+        <width>255</width>
+        <contains-null>true</contains-null>
+        <collation flag='0' name='binary' />
+        <attributes>
+          <attribute datatype='string' name='DebugRemoteType'>&quot;SQL_VARCHAR&quot;</attribute>
+          <attribute datatype='string' name='DebugWireType'>&quot;SQL_C_CHAR&quot;</attribute>
+          <attribute datatype='string' name='TypeIsVarchar'>&quot;true&quot;</attribute>
+        </attributes>
+        <object-id>[_45B6D75ECD4D4E19AD476AA7331DF17A]</object-id>
+      </metadata-record>
+      <metadata-record class='column'>
+        <remote-name>Profit</remote-name>
+        <remote-type>5</remote-type>
+        <local-name>[Profit]</local-name>
+        <parent-name>[Custom SQL Query]</parent-name>
+        <remote-alias>Profit</remote-alias>
+        <ordinal>3</ordinal>
+        <local-type>real</local-type>
+        <aggregation>Sum</aggregation>
+        <precision>4</precision>
+        <contains-null>true</contains-null>
+        <attributes>
+          <attribute datatype='string' name='DebugRemoteType'>&quot;SQL_DOUBLE&quot;</attribute>
+          <attribute datatype='string' name='DebugWireType'>&quot;SQL_C_DOUBLE&quot;</attribute>
+        </attributes>
+        <object-id>[_45B6D75ECD4D4E19AD476AA7331DF17A]</object-id>
+      </metadata-record>
+      <metadata-record class='column'>
+        <remote-name>Sales</remote-name>
+        <remote-type>5</remote-type>
+        <local-name>[Sales]</local-name>
+        <parent-name>[Custom SQL Query]</parent-name>
+        <remote-alias>Sales</remote-alias>
+        <ordinal>4</ordinal>
+        <local-type>real</local-type>
+        <aggregation>Sum</aggregation>
+        <precision>4</precision>
+        <contains-null>true</contains-null>
+        <attributes>
+          <attribute datatype='string' name='DebugRemoteType'>&quot;SQL_DOUBLE&quot;</attribute>
+          <attribute datatype='string' name='DebugWireType'>&quot;SQL_C_DOUBLE&quot;</attribute>
+        </attributes>
+        <object-id>[_45B6D75ECD4D4E19AD476AA7331DF17A]</object-id>
+      </metadata-record>
+    </metadata-records>
+  </connection>
+  <aliases enabled='yes' />
+  <column caption='Custom SQL Query' datatype='table' name='[__tableau_internal_object_id__].[_45B6D75ECD4D4E19AD476AA7331DF17A]' role='measure' type='quantitative' />
+  <layout dim-ordering='alphabetic' measure-ordering='alphabetic' show-structure='true' />
+  <semantic-values>
+    <semantic-value key='[Country].[Name]' value='&quot;United States&quot;' />
+  </semantic-values>
+  <datasource-dependencies datasource='Parameters'>
+    <column caption='Min Profit Threshold' datatype='real' name='[Parameter 0014036665946123]' param-domain-type='any' role='measure' type='quantitative' value='100.'>
+      <calculation class='tableau' formula='100.' />
+    </column>
+  </datasource-dependencies>
+  <object-graph>
+    <objects>
+      <object caption='Custom SQL Query' id='_45B6D75ECD4D4E19AD476AA7331DF17A'>
+        <properties context=''>
+          <relation connection='databricks.1m8fiiq0gddv4d17k40wf0ptqxg4' name='Custom SQL Query' type='text'><![CDATA[SELECT
+    o.`Order ID`,
+    o.`Customer Name`,
+    o.Profit,
+    o.Sales
+FROM fixture_catalog.default.orders AS o
+WHERE o.Profit >> <[Parameters].[Parameter 0014036665946123]>   -- parameter
+  AND o.Sales  << 5000                                   -- literal control]]></relation>
+        </properties>
+      </object>
+    </objects>
+  </object-graph>
+  <column caption='Metric Swap' datatype='real' name='[Calculation_557754699576291330]' role='measure' type='quantitative'>
+    <calculation class='tableau' formula='CASE [Parameters].[Metric] WHEN &quot;Sales&quot; THEN [Sales] WHEN &quot;Profit&quot; THEN [Profit] END' />
+  </column>
+  <column caption='Grouping Swap' datatype='string' name='[Calculation_557754699576291331]' role='dimension' type='nominal'>
+    <calculation class='tableau' formula='CASE [Parameters].[Grouping] WHEN &quot;Order&quot; THEN [Order ID] WHEN &quot;Customer&quot; THEN [Customer Name] END' />
+  </column>
+</datasource>

--- a/tests/fixtures/datasource-field-parameter-page/Swap_Datasource_With_Field_Parameters.tds
+++ b/tests/fixtures/datasource-field-parameter-page/Swap_Datasource_With_Field_Parameters.tds
@@ -247,6 +247,28 @@ WHERE o.Profit >> <[Parameters].[Parameter 0014036665946123]>   -- parameter
     <column caption='Min Profit Threshold' datatype='real' name='[Parameter 0014036665946123]' param-domain-type='any' role='measure' type='quantitative' value='100.'>
       <calculation class='tableau' formula='100.' />
     </column>
+    <column caption='Metric' datatype='string' name='[Parameter 0014036665946124]' param-domain-type='list' role='measure' type='nominal' value='&quot;Sales&quot;'>
+      <calculation class='tableau' formula='&quot;Sales&quot;' />
+      <members>
+        <member value='&quot;Sales&quot;' />
+        <member value='&quot;Profit&quot;' />
+      </members>
+      <aliases>
+        <alias key='&quot;Sales&quot;' value='Sales' />
+        <alias key='&quot;Profit&quot;' value='Profit' />
+      </aliases>
+    </column>
+    <column caption='Grouping' datatype='string' name='[Parameter 0014036665946125]' param-domain-type='list' role='measure' type='nominal' value='&quot;Order&quot;'>
+      <calculation class='tableau' formula='&quot;Order&quot;' />
+      <members>
+        <member value='&quot;Order&quot;' />
+        <member value='&quot;Customer&quot;' />
+      </members>
+      <aliases>
+        <alias key='&quot;Order&quot;' value='Order' />
+        <alias key='&quot;Customer&quot;' value='Customer' />
+      </aliases>
+    </column>
   </datasource-dependencies>
   <object-graph>
     <objects>

--- a/tests/test_datasource_path_envelope.py
+++ b/tests/test_datasource_path_envelope.py
@@ -1,0 +1,295 @@
+"""A standalone datasource unit is NOT a visual-free shell — the fail-open control for any
+kind-aware PBIP path-ceiling envelope.
+
+**The finding this file exists to keep true.** Run 409's pre-conversion refusal
+(`run_estate.project_estate_path_ceiling`, file 275 / dir 263 at a 92-unit output root) was driven
+entirely by the longest unit name, `Meridian_Calc_Gauntlet__Live_Snowflake_` — a **standalone
+datasource**. The 437 paths canonical engine 2.368.0 actually emitted from the same three inputs,
+rebased onto that same root, max out at **file 237 / dir 225 with 0 offenders**: the tree fitted.
+The projector over-projected that one unit by **+48 file / +54 dir** while projecting both workbook
+units accurate to **+4**, because it hands every unit the workbook worst case — a 24-unit page id
+and a 26+2-unit visual id — regardless of kind.
+
+**The obvious remedy is fail-open, which is why this fixture is committed.** Giving a datasource
+unit a *visual-free* envelope would understate its own emitted path by **45 characters**
+(measured below), i.e. it would pass a tree Desktop refuses. `migrate_estate.py` passes `swap_specs`
+into `write_local_pbip` on the datasource branch, so `assemble_model.build_swap_report_parts` →
+`twb_to_pbir.build_field_parameter_page` emits a real `pageSelfService` page with a field-parameter
+table and one `listSlicer` per swap parameter whenever the `.tds` carries field-swap calcs.
+
+⚠️ **And a SOUND kind-aware envelope still would not have rescued run 409.** At that root the
+datasource projects 262 / 250 with `pageSelfService` + a 24-unit visual — still over 259 / 247. The
+real tree fitted only because that datasource happened to carry **no** field-swap calcs, which is a
+**data**-dependent property the projector cannot read from a name. So "carry the unit kind" is a
+correct reduction in pessimism, not a fix for the over-refusal; do not let it be sold as one.
+
+Two kinds of assertion live here, with opposite lifetimes, in the shape
+`tests/test_issue_424_chart_type_pin.py` established:
+
+* the **input specification** (`test_the_fixture_is_swap_shaped`) is hand-written, parsed straight
+  from the `.tds`, and runs with no engine — so CI still guards the thing that makes the fixture a
+  fixture;
+* the **permanent invariant** (`test_a_visual_free_datasource_envelope_would_be_fail_open`) must
+  hold before AND after any kind-aware envelope lands. It is what kills the over-broad remedy.
+
+Fixture and provenance: `tests/fixtures/datasource-field-parameter-page/README.md`.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+SCRIPTS = REPO / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+import engine_source  # noqa: E402  # pylint: disable=wrong-import-position
+import run_estate  # noqa: E402  # pylint: disable=wrong-import-position
+from check_path_ceiling import utf16_len  # noqa: E402
+
+FIXTURE = REPO / "tests" / "fixtures" / "datasource-field-parameter-page"
+UNIT = "Swap_Datasource_With_Field_Parameters"
+RUN_ROOT = REPO / ".pytest_cache" / "datasource-path-envelope"
+SIMULATE_ENGINE_ABSENT = "T2P_SIMULATE_ENGINE_ABSENT_FOR_TESTS"
+ENGINE_SKIP_REASON = "deterministic tier not installed"
+
+#: What `build_field_parameter_page` writes. The page name is a hard-coded default in the engine,
+#: so observing it is itself the proof that the swap branch — not the thin branch — was reached.
+SELF_SERVICE_PAGE = "pageSelfService"
+
+#: `twb_to_pbir._sanitize` returns `name[:24]`, so no emitted identifier can exceed this.
+ENGINE_IDENTIFIER_CAP = 24
+
+#: The engine's visual-free datasource shell, for the understatement arithmetic below.
+THIN_TAIL = "definition/pages/page1/page.json"
+
+#: The two calcs grafted onto the base fixture, and the exact shape `parameters.detect_field_swap`
+#: accepts: a `[Parameters].[X]`-driven CASE whose every branch is a BARE field reference, >= 2
+#: branches. One measure-role and one dimension-role, so the emitted page carries the table AND a
+#: slicer per parameter. Hand-written; never derived from a parse.
+EXPECTED_SWAPS = {
+    "Metric Swap": (
+        "measure",
+        'CASE [Parameters].[Metric] WHEN "Sales" THEN [Sales] WHEN "Profit" THEN [Profit] END',
+    ),
+    "Grouping Swap": (
+        "dimension",
+        'CASE [Parameters].[Grouping] WHEN "Order" THEN [Order ID] WHEN "Customer" THEN [Customer Name] END',
+    ),
+}
+
+_ENGINE_RUN: dict[str, Any] | None = None
+
+
+def _contract() -> Path | None:
+    """The canonical engine root, or None when the deterministic tier is not installed."""
+    if os.environ.get(SIMULATE_ENGINE_ABSENT):
+        return None
+    try:
+        return engine_source.engine_root()
+    except engine_source.EngineNotFoundError:
+        return None
+
+
+def requires_engine(test):
+    """Mark an engine-dependent test and skip it when the canonical engine is absent."""
+    test = pytest.mark.engine_dependency(expected_skip_reason=ENGINE_SKIP_REASON)(test)
+    return pytest.mark.skipif(_contract() is None, reason=ENGINE_SKIP_REASON)(test)
+
+
+# -- the fixture INPUT (no engine; this half runs in CI) -------------------------------------------
+def _fixture_swaps() -> dict[str, tuple[str, str]]:
+    """Every calculated column in the fixture, as `{caption: (role, formula)}`."""
+    root = ET.parse(FIXTURE / f"{UNIT}.tds").getroot()
+    found: dict[str, tuple[str, str]] = {}
+    for column in root.iter("column"):
+        calculation = column.find("calculation")
+        caption = column.get("caption")
+        if calculation is None or not caption:
+            continue
+        formula = (calculation.get("formula") or "").strip()
+        if formula.lower().startswith("case [parameters]"):
+            found[caption] = (column.get("role") or "", formula)
+    return found
+
+
+def test_the_fixture_is_swap_shaped() -> None:
+    """Without these two calcs the engine falls back to the thin shell and the fixture proves nothing.
+
+    Pinned against the source rather than the output so it still guards the fixture on a machine
+    with no engine — and because `build_swap_report_parts` silently returns
+    `build_thin_report_parts` when no spec is usable, which would turn every assertion below into a
+    vacuous pass rather than a failure.
+    """
+    assert _fixture_swaps() == EXPECTED_SWAPS, (
+        "The fixture's field-swap calcs changed. `detect_field_swap` needs a `[Parameters].[X]`-driven "
+        "CASE with >= 2 BARE-field branches; anything else falls through to ordinary calc translation "
+        "and the engine emits the thin `page1` shell instead of a self-service page.\n"
+        f"  expected: {EXPECTED_SWAPS}\n  observed: {_fixture_swaps()}"
+    )
+
+
+# -- what the ENGINE emits ------------------------------------------------------------------------
+def _run_engine_once() -> dict[str, Any]:
+    global _ENGINE_RUN  # pylint: disable=global-statement
+    if _ENGINE_RUN is not None:
+        return _ENGINE_RUN
+
+    engine = _contract()
+    if engine is None:  # pragma: no cover - requires_engine handles collection-time absence.
+        pytest.skip(ENGINE_SKIP_REASON)
+
+    if RUN_ROOT.exists():
+        shutil.rmtree(RUN_ROOT)
+    RUN_ROOT.mkdir(parents=True)
+
+    cmd = [
+        sys.executable,
+        str(engine_source.engine_scripts_dir(engine) / "migrate_estate.py"),
+        "-i",
+        str(FIXTURE),
+        "-o",
+        str(RUN_ROOT),
+    ]
+    completed = subprocess.run(cmd, cwd=REPO, text=True, capture_output=True, timeout=900, check=False)
+    assert completed.returncode == 0, (
+        "This harness could not run the canonical engine. That is a harness failure, not a pinned "
+        f"behaviour change.\nCommand: {cmd}\nSTDOUT:\n{completed.stdout}\nSTDERR:\n{completed.stderr}"
+    )
+
+    pages = RUN_ROOT / "pbip" / UNIT / f"{UNIT}.Report" / "definition" / "pages"
+    page_dirs = sorted(p.name for p in pages.iterdir() if p.is_dir()) if pages.is_dir() else []
+    visuals = sorted(
+        v.name
+        for page in (pages.iterdir() if pages.is_dir() else [])
+        if page.is_dir()
+        for v in ((page / "visuals").iterdir() if (page / "visuals").is_dir() else [])
+        if v.is_dir()
+    )
+    _ENGINE_RUN = {
+        "version": engine_source.engine_version(engine),
+        "pages": page_dirs,
+        "visuals": visuals,
+        "deepest_tail": max(
+            (
+                str(p.relative_to(RUN_ROOT / "pbip" / UNIT / f"{UNIT}.Report")).replace("\\", "/")
+                for p in pages.rglob("*")
+                if p.is_file()
+            ),
+            key=utf16_len,
+            default="",
+        ),
+    }
+    return _ENGINE_RUN
+
+
+@requires_engine
+def test_a_standalone_datasource_emits_a_self_service_page_with_visuals() -> None:
+    """The refutation: a `.tds` unit is not structurally visual-free.
+
+    `pageSelfService` is a hard-coded default of `twb_to_pbir.build_field_parameter_page`, so seeing
+    it is the proof that the engine's **swap** branch was reached rather than the thin one — the
+    production code path this fixture exists to exercise.
+    """
+    run = _run_engine_once()
+    assert run["pages"] == [SELF_SERVICE_PAGE], (
+        f"A standalone datasource emitted pages {run['pages']} on canonical engine {run['version']}, "
+        f"not the expected [{SELF_SERVICE_PAGE!r}]. If it now emits ['page1'], the swap branch was "
+        "NOT reached and every assertion in this module is vacuous - fix the fixture before trusting "
+        "any datasource path-envelope conclusion."
+    )
+    assert len(run["visuals"]) >= 1, (
+        f"A standalone datasource emitted NO visuals on canonical engine {run['version']}. That is "
+        "the belief this fixture exists to refute; if the engine genuinely changed, a visual-free "
+        "datasource envelope becomes arguable - re-derive it, do not simply delete this test."
+    )
+    longest = max(utf16_len(name) for name in run["visuals"])
+    assert longest == ENGINE_IDENTIFIER_CAP, (
+        f"The longest emitted datasource visual identifier is {longest} UTF-16 units, not the "
+        f"{ENGINE_IDENTIFIER_CAP} that `twb_to_pbir._sanitize` caps at (observed {run['visuals']} on "
+        f"engine {run['version']}). Any datasource path envelope must cover whatever this is."
+    )
+
+
+@requires_engine
+def test_a_visual_free_datasource_envelope_would_be_fail_open() -> None:
+    """PERMANENT INVARIANT — must hold before AND after any kind-aware envelope lands.
+
+    A datasource envelope that models only `pages/page1/page.json` understates this unit's own
+    emitted deepest path. Fail-open is the direction that ships a tree Power BI Desktop refuses, so
+    this is the assertion that kills the over-broad remedy.
+    """
+    run = _run_engine_once()
+    emitted = utf16_len(run["deepest_tail"])
+    thin = utf16_len(THIN_TAIL)
+    assert emitted > thin, (
+        f"A visual-free datasource envelope ({thin}) no longer understates the emitted deepest tail "
+        f"({emitted}, {run['deepest_tail']!r}) on engine {run['version']}."
+    )
+    assert emitted - thin >= 40, (
+        f"The understatement shrank to {emitted - thin} characters (emitted {emitted} "
+        f"{run['deepest_tail']!r} vs visual-free {thin}). Measured 45 on engine 2.368.0. A shrinking "
+        "gap is a signal the engine changed its datasource report shape, not a licence to relax the "
+        "envelope."
+    )
+
+
+@requires_engine
+def test_the_projector_is_blind_to_unit_kind_and_over_projects_this_datasource() -> None:
+    """The classification defect, stated against the production function and real emitted paths.
+
+    `project_estate_path_ceiling` takes only NAMES, so it cannot tell a datasource from a workbook
+    and assigns both the workbook worst case. Measured here as the gap between what it projects and
+    what the engine actually wrote for the same unit at the same root.
+
+    ⚠️ The gap is real but it is NOT the whole of run 409's over-refusal: with the *sound*
+    datasource envelope this fixture measures (`pageSelfService` + a 24-unit visual) that unit still
+    projects over the ceiling. Deleting the pessimism is worth doing; it is not a fix.
+    """
+    run = _run_engine_once()
+    root = RUN_ROOT
+    projection = run_estate.project_estate_path_ceiling(root, [UNIT])
+    projected_file = next(r for r in projection["paths"] if r["kind"] == "file")["length"]
+
+    report_root = root / "pbip" / UNIT / f"{UNIT}.Report"
+    actual_file = max(utf16_len(str(p)) for p in report_root.rglob("*") if p.is_file())
+
+    assert projected_file > actual_file, (
+        f"The projection ({projected_file}) no longer exceeds the emitted report path ({actual_file}) "
+        f"for datasource unit {UNIT!r} on engine {run['version']}. If the projector became "
+        "kind-aware, re-derive this expectation from the new envelope rather than deleting it."
+    )
+    sound = utf16_len(
+        str(
+            report_root
+            / "definition"
+            / "pages"
+            / SELF_SERVICE_PAGE
+            / "visuals"
+            / ("v" * ENGINE_IDENTIFIER_CAP)
+            / "visual.json"
+        )
+    )
+    assert sound < projected_file, (
+        f"A kind-aware datasource envelope ({sound}) is no cheaper than the workbook worst case "
+        f"({projected_file}); the classification this module argues for would buy nothing."
+    )
+    assert sound >= actual_file, (
+        f"The sound datasource envelope ({sound}) does not cover the emitted path ({actual_file}); an "
+        "envelope that fails to cover real output is fail-open by construction."
+    )
+    assert sound - actual_file <= 2, (
+        f"The sound datasource envelope ({sound}) now has {sound - actual_file} characters of slack "
+        f"over the emitted path ({actual_file}). Measured 0 on engine 2.368.0 - the emitted visual "
+        f"identifiers sit exactly at `_sanitize`'s {ENGINE_IDENTIFIER_CAP}-unit cap, so a datasource "
+        "envelope built on `pageSelfService` + that cap is EXACTLY tight and carries no margin."
+    )

--- a/tests/test_datasource_path_envelope.py
+++ b/tests/test_datasource_path_envelope.py
@@ -60,7 +60,7 @@ if str(SCRIPTS) not in sys.path:
 
 import engine_source  # noqa: E402  # pylint: disable=wrong-import-position
 import run_estate  # noqa: E402  # pylint: disable=wrong-import-position
-from check_path_ceiling import FILE_CEILING, utf16_len  # noqa: E402
+from check_path_ceiling import DIR_CEILING, FILE_CEILING, utf16_len  # noqa: E402  # pylint: disable=wrong-import-position
 
 FIXTURE_DIR = REPO / "tests" / "fixtures" / "datasource-field-parameter-page"
 SWAP_UNIT = "Swap_Datasource_With_Field_Parameters"
@@ -95,12 +95,27 @@ THIN_PAGE = "page1"
 ENGINE_IDENTIFIER_CAP = 24
 
 
-#: The envelope tail each source kind would be modelled with, longest first. A tail is the part of
-#: the path below `<unit>.Report/`, in UTF-16 units.
+#: The envelope tail each source kind would be modelled with, in UTF-16 units below `<unit>.Report/`.
+#: ⚠️ Round-2 review: these are **documentation of a capability comparison**, never production
+#: coverage. `run_estate` owns the envelope that actually gates a run; anything asserted against the
+#: constants below is a statement about what a kind-aware envelope COULD look like, which is why the
+#: two tests that gate on production call `project_estate_path_ceiling` directly instead.
 def _tail(page: str, visual: str | None) -> int:
     if visual is None:
         return utf16_len(f"definition/pages/{page}/page.json")
     return utf16_len(f"definition/pages/{page}/visuals/{visual}/visual.json")
+
+
+def _root_for_length(length: int) -> Path:
+    """A synthetic resolved root with an exact UTF-16 length on the current host.
+
+    Same idiom as `tests/test_run_estate.py::_root_for_length`, kept local rather than imported so
+    this module has no cross-test-module dependency.
+    """
+    anchor = Path.cwd().anchor
+    root = Path(anchor + "r" * (length - utf16_len(anchor))).resolve()
+    assert utf16_len(str(root)) == length, f"could not build a {length}-unit root; got {root}"
+    return root
 
 
 ENVELOPE_TAIL = {
@@ -246,7 +261,7 @@ def test_every_swap_controller_is_a_declared_parameter() -> None:
 
 # -- what the ENGINE emits -------------------------------------------------------------------------
 @pytest.fixture(scope="session", name="engine_bundle")
-def _engine_bundle(tmp_path_factory: pytest.TempPathFactory) -> dict[str, Any]:
+def _engine_bundle(tmp_path_factory: pytest.TempPathFactory) -> dict[str, Any]:  # pylint: disable=too-many-locals
     """Run the canonical engine ONCE over all three source shapes, into a per-process directory.
 
     `tmp_path_factory` gives a base temp that is unique per pytest process and per xdist worker, so
@@ -298,14 +313,23 @@ def _engine_bundle(tmp_path_factory: pytest.TempPathFactory) -> dict[str, Any]:
             if report.is_dir()
             else []
         )
+        dir_tails = (
+            [str(p.relative_to(report)).replace("\\", "/") for p in report.rglob("*") if p.is_dir()]
+            if report.is_dir()
+            else []
+        )
         deepest = max(tails, key=utf16_len, default="")
+        deepest_dir = max(dir_tails, key=utf16_len, default="")
         shapes[unit] = {
             "report": report,
             "pages": page_dirs,
             "visuals": visuals,
             "deepest_tail": deepest,
             "deepest_tail_len": utf16_len(deepest),
+            "deepest_dir_tail": deepest_dir,
+            "deepest_dir_tail_len": utf16_len(deepest_dir),
             "longest_visual_id": max((utf16_len(v) for v in visuals), default=0),
+            "longest_page_id": max((utf16_len(p) for p in page_dirs), default=0),
         }
     return {"version": engine_source.engine_version(engine), "root": out, "shapes": shapes}
 
@@ -340,7 +364,7 @@ def test_a_standalone_datasource_emits_a_self_service_page_with_visuals(engine_b
 
 
 @requires_engine
-def test_the_engine_itself_resolves_both_declared_swap_controllers(engine_bundle) -> None:
+def test_the_engine_itself_resolves_both_declared_swap_controllers() -> None:
     """The engine's OWN parser must see the parameters, not just our XML reading of them.
 
     `test_every_swap_controller_is_a_declared_parameter` reads the `.tds` with this repository's
@@ -442,36 +466,91 @@ def test_the_three_source_shapes_emit_their_documented_reports(
 
 
 @requires_engine
+@pytest.mark.parametrize("kind", ["file", "directory"])
 @pytest.mark.parametrize("unit", sorted(MATRIX_SOURCES))
-def test_each_shape_envelope_covers_its_tail_and_one_unit_less_would_not(engine_bundle, unit: str) -> None:
-    """A per-kind envelope must COVER its own emitted tail, and be tight enough to matter.
+def test_the_production_projection_refuses_each_emitted_shape_at_its_own_boundary(
+    engine_bundle, unit: str, kind: str
+) -> None:
+    """The PRODUCTION projector, at a root derived from what the engine really wrote.
 
-    The boundary is computed, not assumed: at `root = FILE_CEILING - envelope - 1` the emitted path
-    must land at or under Desktop's file ceiling, and an envelope one unit shorter must push that
-    same emitted path one unit over. That is the exact place a one-unit understatement flips a
-    refusal into a pass.
+    ⚠️ Round-2 review: the assertion this replaces compared a **test-owned** `ENVELOPE_TAIL`
+    constant against the emitted tail, and closed with the tautology
+    `(CEILING - (actual - 1) - 1) + 1 + actual == CEILING + 1`, which is true for every `actual`.
+    Understating production's own `_PBIR_VISUAL_ID` by four units left all of it green.
+
+    So the root here is sized so the **actually emitted** path measures exactly `ceiling + 1`, and
+    `run_estate.project_estate_path_ceiling` — the real function — must refuse it, naming the right
+    kind, ceiling and unit, and projecting a length that COVERS the real one.
+
+    ⚠️ Honest limit of this boundary, stated rather than implied: it is only as sensitive as the
+    slack between production's envelope and *this fixture's* instance. The workbook fixture emits a
+    19-unit page id and a 24-unit visual id against a 24 + 28 envelope, i.e. 9 units of slack, so a
+    four-unit understatement still covers here. What bounds the envelope against the engine's own
+    maximum is `test_the_production_identifier_envelope_stays_above_the_engines_measured_cap`.
     """
     shape = engine_bundle["shapes"][unit]
-    actual = shape["deepest_tail_len"]
-    envelope = ENVELOPE_TAIL[unit]
+    tail = shape["deepest_tail"] if kind == "file" else shape["deepest_dir_tail"]
+    ceiling = FILE_CEILING if kind == "file" else DIR_CEILING
+    assert tail, f"{unit}: the engine emitted no {kind} under its .Report folder"
 
-    assert envelope >= actual, (
-        f"{unit}: the modelled envelope tail ({envelope}) does not cover the emitted tail "
-        f"({actual}, {shape['deepest_tail']!r}). An envelope that fails to cover real output is "
-        "fail-open by construction."
+    relative = f"pbip/{unit}/{unit}.Report/{tail}"
+    root = _root_for_length(ceiling + 1 - 1 - utf16_len(relative))
+    at_root = utf16_len(str(root)) + 1 + utf16_len(relative)
+    assert at_root == ceiling + 1, (
+        f"harness error: the emitted {kind} measures {at_root} at the constructed root, not the intended {ceiling + 1}"
     )
 
-    boundary_root = FILE_CEILING - envelope - 1
-    assert boundary_root + 1 + actual <= FILE_CEILING, (
-        f"{unit}: at the envelope-derived root {boundary_root} the emitted path measures "
-        f"{boundary_root + 1 + actual}, over the {FILE_CEILING} ceiling"
+    projection = run_estate.project_estate_path_ceiling(root, [unit])
+    record = next(r for r in projection["paths"] if r["kind"] == kind)
+
+    assert record["length"] >= at_root, (
+        f"{unit}/{kind}: the PRODUCTION envelope projects {record['length']} units where the engine "
+        f"really wrote {at_root} ({relative!r}). An envelope that does not cover real output is "
+        "fail-open by construction - this is the assertion a shortened production identifier breaks."
+    )
+    assert projection["status"] == "over_ceiling", (
+        f"{unit}/{kind}: production reported {projection['status']!r} at a root where its own emitted "
+        f"{kind} measures {at_root}, one unit over the {ceiling} ceiling"
+    )
+    assert record["ceiling"] == ceiling, f"{unit}/{kind}: production judged against ceiling {record['ceiling']}"
+    assert projection["longest_unit"] == unit, f"{unit}/{kind}: production named unit {projection['longest_unit']!r}"
+    assert any(offender["kind"] == kind for offender in projection["offenders"]), (
+        f"{unit}/{kind}: production refused, but not on the {kind} rule: "
+        f"{[(o['kind'], o['length'], o['ceiling']) for o in projection['offenders']]}"
     )
 
-    understated_root = FILE_CEILING - (actual - 1) - 1
-    assert understated_root + 1 + actual == FILE_CEILING + 1, (
-        f"{unit}: an envelope one unit under the emitted tail ({actual - 1}) would derive root "
-        f"{understated_root}, at which the emitted path measures {understated_root + 1 + actual}; "
-        f"expected exactly {FILE_CEILING + 1}, i.e. one unit over the ceiling"
+
+@requires_engine
+def test_the_production_identifier_envelope_stays_above_the_engines_measured_cap(engine_bundle) -> None:
+    """Production's projected identifiers must bound what the engine can actually emit.
+
+    `_sanitize` returns `name[:24]`, and this bundle's three shapes are measured, not assumed. The
+    projector deliberately carries `_PBIR_IDENTIFIER_SAFETY_MARGIN` on top of that
+    ("so the envelope remains conservative for a future engine identifier", `run_estate.py`), so an
+    envelope that has been trimmed back to — or below — the observed cap has spent a margin the
+    module documents as intentional. This is the assertion that a four-unit understatement breaks,
+    where a per-fixture boundary cannot: it compares production against the ENGINE's maximum rather
+    than against one artifact's instance.
+    """
+    measured_visual = max(shape["longest_visual_id"] for shape in engine_bundle["shapes"].values())
+    measured_page = max(shape["longest_page_id"] for shape in engine_bundle["shapes"].values())
+    projected_visual = utf16_len(run_estate._PBIR_VISUAL_ID)  # pylint: disable=protected-access
+    projected_page = utf16_len(run_estate._PBIR_PAGE_ID)  # pylint: disable=protected-access
+    margin = run_estate._PBIR_IDENTIFIER_SAFETY_MARGIN  # pylint: disable=protected-access
+
+    assert measured_visual == ENGINE_IDENTIFIER_CAP, (
+        f"the engine's longest emitted visual identifier across all three shapes is {measured_visual}, "
+        f"not `_sanitize`'s {ENGINE_IDENTIFIER_CAP}-unit cap, on engine {engine_bundle['version']}"
+    )
+    assert projected_visual >= measured_visual + margin, (
+        f"production projects a {projected_visual}-unit visual identifier, which is not the measured "
+        f"engine cap ({measured_visual}) plus the documented safety margin ({margin}). Trimming this "
+        "spends a margin `run_estate` states it keeps on purpose, and no per-fixture boundary test "
+        "will notice, because every committed fixture emits shorter identifiers than the cap allows."
+    )
+    assert projected_page >= measured_page, (
+        f"production projects a {projected_page}-unit page identifier, under the {measured_page} the "
+        f"engine emitted on engine {engine_bundle['version']}"
     )
 
 

--- a/tests/test_datasource_path_envelope.py
+++ b/tests/test_datasource_path_envelope.py
@@ -212,7 +212,7 @@ def test_a_standalone_datasource_emits_a_self_service_page_with_visuals() -> Non
         "the belief this fixture exists to refute; if the engine genuinely changed, a visual-free "
         "datasource envelope becomes arguable - re-derive it, do not simply delete this test."
     )
-    longest = max(utf16_len(name) for name in run["visuals"])
+    longest = max((utf16_len(name) for name in run["visuals"]), default=0)
     assert longest == ENGINE_IDENTIFIER_CAP, (
         f"The longest emitted datasource visual identifier is {longest} UTF-16 units, not the "
         f"{ENGINE_IDENTIFIER_CAP} that `twb_to_pbir._sanitize` caps at (observed {run['visuals']} on "

--- a/tests/test_datasource_path_envelope.py
+++ b/tests/test_datasource_path_envelope.py
@@ -1,44 +1,50 @@
-"""A standalone datasource unit is NOT a visual-free shell — the fail-open control for any
-kind-aware PBIP path-ceiling envelope.
+"""A standalone datasource unit is NOT a visual-free PBIP shell — the fail-open control for any
+kind-aware PBIP path-ceiling envelope, plus the three-shape envelope matrix.
 
-**The finding this file exists to keep true.** Run 409's pre-conversion refusal
+**The finding this file exists to keep true.** Run 409's pre-conversion path-ceiling refusal
 (`run_estate.project_estate_path_ceiling`, file 275 / dir 263 at a 92-unit output root) was driven
 entirely by the longest unit name, `Meridian_Calc_Gauntlet__Live_Snowflake_` — a **standalone
 datasource**. The 437 paths canonical engine 2.368.0 actually emitted from the same three inputs,
-rebased onto that same root, max out at **file 237 / dir 225 with 0 offenders**: the tree fitted.
-The projector over-projected that one unit by **+48 file / +54 dir** while projecting both workbook
-units accurate to **+4**, because it hands every unit the workbook worst case — a 24-unit page id
-and a 26+2-unit visual id — regardless of kind.
+rebased onto that root, max out at file 237 / dir 225 with 0 offenders: the tree fitted, and Power
+BI Desktop opened it at that exact root. The projector over-projected that unit by +48 file / +54
+dir while projecting both workbook units accurate to +4, because it takes only NAMES and hands
+every unit the workbook worst case regardless of kind.
 
-**The obvious remedy is fail-open, which is why this fixture is committed.** Giving a datasource
-unit a *visual-free* envelope would understate its own emitted path by **45 characters**
-(measured below), i.e. it would pass a tree Desktop refuses. `migrate_estate.py` passes `swap_specs`
-into `write_local_pbip` on the datasource branch, so `assemble_model.build_swap_report_parts` →
-`twb_to_pbir.build_field_parameter_page` emits a real `pageSelfService` page with a field-parameter
-table and one `listSlicer` per swap parameter whenever the `.tds` carries field-swap calcs.
+**The obvious remedy — a visual-free datasource envelope — is FAIL-OPEN.** `migrate_estate.py`
+passes `swap_specs` into `write_local_pbip` on the datasource branch, so
+`assemble_model.build_swap_report_parts` → `twb_to_pbir.build_field_parameter_page` emits a real
+`pageSelfService` page with a field-parameter table and one `listSlicer` per swap parameter.
 
-⚠️ **And a SOUND kind-aware envelope still would not have rescued run 409.** At that root the
-datasource projects 262 / 250 with `pageSelfService` + a 24-unit visual — still over 259 / 247. The
-real tree fitted only because that datasource happened to carry **no** field-swap calcs, which is a
-**data**-dependent property the projector cannot read from a name. So "carry the unit kind" is a
-correct reduction in pessimism, not a fix for the over-refusal; do not let it be sold as one.
+⚠️ **And a SOUND kind-aware envelope still would not have rescued run 409** (262 / 250 at that root,
+still over 259 / 247). The tree fitted only because that datasource carried no field-swap calcs,
+which is **data**-dependent, not **kind**-dependent. Do not let "carry the unit kind" be sold as the
+fix for the over-refusal.
 
-Two kinds of assertion live here, with opposite lifetimes, in the shape
-`tests/test_issue_424_chart_type_pin.py` established:
+Assertion families, with deliberately different lifetimes (the shape
+`tests/test_issue_424_chart_type_pin.py` established):
 
-* the **input specification** (`test_the_fixture_is_swap_shaped`) is hand-written, parsed straight
-  from the `.tds`, and runs with no engine — so CI still guards the thing that makes the fixture a
-  fixture;
+* the **input specification** (`test_the_fixture_is_swap_shaped`,
+  `test_every_swap_controller_is_a_declared_parameter`) is hand-written, parsed straight from the
+  `.tds`, and runs with **no engine** — so CI still guards what makes the fixture a fixture;
+* the **three-shape matrix** proves the envelope is calibrated per source kind against real engine
+  output, not against one artifact;
 * the **permanent invariant** (`test_a_visual_free_datasource_envelope_would_be_fail_open`) must
-  hold before AND after any kind-aware envelope lands. It is what kills the over-broad remedy.
+  hold before AND after any kind-aware envelope lands — it is what kills the over-broad remedy.
+
+⚠️ **Engine output is written to a per-session, per-process temporary directory** obtained from
+`tmp_path_factory`, never to a fixed path under `.pytest_cache`. An earlier revision used one shared
+`RUN_ROOT` and `rmtree`d it on entry, so two concurrent pytest processes could delete each other's
+output mid-read (reproduced as `WinError 145` and an empty page list).
+`test_two_concurrent_pytest_processes_do_not_collide` is the control for that.
 
 Fixture and provenance: `tests/fixtures/datasource-field-parameter-page/README.md`.
 """
 
 from __future__ import annotations
 
+import json
 import os
-import shutil
+import re
 import subprocess
 import sys
 import xml.etree.ElementTree as ET
@@ -54,23 +60,54 @@ if str(SCRIPTS) not in sys.path:
 
 import engine_source  # noqa: E402  # pylint: disable=wrong-import-position
 import run_estate  # noqa: E402  # pylint: disable=wrong-import-position
-from check_path_ceiling import utf16_len  # noqa: E402
+from check_path_ceiling import FILE_CEILING, utf16_len  # noqa: E402
 
-FIXTURE = REPO / "tests" / "fixtures" / "datasource-field-parameter-page"
-UNIT = "Swap_Datasource_With_Field_Parameters"
-RUN_ROOT = REPO / ".pytest_cache" / "datasource-path-envelope"
+FIXTURE_DIR = REPO / "tests" / "fixtures" / "datasource-field-parameter-page"
+SWAP_UNIT = "Swap_Datasource_With_Field_Parameters"
+THIN_UNIT = "CustomSQL_Parameter_And_Doubled_Operators"
+WORKBOOK_UNIT = "issue-424-d-explicit-bar-mark"
+
+#: The three inputs of the shape matrix. All three are EXISTING committed fixtures - the swap
+#: datasource is the only one this module added, and the workbook is borrowed from the #424 repro
+#: set rather than duplicating a long-name proof that `tests/test_run_estate.py` already owns.
+MATRIX_SOURCES = {
+    THIN_UNIT: REPO / "tests" / "fixtures" / f"{THIN_UNIT}.tds",
+    SWAP_UNIT: FIXTURE_DIR / f"{SWAP_UNIT}.tds",
+    WORKBOOK_UNIT: REPO
+    / "fixtures"
+    / "upstream-repros"
+    / "issue-424-automatic-mark-discrete-date"
+    / f"{WORKBOOK_UNIT}.twb",
+}
+
 SIMULATE_ENGINE_ABSENT = "T2P_SIMULATE_ENGINE_ABSENT_FOR_TESTS"
+CHILD_SENTINEL = "T2P_DS_ENVELOPE_CONCURRENCY_CHILD"
 ENGINE_SKIP_REASON = "deterministic tier not installed"
 
 #: What `build_field_parameter_page` writes. The page name is a hard-coded default in the engine,
 #: so observing it is itself the proof that the swap branch — not the thin branch — was reached.
 SELF_SERVICE_PAGE = "pageSelfService"
 
+#: The engine's visual-free datasource shell page.
+THIN_PAGE = "page1"
+
 #: `twb_to_pbir._sanitize` returns `name[:24]`, so no emitted identifier can exceed this.
 ENGINE_IDENTIFIER_CAP = 24
 
-#: The engine's visual-free datasource shell, for the understatement arithmetic below.
-THIN_TAIL = "definition/pages/page1/page.json"
+
+#: The envelope tail each source kind would be modelled with, longest first. A tail is the part of
+#: the path below `<unit>.Report/`, in UTF-16 units.
+def _tail(page: str, visual: str | None) -> int:
+    if visual is None:
+        return utf16_len(f"definition/pages/{page}/page.json")
+    return utf16_len(f"definition/pages/{page}/visuals/{visual}/visual.json")
+
+
+ENVELOPE_TAIL = {
+    WORKBOOK_UNIT: _tail("p" * ENGINE_IDENTIFIER_CAP, "v" * ENGINE_IDENTIFIER_CAP),
+    SWAP_UNIT: _tail(SELF_SERVICE_PAGE, "v" * ENGINE_IDENTIFIER_CAP),
+    THIN_UNIT: _tail(THIN_PAGE, None),
+}
 
 #: The two calcs grafted onto the base fixture, and the exact shape `parameters.detect_field_swap`
 #: accepts: a `[Parameters].[X]`-driven CASE whose every branch is a BARE field reference, >= 2
@@ -87,7 +124,13 @@ EXPECTED_SWAPS = {
     ),
 }
 
-_ENGINE_RUN: dict[str, Any] | None = None
+#: Each swap's controlling parameter, as Tableau would really declare it. A controller that is not
+#: declared is a dangling name the engine happens to accept, and the fixture would then be proving
+#: regex tolerance rather than a real swap.
+EXPECTED_CONTROLLERS = {
+    "Metric": {"domain": "list", "default": "Sales", "members": ["Sales", "Profit"]},
+    "Grouping": {"domain": "list", "default": "Order", "members": ["Order", "Customer"]},
+}
 
 
 def _contract() -> Path | None:
@@ -107,11 +150,14 @@ def requires_engine(test):
 
 
 # -- the fixture INPUT (no engine; this half runs in CI) -------------------------------------------
+def _fixture_root() -> ET.Element:
+    return ET.parse(MATRIX_SOURCES[SWAP_UNIT]).getroot()
+
+
 def _fixture_swaps() -> dict[str, tuple[str, str]]:
-    """Every calculated column in the fixture, as `{caption: (role, formula)}`."""
-    root = ET.parse(FIXTURE / f"{UNIT}.tds").getroot()
+    """Every `[Parameters].[X]`-driven calculated column, as `{caption: (role, formula)}`."""
     found: dict[str, tuple[str, str]] = {}
-    for column in root.iter("column"):
+    for column in _fixture_root().iter("column"):
         calculation = column.find("calculation")
         caption = column.get("caption")
         if calculation is None or not caption:
@@ -122,13 +168,44 @@ def _fixture_swaps() -> dict[str, tuple[str, str]]:
     return found
 
 
+def _declared_parameters() -> dict[str, dict[str, Any]]:
+    """Parameters the fixture DECLARES, read the way the engine reads them (`param-domain-type`)."""
+    declared: dict[str, dict[str, Any]] = {}
+    for column in _fixture_root().iter("column"):
+        if column.get("param-domain-type") is None:
+            continue
+        members = [
+            (member.get("value") or "").strip('"')
+            for group in column
+            if group.tag.endswith("members")
+            for member in group
+            if member.tag.endswith("member")
+        ]
+        declared[column.get("caption") or column.get("name") or ""] = {
+            "domain": column.get("param-domain-type"),
+            "default": (column.get("value") or "").strip('"'),
+            "members": members,
+        }
+    return declared
+
+
+def _controllers() -> dict[str, list[str]]:
+    """`{controller: [branch label, ...]}` read straight out of the swap formulas."""
+    out: dict[str, list[str]] = {}
+    for _caption, (_role, formula) in _fixture_swaps().items():
+        head = re.match(r"(?is)^case\s*\[Parameters\]\.\[([^\]]+)\]\s*(.*)$", formula)
+        assert head, f"formula is not a `[Parameters].[X]`-driven CASE: {formula!r}"
+        out[head.group(1)] = re.findall(r'(?i)\bwhen\s*"([^"]+)"', head.group(2))
+    return out
+
+
 def test_the_fixture_is_swap_shaped() -> None:
     """Without these two calcs the engine falls back to the thin shell and the fixture proves nothing.
 
     Pinned against the source rather than the output so it still guards the fixture on a machine
     with no engine — and because `build_swap_report_parts` silently returns
-    `build_thin_report_parts` when no spec is usable, which would turn every assertion below into a
-    vacuous pass rather than a failure.
+    `build_thin_report_parts` when no spec is usable, which would turn every engine assertion below
+    into a vacuous pass rather than a failure.
     """
     assert _fixture_swaps() == EXPECTED_SWAPS, (
         "The fixture's field-swap calcs changed. `detect_field_swap` needs a `[Parameters].[X]`-driven "
@@ -138,147 +215,316 @@ def test_the_fixture_is_swap_shaped() -> None:
     )
 
 
-# -- what the ENGINE emits ------------------------------------------------------------------------
-def _run_engine_once() -> dict[str, Any]:
-    global _ENGINE_RUN  # pylint: disable=global-statement
-    if _ENGINE_RUN is not None:
-        return _ENGINE_RUN
+def test_every_swap_controller_is_a_declared_parameter() -> None:
+    """A swap whose controller is not declared is a dangling name, not a swap.
 
+    `detect_field_swap` only pattern-matches the FORMULA, so a fixture can reach the self-service
+    branch while referencing a parameter that does not exist — proving the engine's regex tolerance
+    rather than a real Tableau shape. This pins the controller, its domain, its default and its
+    members against the swap's own branch labels.
+    """
+    declared = _declared_parameters()
+    controllers = _controllers()
+    missing = sorted(set(controllers) - set(declared))
+    assert not missing, (
+        f"swap controller(s) {missing} are referenced by a calc but not declared as parameters in "
+        f"the fixture. Declared: {sorted(declared)}. A dangling controller makes this fixture a test "
+        "of regex tolerance, not of a real field swap."
+    )
+    for controller, labels in controllers.items():
+        spec = declared[controller]
+        expected = EXPECTED_CONTROLLERS[controller]
+        assert spec["domain"] == expected["domain"], f"{controller}: domain {spec['domain']!r}"
+        assert spec["members"] == expected["members"], f"{controller}: members {spec['members']!r}"
+        assert spec["default"] == expected["default"], f"{controller}: default {spec['default']!r}"
+        assert spec["members"] == labels, (
+            f"{controller}: declared members {spec['members']} do not match the swap's own branch "
+            f"labels {labels}. The parameter and the calc must describe the same choice."
+        )
+        assert spec["default"] in labels, f"{controller}: default {spec['default']!r} is not a branch"
+
+
+# -- what the ENGINE emits -------------------------------------------------------------------------
+@pytest.fixture(scope="session", name="engine_bundle")
+def _engine_bundle(tmp_path_factory: pytest.TempPathFactory) -> dict[str, Any]:
+    """Run the canonical engine ONCE over all three source shapes, into a per-process directory.
+
+    `tmp_path_factory` gives a base temp that is unique per pytest process and per xdist worker, so
+    nothing here is shared and nothing is destructively removed. That is the whole point: the
+    previous fixed `.pytest_cache` root let two concurrent runs delete each other's output.
+    """
     engine = _contract()
-    if engine is None:  # pragma: no cover - requires_engine handles collection-time absence.
+    if engine is None:  # pragma: no cover - requires_engine handles collection-time absence
         pytest.skip(ENGINE_SKIP_REASON)
 
-    if RUN_ROOT.exists():
-        shutil.rmtree(RUN_ROOT)
-    RUN_ROOT.mkdir(parents=True)
+    base = tmp_path_factory.mktemp("ds-path-envelope")
+    source_dir = base / "input"
+    source_dir.mkdir()
+    for unit, path in MATRIX_SOURCES.items():
+        assert path.is_file(), f"matrix source for {unit} is missing: {path}"
+        (source_dir / path.name).write_bytes(path.read_bytes())
+    out = base / "bundle"
 
     cmd = [
         sys.executable,
         str(engine_source.engine_scripts_dir(engine) / "migrate_estate.py"),
         "-i",
-        str(FIXTURE),
+        str(source_dir),
         "-o",
-        str(RUN_ROOT),
+        str(out),
     ]
-    completed = subprocess.run(cmd, cwd=REPO, text=True, capture_output=True, timeout=900, check=False)
+    completed = subprocess.run(
+        cmd, cwd=REPO, text=True, capture_output=True, errors="replace", timeout=1800, check=False
+    )
     assert completed.returncode == 0, (
         "This harness could not run the canonical engine. That is a harness failure, not a pinned "
         f"behaviour change.\nCommand: {cmd}\nSTDOUT:\n{completed.stdout}\nSTDERR:\n{completed.stderr}"
     )
 
-    pages = RUN_ROOT / "pbip" / UNIT / f"{UNIT}.Report" / "definition" / "pages"
-    page_dirs = sorted(p.name for p in pages.iterdir() if p.is_dir()) if pages.is_dir() else []
-    visuals = sorted(
-        v.name
-        for page in (pages.iterdir() if pages.is_dir() else [])
-        if page.is_dir()
-        for v in ((page / "visuals").iterdir() if (page / "visuals").is_dir() else [])
-        if v.is_dir()
-    )
-    _ENGINE_RUN = {
-        "version": engine_source.engine_version(engine),
-        "pages": page_dirs,
-        "visuals": visuals,
-        "deepest_tail": max(
-            (
-                str(p.relative_to(RUN_ROOT / "pbip" / UNIT / f"{UNIT}.Report")).replace("\\", "/")
-                for p in pages.rglob("*")
-                if p.is_file()
-            ),
-            key=utf16_len,
-            default="",
-        ),
-    }
-    return _ENGINE_RUN
+    shapes: dict[str, Any] = {}
+    for unit in MATRIX_SOURCES:
+        report = out / "pbip" / unit / f"{unit}.Report"
+        pages_dir = report / "definition" / "pages"
+        page_dirs = sorted(p.name for p in pages_dir.iterdir() if p.is_dir()) if pages_dir.is_dir() else []
+        visuals = sorted(
+            v.name
+            for page in (pages_dir.iterdir() if pages_dir.is_dir() else [])
+            if page.is_dir()
+            for v in ((page / "visuals").iterdir() if (page / "visuals").is_dir() else [])
+            if v.is_dir()
+        )
+        tails = (
+            [str(p.relative_to(report)).replace("\\", "/") for p in report.rglob("*") if p.is_file()]
+            if report.is_dir()
+            else []
+        )
+        deepest = max(tails, key=utf16_len, default="")
+        shapes[unit] = {
+            "report": report,
+            "pages": page_dirs,
+            "visuals": visuals,
+            "deepest_tail": deepest,
+            "deepest_tail_len": utf16_len(deepest),
+            "longest_visual_id": max((utf16_len(v) for v in visuals), default=0),
+        }
+    return {"version": engine_source.engine_version(engine), "root": out, "shapes": shapes}
 
 
 @requires_engine
-def test_a_standalone_datasource_emits_a_self_service_page_with_visuals() -> None:
+def test_a_standalone_datasource_emits_a_self_service_page_with_visuals(engine_bundle) -> None:
     """The refutation: a `.tds` unit is not structurally visual-free.
 
     `pageSelfService` is a hard-coded default of `twb_to_pbir.build_field_parameter_page`, so seeing
     it is the proof that the engine's **swap** branch was reached rather than the thin one — the
     production code path this fixture exists to exercise.
     """
-    run = _run_engine_once()
+    run = engine_bundle["shapes"][SWAP_UNIT]
+    version = engine_bundle["version"]
     assert run["pages"] == [SELF_SERVICE_PAGE], (
-        f"A standalone datasource emitted pages {run['pages']} on canonical engine {run['version']}, "
-        f"not the expected [{SELF_SERVICE_PAGE!r}]. If it now emits ['page1'], the swap branch was "
-        "NOT reached and every assertion in this module is vacuous - fix the fixture before trusting "
-        "any datasource path-envelope conclusion."
+        f"A standalone datasource emitted pages {run['pages']} on canonical engine {version}, not the "
+        f"expected [{SELF_SERVICE_PAGE!r}]. If it now emits ['{THIN_PAGE}'], the swap branch was NOT "
+        "reached and every engine assertion in this module is vacuous - fix the fixture before "
+        "trusting any datasource path-envelope conclusion."
     )
     assert len(run["visuals"]) >= 1, (
-        f"A standalone datasource emitted NO visuals on canonical engine {run['version']}. That is "
-        "the belief this fixture exists to refute; if the engine genuinely changed, a visual-free "
-        "datasource envelope becomes arguable - re-derive it, do not simply delete this test."
+        f"A standalone datasource emitted NO visuals on canonical engine {version}. That is the belief "
+        "this fixture exists to refute; if the engine genuinely changed, a visual-free datasource "
+        "envelope becomes arguable - re-derive it, do not simply delete this test."
     )
-    longest = max((utf16_len(name) for name in run["visuals"]), default=0)
-    assert longest == ENGINE_IDENTIFIER_CAP, (
-        f"The longest emitted datasource visual identifier is {longest} UTF-16 units, not the "
-        f"{ENGINE_IDENTIFIER_CAP} that `twb_to_pbir._sanitize` caps at (observed {run['visuals']} on "
-        f"engine {run['version']}). Any datasource path envelope must cover whatever this is."
+    assert run["longest_visual_id"] == ENGINE_IDENTIFIER_CAP, (
+        f"The longest emitted datasource visual identifier is {run['longest_visual_id']} UTF-16 units, "
+        f"not the {ENGINE_IDENTIFIER_CAP} that `twb_to_pbir._sanitize` caps at (observed "
+        f"{run['visuals']} on engine {version}). Any datasource path envelope must cover whatever "
+        "this is."
     )
 
 
 @requires_engine
-def test_a_visual_free_datasource_envelope_would_be_fail_open() -> None:
+def test_the_engine_itself_resolves_both_declared_swap_controllers(engine_bundle) -> None:
+    """The engine's OWN parser must see the parameters, not just our XML reading of them.
+
+    `test_every_swap_controller_is_a_declared_parameter` reads the `.tds` with this repository's
+    interpretation of Tableau's shape. This runs `parameters.parse_parameters` and
+    `parameters.detect_field_swap` from the canonical plugin over the same bytes, so the fixture is
+    pinned against the consumer that actually matters.
+    """
+    engine = _contract()
+    snippet = (
+        "import json, sys\n"
+        "sys.path.insert(0, sys.argv[1])\n"
+        "from parameters import parse_parameters, detect_field_swap\n"
+        "xml = open(sys.argv[2], encoding='utf-8').read()\n"
+        "params = {p['caption']: {'domain': p['domain'], 'default': (p['default'] or '').strip('\\\"'),\n"
+        "                          'members': p['members']} for p in parse_parameters(xml)}\n"
+        "swaps = []\n"
+        "import xml.etree.ElementTree as ET\n"
+        "for col in ET.fromstring(xml).iter('column'):\n"
+        "    calc = col.find('calculation')\n"
+        "    if calc is None:\n"
+        "        continue\n"
+        "    sw = detect_field_swap(calc.get('formula') or '', role=col.get('role') or 'measure')\n"
+        "    if sw:\n"
+        "        swaps.append({'controller': sw['controller'],\n"
+        "                      'branches': [b['label'] for b in sw['branches']]})\n"
+        "print(json.dumps({'params': params, 'swaps': swaps}))\n"
+    )
+    done = subprocess.run(
+        [sys.executable, "-c", snippet, str(engine_source.engine_scripts_dir(engine)), str(MATRIX_SOURCES[SWAP_UNIT])],
+        capture_output=True,
+        text=True,
+        errors="replace",
+        timeout=300,
+        check=False,
+    )
+    assert done.returncode == 0, f"could not run the engine's own parameter parser:\n{done.stderr}"
+    seen = json.loads(done.stdout)
+    assert len(seen["swaps"]) == len(EXPECTED_CONTROLLERS), (
+        f"the engine detected {len(seen['swaps'])} field swap(s), expected {len(EXPECTED_CONTROLLERS)}: {seen['swaps']}"
+    )
+    for swap in seen["swaps"]:
+        controller = swap["controller"]
+        assert controller in seen["params"], (
+            f"the engine detected a swap controlled by {controller!r} but its own `parse_parameters` "
+            f"does not return that parameter (it returns {sorted(seen['params'])}). The fixture would "
+            "be exercising regex tolerance, not a declared Tableau parameter."
+        )
+        declared = seen["params"][controller]
+        expected = EXPECTED_CONTROLLERS[controller]
+        assert declared["domain"] == expected["domain"], f"{controller}: engine saw domain {declared['domain']!r}"
+        assert declared["members"] == expected["members"], f"{controller}: engine saw members {declared['members']}"
+        assert declared["default"] == expected["default"], f"{controller}: engine saw default {declared['default']!r}"
+        assert swap["branches"] == expected["members"], (
+            f"{controller}: the swap's branch labels {swap['branches']} and the parameter's members "
+            f"{expected['members']} must describe the same choice"
+        )
+
+
+@requires_engine
+@pytest.mark.parametrize(
+    ("unit", "expected_page", "expect_visuals"),
+    [
+        (THIN_UNIT, THIN_PAGE, False),
+        (SWAP_UNIT, SELF_SERVICE_PAGE, True),
+        (WORKBOOK_UNIT, None, True),
+    ],
+)
+def test_the_three_source_shapes_emit_their_documented_reports(
+    engine_bundle, unit: str, expected_page: str | None, expect_visuals: bool
+) -> None:
+    """One engine run, three source kinds - so no conclusion rests on a single artifact.
+
+    (a) an ordinary datasource -> the thin `page1` shell with no visuals;
+    (b) a field-swap datasource -> `pageSelfService` with capped visual identifiers;
+    (c) a real visual-owning workbook -> a `_sanitize`d page and a capped visual identifier.
+    """
+    shape = engine_bundle["shapes"][unit]
+    version = engine_bundle["version"]
+    assert len(shape["pages"]) == 1, f"{unit} emitted pages {shape['pages']} on engine {version}"
+    if expected_page is not None:
+        assert shape["pages"] == [expected_page], (
+            f"{unit} emitted {shape['pages']}, expected [{expected_page!r}] on engine {version}"
+        )
+    else:
+        assert utf16_len(shape["pages"][0]) <= ENGINE_IDENTIFIER_CAP, (
+            f"{unit} emitted page id {shape['pages'][0]!r} longer than `_sanitize`'s cap"
+        )
+    if expect_visuals:
+        assert shape["visuals"], f"{unit} emitted no visuals on engine {version}"
+        assert shape["longest_visual_id"] == ENGINE_IDENTIFIER_CAP, (
+            f"{unit}: longest visual id {shape['longest_visual_id']}, expected the "
+            f"{ENGINE_IDENTIFIER_CAP}-unit `_sanitize` cap (observed {shape['visuals']})"
+        )
+    else:
+        assert not shape["visuals"], (
+            f"{unit} emitted visuals {shape['visuals']} on engine {version}. An ordinary datasource "
+            "is expected to be the thin shell; if that changed, the whole kind distinction moves."
+        )
+
+
+@requires_engine
+@pytest.mark.parametrize("unit", sorted(MATRIX_SOURCES))
+def test_each_shape_envelope_covers_its_tail_and_one_unit_less_would_not(engine_bundle, unit: str) -> None:
+    """A per-kind envelope must COVER its own emitted tail, and be tight enough to matter.
+
+    The boundary is computed, not assumed: at `root = FILE_CEILING - envelope - 1` the emitted path
+    must land at or under Desktop's file ceiling, and an envelope one unit shorter must push that
+    same emitted path one unit over. That is the exact place a one-unit understatement flips a
+    refusal into a pass.
+    """
+    shape = engine_bundle["shapes"][unit]
+    actual = shape["deepest_tail_len"]
+    envelope = ENVELOPE_TAIL[unit]
+
+    assert envelope >= actual, (
+        f"{unit}: the modelled envelope tail ({envelope}) does not cover the emitted tail "
+        f"({actual}, {shape['deepest_tail']!r}). An envelope that fails to cover real output is "
+        "fail-open by construction."
+    )
+
+    boundary_root = FILE_CEILING - envelope - 1
+    assert boundary_root + 1 + actual <= FILE_CEILING, (
+        f"{unit}: at the envelope-derived root {boundary_root} the emitted path measures "
+        f"{boundary_root + 1 + actual}, over the {FILE_CEILING} ceiling"
+    )
+
+    understated_root = FILE_CEILING - (actual - 1) - 1
+    assert understated_root + 1 + actual == FILE_CEILING + 1, (
+        f"{unit}: an envelope one unit under the emitted tail ({actual - 1}) would derive root "
+        f"{understated_root}, at which the emitted path measures {understated_root + 1 + actual}; "
+        f"expected exactly {FILE_CEILING + 1}, i.e. one unit over the ceiling"
+    )
+
+
+@requires_engine
+def test_a_visual_free_datasource_envelope_would_be_fail_open(engine_bundle) -> None:
     """PERMANENT INVARIANT — must hold before AND after any kind-aware envelope lands.
 
-    A datasource envelope that models only `pages/page1/page.json` understates this unit's own
-    emitted deepest path. Fail-open is the direction that ships a tree Power BI Desktop refuses, so
-    this is the assertion that kills the over-broad remedy.
+    A datasource envelope modelled on the thin shell understates the SWAP datasource's own emitted
+    path. Fail-open is the direction that ships a tree Power BI Desktop refuses, so this is the
+    assertion that kills the over-broad remedy.
     """
-    run = _run_engine_once()
-    emitted = utf16_len(run["deepest_tail"])
-    thin = utf16_len(THIN_TAIL)
-    assert emitted > thin, (
-        f"A visual-free datasource envelope ({thin}) no longer understates the emitted deepest tail "
-        f"({emitted}, {run['deepest_tail']!r}) on engine {run['version']}."
+    swap = engine_bundle["shapes"][SWAP_UNIT]["deepest_tail_len"]
+    thin_envelope = ENVELOPE_TAIL[THIN_UNIT]
+    assert swap > thin_envelope, (
+        f"A visual-free datasource envelope ({thin_envelope}) no longer understates the swap "
+        f"datasource's emitted tail ({swap}) on engine {engine_bundle['version']}."
     )
-    assert emitted - thin >= 40, (
-        f"The understatement shrank to {emitted - thin} characters (emitted {emitted} "
-        f"{run['deepest_tail']!r} vs visual-free {thin}). Measured 45 on engine 2.368.0. A shrinking "
-        "gap is a signal the engine changed its datasource report shape, not a licence to relax the "
-        "envelope."
+    assert swap - thin_envelope >= 40, (
+        f"The understatement shrank to {swap - thin_envelope} characters (emitted {swap} vs "
+        f"visual-free {thin_envelope}). Measured 45 on engine 2.368.0. A shrinking gap is a signal "
+        "the engine changed its datasource report shape, not a licence to relax the envelope."
+    )
+    boundary_root = FILE_CEILING - thin_envelope - 1
+    assert boundary_root + 1 + swap > FILE_CEILING, (
+        "a thin-shell envelope would allow a root at which the swap datasource's own emitted path "
+        f"measures {boundary_root + 1 + swap}, over the {FILE_CEILING} ceiling - that is the "
+        "fail-open outcome, stated as the refusal it should have produced"
     )
 
 
 @requires_engine
-def test_the_projector_is_blind_to_unit_kind_and_over_projects_this_datasource() -> None:
+def test_the_projector_is_blind_to_unit_kind_and_over_projects_this_datasource(engine_bundle) -> None:
     """The classification defect, stated against the production function and real emitted paths.
 
     `project_estate_path_ceiling` takes only NAMES, so it cannot tell a datasource from a workbook
-    and assigns both the workbook worst case. Measured here as the gap between what it projects and
-    what the engine actually wrote for the same unit at the same root.
+    and assigns both the workbook worst case.
 
     ⚠️ The gap is real but it is NOT the whole of run 409's over-refusal: with the *sound*
     datasource envelope this fixture measures (`pageSelfService` + a 24-unit visual) that unit still
     projects over the ceiling. Deleting the pessimism is worth doing; it is not a fix.
     """
-    run = _run_engine_once()
-    root = RUN_ROOT
-    projection = run_estate.project_estate_path_ceiling(root, [UNIT])
+    shape = engine_bundle["shapes"][SWAP_UNIT]
+    root = engine_bundle["root"]
+    projection = run_estate.project_estate_path_ceiling(root, [SWAP_UNIT])
     projected_file = next(r for r in projection["paths"] if r["kind"] == "file")["length"]
-
-    report_root = root / "pbip" / UNIT / f"{UNIT}.Report"
-    actual_file = max(utf16_len(str(p)) for p in report_root.rglob("*") if p.is_file())
+    actual_file = max(utf16_len(str(p)) for p in shape["report"].rglob("*") if p.is_file())
 
     assert projected_file > actual_file, (
         f"The projection ({projected_file}) no longer exceeds the emitted report path ({actual_file}) "
-        f"for datasource unit {UNIT!r} on engine {run['version']}. If the projector became "
-        "kind-aware, re-derive this expectation from the new envelope rather than deleting it."
+        f"for datasource unit {SWAP_UNIT!r} on engine {engine_bundle['version']}. If the projector "
+        "became kind-aware, re-derive this expectation from the new envelope rather than deleting it."
     )
-    sound = utf16_len(
-        str(
-            report_root
-            / "definition"
-            / "pages"
-            / SELF_SERVICE_PAGE
-            / "visuals"
-            / ("v" * ENGINE_IDENTIFIER_CAP)
-            / "visual.json"
-        )
-    )
+    sound = utf16_len(str(root)) + 1 + utf16_len(f"pbip/{SWAP_UNIT}/{SWAP_UNIT}.Report") + 1 + ENVELOPE_TAIL[SWAP_UNIT]
     assert sound < projected_file, (
         f"A kind-aware datasource envelope ({sound}) is no cheaper than the workbook worst case "
         f"({projected_file}); the classification this module argues for would buy nothing."
@@ -287,9 +533,45 @@ def test_the_projector_is_blind_to_unit_kind_and_over_projects_this_datasource()
         f"The sound datasource envelope ({sound}) does not cover the emitted path ({actual_file}); an "
         "envelope that fails to cover real output is fail-open by construction."
     )
-    assert sound - actual_file <= 2, (
-        f"The sound datasource envelope ({sound}) now has {sound - actual_file} characters of slack "
-        f"over the emitted path ({actual_file}). Measured 0 on engine 2.368.0 - the emitted visual "
-        f"identifiers sit exactly at `_sanitize`'s {ENGINE_IDENTIFIER_CAP}-unit cap, so a datasource "
-        "envelope built on `pageSelfService` + that cap is EXACTLY tight and carries no margin."
+
+
+@requires_engine
+@pytest.mark.skipif(bool(os.environ.get(CHILD_SENTINEL)), reason="child of the concurrency control - would recurse")
+def test_two_concurrent_pytest_processes_do_not_collide() -> None:
+    """The control for the shared-root race this module used to have.
+
+    Two pytest processes run the engine-backed shape matrix at the same time. With the old fixed
+    `.pytest_cache` root one would `rmtree` the other's output mid-read; with a per-process
+    `tmp_path_factory` directory both must succeed and must report different output roots.
+    """
+    env = dict(os.environ)
+    env[CHILD_SENTINEL] = "1"
+    env["PYTHONIOENCODING"] = "utf-8"
+    selector = "test_the_three_source_shapes_emit_their_documented_reports"
+    children = [
+        subprocess.Popen(  # noqa: S603  # pylint: disable=consider-using-with
+            [
+                sys.executable,
+                "-m",
+                "pytest",
+                f"{Path(__file__).name}::{selector}",
+                "-q",
+                "--no-header",
+                "-p",
+                "no:randomly",
+            ],
+            cwd=REPO / "tests",
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            errors="replace",
+        )
+        for _ in range(2)
+    ]
+    outputs = [child.communicate(timeout=1800)[0] for child in children]
+    codes = [child.returncode for child in children]
+    assert codes == [0, 0], (
+        "concurrent pytest processes did not both succeed - a shared, destructively cleared engine "
+        f"output root is the usual cause.\nexit codes: {codes}\n" + "\n---\n".join(out[-3000:] for out in outputs)
     )

--- a/tests/test_expected_skips_gate.py
+++ b/tests/test_expected_skips_gate.py
@@ -29,6 +29,7 @@ PINNED_ENGINE_SHA = "962d16cfe6f711622d419a567f992da8d90c8781"
 PINNED_ENGINE_VERSION = "2.356.0"
 ENGINE_TEST_TARGETS = (
     "tests/test_issue_424_chart_type_pin.py",
+    "tests/test_datasource_path_envelope.py",
     "tests/test_dax_oracle_server.py",
     "tests/test_upstream_repro_pins.py",
     "tests/test_harvest_download_watchdog.py::test_the_ceiling_constants_match_the_INSTALLED_engine",
@@ -405,6 +406,9 @@ def test_all_engine_dependent_tests_are_accounted_for() -> None:
     - 4 in tests/test_dax_oracle_server.py
     - 8 in tests/test_issue_424_chart_type_pin.py (5 decorators, one 4x parametrized)
     - 3 in tests/test_upstream_repro_pins.py
+
+    Since then tests/test_datasource_path_envelope.py added 3 more (the datasource self-service-page
+    fail-open control), taking the denominator to 18.
 
     The skip-reason classifier also treats the installed-engine-constants watchdog as engine-backed,
     so the engine jobs must run that one too instead of marking it NOT_CHECKED in the main job.

--- a/tests/test_expected_skips_gate.py
+++ b/tests/test_expected_skips_gate.py
@@ -407,10 +407,11 @@ def test_all_engine_dependent_tests_are_accounted_for() -> None:
     - 8 in tests/test_issue_424_chart_type_pin.py (5 decorators, one 4x parametrized)
     - 3 in tests/test_upstream_repro_pins.py
 
-    Since then tests/test_datasource_path_envelope.py added 11 more — the datasource
-    self-service-page fail-open control, the three-source-shape matrix (3x), the per-shape envelope
-    boundary (3x), the engine's own swap-parameter resolution, and the concurrency control — taking
-    the denominator to 26.
+    Since then tests/test_datasource_path_envelope.py added 15 more — the datasource
+    self-service-page fail-open control, the three-source-shape matrix (3x), the production
+    projection boundary per shape and per path kind (6x), the production identifier-envelope bound,
+    the engine's own swap-parameter resolution, the kind-blindness pin and the concurrency control —
+    taking the denominator to 30.
 
     The skip-reason classifier also treats the installed-engine-constants watchdog as engine-backed,
     so the engine jobs must run that one too instead of marking it NOT_CHECKED in the main job.

--- a/tests/test_expected_skips_gate.py
+++ b/tests/test_expected_skips_gate.py
@@ -407,8 +407,10 @@ def test_all_engine_dependent_tests_are_accounted_for() -> None:
     - 8 in tests/test_issue_424_chart_type_pin.py (5 decorators, one 4x parametrized)
     - 3 in tests/test_upstream_repro_pins.py
 
-    Since then tests/test_datasource_path_envelope.py added 3 more (the datasource self-service-page
-    fail-open control), taking the denominator to 18.
+    Since then tests/test_datasource_path_envelope.py added 11 more — the datasource
+    self-service-page fail-open control, the three-source-shape matrix (3x), the per-shape envelope
+    boundary (3x), the engine's own swap-parameter resolution, and the concurrency control — taking
+    the denominator to 26.
 
     The skip-reason classifier also treats the installed-engine-constants watchdog as engine-backed,
     so the engine jobs must run that one too instead of marking it NOT_CHECKED in the main job.

--- a/tests/test_run_estate.py
+++ b/tests/test_run_estate.py
@@ -7,8 +7,11 @@ defensible for that job. They are simply not safe for a CONSUMER, which is what 
 
 from __future__ import annotations
 
+import contextlib
+import io
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -230,35 +233,92 @@ def test_realistic_long_estate_is_refused_by_conservative_pbir_envelope() -> Non
     assert projection["status"] == "over_ceiling"
 
 
-@pytest.mark.parametrize("unreadable", [False, True])
-def test_main_refuses_path_preflight_before_engine(tmp_path: Path, monkeypatch, unreadable: bool) -> None:
+def _refuse_before_engine(tmp_path: Path, monkeypatch, output: Path) -> tuple[int, list[Path], str]:
+    """Run `main` to the preflight refusal and return (exit code, engine calls, printed detail)."""
     engine = _versioned_engine(tmp_path / "engine", "2.126.0")
     source = tmp_path / "src"
     source.mkdir()
     (source / "Sales.twb").write_text("<workbook />", encoding="utf-8")
     calls: list[Path] = []
     monkeypatch.setattr(run_estate, "run_engine", lambda *args: calls.append(args[0]) or (0, ""))
-    if unreadable:
-        monkeypatch.setattr(run_estate, "_readable_source", lambda _path: False)
-        output = tmp_path / "short"
-    else:
-        output = _boundary_root("Sales", FILE_CEILING + 1)
+    buffer = io.StringIO()
+    with contextlib.redirect_stdout(buffer):
+        code = run_estate.main(
+            [
+                "--engine",
+                str(engine),
+                "--allow-noncanonical-engine",
+                "--input",
+                str(source),
+                "--output",
+                str(output),
+            ]
+        )
+    return code, calls, buffer.getvalue()
 
-    code = run_estate.main(
-        [
-            "--engine",
-            str(engine),
-            "--allow-noncanonical-engine",
-            "--input",
-            str(source),
-            "--output",
-            str(output),
-        ]
+
+def test_main_refuses_an_over_ceiling_projection_and_says_which_path_and_by_how_much(tmp_path, monkeypatch) -> None:
+    """The refusal must be ATTRIBUTABLE, not merely non-zero.
+
+    ⚠️ Round-1 review: this test previously shared one body (and one assertion set) with the
+    unreadable-source case below, so `EXIT_PATH_CEILING` plus "engine not called, output absent" was
+    accepted for a `CANNOT ASSESS` result that names no path at all. Those two arms refuse for
+    different reasons and now assert their own reason. The exit code is deliberately checked LAST:
+    it is the weakest signal here and it is shared by both arms.
+    """
+    output = _boundary_root("Sales", FILE_CEILING + 1)
+    code, calls, printed = _refuse_before_engine(tmp_path, monkeypatch, output)
+
+    match = re.search(
+        r"PATH CEILING: projected (?P<kind>directory|file) is (?P<length>\d+) UTF-16 units "
+        r"\(ceiling (?P<ceiling>\d+)\) for unit (?P<unit>'[^']+')",
+        printed,
     )
-
+    assert match, f"the refusal did not name the offending path.\nprinted:\n{printed}"
+    kind, length, ceiling, unit = (
+        match.group("kind"),
+        int(match.group("length")),
+        int(match.group("ceiling")),
+        match.group("unit"),
+    )
+    # The root was constructed to sit exactly ONE unit over both ceilings, so only these two
+    # (kind, length, ceiling) triples are legitimate. Membership rather than a single expectation,
+    # because which of the two equally-over offenders wins is an incidental tie-break.
+    assert (kind, length, ceiling) in {
+        ("directory", DIR_CEILING + 1, DIR_CEILING),
+        ("file", FILE_CEILING + 1, FILE_CEILING),
+    }, f"named {kind} {length} vs ceiling {ceiling}; the boundary root puts both exactly one over"
+    assert unit == "'Sales'", f"the refusal named unit {unit}, not the estate's only unit"
+    assert "CANNOT ASSESS" not in printed, "an over-ceiling projection must not report itself as unassessable"
+    assert "--runs-parent" in printed, "the refusal must name the supported escape command (issue #479)"
+    assert not calls, "the engine must not run after a path-ceiling refusal"
+    assert not output.exists(), "a refused run must not create its output root"
     assert code == run_estate.EXIT_PATH_CEILING
-    assert not calls
-    assert not output.exists()
+
+
+def test_main_refuses_an_unreadable_source_with_its_own_cannot_assess_reason(tmp_path, monkeypatch) -> None:
+    """The other arm: nothing could be measured, so nothing may be reported as measured.
+
+    It shares `EXIT_PATH_CEILING` with the case above, which is exactly why the diagnostic — not the
+    exit code — carries the meaning.
+    """
+    monkeypatch.setattr(run_estate, "_readable_source", lambda _path: False)
+    output = tmp_path / "short"
+    code, calls, printed = _refuse_before_engine(tmp_path, monkeypatch, output)
+
+    assert "CANNOT ASSESS downstream PBIP path length" in printed, (
+        f"an unreadable source must refuse as unassessable.\nprinted:\n{printed}"
+    )
+    assert "no usable unit/workbook name" in printed, (
+        f"the CANNOT ASSESS refusal must say WHY it could not measure.\nprinted:\n{printed}"
+    )
+    assert not re.search(r"PATH CEILING: projected (directory|file) is \d+", printed), (
+        "an unmeasurable estate must not claim a projected length it never computed"
+    )
+    assert "--runs-parent" in printed
+    assert not calls, "the engine must not run after a preflight refusal"
+    assert not output.exists(), "a refused run must not create its output root"
+    assert code == run_estate.EXIT_PATH_CEILING
 
 
 def test_estate_path_preflight_accepts_short_root_and_refuses_long_root(tmp_path: Path) -> None:


### PR DESCRIPTION
## What

- adds a realistic standalone datasource fixture whose declared field-swap parameters make canonical engine 2.368.0 emit `pageSelfService` with three visuals;
- pins a three-shape engine matrix: ordinary datasource, swap datasource, and real visual-owning workbook;
- proves the production path projector refuses at exact file and directory boundaries derived from each real emitted shape;
- makes the engine harness process-unique and adds a real concurrent-pytest control;
- registers every engine-dependent node in the reason-keyed skip denominator and both CI engine jobs;
- splits path-ceiling refusal from `CANNOT ASSESS` so tests assert the guard that actually fired.

No production behavior, path algorithm, PBIR identifier, or engine plugin code changes.

## Why

A tempting optimization was to treat standalone datasources as visual-free. Canonical engine output disproves that: a datasource carrying field-swap metadata emits a self-service report page with full-length visual identifiers. A thin datasource envelope would therefore be fail-open.

The existing run-409 and synthetic boundary tests covered arithmetic, but did not exercise ordinary/swap/workbook output shapes through the canonical engine or prove the production projector covered each emitted boundary.

## Review contract

- **Can the tests reach production?** Yes: engine-required cases invoke the canonical installed plugin and `run_estate.project_estate_path_ceiling`; the engine-absent path is separately reason-keyed.
- **Does the guard cover the named surface?** The matrix covers ordinary datasource, swap datasource, workbook, file boundary, directory boundary, concurrency, and exact diagnostic attribution.
- **Does the evidence prove the verdict?** Each boundary is derived from actual emitted paths; the exact four-unit understatement mutation fails only the production-envelope assertion while the unrelated long-estate test stays green.

## Validation

- engine-present denominator: **84 passed**;
- engine-absent path: **31 explicit NOT_CHECKED cases**, all with registered reasons;
- related suites: **407 passed, 2 registered platform skips**;
- Ruff format/check: clean;
- pylint on the new module: **10.00/10**;
- navigation index: pass;
- independent review: R1 four corrections, R2 one same-class correction, final exact-mutation confirmation **CLEAN**.

Refs #479