### PR TITLE
docs: make the credential-dialog verdict wording internally honest

### DIFF
--- a/.github/skills/pbip-model-refresh/SKILL.md
+++ b/.github/skills/pbip-model-refresh/SKILL.md
@@ -30,9 +30,11 @@ so `dotnet add` cannot silently no-op on a net10 default:
   refresh TIMEOUT names: a UI-Automation check for a data-source sign-in modal, so "slow" and
   "blocked" are told apart by evidence, not guessed. Ships **inside** the bundle, so the instruction
   the script prints at runtime resolves to a file that is actually here. **Only `CREDENTIAL_MISSING`
-  (exit 1) is a hard stop**; everything it cannot positively identify as a credential prompt lands in
-  the exit-3 "could not probe" band (`REFRESH_IN_PROGRESS` / `DIALOG_UNRECOGNIZED` /
-  `DIALOG_UNREADABLE` / `UNKNOWN`) rather than escalating to a human — see the verdict table below.
+  (exit 1) is a hard stop**, and it requires positive authentication-specific signature evidence;
+  everything it cannot positively identify as a credential prompt lands in the exit-3 "could not
+  probe" band (`REFRESH_IN_PROGRESS` / `DIALOG_UNRECOGNIZED` / `DIALOG_UNREADABLE` / `UNKNOWN`), which
+  asserts nothing about sign-in in either direction — a human must inspect Desktop and settle whatever
+  is up before the run proceeds. See the verdict table below.
 - [**`tests/`**](tests) - the regression suite for both, runnable from this folder
   (`pytest tests`). It is what makes the portability claim below checkable rather than aspirational.
 
@@ -152,13 +154,22 @@ stay byte-identical.
 >
 > | verdict | exit | what was actually observed |
 > |---|---|---|
-> | `CREDENTIAL_MISSING` | 1 | text matched `credential_modal_signature.regex`. The hard stop. |
+> | `CREDENTIAL_MISSING` | 1 | positive authentication-specific evidence: text matched `credential_modal_signature.regex`. The hard stop. |
 > | `CREDENTIAL_PRESENT` | 0 | a refresh was invoked and ran to the deadline with nothing unclassifiable up. Still not the gate of record for a serverless source — confirm with the one-row data probe. |
 > | `REFRESH_IN_PROGRESS` | 3 | a dialog whose **whole content** positively reads as refresh progress was already up **at t=0**: another refresh owns this instance. Wait for it or cancel the stale one; do not stack a second refresh. |
 > | `DIALOG_NEEDS_HUMAN` | 3 | a **known** human-blocking prompt that is not a credential prompt — the **native-database-query approval modal** above all. Not exit 1, because the remedy is an approval, not a sign-in. Never suppressed, and it outranks any progress text in the same window. |
-> | `DIALOG_UNRECOGNIZED` | 3 | a dialog is up whose text matched **no** signature, **or** which shows progress text *alongside* prose that is not progress status. We read it, and it is **not** a credential prompt — but we cannot account for all of it. |
-> | `DIALOG_UNREADABLE` | 3 | a dialog is up that could not be **shown to be harmless**: no text at all, or only a reassuring **caption**, or benign-looking content read from an **incomplete** harvest (truncated, timed out, or a pattern that threw). Deliberately distinct from `DIALOG_UNRECOGNIZED`: *absent is not empty*, and "we could not establish it" is a weaker state of knowledge than "we read it and it did not match". |
+> | `DIALOG_UNRECOGNIZED` | 3 | a dialog is up whose text matched **no** signature, **or** which shows progress text *alongside* prose that is not progress status. We read the content, and it matched nothing we know — including the credential signature, which is **not** proof it is non-credential. The credential question is left undetermined; a human must inspect Desktop. |
+> | `DIALOG_UNREADABLE` | 3 | a dialog is up whose **content could not be established**: no text at all, or only a reassuring **caption**, or benign-looking content read from an **incomplete** harvest (truncated, timed out, or a pattern that threw). Deliberately distinct from `DIALOG_UNRECOGNIZED`: *absent is not empty*, and "we could not establish it" is a weaker state of knowledge than "we read it and it did not match". Nothing here asserts a sign-in wall, and nothing rules one out; a human must inspect Desktop. |
 > | `UNKNOWN` | 3 | no window for the pid, a minimized owner, or no Refresh control was ever invoked. |
+>
+> **Accepted limitation (issue #146, open).** Some connector authentication dialogs expose no readable
+> text, so `DIALOG_UNREADABLE` / `DIALOG_UNRECOGNIZED` can be the *best available* answer about a
+> window that really is a sign-in form. The band is therefore fail-closed and undetermined, not
+> cleared: only a human at the Desktop screen can settle it, `REFRESH_IN_PROGRESS` means wait rather
+> than stack a second refresh, and a `DATA_OK` never overrides an active or unsettled dialog — it is
+> authoritative only once the dialog is settled and a clean probe actually executes. Autopilot changes
+> none of this: it governs choices, not a window no automation can read or dismiss, so it never
+> bypasses or clears a dialog verdict.
 >
 > **Which way it errs, and why.** A false *positive* here terminates at exit 1 and escalates to a
 > human, so nothing downstream ever runs. A false *negative* lands on `CREDENTIAL_PRESENT`, which the
@@ -177,10 +188,11 @@ stay byte-identical.
 > - **`scripts/benign_dialog_signature.regex`** is the progress vocabulary ("Evaluating", "N rows
 >   loaded", "Waiting for other queries"). ⚠️ It is **inferred** from Power BI's refresh UI, not
 >   captured from a live dialog, and it is deliberately not load-bearing: a miss only downgrades
->   `REFRESH_IN_PROGRESS` to `DIALOG_UNRECOGNIZED` — both exit 3, neither a credential wall. Keep its
->   alternatives narrow and anchored; a broad pattern here is the one way this file could hide a real
->   modal, and `test_the_benign_signature_can_never_shadow_a_credential_prompt` gates exactly that. If
->   you ever have a real progress dialog on screen, capture its exact text and tighten this file.
+>   `REFRESH_IN_PROGRESS` to `DIALOG_UNRECOGNIZED` — both exit 3, neither reported as a credential
+>   wall. Keep its alternatives narrow and anchored; a broad pattern here is the one way this file
+>   could hide a real modal, and `test_the_benign_signature_can_never_shadow_a_credential_prompt`
+>   gates exactly that. If you ever have a real progress dialog on screen, capture its exact text and
+>   tighten this file.
 
 > ⚠️ **Win32 child-HWND text does NOT see inside a WPF dialog — and the burden of proof runs ONE WAY.**
 > WPF renders its entire visual tree into **one** HWND, so `EnumChildWindows` harvests nothing and only

--- a/docs/data-source-credentials.md
+++ b/docs/data-source-credentials.md
@@ -89,7 +89,10 @@ sign-in modal appeared only *after* the probe's 90s window. The one-row data pro
 UIA re-dump confirmed the modal was open. So: **treat `probe_desktop_query.py` (`DATA_OK` vs
 `NO_DATA`/`ERROR`) as the gate of record**, and use `probe_desktop_credential.ps1` only to *explain* a
 `NO_DATA` (i.e. "is a credential modal the reason?"). A `CREDENTIAL_PRESENT` from the modal probe must
-NOT be trusted on its own for a serverless source — always confirm with `DATA_OK`.
+NOT be trusted on its own for a serverless source — always confirm with `DATA_OK`. ⚠️ That authority
+runs one way only: `DATA_OK` is authoritative once a clean probe has actually executed with no dialog
+outstanding, and it never overrides an active or unsettled dialog. Settle the dialog first, then
+re-probe.
 
 `scripts/probe_desktop_credential.ps1 -DesktopPid <pid>` triggers a refresh via UI Automation and
 watches for the connector modal:
@@ -97,19 +100,24 @@ watches for the connector modal:
   sign in once. **This is the only verdict that is a hard stop.**
 - No modal within the timeout -> `VERDICT: CREDENTIAL_PRESENT` (exit 0), **but** re-confirm with the
   data probe before trusting it (see the serverless false-positive above).
-- A dialog is up that is *not* a credential prompt -> one of `REFRESH_IN_PROGRESS` (another refresh
-  already owns this instance — wait for it or cancel the stale one), `DIALOG_NEEDS_HUMAN` (a **known**
-  human-blocking prompt that is not a credential prompt — the native-database-query approval modal;
-  approve it, no sign-in implied), `DIALOG_UNRECOGNIZED` (no signature matched, or progress text
-  alongside prose that is not progress status) or `DIALOG_UNREADABLE` (its **content** could not be
-  shown to be harmless), each **exit 3**. All four mean *"could not probe"*, never *"a human must sign
-  in"*.
+- A dialog is up that could not be identified as a credential prompt -> one of `REFRESH_IN_PROGRESS`
+  (another refresh already owns this instance — wait for it or cancel the stale one; do not stack a
+  second refresh), `DIALOG_NEEDS_HUMAN` (a **known** human-blocking prompt that is not a credential
+  prompt — the native-database-query approval modal; approve it, no sign-in implied),
+  `DIALOG_UNRECOGNIZED` (content was read but matched no known signature — which is **not** proof it
+  is non-credential) or `DIALOG_UNREADABLE` (its **content** could not be established at all), each
+  **exit 3**. All four mean *"could not probe"*. Only `DIALOG_NEEDS_HUMAN` positively identifies what
+  is up; for the other two the credential question is left **undetermined**, so they assert neither
+  *"a human must sign in"* nor its opposite — a human must inspect Desktop and settle the dialog. No
+  automation clears one, and autopilot is no exception: "decide, don't ask" governs choices, not a
+  window only a person can read.
 
-⚠️ **Do not read a non-`CREDENTIAL_MISSING` verdict as a credential wall.** Until issue #367 the probe
-returned `BLOCKED_BY_DIALOG` at **exit 1** for *any* visible non-main window >= 100x100 — a Power BI
-Refresh progress dialog trips that trivially, and a field report on 2026-08-28 caught it doing so under
-three concurrent refreshes against a cold Snowflake warehouse. The probe now classifies a dialog by its
-text and reports what it actually saw; the size test only decides which windows are worth reading.
+⚠️ **Do not read a non-`CREDENTIAL_MISSING` verdict as a credential wall — and do not read one as
+proof there is no credential wall either.** Until issue #367 the probe returned `BLOCKED_BY_DIALOG` at
+**exit 1** for *any* visible non-main window >= 100x100 — a Power BI Refresh progress dialog trips
+that trivially, and a field report on 2026-08-28 caught it doing so under three concurrent refreshes
+against a cold Snowflake warehouse. The probe now classifies a dialog by its text and reports what it
+actually saw; the size test only decides which windows are worth reading.
 
 ✅ **The Python fast check (`probe_desktop_query.py` / `refresh_pbip_model.py`) was fixed the same way
 in issue #376, and `BLOCKED_BY_DIALOG` is retired from it.** It carried the identical size-only rule on
@@ -139,8 +147,13 @@ exit 3. Two consequences worth knowing:
   same suppression — measured, filed as #406 rather than fixed in passing.
 - `probe_live_source` recognises the dialog tokens **structurally** and maps them to **`ERROR`** —
   "the probe itself could not run". The gate stays armed; nothing asserts a sign-in wall that was never
-  observed. Without that structural step the transcript fell through to an unanchored keyword scan, and
-  `DIALOG_NEEDS_HUMAN` quoting `Authentication required` came back out as `NO_CREDENTIAL`.
+  observed, and nothing rules one out either. Without that structural step the transcript fell through
+  to an unanchored keyword scan, and `DIALOG_NEEDS_HUMAN` quoting `Authentication required` came back
+  out as `NO_CREDENTIAL`. ⚠️ Note the parent verdict `NO_CREDENTIAL` is **broader** than the
+  modal-level `CREDENTIAL_MISSING`, which needs a positive authentication-specific signature match:
+  the parent is also reached from an anchored credential-stop verdict line and from free-text
+  connector credential markers (a revoked PAT returns a 403 with no modal at all), so it is not a
+  text-signature-only verdict.
 
 Two gotchas learned building it: (a) use a **generous timeout (>=60s)** because a serverless warehouse
 (Databricks) can **cold-start** before the modal appears, so a short wait yields a false PRESENT; and


### PR DESCRIPTION
Minimal in-place replacement for closed PR #577. No new sections, no additive
blocks copied from that PR: the existing introduction, verdict rows and the
directly corresponding lines in `docs/data-source-credentials.md` are edited in
place, plus **one** short paragraph for the accepted limitation.

### The contradiction this removes

The same band was documented two incompatible ways:

- the introduction said the exit-3 verdicts land there *"rather than escalating to a human"*;
- the `DIALOG_UNRECOGNIZED` row asserted *"it is **not** a credential prompt"*.

Both exceed the evidence the detector has. `scripts/_verdict_lines.py`
(`classify_child_verdict`) deliberately says the opposite for those tokens:
only `DIALOG_NEEDS_HUMAN` gets the *"it is NOT a sign-in prompt"* sentence,
while the unreadable/unrecognized branch says *"the dialog COULD be a connector
authentication form whose text was not readable — do not assume sign-in is NOT
needed"* (`Refs #146` is cited in that code comment).

### What the text now says

| verdict | documented meaning |
|---|---|
| `CREDENTIAL_MISSING` (exit 1) | requires **positive authentication-specific signature evidence**; the only hard stop |
| `NO_CREDENTIAL` (parent) | **broader** than the modal-level verdict — also reached from the anchored credential-stop verdict line and from free-text connector credential markers (a revoked PAT returns a 403 with no modal), so **not** text-signature-only |
| `DIALOG_UNREADABLE` (exit 3) | content **could not be established**; a human must inspect Desktop; no sign-in assertion in either direction |
| `DIALOG_UNRECOGNIZED` (exit 3) | content **was read** but matched no known signature; **not** proof it is non-credential; a human must inspect Desktop |
| `DIALOG_NEEDS_HUMAN` (exit 3) | known non-credential blocking prompt (keeps its positive claim) |
| `REFRESH_IN_PROGRESS` (exit 3) | somebody else's refresh — wait, do not stack a second |
| `DATA_OK` | authoritative **only** once the dialog is settled and a clean probe actually executes; never overrides an active or unsettled dialog |

Autopilot is stated to never bypass or clear a dialog verdict — it governs
choices, not a window no automation can read.

### Scope

- `.github/skills/pbip-model-refresh/SKILL.md` — +22 / −10
- `docs/data-source-credentials.md` — +29 / −16

No code, tests, operator-runbook, AGENTS/personas or generated blocks touched.

### Checks

- `python scripts/check_agent_capabilities.py` → exit 0
- `python scripts/check_navigation_index.py` → exit 0
- `pytest tests/test_skills.py tests/test_openability_claim_citations.py tests/test_skill_plugin_source.py` → 176 passed, exit 0

Refs #146 — the issue stays open and fail-closed; this documents an accepted
limitation, it does not solve credential identification.
