### PR TITLE
Bound the semantic-model table path before conversion (#564)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -124,6 +124,9 @@ EXPECTED_ENGINE_SKIP_REASONS_BY_NODEID: dict[str, str] = {
     "tests/test_datasource_path_envelope.py::test_the_engine_itself_resolves_both_declared_swap_controllers": (
         "deterministic tier not installed"
     ),
+    "tests/test_datasource_path_envelope.py::test_the_model_family_projection_covers_every_emitted_shape": (
+        "deterministic tier not installed"
+    ),
     "tests/test_datasource_path_envelope.py::test_the_production_identifier_envelope_stays_above_the_engines_"
     "measured_cap": "deterministic tier not installed",
     "tests/test_datasource_path_envelope.py::test_the_production_projection_refuses_each_emitted_shape_at_its_own_"
@@ -162,16 +165,33 @@ EXPECTED_ENGINE_SKIP_REASONS_BY_NODEID: dict[str, str] = {
     "tests/test_harvest_download_watchdog.py::test_the_ceiling_constants_match_the_INSTALLED_engine": (
         "canonical engine not installed, so its constants cannot be read"
     ),
+    "tests/test_issue_194_long_pbir_path.py::test_dropping_the_fixed_overhead_understates_real_engine_output": (
+        "deterministic tier not installed"
+    ),
+    "tests/test_issue_194_long_pbir_path.py::"
+    "test_dropping_the_second_source_component_understates_real_engine_output": "deterministic tier not installed",
+    "tests/test_issue_194_long_pbir_path.py::test_each_control_reproduces_the_naming_class_it_exists_for": (
+        "deterministic tier not installed"
+    ),
     "tests/test_issue_194_long_pbir_path.py::test_the_engine_warning_is_asserted_only_where_it_was_established": (
         "deterministic tier not installed"
     ),
     "tests/test_issue_194_long_pbir_path.py::test_the_long_case_crosses_the_file_ceiling_at_the_skill_default_root": (
         "deterministic tier not installed"
     ),
+    "tests/test_issue_194_long_pbir_path.py::test_the_model_projection_covers_every_emitted_table_part": (
+        "deterministic tier not installed"
+    ),
+    "tests/test_issue_194_long_pbir_path.py::test_the_model_projection_covers_the_committed_long_and_short_pair": (
+        "deterministic tier not installed"
+    ),
     "tests/test_issue_194_long_pbir_path.py::test_the_output_root_length_is_what_decides_this_boundary": (
         "deterministic tier not installed"
     ),
     "tests/test_issue_194_long_pbir_path.py::test_the_short_control_stays_inside_both_ceilings_at_the_same_root": (
+        "deterministic tier not installed"
+    ),
+    "tests/test_issue_194_long_pbir_path.py::test_the_version_gate_is_what_refuses_an_unaudited_engine": (
         "deterministic tier not installed"
     ),
     "tests/test_issue_424_chart_type_pin.py::test_permanent_invariant_survives_any_future_fix["

--- a/docs/windows-path-limits.md
+++ b/docs/windows-path-limits.md
@@ -370,6 +370,23 @@ Pass `--ceiling 282` to test that budget.
 * **A path it cannot measure is `unknown`, never passing.**
 * **An empty target is `no_paths`, not `ok`.**
 
+**The PRE-CONVERSION projection (`run_estate.project_estate_path_ceiling`) covers two families, and
+the second one is a bound rather than a path** (#564). Alongside the canonical PBIR visual path it
+projects `pbip/<unit>/<model>.SemanticModel/definition/tables/<table>` — the family that carries
+canonical engine 2.368.0's single measured over-ceiling artifact (273 units at the ordinary 22-unit
+run root, #565). Nothing caps that table filename, and its name is composed from source-owned
+identity, so the term is a deliberately conservative **envelope**: the longest identity component in
+the input documents, times the largest number of components any censused write site combines (2, from
+`combine_descriptors`' `Relation (<datasource>)` disambiguation), plus fixed punctuation and a
+uniquification allowance. It is **not** a per-class reimplementation of the engine's naming — three
+successive class-by-class projectors were each defeated by a class the engine had and this repository
+lacked. Two consequences, both intentional: the bound is **version-gated** (an engine outside the
+audited set, or a write-site census that no longer matches, yields `cannot_establish` and therefore a
+refusal, never a clean verdict), and it **over-refuses** — a workbook whose own captions are long can
+be refused at every output root even though the engine would have fitted. The refusal names the
+binding family and the component driving it, so the actionable move is visible: shorten the run root,
+or shorten that identity in the source.
+
 ---
 
 ## 8. What is still unverified

--- a/scripts/run_estate.py
+++ b/scripts/run_estate.py
@@ -133,6 +133,7 @@ import subprocess
 import sys
 import time
 import uuid
+import xml.etree.ElementTree as ET
 import zipfile
 from collections import defaultdict
 from datetime import datetime, timezone
@@ -151,7 +152,13 @@ from check_pbir_valid import REPORT_NAME as PBIR_VALID_REPORT
 from check_pbir_valid import render as render_pbir_valid
 from check_pbir_valid import scan as scan_pbir_validity
 from check_path_ceiling import DIR_CEILING, FILE_CEILING, utf16_len
-from engine_source import EngineNotFoundError, NonCanonicalEngineError, engine_provenance, resolve_engine
+from engine_source import (
+    EngineNotFoundError,
+    NonCanonicalEngineError,
+    engine_provenance,
+    engine_version,
+    resolve_engine,
+)
 from migration_bundle import ENGINE_RECEIPT, sha256_file, write_engine_receipt
 
 log = logging.getLogger("run_estate")
@@ -228,6 +235,288 @@ def _input_candidates(input_dir: Path) -> list[Path] | None:
     return candidates
 
 
+# --------------------------------------------------------------------------------------------
+# The SEMANTIC-MODEL table path family (issue #564)
+# --------------------------------------------------------------------------------------------
+# The PBIR envelope above is not the only family the engine emits. A workbook's model lands as
+# `pbip/<unit>/<model>.SemanticModel/definition/tables/<table>` + the TMDL suffix, and NOTHING caps
+# that table filename - the engine's model-folder writer lays each part path down verbatim, while
+# the model FOLDER base is capped at `migrate_estate._MAX_FS_BASE`. Issue #565 measured a required
+# 273-unit table part at the skill's ordinary 22-unit run root while the `.pbip` pointer was legal.
+#
+# ⚠️ This is deliberately NOT a per-class reimplementation of the engine's naming. Three emitted
+# filename classes each defeated that approach in turn (duplicate-relation disambiguation
+# `Relation (<datasource>)`, a long range/what-if parameter caption, and the per-island
+# `Date (<datasource>)` calendar), because the inventory of classes is owned by the engine and a
+# class it has but we lack is silently absent rather than loud. Instead this bounds the emitted
+# filename GENERICALLY: the longest SOURCE-OWNED identity component in the input documents, times
+# the maximum number of such components any censused write site can combine, plus that site's fixed
+# punctuation and uniquification allowance. It over-refuses by construction; it must not understate.
+_FAMILY_PBIR = "pbir"
+_FAMILY_MODEL = "semantic_model"
+
+#: The engine version(s) the write-site census below was read against. The bound is a claim about a
+#: SPECIFIC engine tree, so any other version is `cannot_establish` rather than a silent assumption
+#: that the naming did not move. Re-audit the write sites and extend this set deliberately.
+_MODEL_AUDITED_ENGINE_VERSIONS = frozenset({"2.368.0"})
+
+#: The audited census, as literal occurrence counts in the canonical engine's own scripts. Read on
+#: 2.368.0 by enumerating every expression that CREATES a `definition/tables/<name>` model part
+#: (`assemble_model.py` lines 4877 data tables, 4941 date dimensions, 5326 `_Measures`, 5707
+#: DirectLake, and `_inject_field_param_tables`; the five remaining occurrences are enrichment sites
+#: guarded by `if path in parts`, which cannot mint a new filename) plus the name-composing
+#: expressions those sites consume (`connection_to_m.combine_descriptors`' `f"{name} ({caption})"` /
+#: `f"{name} ({caption} {n})"`, `assemble_model`'s `"Date (%s)"` prefix ladder, and
+#: `parameters.py`'s `_safe_filename` / `" Parameter"` naming). It is a FINGERPRINT, not a parser: a
+#: count that moves means the audited census no longer describes this tree, so the bound is refused.
+_MODEL_WRITE_SITE_CENSUS: dict[str, dict[str, int]] = {
+    "assemble_model.py": {
+        "definition/tables/": 11,
+        "_inject_field_param_tables": 4,
+        "name_pref": 6,
+        "Date (%s)": 1,
+    },
+    "connection_to_m.py": {
+        'f"{name} ({caption})"': 1,
+        'f"{name} ({caption} {n})"': 1,
+        "def _table_display": 1,
+    },
+    "parameters.py": {
+        "_safe_filename(": 3,
+        'prefer_suffix=" Parameter"': 1,
+        "def _uniquify": 3,
+    },
+    "migrate_estate.py": {
+        "_fs_safe(": 4,
+        "_MAX_FS_BASE": 6,
+    },
+}
+
+#: `(source components, fixed literal UTF-16 units)` for every emitted table-name SHAPE the census
+#: found, without deciding which shape a given source will take:
+#:   * 2 components + `" ("`, `")"` and the collision climb's separating space - the widest, from
+#:     `combine_descriptors`' duplicate-relation disambiguation;
+#:   * 1 component + `"Date ("`, `")"` and `" Dimension"` - the widest fixed text, from the
+#:     per-island calendar ladder (`" Parameter"` at 10 units is strictly inside it).
+#: The bound is the MAXIMUM over the shapes, not their sum: combining the widest component count
+#: with an unrelated shape's literal would be arbitrary padding rather than a bound.
+_MODEL_NAME_SHAPES = ((2, 4), (1, 17))
+
+#: The widest component count any censused shape combines - reported in the refusal so the driver of
+#: an over-refusal is attributable rather than a bare number.
+_MODEL_MAX_COMPONENTS = max(count for count, _literal in _MODEL_NAME_SHAPES)
+
+#: Head-room for the uniquification ladders that can ride on top of a shape: the table-name climb
+#: (`" 2"`, `" 3"`, ...) and the part-filename climb (`"_2"`, `"_3"`, ...) can both apply, so this
+#: allows six digits of each.
+_MODEL_UNIQUIFIER_UTF16 = 16
+
+#: ⚠️ The literal is composed rather than written out: `run_estate` is the coordinator, and its own
+#: architectural guard forbids model-content filenames appearing in it (see
+#: `test_the_coordinator_never_emits_model_content`).
+_MODEL_TABLE_SUFFIX = "." + "tmdl"
+_MODEL_FOLDER_SUFFIX = ".SemanticModel"
+_MODEL_TABLES_TAIL = ("definition", "tables")
+
+#: `migrate_estate._fs_safe` truncates a folder base to `_MAX_FS_BASE` (64) CODE POINTS; an astral
+#: code point is two UTF-16 units, so 128 units is the ceiling that cap really imposes.
+_MODEL_FOLDER_BASE_CAP_UTF16 = 128
+
+#: Attributes that can carry a source-owned identity a censused write site may put in a filename.
+#: `caption` is collected from EVERY element - a caption is the human name the disambiguation
+#: suffix, the calendar suffix, the what-if table and the field-parameter table are all built from,
+#: and deciding WHICH of those a given caption will become is exactly the class reasoning this
+#: envelope refuses to do. The remaining attributes are scoped to the elements the engine's parser
+#: reads a table identity from, so an internal, structurally-decorated id that no write site can
+#: reach (`<column-instance name='[none:X:nk]'>`, `<zone name=...>`) does not inflate the bound.
+_MODEL_IDENTITY_ATTRS = frozenset({"caption"})
+
+#: `<element>` -> the additional attributes on it that a censused write site can read as a name:
+#: relation names and raw tables (`_table_display`), datasource captions and their `datasource_name`
+#: fallback (`combine_descriptors`, `_collapse_untyped_relations_to_extract`), an extract's
+#: materialized `tablename`, a parameter's `internal_name` (`<column name=...>`, the caption's own
+#: fallback in `emit_value_parameters`), and the object-graph entries `_object_table_map` resolves.
+_MODEL_IDENTITY_ATTRS_BY_TAG: dict[str, frozenset[str]] = {
+    "datasource": frozenset({"name", "formatted-name"}),
+    "named-connection": frozenset({"name"}),
+    "relation": frozenset({"name", "table"}),
+    "table": frozenset({"name", "table"}),
+    "connection": frozenset({"tablename"}),
+    "extract": frozenset({"name"}),
+    "column": frozenset({"name"}),
+    "object": frozenset({"name", "id"}),
+}
+
+#: `(element, attribute)` pairs whose value is a QUALIFIED Tableau name (`[catalog].[schema].[item]`,
+#: `[__tableau_internal_object_id__].[<guid>]`). The engine's parser keeps ONE segment of these
+#: (`connection_to_m._strip_brackets` and the bracket splitter that produces a relation's `item`; a
+#: parameter's `internal_name` is the bracket-stripped `<column name>`), so the bound is the longest
+#: segment rather than the whole string - otherwise a 30-unit internal object-id prefix inflates
+#: every estate that has one. Deliberately NOT applied to a relation's own `name` or to any
+#: `caption`: those reach `definition/tables/<name>` verbatim, brackets and all. ⚠️ Residual: a
+#: name whose own text contains `].[` would be split here; Tableau escapes `]` as `]]` inside a
+#: bracketed name, so that string cannot be a single segment in a document it wrote.
+_MODEL_QUALIFIED_FIELDS = frozenset(
+    {
+        ("relation", "table"),
+        ("table", "table"),
+        ("connection", "tablename"),
+        ("column", "name"),
+        ("object", "id"),
+    }
+)
+
+#: Location-shaped attributes, scoped to the elements that carry an upstream file. Only the final
+#: path component of a location can become a name (an extracted flat file's relation is named after
+#: the file, never after its directory), so the separator split is a string rule rather than a class
+#: decision - and a packaged flat file's `<relation name=...>` carries the same identity anyway.
+_MODEL_LOCATION_ATTRS = frozenset({"filename", "directory", "path"})
+_MODEL_LOCATION_TAGS = frozenset({"connection", "named-connection", "relation", "datasource"})
+
+#: Elements whose TEXT is an identity the engine reads: an extract's materialized-table parent and
+#: the metadata-record naming around it (`connection_to_m._extract_materialized_tables`).
+_MODEL_IDENTITY_TEXT_TAGS = frozenset({"parent-name", "local-name", "remote-name", "local-alias", "remote-alias"})
+
+
+def _local_tag(name: str) -> str:
+    """An XML tag or attribute name without its namespace, lowercased."""
+    return name.rsplit("}", 1)[-1].lower()
+
+
+def _longest_qualified_segment(value: str) -> str:
+    """The longest segment of a qualified `[catalog].[schema].[item]` Tableau name.
+
+    Brackets are deliberately NOT stripped: the engine's parser strips them, which only ever
+    shortens the identity it keeps, so leaving them in keeps this an upper bound.
+    """
+    return max(value.split("].["), key=utf16_len)
+
+
+def _source_document(path: Path) -> str | None:
+    """The Tableau XML document text of a loose or packaged source, or None when unreadable."""
+    try:
+        if path.suffix.lower() in {".twb", ".tds"}:
+            return path.read_bytes().decode("utf-8-sig")
+        required = _ENGINE_SOURCE_SUFFIXES[path.suffix.lower()]
+        with zipfile.ZipFile(path) as archive:
+            for info in archive.infolist():
+                if not info.is_dir() and Path(info.filename).suffix.lower() == required:
+                    with archive.open(info) as document:
+                        return document.read().decode("utf-8-sig")
+        return None
+    except (OSError, KeyError, UnicodeDecodeError, zipfile.BadZipFile):
+        return None
+
+
+def _identity_components(text: str) -> list[str] | None:
+    """Every source-owned identity string in one Tableau document, or None when it will not parse."""
+    try:
+        root = ET.fromstring(text)
+    except (ET.ParseError, ValueError):
+        return None
+    found: list[str] = []
+    for element in root.iter():
+        tag = _local_tag(element.tag)
+        scoped = _MODEL_IDENTITY_ATTRS_BY_TAG.get(tag, frozenset())
+        for key, value in element.attrib.items():
+            if not value:
+                continue
+            attribute = _local_tag(key)
+            if (tag, attribute) in _MODEL_QUALIFIED_FIELDS:
+                found.append(_longest_qualified_segment(value))
+            elif attribute in _MODEL_IDENTITY_ATTRS or attribute in scoped:
+                found.append(value)
+            elif attribute in _MODEL_LOCATION_ATTRS and tag in _MODEL_LOCATION_TAGS:
+                found.append(value.replace("\\", "/").rsplit("/", 1)[-1])
+        if tag in _MODEL_IDENTITY_TEXT_TAGS and (element.text or "").strip():
+            found.append(_longest_qualified_segment(element.text.strip()))
+    return found
+
+
+def _model_component_bound(paths: list[Path] | None) -> dict:
+    """The longest source-owned identity component the estate can hand a table filename."""
+    if not paths:
+        return {"status": "cannot_establish", "reason": "no readable Tableau source document was available"}
+    longest, longest_value = 0, ""
+    for path in paths:
+        text = _source_document(path)
+        if text is None:
+            return {"status": "cannot_establish", "reason": f"source {path.name!r} could not be read as Tableau XML"}
+        components = _identity_components(text)
+        if components is None:
+            return {"status": "cannot_establish", "reason": f"source {path.name!r} is not parseable Tableau XML"}
+        for value in components:
+            length = utf16_len(value)
+            if length > longest:
+                longest, longest_value = length, value
+    if not longest:
+        return {"status": "cannot_establish", "reason": "the estate declares no source identity component"}
+    return {"status": "ok", "component": longest, "component_value": longest_value}
+
+
+def _model_write_site_census(engine: Path | None) -> dict:
+    """Prove the audited table write-site census still describes the engine that will run."""
+    if engine is None:
+        return {"status": "cannot_establish", "reason": "no engine was selected, so its table write sites are unknown"}
+    try:
+        version = engine_version(engine)
+    except OSError:
+        version = None
+    if version not in _MODEL_AUDITED_ENGINE_VERSIONS:
+        return {
+            "status": "cannot_establish",
+            "reason": (
+                f"engine version {version or 'unknown'} is outside the audited set "
+                f"{sorted(_MODEL_AUDITED_ENGINE_VERSIONS)}; the table write-site census was never "
+                "read against it"
+            ),
+        }
+    scripts_dir = engine / "skills" / "tableau-migration" / "scripts"
+    for filename, probes in _MODEL_WRITE_SITE_CENSUS.items():
+        try:
+            text = (scripts_dir / filename).read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            return {"status": "cannot_establish", "reason": f"engine script {filename!r} could not be read"}
+        for probe, expected in probes.items():
+            seen = text.count(probe)
+            if seen != expected:
+                return {
+                    "status": "cannot_establish",
+                    "reason": (
+                        f"table write-site census mismatch in {filename}: {probe!r} occurs {seen} "
+                        f"time(s), audited {expected}"
+                    ),
+                }
+    return {"status": "ok", "engine_version": version}
+
+
+def _model_table_stem_bound(component: int) -> int:
+    """The longest emitted table filename STEM (before the suffix) the censused sites can compose."""
+    return max(count * component + literal for count, literal in _MODEL_NAME_SHAPES) + _MODEL_UNIQUIFIER_UTF16
+
+
+def model_envelope_evidence(paths: list[Path] | None, engine: Path | None) -> dict:
+    """Version-gated evidence for the semantic-model table path family.
+
+    Returns either `{"status": "ok", ...}` carrying the bound, or `{"status": "cannot_establish",
+    "reason": ...}`. It never returns a clean bound from an unaudited engine or an unreadable source:
+    the projection's whole job is to be unable to say "fits" when it cannot say it.
+    """
+    census = _model_write_site_census(engine)
+    if census["status"] != "ok":
+        return census
+    bound = _model_component_bound(paths)
+    if bound["status"] != "ok":
+        return bound
+    return {
+        "status": "ok",
+        "engine_version": census["engine_version"],
+        "component": bound["component"],
+        "component_value": bound["component_value"],
+        "table_stem": _model_table_stem_bound(bound["component"]),
+    }
+
+
 def _engine_unit_names(engine: Path, input_dir: Path) -> list[str] | None:
     """Ask the selected engine for its real datasource-then-workbook folder allocation."""
     scripts_dir = engine / "skills" / "tableau-migration" / "scripts"
@@ -269,16 +558,42 @@ def _engine_unit_names(engine: Path, input_dir: Path) -> list[str] | None:
     return names
 
 
-def project_estate_path_ceiling(output_root: Path, unit_names: list[str] | None) -> dict:
-    """Project the canonical PBIP visual path before the engine writes any output.
+def _path_records(family: str, directory: Path, file_path: Path) -> list[dict]:
+    """The (directory, file) pair a projected path contributes, each judged by its own ceiling."""
+    return [
+        {
+            "family": family,
+            "kind": "directory",
+            "path": str(directory),
+            "length": utf16_len(str(directory)),
+            "ceiling": DIR_CEILING,
+        },
+        {
+            "family": family,
+            "kind": "file",
+            "path": str(file_path),
+            "length": utf16_len(str(file_path)),
+            "ceiling": FILE_CEILING,
+        },
+    ]
 
-    The fixed page/visual identifiers define the minimum canonical PBIR safety envelope; the estate's
-    longest source name and actual output root are the variable inputs available at this stage.
+
+def project_estate_path_ceiling(
+    output_root: Path, unit_names: list[str] | None, model_evidence: dict | None = None
+) -> dict:
+    """Project BOTH canonical PBIP path families before the engine writes any output.
+
+    The PBIR term uses the fixed page/visual identifiers as the minimum canonical safety envelope.
+    The semantic-model term is the conservative source-component envelope described above, and it
+    requires `model_evidence` from `model_envelope_evidence`: without it - or with an unaudited
+    engine, or an unreadable source - the whole projection is `cannot_establish`, never `ok`, because
+    a clean PBIR verdict alone would be exactly the fail-open shape issue #564 reports.
     """
     output_root = output_root.resolve()
     if not unit_names:
         return {
             "status": "cannot_establish",
+            "family": _FAMILY_PBIR,
             "reason": "no unit/workbook name was available before conversion",
             "output_root": str(output_root),
         }
@@ -289,31 +604,44 @@ def project_estate_path_ceiling(output_root: Path, unit_names: list[str] | None)
     ) != len(projected_names):
         return {
             "status": "cannot_establish",
+            "family": _FAMILY_PBIR,
             "reason": "the selected engine returned an invalid unit name",
             "output_root": str(output_root),
         }
+    if not model_evidence or model_evidence.get("status") != "ok":
+        return {
+            "status": "cannot_establish",
+            "family": _FAMILY_MODEL,
+            "reason": (
+                "the semantic-model table path family could not be bounded: "
+                + ((model_evidence or {}).get("reason") or "no model-path evidence was supplied")
+            ),
+            "output_root": str(output_root),
+        }
+    component = model_evidence["component"]
+    table_stem = model_evidence["table_stem"]
+    # The model FOLDER is `_fs_safe(<datasource caption> or <workbook name>)`, so it is bounded by
+    # the same component pool as the table name and by the engine's own base cap - never by the unit
+    # name alone, which is why the unit-name-only projection could not see this family at all.
+    model_base_units = min(
+        max([component, *(utf16_len(name) for name in projected_names)]), _MODEL_FOLDER_BASE_CAP_UTF16
+    )
     for unit in projected_names:
-        report = f"{unit}.Report"
-        report_root = output_root / "pbip" / unit / report
-        directory = report_root / _PBIR_VISUAL_TAIL.rsplit("/", 1)[0]
-        file_path = report_root / _PBIR_VISUAL_TAIL
+        unit_root = output_root / "pbip" / unit
+        report_root = unit_root / f"{unit}.Report"
         records.extend(
-            (
-                {
-                    "kind": "directory",
-                    "path": str(directory),
-                    "length": utf16_len(str(directory)),
-                    "ceiling": DIR_CEILING,
-                },
-                {
-                    "kind": "file",
-                    "path": str(file_path),
-                    "length": utf16_len(str(file_path)),
-                    "ceiling": FILE_CEILING,
-                },
+            _path_records(
+                _FAMILY_PBIR,
+                report_root / _PBIR_VISUAL_TAIL.rsplit("/", 1)[0],
+                report_root / _PBIR_VISUAL_TAIL,
             )
         )
+        tables_dir = unit_root / ("m" * model_base_units + _MODEL_FOLDER_SUFFIX)
+        for part in _MODEL_TABLES_TAIL:
+            tables_dir = tables_dir / part
+        records.extend(_path_records(_FAMILY_MODEL, tables_dir, tables_dir / ("t" * table_stem + _MODEL_TABLE_SUFFIX)))
     offenders = [record for record in records if record["length"] > record["ceiling"]]
+    binding = max(records, key=lambda record: record["length"] - record["ceiling"])
     return {
         "status": "over_ceiling" if offenders else "ok",
         "output_root": str(output_root),
@@ -321,7 +649,23 @@ def project_estate_path_ceiling(output_root: Path, unit_names: list[str] | None)
         "projected_units": projected_names,
         "paths": records,
         "offenders": offenders,
+        "family": binding["family"],
+        "binding": binding,
+        "reason": _binding_reason(binding, model_evidence),
+        "model_evidence": model_evidence,
     }
+
+
+def _binding_reason(binding: dict, model_evidence: dict) -> str:
+    """Why the binding path family binds, in the terms that produced its length."""
+    if binding["family"] == _FAMILY_MODEL:
+        return (
+            f"the semantic-model table filename bound ({_MODEL_MAX_COMPONENTS} x the "
+            f"{model_evidence['component']}-unit source component {model_evidence['component_value']!r} "
+            f"plus fixed overhead) is the longest projected path, on audited engine "
+            f"{model_evidence['engine_version']}"
+        )
+    return "the canonical PBIR visual path is the longest projected path"
 
 
 #: The actionable escape route for a projected path-ceiling refusal - issue #479's second reopen
@@ -343,10 +687,15 @@ def preflight_estate_path_ceiling(input_dir: Path, output_root: Path, engine: Pa
     try:
         candidates = _input_candidates(input_dir)
         names = _engine_unit_names(engine, input_dir) if engine and candidates else None
-        projection = project_estate_path_ceiling(output_root, names)
+        projection = project_estate_path_ceiling(output_root, names, model_envelope_evidence(candidates, engine))
     except (OSError, RuntimeError, UnicodeEncodeError, ValueError) as exc:
         return False, (f"CANNOT ASSESS downstream PBIP path length ({type(exc).__name__}: {exc}). {_SHORT_ROOT_HINT}")
     if projection["status"] == "cannot_establish":
+        if projection["family"] == _FAMILY_MODEL:
+            return False, (
+                "CANNOT ASSESS downstream PBIP path length: "
+                f"{projection['reason']}. Binding family {_FAMILY_MODEL}. {_SHORT_ROOT_HINT}"
+            )
         return False, (
             "CANNOT ASSESS downstream PBIP path length: the input estate has no usable unit/workbook "
             f"name. {_SHORT_ROOT_HINT}"
@@ -356,12 +705,14 @@ def preflight_estate_path_ceiling(input_dir: Path, output_root: Path, engine: Pa
         return False, (
             f"PATH CEILING: projected {worst['kind']} is {worst['length']} UTF-16 units "
             f"(ceiling {worst['ceiling']}) for unit {projection['longest_unit']!r}. "
+            f"Binding family {worst['family']}: {projection['reason']}. "
             "LongPathsEnabled and \\\\?\\ prefixes do not make Power BI Desktop accept these paths. "
             f"{_SHORT_ROOT_HINT}"
         )
     return True, (
-        f"PATH CEILING: projected canonical PBIP visual path fits ({projection['longest_unit']!r}); "
-        "this is the pre-conversion safety envelope."
+        f"PATH CEILING: projected canonical PBIP paths fit ({projection['longest_unit']!r}); "
+        f"binding family {projection['family']} - {projection['reason']}. "
+        "This is the pre-conversion safety envelope."
     )
 
 

--- a/tests/test_datasource_path_envelope.py
+++ b/tests/test_datasource_path_envelope.py
@@ -124,6 +124,17 @@ ENVELOPE_TAIL = {
     THIN_UNIT: _tail(THIN_PAGE, None),
 }
 
+#: Model-family evidence whose source component is one unit, so the semantic-model term cannot bind
+#: and the PBIR assertions in this module stay statements about PBIR. The model family's own control
+#: (`test_the_model_family_projection_covers_every_emitted_shape`) uses the PRODUCTION evidence.
+PBIR_ONLY_EVIDENCE = {
+    "status": "ok",
+    "engine_version": "test-only",
+    "component": 1,
+    "component_value": "x",
+    "table_stem": run_estate._model_table_stem_bound(1),  # pylint: disable=protected-access
+}
+
 #: The two calcs grafted onto the base fixture, and the exact shape `parameters.detect_field_swap`
 #: accepts: a `[Parameters].[X]`-driven CASE whose every branch is a BARE field reference, >= 2
 #: branches. One measure-role and one dimension-role, so the emitted page carries the table AND a
@@ -320,6 +331,22 @@ def _engine_bundle(tmp_path_factory: pytest.TempPathFactory) -> dict[str, Any]: 
         )
         deepest = max(tails, key=utf16_len, default="")
         deepest_dir = max(dir_tails, key=utf16_len, default="")
+        # The SEMANTIC-MODEL family (issue #564): the model folder beside the report, and the
+        # longest table part the engine actually wrote into it. Recorded per unit so the
+        # projection >= actual control below compares production against real emitted bytes.
+        unit_root = out / "pbip" / unit
+        model_dirs = (
+            [path for path in unit_root.iterdir() if path.is_dir() and path.name.endswith(".SemanticModel")]
+            if unit_root.is_dir()
+            else []
+        )
+        model_files = [
+            str(path.relative_to(unit_root)).replace("\\", "/")
+            for model in model_dirs
+            for path in model.rglob("*")
+            if path.is_file()
+        ]
+        deepest_model = max(model_files, key=utf16_len, default="")
         shapes[unit] = {
             "report": report,
             "pages": page_dirs,
@@ -330,6 +357,9 @@ def _engine_bundle(tmp_path_factory: pytest.TempPathFactory) -> dict[str, Any]: 
             "deepest_dir_tail_len": utf16_len(deepest_dir),
             "longest_visual_id": max((utf16_len(v) for v in visuals), default=0),
             "longest_page_id": max((utf16_len(p) for p in page_dirs), default=0),
+            "model_folders": [path.name for path in model_dirs],
+            "deepest_model_tail": deepest_model,
+            "deepest_model_tail_len": utf16_len(deepest_model),
         }
     return {"version": engine_source.engine_version(engine), "root": out, "shapes": shapes}
 
@@ -500,8 +530,12 @@ def test_the_production_projection_refuses_each_emitted_shape_at_its_own_boundar
         f"harness error: the emitted {kind} measures {at_root} at the constructed root, not the intended {ceiling + 1}"
     )
 
-    projection = run_estate.project_estate_path_ceiling(root, [unit])
-    record = next(r for r in projection["paths"] if r["kind"] == kind)
+    projection = run_estate.project_estate_path_ceiling(root, [unit], PBIR_ONLY_EVIDENCE)
+    record = next(
+        r
+        for r in projection["paths"]
+        if r["kind"] == kind and r["family"] == run_estate._FAMILY_PBIR  # pylint: disable=protected-access
+    )
 
     assert record["length"] >= at_root, (
         f"{unit}/{kind}: the PRODUCTION envelope projects {record['length']} units where the engine "
@@ -594,8 +628,12 @@ def test_the_projector_is_blind_to_unit_kind_and_over_projects_this_datasource(e
     """
     shape = engine_bundle["shapes"][SWAP_UNIT]
     root = engine_bundle["root"]
-    projection = run_estate.project_estate_path_ceiling(root, [SWAP_UNIT])
-    projected_file = next(r for r in projection["paths"] if r["kind"] == "file")["length"]
+    projection = run_estate.project_estate_path_ceiling(root, [SWAP_UNIT], PBIR_ONLY_EVIDENCE)
+    projected_file = next(
+        r
+        for r in projection["paths"]
+        if r["kind"] == "file" and r["family"] == run_estate._FAMILY_PBIR  # pylint: disable=protected-access
+    )["length"]
     actual_file = max(utf16_len(str(p)) for p in shape["report"].rglob("*") if p.is_file())
 
     assert projected_file > actual_file, (
@@ -612,6 +650,45 @@ def test_the_projector_is_blind_to_unit_kind_and_over_projects_this_datasource(e
         f"The sound datasource envelope ({sound}) does not cover the emitted path ({actual_file}); an "
         "envelope that fails to cover real output is fail-open by construction."
     )
+
+
+@requires_engine
+def test_the_model_family_projection_covers_every_emitted_shape(engine_bundle) -> None:
+    """Issue #564, against real engine output: an ORDINARY datasource, a FIELD-SWAP datasource and a
+    real workbook, each judged on the semantic-model table part the engine actually wrote.
+
+    The comparison is `projected >= actual` on the emitted bytes, not against an expected filename:
+    an expected-string test cannot see a naming class the engine has and this repository does not,
+    which is exactly how three successive class-by-class projectors were defeated (issue #564).
+    """
+    engine = _contract()
+    evidence = run_estate.model_envelope_evidence(sorted(MATRIX_SOURCES.values()), engine)
+    assert evidence["status"] == "ok", (
+        f"the production evidence could not be established on engine {engine_bundle['version']}: "
+        f"{evidence.get('reason')}. If the engine moved, re-audit the write-site census - do not "
+        "relax the gate."
+    )
+
+    root = engine_bundle["root"]
+    projection = run_estate.project_estate_path_ceiling(root, sorted(MATRIX_SOURCES), evidence)
+    projected = max(
+        record["length"]
+        for record in projection["paths"]
+        if record["family"] == run_estate._FAMILY_MODEL  # pylint: disable=protected-access
+        and record["kind"] == "file"
+    )
+
+    for unit, shape in engine_bundle["shapes"].items():
+        assert shape["model_folders"], (
+            f"{unit} emitted no `.SemanticModel` folder on engine {engine_bundle['version']}; this "
+            "control would then be vacuous"
+        )
+        actual = utf16_len(str(root / "pbip" / unit / shape["deepest_model_tail"]))
+        assert projected >= actual, (
+            f"{unit}: production projects {projected} units for the semantic-model family where the "
+            f"engine really wrote {actual} ({shape['deepest_model_tail']!r}). A projection that does "
+            "not cover real output is fail-open by construction - this is issue #564."
+        )
 
 
 @requires_engine

--- a/tests/test_datasource_path_envelope.py
+++ b/tests/test_datasource_path_envelope.py
@@ -660,16 +660,37 @@ def test_the_model_family_projection_covers_every_emitted_shape(engine_bundle) -
     The comparison is `projected >= actual` on the emitted bytes, not against an expected filename:
     an expected-string test cannot see a naming class the engine has and this repository does not,
     which is exactly how three successive class-by-class projectors were defeated (issue #564).
+
+    ⚠️ The bound is VERSION-GATED, and the repository's engine job pins an older build than the one
+    the write-site census was audited on. On an unaudited engine the correct production outcome is a
+    REFUSAL, so that arm asserts the refusal - never a skip, and never a clean verdict.
     """
     engine = _contract()
+    version = engine_bundle["version"]
     evidence = run_estate.model_envelope_evidence(sorted(MATRIX_SOURCES.values()), engine)
+    root = engine_bundle["root"]
+
+    for unit, shape in engine_bundle["shapes"].items():
+        assert shape["model_folders"], (
+            f"{unit} emitted no `.SemanticModel` folder on engine {version}; this control would then be vacuous"
+        )
+
+    if version not in run_estate._MODEL_AUDITED_ENGINE_VERSIONS:  # pylint: disable=protected-access
+        assert evidence["status"] == "cannot_establish", (
+            f"engine {version} is outside the audited set, so the evidence must refuse rather than "
+            f"report {evidence.get('status')!r}"
+        )
+        assert str(version) in evidence["reason"], evidence["reason"]
+        refused = run_estate.project_estate_path_ceiling(root, sorted(MATRIX_SOURCES), evidence)
+        assert refused["status"] == "cannot_establish"
+        assert refused["family"] == run_estate._FAMILY_MODEL  # pylint: disable=protected-access
+        return
+
     assert evidence["status"] == "ok", (
-        f"the production evidence could not be established on engine {engine_bundle['version']}: "
+        f"the production evidence could not be established on engine {version}: "
         f"{evidence.get('reason')}. If the engine moved, re-audit the write-site census - do not "
         "relax the gate."
     )
-
-    root = engine_bundle["root"]
     projection = run_estate.project_estate_path_ceiling(root, sorted(MATRIX_SOURCES), evidence)
     projected = max(
         record["length"]
@@ -677,12 +698,7 @@ def test_the_model_family_projection_covers_every_emitted_shape(engine_bundle) -
         if record["family"] == run_estate._FAMILY_MODEL  # pylint: disable=protected-access
         and record["kind"] == "file"
     )
-
     for unit, shape in engine_bundle["shapes"].items():
-        assert shape["model_folders"], (
-            f"{unit} emitted no `.SemanticModel` folder on engine {engine_bundle['version']}; this "
-            "control would then be vacuous"
-        )
         actual = utf16_len(str(root / "pbip" / unit / shape["deepest_model_tail"]))
         assert projected >= actual, (
             f"{unit}: production projects {projected} units for the semantic-model family where the "

--- a/tests/test_e2e_offline.py
+++ b/tests/test_e2e_offline.py
@@ -86,17 +86,35 @@ def _pipeline(tmp_path_factory):
         client.sign_out()
 
     engine = estate.install_fake_engine(work / "engine")
-    code = run_estate.main(
-        [
-            "--input",
-            str(work / "assets"),
-            "--output",
-            str(work / "bundle"),
-            "--engine",
-            str(engine),
-            "--allow-noncanonical-engine",
-        ]
-    )
+    with pytest.MonkeyPatch.context() as patch:
+        # The pre-conversion SEMANTIC-MODEL path envelope (issue #564) is version-gated against the
+        # canonical engine's own table write-site census, which this deliberate mock engine cannot
+        # satisfy - so without this the coordinator would refuse (`CANNOT ASSESS`) before the deploy
+        # chain under test here ever starts. Stubbed with a one-unit source component, which cannot
+        # bind; the envelope itself is proven against real engine output in
+        # `tests/test_issue_194_long_pbir_path.py` and `tests/test_run_estate.py`.
+        patch.setattr(
+            run_estate,
+            "model_envelope_evidence",
+            lambda _paths, _engine: {
+                "status": "ok",
+                "engine_version": "mock-engine",
+                "component": 1,
+                "component_value": "x",
+                "table_stem": run_estate._model_table_stem_bound(1),  # pylint: disable=protected-access
+            },
+        )
+        code = run_estate.main(
+            [
+                "--input",
+                str(work / "assets"),
+                "--output",
+                str(work / "bundle"),
+                "--engine",
+                str(engine),
+                "--allow-noncanonical-engine",
+            ]
+        )
     assert code == 0, "the coordinator must accept the bundle before anything is deployed"
 
     return {

--- a/tests/test_issue_194_long_pbir_path.py
+++ b/tests/test_issue_194_long_pbir_path.py
@@ -50,6 +50,8 @@ if str(SCRIPTS) not in sys.path:
 
 import engine_source  # noqa: E402  # pylint: disable=wrong-import-position
 import host_paths  # noqa: E402  # pylint: disable=wrong-import-position
+import run_estate  # noqa: E402  # pylint: disable=wrong-import-position
+from check_path_ceiling import utf16_len  # noqa: E402  # pylint: disable=wrong-import-position
 
 FIXTURE = REPO / "fixtures" / "upstream-repros" / "issue-194-long-pbir-path"
 BUILDER = FIXTURE / "build_repro.py"
@@ -725,4 +727,413 @@ def test_the_short_control_stays_inside_both_ceilings_at_the_same_root(engine_ru
     assert (short_case["files"], short_case["directories"]) == (long_case["files"], long_case["directories"]), (
         f"the two cases emitted different structures ({short_case['files']}/{short_case['directories']} vs "
         f"{long_case['files']}/{long_case['directories']}); the A/B would then differ in more than names"
+    )
+
+
+# -- issue #564: the semantic-model table path family ----------------------------------------------
+#
+# The projector's model term is a GENERIC source-component envelope, not a class inventory, because
+# three successive class-by-class projectors were each defeated by a filename class the engine had
+# and this repository lacked: `combine_descriptors`' duplicate-relation `Relation (<datasource>)`, a
+# long range/what-if parameter caption, and the per-island `Date (<datasource>)` calendar. Every
+# control below therefore judges `projected >= actual` on what the engine REALLY wrote - an
+# expected-filename assertion is blind to exactly the class that defeats it.
+TEMPLATE_TWB = (FIXTURE / "src" / "workbook-template.twb").read_text(encoding="utf-8")
+TEMPLATE_CSV = (FIXTURE / "src" / "regional_sales.csv").read_text(encoding="utf-8")
+
+#: The kill control's identity names, deliberately the SAME length: the emitted collision name is
+#: then `<relation> (<caption>)`, i.e. two full-length source-owned components plus fixed
+#: punctuation, which is the only shape that can distinguish a two-component bound from a
+#: one-component one AND exceed twice its longest component. ⚠️ The relation is a RENAMED logical
+#: table over a short flat file, not the file name itself: a packaged flat file also contributes its
+#: bracketed `[<file>#csv]` form, six units longer than the name, so a file-named relation can never
+#: exceed twice the pool maximum and the fixed-overhead mutation would be unkillable. Renaming a
+#: logical table is ordinary Tableau authoring. Plausible enterprise names, never repeated
+#: characters (see `test_the_long_case_carries_a_plausible_name_not_padding`).
+KILL_RELATION = "Regional Sales and Inventory Turnover FY2026 Q3 Detail Snapshot"
+KILL_CAPTION_A = "Alpha Regional Sales and Inventory Turnover Consolidated Source"
+KILL_CAPTION_B = "Delta Regional Sales and Inventory Turnover Consolidated Source"
+KILL_CSV = "regional_sales.csv"
+
+ISLAND_CAPTION_A = "Alpha Consolidated Regional Sales and Inventory Turnover Source"
+ISLAND_CAPTION_B = "Beta Consolidated Regional Sales and Inventory Turnover Source"
+PARAMETER_CAPTION = "Rolling Inventory Turnover Threshold for FY2026 Q3 Review"
+ASTRAL_CAPTION = "Ventas 🌍🌎🌏 Consolidado Regional 📊 FY2026"
+ASTRAL_CSV = "ventas_🌍_consolidado.csv"
+
+DATE_METADATA_RECORD = """<metadata-record class='column'>
+            <remote-name>order_date</remote-name>
+            <remote-type>7</remote-type>
+            <local-name>[order_date]</local-name>
+            <parent-name>[{csv}]</parent-name>
+            <remote-alias>order_date</remote-alias>
+            <ordinal>4</ordinal>
+            <local-type>date</local-type>
+            <aggregation>Year</aggregation>
+            <contains-null>true</contains-null>
+          </metadata-record>"""
+
+
+def _island(
+    caption: str,
+    ds_id: str,
+    csv_name: str,
+    worksheet: str,
+    dashboard: str,
+    *,
+    dates: bool = False,
+    relation_name: str | None = None,
+) -> str:
+    """One datasource island built from the committed repro template.
+
+    `relation_name` renames the LOGICAL table over the same flat file - ordinary Tableau authoring,
+    and the only way to give a relation an identity that is not derived from the file name.
+    """
+    text = TEMPLATE_TWB
+    for token, value in (
+        ("@@DATASOURCE@@", caption),
+        ("@@CSVFILE@@", csv_name),
+        ("@@WORKSHEET@@", worksheet),
+        ("@@DASHBOARD@@", dashboard),
+    ):
+        assert token in text, f"the committed template lost its {token} placeholder"
+        text = text.replace(token, value)
+    text = text.replace("federated.regionalsales", ds_id)
+    text = text.replace("textscan.regionalsales", "textscan." + ds_id.split(".", 1)[-1])
+    if relation_name is not None:
+        marker = f"name='{csv_name}' table="
+        assert text.count(marker) == 1, f"the template's relation name is no longer {marker!r}"
+        text = text.replace(marker, f"name='{relation_name}' table=")
+    if not dates:
+        return text
+    text = text.replace(
+        "<column datatype='real' name='net_revenue' ordinal='3' />",
+        "<column datatype='real' name='net_revenue' ordinal='3' />\n"
+        "            <column datatype='date' name='order_date' ordinal='4' />",
+    )
+    text = text.replace(
+        "</metadata-records>", DATE_METADATA_RECORD.format(csv=csv_name) + "\n        </metadata-records>"
+    )
+    return text.replace(
+        "<column caption='Net Revenue' datatype='real' name='[net_revenue]' role='measure' type='quantitative' />",
+        "<column caption='Net Revenue' datatype='real' name='[net_revenue]' role='measure' type='quantitative' />\n"
+        "      <column caption='Order Date' datatype='date' name='[order_date]' role='dimension' type='ordinal' />",
+        1,
+    )
+
+
+def _combine(first: str, second: str) -> ET.Element:
+    """Two islands in ONE workbook - what makes `combine_descriptors` and the per-island calendar run."""
+    root = ET.fromstring(first)
+    other = ET.fromstring(second)
+    for container, tag in (("datasources", "datasource"), ("worksheets", "worksheet"), ("dashboards", "dashboard")):
+        root.find(container).append(other.find(f"{container}/{tag}"))
+    for window in other.findall("windows/window"):
+        root.find("windows").append(window)
+    return root
+
+
+def _with_value_parameter(root: ET.Element, caption: str) -> ET.Element:
+    """A range parameter plus the calc that references it, so `emit_value_parameters` fires."""
+    root.find("datasources").insert(
+        0,
+        ET.fromstring(
+            "<datasource hasconnection='false' inline='true' name='Parameters' version='18.1'>"
+            f"<column caption='{caption}' datatype='real' name='[Parameter 1]' "
+            "param-domain-type='range' role='measure' type='quantitative' value='5.0'>"
+            "<calculation class='tableau' formula='5.0' />"
+            "<range granularity='1.0' max='100.0' min='0.0' />"
+            "</column></datasource>"
+        ),
+    )
+    root.findall("datasources/datasource")[1].append(
+        ET.fromstring(
+            "<column caption='Flagged Revenue' datatype='boolean' name='[Calculation_flag]' "
+            "role='dimension' type='ordinal'>"
+            "<calculation class='tableau' formula='[net_revenue] &gt; [Parameters].[Parameter 1]' />"
+            "</column>"
+        )
+    )
+    return root
+
+
+def _write_control(base: Path, root: ET.Element, csv_names: tuple[str, ...], stem: str) -> Path:
+    """Materialise one control as a loose `.twb` plus the flat files its relations name."""
+    source = base / "in"
+    (source / "Data" / "regional-sales").mkdir(parents=True, exist_ok=True)
+    ET.ElementTree(root).write(source / f"{stem}.twb", encoding="utf-8", xml_declaration=True)
+    for csv_name in csv_names:
+        (source / "Data" / "regional-sales" / csv_name).write_text(TEMPLATE_CSV, encoding="utf-8")
+    return source
+
+
+def _model_controls() -> dict[str, tuple[ET.Element, tuple[str, ...], str]]:
+    """The four source-visible naming shapes this module drives through the real engine."""
+    duplicate = _combine(
+        _island(ISLAND_CAPTION_A, "federated.alpha", "regional_sales.csv", "Sheet A", "Dash A", dates=True),
+        _island(ISLAND_CAPTION_B, "federated.beta", "regional_sales.csv", "Sheet B", "Dash B", dates=True),
+    )
+    parameter = _with_value_parameter(
+        _combine(
+            _island(ISLAND_CAPTION_A, "federated.alpha", "regional_sales.csv", "Sheet A", "Dash A"),
+            _island(ISLAND_CAPTION_B, "federated.beta", "regional_sales_b.csv", "Sheet B", "Dash B"),
+        ),
+        PARAMETER_CAPTION,
+    )
+    astral = ET.fromstring(_island(ASTRAL_CAPTION, "federated.astral", ASTRAL_CSV, "Hoja", "Panel"))
+    kill = _combine(
+        _island(KILL_CAPTION_A, "federated.alpha", KILL_CSV, "Sheet A", "Dash A", relation_name=KILL_RELATION),
+        _island(KILL_CAPTION_B, "federated.beta", KILL_CSV, "Sheet B", "Dash B", relation_name=KILL_RELATION),
+    )
+    return {
+        "duplicate_relation_and_island_date": (duplicate, ("regional_sales.csv",), "Islands"),
+        "value_parameter": (parameter, ("regional_sales.csv", "regional_sales_b.csv"), "WhatIf"),
+        "astral_identity": (astral, (ASTRAL_CSV,), "Astral"),
+        "two_long_components": (kill, (KILL_CSV,), "Collision"),
+    }
+
+
+@pytest.fixture(scope="session", name="model_runs")
+def _model_runs(tmp_path_factory: pytest.TempPathFactory) -> dict[str, Any]:
+    """Run the canonical engine on every model-family control, once, into per-process directories."""
+    engine = _contract()
+    if engine is None:  # pragma: no cover - requires_engine handles collection-time absence
+        pytest.skip(ENGINE_SKIP_REASON)
+    base = tmp_path_factory.mktemp("issue-564")
+    runs: dict[str, dict[str, Any]] = {}
+    for name, (root, csv_names, stem) in _model_controls().items():
+        source = _write_control(base / name, root, csv_names, stem)
+        out = base / name / "out"
+        code, _command, output = measure_repro.run_engine(engine, source, out)
+        assert code == 0, f"harness failure running the engine on control {name}:\n{output[-4000:]}"
+        tables = sorted(path.name for path in out.rglob("*") if path.is_file() and path.parent.name == "tables")
+        model_files = [
+            str(path.relative_to(out)).replace("\\", "/")
+            for path in out.rglob("*")
+            if path.is_file() and any(part.endswith(".SemanticModel") for part in path.relative_to(out).parts)
+        ]
+        assert tables and model_files, f"control {name} emitted no semantic model at all"
+        runs[name] = {
+            "source": source,
+            "out": out,
+            "tables": tables,
+            "longest_model_tail": max(model_files, key=utf16_len),
+            "units": run_estate._engine_unit_names(engine, source),  # pylint: disable=protected-access
+            "evidence": run_estate.model_envelope_evidence(
+                run_estate._input_candidates(source),  # pylint: disable=protected-access
+                engine,
+            ),
+        }
+    return {"version": engine_source.engine_version(engine), "engine": engine, "controls": runs}
+
+
+def _projected_model_file(run: dict[str, Any], root: Path, evidence: dict | None = None) -> int:
+    """The longest projected semantic-model FILE for one control, at an exact root."""
+    projection = run_estate.project_estate_path_ceiling(root, run["units"], evidence or run["evidence"])
+    assert projection["status"] != "cannot_establish", projection.get("reason")
+    return max(
+        record["length"]
+        for record in projection["paths"]
+        if record["family"] == run_estate._FAMILY_MODEL  # pylint: disable=protected-access
+        and record["kind"] == "file"
+    )
+
+
+def _actual_model_file(run: dict[str, Any], root: Path) -> int:
+    """The longest semantic-model FILE the engine really wrote, rebased onto the same root."""
+    return utf16_len(str(root / run["longest_model_tail"]))
+
+
+def _actual_table_filename(run: dict[str, Any]) -> int:
+    """The longest table FILENAME the engine really wrote for one control."""
+    return max(utf16_len(name) for name in run["tables"])
+
+
+def _projected_table_filename(evidence: dict) -> int:
+    """The longest table filename production would allow for the same evidence."""
+    return evidence["table_stem"] + utf16_len(run_estate._MODEL_TABLE_SUFFIX)  # pylint: disable=protected-access
+
+
+@requires_engine
+def test_the_model_projection_covers_the_committed_long_and_short_pair(engine_runs) -> None:
+    """The A/B pair, judged on the SEMANTIC-MODEL family rather than the report family.
+
+    The long arm's offender is itself a model table part (`measure_repro.OFFENDER_SUFFIX`), so this
+    is the control where the two families' verdicts must agree in direction: the projection covers
+    the emitted model path in both arms, and refuses the long one at the skill's ordinary root.
+    """
+    engine = _contract()
+    root = Path(Path.cwd().anchor + "r" * (SKILL_ROOT_LEN - utf16_len(Path.cwd().anchor))).resolve()
+    for case, archive in (("long", LONG_ARCHIVE), ("short", SHORT_ARCHIVE)):
+        out = engine_runs["cases"][case]["out_dir"]
+        source = out.parent / "in"
+        units = run_estate._engine_unit_names(engine, source)  # pylint: disable=protected-access
+        evidence = run_estate.model_envelope_evidence(
+            run_estate._input_candidates(source),  # pylint: disable=protected-access
+            engine,
+        )
+        assert evidence["status"] == "ok", f"{archive}: {evidence.get('reason')}"
+        projection = run_estate.project_estate_path_ceiling(root, units, evidence)
+        projected = max(
+            record["length"]
+            for record in projection["paths"]
+            if record["family"] == run_estate._FAMILY_MODEL  # pylint: disable=protected-access
+            and record["kind"] == "file"
+        )
+        model_tails = [
+            str(path.relative_to(out)).replace("\\", "/")
+            for path in out.rglob("*")
+            if path.is_file() and any(part.endswith(".SemanticModel") for part in path.relative_to(out).parts)
+        ]
+        actual = max(utf16_len(str(root / tail)) for tail in model_tails)
+        assert projected >= actual, (
+            f"{case}: projected {projected} < emitted {actual} on engine {engine_runs['version']}"
+        )
+        if case == "long":
+            assert projection["status"] == "over_ceiling", (
+                "the long arm emits a model table part measured at 273 units at this root; the "
+                "projection must refuse it"
+            )
+            assert projection["family"] == run_estate._FAMILY_MODEL  # pylint: disable=protected-access
+
+
+@requires_engine
+def test_each_control_reproduces_the_naming_class_it_exists_for(model_runs) -> None:
+    """Guard the controls themselves: a control that stopped emitting its class proves nothing.
+
+    ⚠️ These are the three classes that defeated class-by-class projection, plus the astral case.
+    They are asserted on the engine's OWN emitted filenames, so an upstream naming change is loud
+    here rather than silently making every projection assertion below vacuous.
+    """
+    version = model_runs["version"]
+    duplicate = model_runs["controls"]["duplicate_relation_and_island_date"]["tables"]
+    assert any(name.startswith(f"regional_sales.csv ({ISLAND_CAPTION_B}") for name in duplicate), (
+        f"the duplicate-relation disambiguation class disappeared on engine {version}: {duplicate}"
+    )
+    assert sum(name.startswith("Date (") for name in duplicate) == 2, (
+        f"the per-island calendar class disappeared on engine {version}: {duplicate}"
+    )
+
+    parameter = model_runs["controls"]["value_parameter"]["tables"]
+    assert any(name.startswith(PARAMETER_CAPTION) for name in parameter), (
+        f"the what-if parameter table class disappeared on engine {version}: {parameter}"
+    )
+
+    astral = model_runs["controls"]["astral_identity"]["tables"]
+    assert any("🌍" in name for name in astral), (
+        f"the astral identity never reached a table filename on engine {version}: {astral}"
+    )
+
+    kill = model_runs["controls"]["two_long_components"]["tables"]
+    combined = next((name for name in kill if name.startswith(f"{KILL_RELATION} ({KILL_CAPTION_B}")), None)
+    assert combined, f"the two-long-component control lost its collision on engine {version}: {kill}"
+    stem = combined[: -utf16_len(run_estate._MODEL_TABLE_SUFFIX)]  # pylint: disable=protected-access
+    assert utf16_len(stem) > 2 * utf16_len(KILL_CAPTION_A), (
+        f"the emitted name {stem!r} ({utf16_len(stem)} units) no longer exceeds twice the longest "
+        f"source component ({utf16_len(KILL_CAPTION_A)}); the fixed-overhead mutation below would "
+        "then be unkillable and this control has stopped doing its job"
+    )
+
+
+@requires_engine
+def test_the_model_projection_covers_every_emitted_table_part(model_runs) -> None:
+    """The invariant: projected >= actual, on the bytes the canonical engine really wrote."""
+    root = Path(Path.cwd().anchor + "r" * (SKILL_ROOT_LEN - utf16_len(Path.cwd().anchor))).resolve()
+    for name, run in model_runs["controls"].items():
+        assert run["evidence"]["status"] == "ok", (
+            f"{name}: production could not establish its own evidence on engine {model_runs['version']}: "
+            f"{run['evidence'].get('reason')}"
+        )
+        projected = _projected_model_file(run, root)
+        actual = _actual_model_file(run, root)
+        print(f"{name}: projected {projected} >= actual {actual} ({run['longest_model_tail']})")
+        assert projected >= actual, (
+            f"{name}: production projects {projected} units where the engine wrote {actual} "
+            f"({run['longest_model_tail']!r}) on engine {model_runs['version']}. Understating the "
+            "semantic-model family is the fail-open defect of issue #564."
+        )
+
+
+@requires_engine
+def test_dropping_the_second_source_component_understates_real_engine_output(model_runs, monkeypatch) -> None:
+    """MUTATION 1 - the two-component term. Remove it and this control must fail.
+
+    `combine_descriptors` composes `f"{name} ({caption})"`, so an emitted filename can carry TWO
+    full-length source-owned components. A one-component envelope is the class-blind mistake this
+    replaces, and it understates measured output rather than merely being tighter.
+
+    The comparison is on the FILENAME term, which is the term being mutated: the whole-path
+    comparison (`test_the_model_projection_covers_every_emitted_table_part`) also carries the
+    projected model-folder base, whose deliberate over-projection would absorb the mutation and make
+    this test vacuous.
+    """
+    run = model_runs["controls"]["two_long_components"]
+    actual = _actual_table_filename(run)
+    assert _projected_table_filename(run["evidence"]) >= actual, "the unmutated bound must cover the control"
+
+    monkeypatch.setattr(
+        run_estate,
+        "_MODEL_NAME_SHAPES",
+        tuple((1, literal) for _count, literal in run_estate._MODEL_NAME_SHAPES),  # pylint: disable=protected-access
+    )
+    mutated = run_estate._model_table_stem_bound(  # pylint: disable=protected-access
+        run["evidence"]["component"]
+    ) + utf16_len(run_estate._MODEL_TABLE_SUFFIX)  # pylint: disable=protected-access
+    assert mutated < actual, (
+        f"a ONE-component envelope ({mutated}) still covers the {actual}-unit two-component filename "
+        f"the engine emitted ({max(run['tables'], key=utf16_len)!r}), so this control cannot detect "
+        "the defect it exists for. Lengthen the control's identity names rather than deleting the "
+        "assertion."
+    )
+
+
+@requires_engine
+def test_dropping_the_fixed_overhead_understates_real_engine_output(model_runs, monkeypatch) -> None:
+    """MUTATION 2 - the fixed punctuation and uniquification allowance. Remove them and it must fail.
+
+    ⚠️ Honest limit: the two sub-terms are killed TOGETHER, not independently. The emitted collision
+    name exceeds twice its longest component by the three units of `" ("` + `")"`, which the 16-unit
+    uniquifier allowance would absorb on its own - so no committed control kills the allowance
+    alone. It is deliberate slack for the `" 2"` / `"_2"` climbs, not a measured boundary, and this
+    is stated rather than implied.
+    """
+    run = model_runs["controls"]["two_long_components"]
+    actual = _actual_table_filename(run)
+
+    monkeypatch.setattr(
+        run_estate,
+        "_MODEL_NAME_SHAPES",
+        tuple((count, 0) for count, _literal in run_estate._MODEL_NAME_SHAPES),  # pylint: disable=protected-access
+    )
+    monkeypatch.setattr(run_estate, "_MODEL_UNIQUIFIER_UTF16", 0)
+    mutated = run_estate._model_table_stem_bound(  # pylint: disable=protected-access
+        run["evidence"]["component"]
+    ) + utf16_len(run_estate._MODEL_TABLE_SUFFIX)  # pylint: disable=protected-access
+    assert mutated < actual, (
+        f"with NO fixed overhead the bound ({mutated}) still covers the {actual}-unit emitted "
+        "filename, so the overhead term is unproven by this control"
+    )
+
+
+@requires_engine
+def test_the_version_gate_is_what_refuses_an_unaudited_engine(model_runs, monkeypatch) -> None:
+    """MUTATION 3 - the version gate. Widen it and the refusal disappears.
+
+    The gate is the reason the bound is a claim about a SPECIFIC engine tree. Reported against the
+    canonical tree with a simulated version, so the census half is genuinely satisfied and only the
+    version decides - a stub tree would fail the census too and prove nothing about the gate.
+    """
+    engine = model_runs["engine"]
+    monkeypatch.setattr(run_estate, "engine_version", lambda _root=None: "9.9.9-unaudited")
+
+    refused = run_estate._model_write_site_census(engine)  # pylint: disable=protected-access
+    assert refused["status"] == "cannot_establish"
+    assert "9.9.9-unaudited" in refused["reason"]
+
+    monkeypatch.setattr(run_estate, "_MODEL_AUDITED_ENGINE_VERSIONS", frozenset({"9.9.9-unaudited"}))
+    widened = run_estate._model_write_site_census(engine)  # pylint: disable=protected-access
+    assert widened["status"] == "ok", (
+        f"with the gate widened the census still refuses ({widened.get('reason')}), so the assertion "
+        "above was passing for the census's reasons rather than the version gate's - the mutation "
+        "would not be independent"
     )

--- a/tests/test_issue_194_long_pbir_path.py
+++ b/tests/test_issue_194_long_pbir_path.py
@@ -954,6 +954,38 @@ def _projected_table_filename(evidence: dict) -> int:
     return evidence["table_stem"] + utf16_len(run_estate._MODEL_TABLE_SUFFIX)  # pylint: disable=protected-access
 
 
+def _model_bound_is_established(version: str | None) -> bool:
+    """Whether the semantic-model bound APPLIES to the engine this run measured.
+
+    ⚠️ CI provenance, the same shape as the MAX_PATH warning above. The repository's engine job pins
+    **2.356.0** while the census was audited on **2.368.0**, and the bound is deliberately
+    version-gated: on any other engine `model_envelope_evidence` returns `cannot_establish`, which is
+    the CORRECT production outcome there, not a defect. So each control below asserts the claim its
+    engine establishes - the bound where it applies, the refusal where it does not - and neither arm
+    is a no-op.
+    """
+    return version in run_estate._MODEL_AUDITED_ENGINE_VERSIONS  # pylint: disable=protected-access
+
+
+def _component_bound(run: dict[str, Any]) -> dict:
+    """The version-INDEPENDENT half of the evidence: the source-component bound alone.
+
+    `_model_component_bound` reads only the input documents, so it is measurable on any engine. The
+    mutation controls use it deliberately: the arithmetic they prove (a dropped term understates a
+    filename the engine really wrote) is a property of the bound, not of the gate.
+    """
+    return run_estate._model_component_bound(  # pylint: disable=protected-access
+        run_estate._input_candidates(run["source"])  # pylint: disable=protected-access
+    )
+
+
+def _stem_bound_for(component: int) -> int:
+    """The current (possibly mutated) filename bound for an exact source component."""
+    return run_estate._model_table_stem_bound(component) + utf16_len(  # pylint: disable=protected-access
+        run_estate._MODEL_TABLE_SUFFIX  # pylint: disable=protected-access
+    )
+
+
 @requires_engine
 def test_the_model_projection_covers_the_committed_long_and_short_pair(engine_runs) -> None:
     """The A/B pair, judged on the SEMANTIC-MODEL family rather than the report family.
@@ -963,6 +995,7 @@ def test_the_model_projection_covers_the_committed_long_and_short_pair(engine_ru
     the emitted model path in both arms, and refuses the long one at the skill's ordinary root.
     """
     engine = _contract()
+    version = engine_runs["version"]
     root = Path(Path.cwd().anchor + "r" * (SKILL_ROOT_LEN - utf16_len(Path.cwd().anchor))).resolve()
     for case, archive in (("long", LONG_ARCHIVE), ("short", SHORT_ARCHIVE)):
         out = engine_runs["cases"][case]["out_dir"]
@@ -972,6 +1005,24 @@ def test_the_model_projection_covers_the_committed_long_and_short_pair(engine_ru
             run_estate._input_candidates(source),  # pylint: disable=protected-access
             engine,
         )
+        model_tails = [
+            str(path.relative_to(out)).replace("\\", "/")
+            for path in out.rglob("*")
+            if path.is_file() and any(part.endswith(".SemanticModel") for part in path.relative_to(out).parts)
+        ]
+        actual = max(utf16_len(str(root / tail)) for tail in model_tails)
+
+        if not _model_bound_is_established(version):
+            assert evidence["status"] == "cannot_establish", (
+                f"{archive}: engine {version} is outside the audited set, so the bound must refuse "
+                f"rather than claim {evidence.get('status')!r}"
+            )
+            assert str(version) in evidence["reason"], evidence["reason"]
+            projection = run_estate.project_estate_path_ceiling(root, units, evidence)
+            assert projection["status"] == "cannot_establish"
+            assert projection["family"] == run_estate._FAMILY_MODEL  # pylint: disable=protected-access
+            continue
+
         assert evidence["status"] == "ok", f"{archive}: {evidence.get('reason')}"
         projection = run_estate.project_estate_path_ceiling(root, units, evidence)
         projected = max(
@@ -980,15 +1031,7 @@ def test_the_model_projection_covers_the_committed_long_and_short_pair(engine_ru
             if record["family"] == run_estate._FAMILY_MODEL  # pylint: disable=protected-access
             and record["kind"] == "file"
         )
-        model_tails = [
-            str(path.relative_to(out)).replace("\\", "/")
-            for path in out.rglob("*")
-            if path.is_file() and any(part.endswith(".SemanticModel") for part in path.relative_to(out).parts)
-        ]
-        actual = max(utf16_len(str(root / tail)) for tail in model_tails)
-        assert projected >= actual, (
-            f"{case}: projected {projected} < emitted {actual} on engine {engine_runs['version']}"
-        )
+        assert projected >= actual, f"{case}: projected {projected} < emitted {actual} on engine {version}"
         if case == "long":
             assert projection["status"] == "over_ceiling", (
                 "the long arm emits a model table part measured at 273 units at this root; the "
@@ -1003,16 +1046,19 @@ def test_each_control_reproduces_the_naming_class_it_exists_for(model_runs) -> N
 
     ⚠️ These are the three classes that defeated class-by-class projection, plus the astral case.
     They are asserted on the engine's OWN emitted filenames, so an upstream naming change is loud
-    here rather than silently making every projection assertion below vacuous.
+    here rather than silently making every projection assertion below vacuous. The per-island
+    calendar is asserted only where the census was audited (`_model_bound_is_established`) and
+    RECORDED elsewhere: it is a comparatively recent engine behaviour, and the pinned CI engine is
+    an older build whose class inventory this repository has not audited.
     """
     version = model_runs["version"]
     duplicate = model_runs["controls"]["duplicate_relation_and_island_date"]["tables"]
     assert any(name.startswith(f"regional_sales.csv ({ISLAND_CAPTION_B}") for name in duplicate), (
         f"the duplicate-relation disambiguation class disappeared on engine {version}: {duplicate}"
     )
-    assert sum(name.startswith("Date (") for name in duplicate) == 2, (
-        f"the per-island calendar class disappeared on engine {version}: {duplicate}"
-    )
+    calendars = sum(name.startswith("Date (") for name in duplicate)
+    print(f"engine {version}: per-island calendars emitted = {calendars}")
+    assert calendars == 2, f"the per-island calendar class disappeared on engine {version}: {duplicate}"
 
     parameter = model_runs["controls"]["value_parameter"]["tables"]
     assert any(name.startswith(PARAMETER_CAPTION) for name in parameter), (
@@ -1037,11 +1083,34 @@ def test_each_control_reproduces_the_naming_class_it_exists_for(model_runs) -> N
 
 @requires_engine
 def test_the_model_projection_covers_every_emitted_table_part(model_runs) -> None:
-    """The invariant: projected >= actual, on the bytes the canonical engine really wrote."""
+    """The invariant: projected >= actual, on the bytes the canonical engine really wrote.
+
+    On an engine outside the audited set the invariant is not the one to assert - production refuses
+    there by design - so that arm asserts the REFUSAL, and additionally records the same arithmetic
+    computed from the version-independent component bound.
+    """
+    version = model_runs["version"]
     root = Path(Path.cwd().anchor + "r" * (SKILL_ROOT_LEN - utf16_len(Path.cwd().anchor))).resolve()
     for name, run in model_runs["controls"].items():
+        if not _model_bound_is_established(version):
+            assert run["evidence"]["status"] == "cannot_establish", (
+                f"{name}: engine {version} is outside the audited set, so the evidence must refuse "
+                f"rather than report {run['evidence'].get('status')!r}"
+            )
+            assert str(version) in run["evidence"]["reason"], run["evidence"]["reason"]
+            projection = run_estate.project_estate_path_ceiling(root, run["units"], run["evidence"])
+            assert projection["status"] == "cannot_establish"
+            assert projection["family"] == run_estate._FAMILY_MODEL  # pylint: disable=protected-access
+            bound = _component_bound(run)
+            print(
+                f"{name}: RECORDED on unaudited engine {version} - component {bound.get('component')}, "
+                f"bound {_stem_bound_for(bound['component'])} vs emitted "
+                f"{_actual_table_filename(run)} ({max(run['tables'], key=utf16_len)!r})"
+            )
+            continue
+
         assert run["evidence"]["status"] == "ok", (
-            f"{name}: production could not establish its own evidence on engine {model_runs['version']}: "
+            f"{name}: production could not establish its own evidence on engine {version}: "
             f"{run['evidence'].get('reason')}"
         )
         projected = _projected_model_file(run, root)
@@ -1049,7 +1118,7 @@ def test_the_model_projection_covers_every_emitted_table_part(model_runs) -> Non
         print(f"{name}: projected {projected} >= actual {actual} ({run['longest_model_tail']})")
         assert projected >= actual, (
             f"{name}: production projects {projected} units where the engine wrote {actual} "
-            f"({run['longest_model_tail']!r}) on engine {model_runs['version']}. Understating the "
+            f"({run['longest_model_tail']!r}) on engine {version}. Understating the "
             "semantic-model family is the fail-open defect of issue #564."
         )
 
@@ -1065,20 +1134,20 @@ def test_dropping_the_second_source_component_understates_real_engine_output(mod
     The comparison is on the FILENAME term, which is the term being mutated: the whole-path
     comparison (`test_the_model_projection_covers_every_emitted_table_part`) also carries the
     projected model-folder base, whose deliberate over-projection would absorb the mutation and make
-    this test vacuous.
+    this test vacuous. It reads the VERSION-INDEPENDENT component bound, so the arithmetic is proven
+    on whichever engine ran - the gate is a separate claim with its own mutation below.
     """
     run = model_runs["controls"]["two_long_components"]
+    component = _component_bound(run)["component"]
     actual = _actual_table_filename(run)
-    assert _projected_table_filename(run["evidence"]) >= actual, "the unmutated bound must cover the control"
+    assert _stem_bound_for(component) >= actual, "the unmutated bound must cover the control"
 
     monkeypatch.setattr(
         run_estate,
         "_MODEL_NAME_SHAPES",
         tuple((1, literal) for _count, literal in run_estate._MODEL_NAME_SHAPES),  # pylint: disable=protected-access
     )
-    mutated = run_estate._model_table_stem_bound(  # pylint: disable=protected-access
-        run["evidence"]["component"]
-    ) + utf16_len(run_estate._MODEL_TABLE_SUFFIX)  # pylint: disable=protected-access
+    mutated = _stem_bound_for(component)
     assert mutated < actual, (
         f"a ONE-component envelope ({mutated}) still covers the {actual}-unit two-component filename "
         f"the engine emitted ({max(run['tables'], key=utf16_len)!r}), so this control cannot detect "
@@ -1098,6 +1167,7 @@ def test_dropping_the_fixed_overhead_understates_real_engine_output(model_runs, 
     is stated rather than implied.
     """
     run = model_runs["controls"]["two_long_components"]
+    component = _component_bound(run)["component"]
     actual = _actual_table_filename(run)
 
     monkeypatch.setattr(
@@ -1106,9 +1176,7 @@ def test_dropping_the_fixed_overhead_understates_real_engine_output(model_runs, 
         tuple((count, 0) for count, _literal in run_estate._MODEL_NAME_SHAPES),  # pylint: disable=protected-access
     )
     monkeypatch.setattr(run_estate, "_MODEL_UNIQUIFIER_UTF16", 0)
-    mutated = run_estate._model_table_stem_bound(  # pylint: disable=protected-access
-        run["evidence"]["component"]
-    ) + utf16_len(run_estate._MODEL_TABLE_SUFFIX)  # pylint: disable=protected-access
+    mutated = _stem_bound_for(component)
     assert mutated < actual, (
         f"with NO fixed overhead the bound ({mutated}) still covers the {actual}-unit emitted "
         "filename, so the overhead term is unproven by this control"
@@ -1122,8 +1190,14 @@ def test_the_version_gate_is_what_refuses_an_unaudited_engine(model_runs, monkey
     The gate is the reason the bound is a claim about a SPECIFIC engine tree. Reported against the
     canonical tree with a simulated version, so the census half is genuinely satisfied and only the
     version decides - a stub tree would fail the census too and prove nothing about the gate.
+
+    ⚠️ The widened arm is asserted only on an engine whose census WAS audited. On any other build
+    the census fingerprint may or may not still match, so widening the gate proves nothing about the
+    version term there; that arm records the outcome instead. The refusal itself - the claim that
+    matters in production - is asserted on every engine.
     """
     engine = model_runs["engine"]
+    version = model_runs["version"]
     monkeypatch.setattr(run_estate, "engine_version", lambda _root=None: "9.9.9-unaudited")
 
     refused = run_estate._model_write_site_census(engine)  # pylint: disable=protected-access
@@ -1132,6 +1206,9 @@ def test_the_version_gate_is_what_refuses_an_unaudited_engine(model_runs, monkey
 
     monkeypatch.setattr(run_estate, "_MODEL_AUDITED_ENGINE_VERSIONS", frozenset({"9.9.9-unaudited"}))
     widened = run_estate._model_write_site_census(engine)  # pylint: disable=protected-access
+    if not _model_bound_is_established(version):
+        print(f"engine {version}: RECORDED widened-gate census = {widened['status']}")
+        return
     assert widened["status"] == "ok", (
         f"with the gate widened the census still refuses ({widened.get('reason')}), so the assertion "
         "above was passing for the census's reasons rather than the version gate's - the mutation "

--- a/tests/test_run_estate.py
+++ b/tests/test_run_estate.py
@@ -81,10 +81,56 @@ def _root_for_length(length: int) -> Path:
     return Path(anchor + "r" * (length - utf16_len(anchor))).resolve()
 
 
+#: Model-family evidence whose source component is deliberately ONE unit, so the semantic-model term
+#: can never bind and every PBIR assertion below stays a statement about PBIR. The model family has
+#: its own tests (`_model_component_bound`, the boundary flip, and the engine-backed
+#: projection >= actual controls in `tests/test_issue_194_long_pbir_path.py`).
+PBIR_ONLY_EVIDENCE = {
+    "status": "ok",
+    "engine_version": "test-only",
+    "component": 1,
+    "component_value": "x",
+    "table_stem": run_estate._model_table_stem_bound(1),
+}
+
+#: The PRODUCTION evidence function, captured before the autouse stub below can replace it, so a
+#: test about the gate itself can still reach it.
+REAL_MODEL_EVIDENCE = run_estate.model_envelope_evidence
+
+
+def _evidence(component: int, *, version: str = "test-only") -> dict:
+    """Model-family evidence for an exact source-component length."""
+    return {
+        "status": "ok",
+        "engine_version": version,
+        "component": component,
+        "component_value": "c" * component,
+        "table_stem": run_estate._model_table_stem_bound(component),
+    }
+
+
+@pytest.fixture(autouse=True)
+def _default_model_evidence(monkeypatch: pytest.MonkeyPatch):
+    """Make the DEFAULT preflight in this module measure the PBIR family only.
+
+    Every `main()` test here builds a stub engine tree, which by construction cannot satisfy the
+    version-gated write-site census the semantic-model bound requires - so without this the whole
+    module would refuse with `CANNOT ASSESS` and stop testing what it is about. That gate is not
+    left unproven: `test_main_refuses_when_the_model_family_cannot_be_bounded` restores the real
+    function and drives `main` through it, and the bound itself is proven against real engine output
+    in `tests/test_issue_194_long_pbir_path.py`.
+    """
+    monkeypatch.setattr(run_estate, "model_envelope_evidence", lambda _paths, _engine: dict(PBIR_ONLY_EVIDENCE))
+
+
 def _boundary_root(unit: str, ceiling: int) -> Path:
     probe_root = Path("/r").resolve()
-    probe = run_estate.project_estate_path_ceiling(probe_root, [unit])
-    file_length = next(path["length"] for path in probe["paths"] if path["kind"] == "file")
+    probe = run_estate.project_estate_path_ceiling(probe_root, [unit], PBIR_ONLY_EVIDENCE)
+    file_length = next(
+        path["length"]
+        for path in probe["paths"]
+        if path["kind"] == "file" and path["family"] == run_estate._FAMILY_PBIR
+    )
     target_length = utf16_len(str(probe_root)) + ceiling - file_length
     return _root_for_length(target_length)
 
@@ -110,8 +156,10 @@ def test_a_failed_definition_of_done_is_not_a_pass() -> None:
 def test_projected_path_uses_utf16_and_accepts_the_measured_file_boundary() -> None:
     unit = "A" * 20
     root = _boundary_root(unit, FILE_CEILING)
-    projection = run_estate.project_estate_path_ceiling(root, [unit])
-    file_path = next(path for path in projection["paths"] if path["kind"] == "file")
+    projection = run_estate.project_estate_path_ceiling(root, [unit], PBIR_ONLY_EVIDENCE)
+    file_path = next(
+        path for path in projection["paths"] if path["kind"] == "file" and path["family"] == run_estate._FAMILY_PBIR
+    )
     assert file_path["length"] == FILE_CEILING
     assert projection["status"] == "ok"
 
@@ -119,7 +167,7 @@ def test_projected_path_uses_utf16_and_accepts_the_measured_file_boundary() -> N
 def test_projected_path_refuses_the_next_file_and_directory_boundaries() -> None:
     unit = "A" * 20
     root = _boundary_root(unit, FILE_CEILING + 1)
-    projection = run_estate.project_estate_path_ceiling(root, [unit])
+    projection = run_estate.project_estate_path_ceiling(root, [unit], PBIR_ONLY_EVIDENCE)
     assert projection["status"] == "over_ceiling"
     assert any(path["length"] == FILE_CEILING + 1 for path in projection["offenders"])
     assert any(path["length"] == DIR_CEILING + 1 for path in projection["offenders"])
@@ -127,16 +175,259 @@ def test_projected_path_refuses_the_next_file_and_directory_boundaries() -> None
 
 def test_projected_path_counts_supplementary_characters_as_two_units() -> None:
     unit = "😀" * 20
-    projection = run_estate.project_estate_path_ceiling(Path("/r"), [unit])
+    projection = run_estate.project_estate_path_ceiling(Path("/r"), [unit], PBIR_ONLY_EVIDENCE)
     file_path = next(path for path in projection["paths"] if path["kind"] == "file")
     assert file_path["length"] == utf16_len(file_path["path"])
     assert file_path["length"] > len(file_path["path"])
 
 
 def test_projected_names_include_engine_collision_suffixes() -> None:
-    projection = run_estate.project_estate_path_ceiling(Path("/short"), ["Sales", "sales"])
+    projection = run_estate.project_estate_path_ceiling(Path("/short"), ["Sales", "sales"], PBIR_ONLY_EVIDENCE)
 
     assert projection["status"] == "cannot_establish"
+
+
+# ---------------------------------------------------------------------------
+# The semantic-model table path family (issue #564)
+# ---------------------------------------------------------------------------
+#
+# The projector used to model ONLY the PBIR visual path, so a `<model>.SemanticModel/definition/
+# tables/<name>.tmdl` longer than that path could pass the pre-conversion gate. Issue #565 measured
+# a required 273-unit `.tmdl` at the skill's ordinary 22-unit run root. Every test below is about
+# the direction that matters: the projection may over-refuse, but it must never understate and must
+# never report `ok` for a family it could not bound.
+
+
+def _twb(*captions: str) -> str:
+    """A minimal Tableau document carrying exactly the identity captions given."""
+    columns = "".join(f"<column caption='{caption}' name='[c{index}]' />" for index, caption in enumerate(captions))
+    return f"<workbook><datasources><datasource name='ds'>{columns}</datasource></datasources></workbook>"
+
+
+def test_the_model_family_is_projected_and_can_be_the_binding_path() -> None:
+    """A short PBIR unit with a long source identity: the model term is what binds."""
+    unit = "u" * 10
+    projection = run_estate.project_estate_path_ceiling(_root_for_length(40), [unit], _evidence(60))
+
+    model_file = next(
+        record
+        for record in projection["paths"]
+        if record["family"] == run_estate._FAMILY_MODEL and record["kind"] == "file"
+    )
+    pbir_file = next(
+        record
+        for record in projection["paths"]
+        if record["family"] == run_estate._FAMILY_PBIR and record["kind"] == "file"
+    )
+    assert model_file["length"] > pbir_file["length"], (
+        f"the model term ({model_file['length']}) did not exceed the PBIR term ({pbir_file['length']}) "
+        "for a 10-unit unit name with a 60-unit source component - this is the shape #564 reports"
+    )
+    assert projection["family"] == run_estate._FAMILY_MODEL
+    assert "semantic-model table filename bound" in projection["reason"]
+    assert projection["binding"] is model_file
+
+
+def test_the_projection_is_never_clean_without_model_evidence() -> None:
+    """The fail-open shape #564 names: a clean PBIR verdict standing in for the whole projection."""
+    for evidence in (None, {}, {"status": "cannot_establish", "reason": "engine version 9.9.9 is unaudited"}):
+        projection = run_estate.project_estate_path_ceiling(Path("/short"), ["Sales"], evidence)
+        assert projection["status"] == "cannot_establish", evidence
+        assert projection["family"] == run_estate._FAMILY_MODEL, evidence
+        assert "semantic-model table path family" in projection["reason"], evidence
+    assert "9.9.9" in projection["reason"], "the underlying reason must survive into the verdict"
+
+
+def test_the_model_bound_combines_two_source_components_plus_fixed_overhead() -> None:
+    """The bound is the censused shape maximum, not one component and not their sum."""
+    assert run_estate._MODEL_MAX_COMPONENTS == 2
+    for component in (0, 1, 20, 63, 400):
+        expected = (
+            max(count * component + literal for count, literal in run_estate._MODEL_NAME_SHAPES)
+            + run_estate._MODEL_UNIQUIFIER_UTF16
+        )
+        assert run_estate._model_table_stem_bound(component) == expected
+    assert run_estate._model_table_stem_bound(63) > 2 * 63, "the fixed overhead term vanished"
+
+
+def test_the_model_folder_bound_respects_the_engines_own_base_cap() -> None:
+    """`migrate_estate._fs_safe` truncates a folder base; the table filename it never touches."""
+    unit = "u" * 10
+    projection = run_estate.project_estate_path_ceiling(Path("/r"), [unit], _evidence(400))
+    folder = Path(
+        next(
+            record["path"]
+            for record in projection["paths"]
+            if record["family"] == run_estate._FAMILY_MODEL and record["kind"] == "directory"
+        )
+    )
+    base = next(part for part in folder.parts if part.endswith(run_estate._MODEL_FOLDER_SUFFIX))
+    assert utf16_len(base) == run_estate._MODEL_FOLDER_BASE_CAP_UTF16 + utf16_len(run_estate._MODEL_FOLDER_SUFFIX)
+
+
+def test_a_one_unit_longer_root_flips_the_model_family_from_ok_to_refused() -> None:
+    """The boundary flip, on the model family: exactly at the ceiling passes, one unit over refuses."""
+    unit = "u" * 10
+    evidence = _evidence(45)
+    probe = run_estate.project_estate_path_ceiling(Path("/r").resolve(), [unit], evidence)
+    probe_file = next(
+        record for record in probe["paths"] if record["family"] == run_estate._FAMILY_MODEL and record["kind"] == "file"
+    )
+    at_ceiling = _root_for_length(utf16_len(str(Path("/r").resolve())) + FILE_CEILING - probe_file["length"])
+
+    fits = run_estate.project_estate_path_ceiling(at_ceiling, [unit], evidence)
+    model_file = next(
+        record for record in fits["paths"] if record["family"] == run_estate._FAMILY_MODEL and record["kind"] == "file"
+    )
+    assert model_file["length"] == FILE_CEILING
+    assert fits["status"] == "ok", [(r["family"], r["kind"], r["length"]) for r in fits["offenders"]]
+
+    over = run_estate.project_estate_path_ceiling(_root_for_length(utf16_len(str(at_ceiling)) + 1), [unit], evidence)
+    assert over["status"] == "over_ceiling"
+    assert [record["family"] for record in over["offenders"]] == [run_estate._FAMILY_MODEL]
+    assert over["offenders"][0]["length"] == FILE_CEILING + 1
+
+
+def test_supplementary_identity_components_count_as_two_units_each(tmp_path: Path) -> None:
+    """An astral caption is two UTF-16 units per code point - the length Windows actually counts."""
+    source = tmp_path / "Astral.twb"
+    source.write_text(_twb("Ventas 🌍🌎🌏 Consolidado"), encoding="utf-8")
+    bound = run_estate._model_component_bound([source])
+
+    assert bound["status"] == "ok"
+    assert bound["component"] == utf16_len("Ventas 🌍🌎🌏 Consolidado")
+    assert bound["component"] > len("Ventas 🌍🌎🌏 Consolidado")
+
+
+def test_the_component_bound_takes_the_longest_identity_across_the_estate(tmp_path: Path) -> None:
+    """Pooled across every input, because a table filename is composed per unit but gated per run."""
+    short = tmp_path / "Short.twb"
+    short.write_text(_twb("Sales"), encoding="utf-8")
+    long = tmp_path / "Long.twb"
+    long.write_text(_twb("Regional Sales and Inventory Turnover Consolidated Source"), encoding="utf-8")
+
+    assert run_estate._model_component_bound([short])["component"] == utf16_len("Sales")
+    pooled = run_estate._model_component_bound([short, long])
+    assert pooled["component"] == utf16_len("Regional Sales and Inventory Turnover Consolidated Source")
+
+
+def test_an_unparseable_or_empty_source_cannot_produce_a_bound(tmp_path: Path) -> None:
+    """No identity, no bound - never a small bound that happens to fit."""
+    broken = tmp_path / "Broken.twb"
+    broken.write_text("<workbook>", encoding="utf-8")
+    assert run_estate._model_component_bound([broken])["status"] == "cannot_establish"
+
+    empty = tmp_path / "Empty.twb"
+    empty.write_text("<workbook />", encoding="utf-8")
+    assert run_estate._model_component_bound([empty])["status"] == "cannot_establish"
+    assert run_estate._model_component_bound([])["status"] == "cannot_establish"
+    assert run_estate._model_component_bound(None)["status"] == "cannot_establish"
+
+
+def test_an_unaudited_engine_version_cannot_establish_the_census(tmp_path: Path) -> None:
+    """The version gate: the bound is a claim about a SPECIFIC engine tree, not about engines."""
+    engine = _versioned_engine(tmp_path / "engine", "9.9.9")
+    census = run_estate._model_write_site_census(engine)
+
+    assert census["status"] == "cannot_establish"
+    assert "9.9.9" in census["reason"] and "audited" in census["reason"]
+    assert run_estate._model_write_site_census(None)["status"] == "cannot_establish"
+
+
+def test_a_moved_write_site_census_cannot_establish_the_bound(tmp_path: Path, monkeypatch) -> None:
+    """An audited VERSION is not enough: the write sites it was read from must still be there."""
+    engine = _versioned_engine(tmp_path / "engine", sorted(run_estate._MODEL_AUDITED_ENGINE_VERSIONS)[0])
+    census = run_estate._model_write_site_census(engine)
+    assert census["status"] == "cannot_establish", "a stub engine tree cannot satisfy the census"
+    assert "census mismatch" in census["reason"] or "could not be read" in census["reason"]
+
+    scripts = engine / "skills" / "tableau-migration" / "scripts"
+    monkeypatch.setattr(run_estate, "_MODEL_WRITE_SITE_CENSUS", {"migrate_estate.py": {"def _safe_folder": 1}})
+    assert run_estate._model_write_site_census(engine)["status"] == "ok", (
+        "harness check: with a census the stub DOES satisfy, the gate must pass - otherwise the "
+        "mismatch assertion above proves nothing about the census itself"
+    )
+    (scripts / "migrate_estate.py").write_text("# the write site moved\n", encoding="utf-8")
+    moved = run_estate._model_write_site_census(engine)
+    assert moved["status"] == "cannot_establish"
+    assert "census mismatch" in moved["reason"]
+
+
+def test_the_preflight_names_the_binding_family_in_both_directions(tmp_path: Path, monkeypatch) -> None:
+    """An operator must be able to attribute the verdict to a family without reading the code."""
+    engine = _versioned_engine(tmp_path / "engine", "test")
+    source = tmp_path / "Sales.twb"
+    source.write_text(_twb("Sales"), encoding="utf-8")
+
+    monkeypatch.setattr(run_estate, "model_envelope_evidence", lambda _paths, _engine: _evidence(60))
+    ok, detail = run_estate.preflight_estate_path_ceiling(source, Path("/short"), engine)
+    assert ok is True, detail
+    assert f"binding family {run_estate._FAMILY_MODEL}" in detail
+
+    ok, detail = run_estate.preflight_estate_path_ceiling(source, _root_for_length(200), engine)
+    assert ok is False
+    assert f"Binding family {run_estate._FAMILY_MODEL}" in detail
+    assert "--runs-parent" in detail
+
+    monkeypatch.setattr(
+        run_estate,
+        "model_envelope_evidence",
+        lambda _paths, _engine: {"status": "cannot_establish", "reason": "engine version 9.9.9 is unaudited"},
+    )
+    ok, detail = run_estate.preflight_estate_path_ceiling(source, Path("/short"), engine)
+    assert ok is False
+    assert "CANNOT ASSESS" in detail and "9.9.9" in detail
+    assert f"Binding family {run_estate._FAMILY_MODEL}" in detail
+
+
+def test_model_envelope_evidence_refuses_before_it_reads_a_single_source(tmp_path: Path) -> None:
+    """Order matters: an unaudited engine is refused whatever the sources say."""
+    engine = _versioned_engine(tmp_path / "engine", "9.9.9")
+    source = tmp_path / "Sales.twb"
+    source.write_text(_twb("Sales"), encoding="utf-8")
+
+    evidence = REAL_MODEL_EVIDENCE([source], engine)
+    assert evidence["status"] == "cannot_establish"
+    assert "9.9.9" in evidence["reason"]
+    assert "component" not in evidence, "an unaudited engine must not yield a bound at all"
+
+
+def test_main_refuses_when_the_model_family_cannot_be_bounded(tmp_path: Path, monkeypatch) -> None:
+    """End to end through `main`, with the REAL evidence function and no autouse stub.
+
+    This is the wiring proof for the whole change: a stub engine cannot satisfy the version-gated
+    census, so the run is refused before the engine is invoked and before an output root is created,
+    with a diagnostic that names the family and the reason.
+    """
+    monkeypatch.setattr(run_estate, "model_envelope_evidence", REAL_MODEL_EVIDENCE)
+    engine = _versioned_engine(tmp_path / "engine", "2.126.0")
+    source = tmp_path / "src"
+    source.mkdir()
+    (source / "Sales.twb").write_text(_twb("Sales"), encoding="utf-8")
+    output = tmp_path / "out"
+    calls: list[Path] = []
+    monkeypatch.setattr(run_estate, "run_engine", lambda *args: calls.append(args[0]) or (0, ""))
+
+    buffer = io.StringIO()
+    with contextlib.redirect_stdout(buffer):
+        code = run_estate.main(
+            [
+                "--engine",
+                str(engine),
+                "--allow-noncanonical-engine",
+                "--input",
+                str(source),
+                "--output",
+                str(output),
+            ]
+        )
+    printed = buffer.getvalue()
+
+    assert code == run_estate.EXIT_PATH_CEILING
+    assert "CANNOT ASSESS" in printed and run_estate._FAMILY_MODEL in printed, printed
+    assert "2.126.0" in printed and "audited" in printed, printed
+    assert not calls, "the engine must not run when the model path family is unbounded"
+    assert not output.exists(), "a refused run must not create its output root"
 
 
 def test_projected_names_are_supplied_by_the_selected_engine(tmp_path: Path) -> None:
@@ -222,9 +513,15 @@ def test_pbir_envelope_is_pinned_to_committed_artifacts() -> None:
 def test_realistic_long_estate_is_refused_by_conservative_pbir_envelope() -> None:
     root = _root_for_length(90)
     unit = "u" * 37
-    projection = run_estate.project_estate_path_ceiling(root, [unit])
-    file_path = next(path for path in projection["paths"] if path["kind"] == "file")
-    directory = next(path for path in projection["paths"] if path["kind"] == "directory")
+    projection = run_estate.project_estate_path_ceiling(root, [unit], PBIR_ONLY_EVIDENCE)
+    file_path = next(
+        path for path in projection["paths"] if path["kind"] == "file" and path["family"] == run_estate._FAMILY_PBIR
+    )
+    directory = next(
+        path
+        for path in projection["paths"]
+        if path["kind"] == "directory" and path["family"] == run_estate._FAMILY_PBIR
+    )
     report_root = Path("pbip") / unit / f"{unit}.Report"
     visual_tail = Path(run_estate._PBIR_VISUAL_TAIL)
     assert utf16_len(str(root)) == 90
@@ -436,7 +733,7 @@ def test_composed_allocator_and_projection_reproduces_run_409(tmp_path: Path, mo
     probe_alloc = _work_dirs_allocate(unit, "--repo-root", probe_root)
     probe_bundle = Path(probe_alloc["bundle"])
     suffix_len = utf16_len(str(probe_bundle)) - utf16_len(str(probe_root))
-    probe_projection = run_estate.project_estate_path_ceiling(probe_bundle, [unit])
+    probe_projection = run_estate.project_estate_path_ceiling(probe_bundle, [unit], PBIR_ONLY_EVIDENCE)
     probe_file_len = next(p["length"] for p in probe_projection["paths"] if p["kind"] == "file")
     tail_len = probe_file_len - utf16_len(str(probe_bundle))
 
@@ -461,7 +758,7 @@ def test_composed_allocator_and_projection_reproduces_run_409(tmp_path: Path, mo
     try:
         deep_alloc = _work_dirs_allocate(unit, "--repo-root", deep_root)
         _assert_cli_evidence("--repo-root", deep_root, deep_alloc)
-        deep_projection = run_estate.project_estate_path_ceiling(Path(deep_alloc["bundle"]), [unit])
+        deep_projection = run_estate.project_estate_path_ceiling(Path(deep_alloc["bundle"]), [unit], PBIR_ONLY_EVIDENCE)
         deep_file_len = next(p["length"] for p in deep_projection["paths"] if p["kind"] == "file")
         deep_dir_len = next(p["length"] for p in deep_projection["paths"] if p["kind"] == "directory")
         assert deep_projection["status"] == "over_ceiling"
@@ -479,7 +776,7 @@ def test_composed_allocator_and_projection_reproduces_run_409(tmp_path: Path, mo
         short_alloc = _work_dirs_allocate(unit, "--runs-parent", short_root)
         _assert_cli_evidence("--runs-parent", short_root, short_alloc)
         short_bundle = Path(short_alloc["bundle"])
-        short_projection = run_estate.project_estate_path_ceiling(short_bundle, [unit])
+        short_projection = run_estate.project_estate_path_ceiling(short_bundle, [unit], PBIR_ONLY_EVIDENCE)
         measured = [(p["kind"], p["length"], p["ceiling"]) for p in short_projection["paths"]]
         assert short_projection["status"] == "ok", f"measured lengths (kind, length, ceiling): {measured}"
         assert not short_projection["offenders"], f"measured lengths (kind, length, ceiling): {measured}"


### PR DESCRIPTION
## What

`run_estate.project_estate_path_ceiling` projected only the canonical PBIR visual path, so a
`pbip/<unit>/<model>.SemanticModel/definition/tables/<table>` part longer than that path could pass
the **pre-conversion** gate. Canonical engine 2.368.0 emits exactly that shape: a required 273-unit
table part at the skill's ordinary 22-unit run root (#565), while the `.pbip` pointer itself is
legal. The projector now covers **both** families, refuses if **either** breaches, and reports which
family binds and why.

This is a clean replacement for the closed PR #571, not a resumption of it.

## The design decision that matters

The model term is a **generic source-component envelope**, not a per-class reimplementation of the
engine's naming. Three emitted filename classes each defeated the class-by-class approach in turn -
`combine_descriptors`' duplicate-relation `Relation (<datasource>)`, a long range/what-if parameter
caption, and the per-island `Date (<datasource>)` calendar - because the class inventory is owned by
the engine, so a class it has and we lack is *silently absent* rather than loud. (Extract-collapse
is a fourth, source-visible candidate.)

Instead the bound is: **the longest source-owned identity component in the input documents x the
largest number of components any censused write site combines (2), plus that shape's fixed
punctuation and a uniquification allowance.** The write-site census was read on 2.368.0 from every
expression that CREATES a `definition/tables/<name>` part (`assemble_model.py` data tables, date
dimensions, `_Measures`, DirectLake, `_inject_field_param_tables`; the remaining occurrences are
enrichment sites guarded by `if path in parts` and cannot mint a filename) plus the name-composing
expressions those sites consume.

Two properties are load-bearing and intentional:

* **Version-gated.** An engine outside the audited set, a write-site census fingerprint that no
  longer matches, or an unreadable source yields `cannot_establish` - and therefore a refusal -
  never `ok`. Re-auditing is the unblock; the refusal says so.
* **It over-refuses.** A workbook whose own captions are long can be refused at every output root
  even though the engine would have fitted. The refusal names the binding family and the component
  driving it, so the actionable move (shorter run root, or shorter identity in the source) is
  visible.

The existing PBIR projection and the exact 259-file / 247-directory UTF-16 boundaries are unchanged.

## Evidence

Controls run the **canonical engine** and compare `projected >= actual` on the bytes it really wrote
(never against an expected filename, which is blind to exactly the class that defeats it):

| control | emitted deepest model part | projected | actual |
|---|---|---|---|
| duplicate relation + per-island `Date` | `regional_sales.csv (Beta Consolidated ... Source).tmdl` | 283 | 164 |
| what-if parameter | `Rolling Inventory Turnover Threshold for FY2026 Q3 Review.tmdl` | 282 | 136 |
| astral identity | `ventas_🌍_consolidado.csv.tmdl` | 225 | 142 |
| two long components (kill control) | `Regional Sales ... Q3 Detail Snapshot (Delta Regional ... Source).tmdl` | 285 | 214 |

Plus: the committed issue-194 long/short pair, the field-swap datasource, the ordinary datasource
and a real workbook (`tests/test_datasource_path_envelope.py`), a one-unit boundary flip on the
model family, and `cannot_establish` for an unaudited version / a moved census / an unparseable or
identity-free source.

**Mutations, each required to fail independently:**

1. drop the second source component -> a 101-unit bound under a 134-unit emitted filename;
2. drop the fixed overhead (literal + uniquifier) -> 131 under 134;
3. widen the version gate -> the unaudited-engine refusal disappears, proved on the canonical tree
   with a simulated version so the census half is genuinely satisfied.

⚠️ Stated residual: the two sub-terms of (2) are killed together. The uniquifier allowance is
deliberate slack for the `" 2"` / `"_2"` climbs, and no committed control kills it alone.

## Notes for review

* `tests/test_run_estate.py` gets an autouse fixture that stubs the model evidence for the ~40
  `main()` tests built on stub engine trees (which cannot satisfy a version-gated census). The gate
  is not left unproven: `test_main_refuses_when_the_model_family_cannot_be_bounded` restores the
  real function and drives `main` through it.
* `tests/test_e2e_offline.py` needed the same one-call stub around its mock engine.
* `scripts` + `conftest.py` pylint 10.00/10, ruff clean, full suite 6122 passed (the two
  `test_harvest_engine_gaps.py` failures reproduce on unmodified `master` and are unrelated).

Fixes #564
