### PR TITLE
feat: closed PBIR/model census and revision digest (#363 A1a)

### DIFF
--- a/scripts/pbir_revision.py
+++ b/scripts/pbir_revision.py
@@ -1,0 +1,856 @@
+"""
+purpose: strict census + deterministic revision digest for ONE local PBIR report and its bound model (#363 slice A1a).
+usage:   import pbir_revision; pbir_revision.establish_revision(fabric_root, report_dir)
+
+What this is
+------------
+Slice A1a of #363 and nothing else: given a `fabric/` root that somebody else has already selected and
+ONE report artifact inside it, either return a strict typed census of every byte that a local capture
+would render from - plus a deterministic digest over exactly those bytes - or refuse and say why.
+
+Deliberately NOT here (later slices own them): package-manifest selection, Power BI Desktop, PIDs,
+`reload`, screenshots, iteration allocation, receipts, comparison, sign-off. There is no live
+evidence in this module, so it can never claim that Desktop LOADED these bytes - only what is on
+disk right now. The independent #363 A1 audit is explicit that a disk-only check is not a
+loaded-revision oracle; A1b adds the PID-scoped barrier on top of this census.
+
+Why a closed census rather than a glob
+--------------------------------------
+The digest is only worth having if the set it covers is decided by an explicit rule. A permissive
+`rglob("*")` silently adopts whatever a future Desktop build writes beside the definition - the exact
+shape that lets a report change while its "revision" does not, or lets a machine-local file make two
+identical reports disagree. So every entry inside the report and the model is either:
+
+* **included** - a byte that a render or a deploy depends on, or
+* **excluded by an explicit named rule** (`.pbi/` local Desktop state, `TMDLScripts/` authoring
+  scratch, volatile sidecars), or
+* **refused** - unknown, so this module does not get to guess.
+
+The allowed sets below were derived from the committed corpus, not assumed. Measured on this repo at
+`bf4a79f1` across `examples/*/fabric` (16 reports, 36 pages, 869 visuals):
+
+* report top level is exactly `.platform`, `definition.pbir`, `definition/`, `StaticResources/`;
+* `definition/` is exactly `version.json`, `report.json`, `pages/`;
+* a page folder holds `page.json` and (in `fixtures/large-refresh`, zero-visual) an OPTIONAL
+  `visuals/`; a visual folder holds exactly `visual.json`;
+* **page folder name == `page.json.name` in 36/36 cases**, so the folder IS the page document id;
+* **visual folder name != `visual.json.name` in 133/869 cases**, so the folder is NOT the visual
+  document id - both are recorded, and uniqueness is asserted on the document id, report-wide;
+* model top level is `.platform`, `definition.pbism`, `definition/` plus one committed
+  `TMDLScripts/`; `definition/` is `model.tmdl`, `database.tmdl`, `relationships.tmdl`,
+  `expressions.tmdl`, `cultures/`, `tables/`.
+
+Anything outside those sets refuses. That is fail-closed on purpose: an unsupported shape is not
+clean, and widening the allow-list is a deliberate edit with corpus evidence behind it.
+
+Privacy
+-------
+Every field this module returns - including refusal detail and evidence - is relative to the
+`fabric_root` the caller passed, or an opaque token. No absolute path, drive, user name or machine
+path reaches `repr()`, `dataclasses.asdict()` or a refusal message.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import stat
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+#: Framing tag for the digest. A change in what is covered, or how it is framed, MUST bump this.
+VERSION_TAG = "pbir-revision/v1"
+
+REPORT_SUFFIX = ".Report"
+MODEL_SUFFIX = ".SemanticModel"
+PBIP_SUFFIX = ".pbip"
+
+# --------------------------------------------------------------------------------------------
+# The closed allow-lists (see the module docstring for the corpus measurement behind each).
+# --------------------------------------------------------------------------------------------
+
+#: Report top-level files that are included in the revision.
+REPORT_FILES = (".platform", "definition.pbir")
+#: Report top-level directories that are censused.
+STATIC_RESOURCES_DIR = "StaticResources"
+REPORT_DIRS = ("definition", STATIC_RESOURCES_DIR)
+#: `definition/` files that are included in the revision.
+DEFINITION_FILES = ("report.json", "version.json")
+#: The only directory `definition/` may hold.
+DEFINITION_DIRS = ("pages",)
+#: The only file a page directory may hold, and the only directory it may hold.
+PAGE_FILE = "page.json"
+PAGE_DIR = "visuals"
+#: The only file a visual directory may hold.
+VISUAL_FILE = "visual.json"
+#: The only directory `StaticResources/` may hold. `SharedResources` base themes are built into
+#: Power BI and are referenced by `report.json` without existing on disk - see `_registered_paths`.
+REGISTERED_RESOURCES_DIR = "RegisteredResources"
+STATIC_RESOURCE_DIRS = (REGISTERED_RESOURCES_DIR,)
+#: Model top-level files: `.platform` is optional (absent in several committed test fixtures).
+MODEL_REQUIRED_FILES = ("definition.pbism",)
+MODEL_OPTIONAL_FILES = (".platform",)
+#: Model `definition/` entries. `model.tmdl` is required; the rest are optional but allowed.
+MODEL_DEFINITION_REQUIRED = ("model.tmdl",)
+MODEL_DEFINITION_OPTIONAL = ("database.tmdl", "relationships.tmdl", "expressions.tmdl")
+MODEL_DEFINITION_DIRS = ("cultures", "tables")
+
+#: Directories excluded by name, with the reason recorded in the census.
+EXCLUDED_DIRS = {
+    ".pbi": "local-desktop-state",
+    "TMDLScripts": "authoring-scratch",
+}
+#: Volatile file sidecars, excluded by an explicit closed rule rather than by a wildcard sweep. Each
+#: clause carries its own control in `tests/test_pbir_revision.py`; a clause nothing exercises is
+#: untested surface, so `localSettings.json` was dropped - Desktop writes it inside `.pbi/`, which
+#: the directory rule above already covers.
+VOLATILE_SUFFIXES = (".abf", ".tmp", ".autosave", ".bak")
+VOLATILE_PREFIXES = ("~$",)
+
+# --------------------------------------------------------------------------------------------
+# Refusal codes. Every one of them names positive evidence, never "something felt wrong".
+# --------------------------------------------------------------------------------------------
+
+ROOT_UNUSABLE = "root_unusable"
+REPORT_UNUSABLE = "report_unusable"
+REPORT_NOT_CONTAINED = "report_not_contained"
+PATH_REPARSE = "path_reparse"
+PATH_IDENTITY_MISMATCH = "path_identity_mismatch"
+PBIP_ABSENT = "pbip_absent"
+PBIP_MALFORMED = "pbip_malformed"
+PBIP_REPORT_UNRELATED = "pbip_report_unrelated"
+PBIP_REPORT_AMBIGUOUS = "pbip_report_ambiguous"
+JSON_MALFORMED = "json_malformed"
+JSON_DUPLICATE_KEY = "json_duplicate_key"
+JSON_TYPE = "json_type"
+ENTRY_UNKNOWN = "entry_unknown"
+ENTRY_MISSING = "entry_missing"
+ENTRY_TYPE = "entry_type"
+BINDING_MALFORMED = "binding_malformed"
+BINDING_REMOTE = "binding_remote"
+BINDING_AMBIGUOUS = "binding_ambiguous"
+MODEL_UNRESOLVED = "model_unresolved"
+MODEL_NOT_CONTAINED = "model_not_contained"
+MODEL_NOT_A_MODEL = "model_not_a_model"
+PAGE_ORDER_MALFORMED = "page_order_malformed"
+PAGE_MISSING = "page_missing"
+PAGE_ORPHAN = "page_orphan"
+PAGE_ID_MISMATCH = "page_id_mismatch"
+PAGE_ID_DUPLICATE = "page_id_duplicate"
+VISUAL_ID_INVALID = "visual_id_invalid"
+VISUAL_ID_DUPLICATE = "visual_id_duplicate"
+RESOURCE_MALFORMED = "resource_malformed"
+RESOURCE_DANGLING = "resource_dangling"
+
+#: Opaque stand-ins used when the offending path cannot be expressed relative to `fabric_root`.
+OPAQUE_ROOT = "<fabric-root>"
+OPAQUE_REPORT = "<report-dir>"
+OPAQUE_MODEL = "<model-dir>"
+
+
+class _Refused(Exception):
+    """Internal control flow: a refusal raised deep in the walk and caught at the entry point."""
+
+    def __init__(self, code: str, detail: str, evidence: Iterable[str] = ()) -> None:
+        super().__init__(code)
+        self.code = code
+        self.detail = detail
+        self.evidence = tuple(evidence)
+
+
+@dataclass(frozen=True)
+class VisualCensus:
+    """One visual: its folder identity AND its document identity, which routinely differ."""
+
+    page_id: str
+    folder: str
+    document_id: str
+    file: str
+
+
+@dataclass(frozen=True)
+class PageCensus:
+    """One page in `pageOrder` position, with its visuals in folder order."""
+
+    page_id: str
+    folder: str
+    display_name: str
+    file: str
+    visuals: tuple[VisualCensus, ...] = ()
+
+
+@dataclass(frozen=True)
+class RevisionRefusal:
+    """An explicit refusal. Falsy so that `if revision:` fails closed rather than fails open."""
+
+    code: str
+    detail: str
+    evidence: tuple[str, ...] = ()
+
+    def __bool__(self) -> bool:
+        return False
+
+
+@dataclass(frozen=True)
+class PbirRevision:  # pylint: disable=too-many-instance-attributes  # one census: locators, order, pages, files, digest
+    """The census of one report plus its bound model, and the digest over exactly those bytes."""
+
+    version: str
+    pbip: str
+    report: str
+    model: str
+    model_binding: str
+    page_order: tuple[str, ...]
+    pages: tuple[PageCensus, ...]
+    files: tuple[tuple[str, str], ...]
+    excluded: tuple[tuple[str, str], ...]
+    digest: str
+
+    def __bool__(self) -> bool:
+        return True
+
+    @property
+    def visual_count(self) -> int:
+        """Total visuals across all pages - the number a capture wrapper reports."""
+        return sum(len(page.visuals) for page in self.pages)
+
+
+@dataclass
+class _Walk:
+    """Mutable accumulator for one establishment attempt. Never returned to a caller."""
+
+    root: Path
+    included: dict[str, bytes] = field(default_factory=dict)
+    excluded: list[tuple[str, str]] = field(default_factory=list)
+
+    def rel(self, path: Path) -> str:
+        """Fabric-relative POSIX spelling, or an opaque token when the path escapes the root."""
+        try:
+            return Path(os.path.relpath(_lexical(path), _lexical(self.root))).as_posix()
+        except ValueError:
+            return OPAQUE_ROOT
+
+    def include(self, path: Path) -> bytes:
+        """Read one file into the revision and return its bytes."""
+        rel = self.rel(path)
+        try:
+            data = path.read_bytes()
+        except OSError as error:
+            raise _Refused(ENTRY_MISSING, f"{rel} could not be read ({error.strerror})", [rel]) from error
+        self.included[rel] = data
+        return data
+
+    def exclude(self, path: Path, reason: str) -> None:
+        """Record an entry that an explicit rule keeps OUT of the revision."""
+        self.excluded.append((self.rel(path), reason))
+
+
+# --------------------------------------------------------------------------------------------
+# Path primitives
+# --------------------------------------------------------------------------------------------
+
+
+def _lexical(path: Path) -> str:
+    """Absolute spelling WITHOUT resolving reparse points - the caller's own spelling, normalised."""
+    return os.path.abspath(str(path))
+
+
+def _is_reparse(path: Path) -> bool:
+    """Whether this entry itself is a symlink, junction or any other reparse point."""
+    try:
+        info = os.lstat(path)
+    except OSError:
+        return False
+    if stat.S_ISLNK(info.st_mode):
+        return True
+    attributes = getattr(info, "st_file_attributes", 0)
+    return bool(attributes & getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0))
+
+
+def _components(root: Path, path: Path) -> list[Path]:
+    """Every path component from ``root`` (inclusive) down to ``path`` (inclusive)."""
+    relative = Path(os.path.relpath(_lexical(path), _lexical(root)))
+    walked = [root]
+    current = root
+    for part in relative.parts:
+        current = current / part
+        walked.append(current)
+    return walked
+
+
+def _reject_reparse(walk: _Walk, root: Path, path: Path) -> None:
+    """Refuse when any component between ``root`` and ``path`` is a reparse point.
+
+    Ancestors ABOVE the root are the caller's declared boundary and are out of scope here; A1b owns
+    the identity of the root itself against a live Desktop instance.
+    """
+    for component in _components(root, path):
+        if _is_reparse(component):
+            rel = walk.rel(component)
+            raise _Refused(PATH_REPARSE, f"{rel} is a symlink/junction/reparse point", [rel])
+
+
+def _reject_uncontained(walk: _Walk, root: Path, path: Path, code: str, token: str) -> str:
+    """Refuse unless ``path`` is a strict descendant of ``root`` both lexically and resolved."""
+    lexical = os.path.relpath(_lexical(path), _lexical(root))
+    try:
+        resolved = os.path.relpath(str(path.resolve()), str(root.resolve()))
+    except (OSError, ValueError) as error:
+        raise _Refused(code, f"{token} could not be resolved for containment", [token]) from error
+    if lexical.startswith("..") or os.path.isabs(lexical) or lexical == os.curdir:
+        raise _Refused(code, f"{token} is not contained under the fabric root", [token])
+    if lexical != resolved:
+        raise _Refused(
+            PATH_IDENTITY_MISMATCH,
+            f"{token} spells one path lexically and another once resolved",
+            [token],
+        )
+    _reject_reparse(walk, root, path)
+    return Path(lexical).as_posix()
+
+
+def _entries(walk: _Walk, directory: Path) -> list[Path]:
+    """Directory children in a filesystem-order-independent sequence.
+
+    Sorted on the UTF-8 bytes of the entry name so two machines that enumerate a directory in
+    different orders - or with different locales - produce the same census and the same digest.
+    """
+    try:
+        children = list(directory.iterdir())
+    except OSError as error:
+        rel = walk.rel(directory)
+        raise _Refused(ENTRY_MISSING, f"{rel} could not be listed ({error.strerror})", [rel]) from error
+    return sorted(children, key=lambda child: child.name.encode("utf-8"))
+
+
+def _volatile(name: str) -> bool:
+    """Whether a file name is an excluded volatile sidecar, by the explicit closed rule."""
+    lowered = name.casefold()
+    return any(lowered.endswith(suffix) for suffix in VOLATILE_SUFFIXES) or any(
+        name.startswith(prefix) for prefix in VOLATILE_PREFIXES
+    )
+
+
+# --------------------------------------------------------------------------------------------
+# Strict JSON
+# --------------------------------------------------------------------------------------------
+
+
+def _no_duplicate_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    """`json.load` keeps the LAST duplicate key silently; this refuses the document instead."""
+    seen: dict[str, object] = {}
+    for key, value in pairs:
+        if key in seen:
+            raise ValueError(f"duplicate key {key!r}")
+        seen[key] = value
+    return seen
+
+
+def _reject_constant(name: str) -> object:
+    raise ValueError(f"non-JSON constant {name}")
+
+
+def _load_object(walk: _Walk, path: Path) -> dict[str, object]:
+    """Read one JSON object strictly: duplicate keys, NaN/Infinity and non-objects all refuse."""
+    rel = walk.rel(path)
+    data = walk.include(path)
+    try:
+        text = data.decode("utf-8-sig")
+    except UnicodeDecodeError as error:
+        raise _Refused(JSON_MALFORMED, f"{rel} is not UTF-8", [rel]) from error
+    try:
+        document = json.loads(text, object_pairs_hook=_no_duplicate_keys, parse_constant=_reject_constant)
+    except ValueError as error:
+        code = JSON_DUPLICATE_KEY if "duplicate key" in str(error) else JSON_MALFORMED
+        raise _Refused(code, f"{rel} is not strict JSON: {error}", [rel]) from error
+    if not isinstance(document, dict):
+        raise _Refused(JSON_TYPE, f"{rel} is not a JSON object", [rel])
+    return document
+
+
+def _string(walk: _Walk, document: dict[str, object], key: str, path: Path) -> str:
+    """One required non-empty string field."""
+    rel = walk.rel(path)
+    value = document.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise _Refused(JSON_TYPE, f"{rel} has no non-empty string {key!r}", [rel])
+    return value
+
+
+def _reject_unknown_keys(walk: _Walk, document: dict[str, object], allowed: Iterable[str], path: Path) -> None:
+    """Refuse a load-bearing document that carries a key this module does not understand."""
+    unknown = sorted(set(document) - set(allowed))
+    if unknown:
+        rel = walk.rel(path)
+        raise _Refused(ENTRY_UNKNOWN, f"{rel} has unsupported keys {unknown}", [rel])
+
+
+# --------------------------------------------------------------------------------------------
+# Directory census helpers
+# --------------------------------------------------------------------------------------------
+
+
+def _classify(walk: _Walk, entry: Path) -> str:
+    """`excluded`, `dir` or `file` - and a refusal for a reparse point or an odd entry type."""
+    if _is_reparse(entry):
+        rel = walk.rel(entry)
+        raise _Refused(PATH_REPARSE, f"{rel} is a symlink/junction/reparse point", [rel])
+    if entry.is_dir():
+        reason = EXCLUDED_DIRS.get(entry.name)
+        if reason:
+            walk.exclude(entry, reason)
+            return "excluded"
+        return "dir"
+    if entry.is_file():
+        if _volatile(entry.name):
+            walk.exclude(entry, "volatile-sidecar")
+            return "excluded"
+        return "file"
+    rel = walk.rel(entry)
+    raise _Refused(ENTRY_TYPE, f"{rel} is neither a regular file nor a directory", [rel])
+
+
+def _census_dir(walk: _Walk, directory: Path, files: Iterable[str], dirs: Iterable[str]) -> dict[str, Path]:
+    """Census one directory against a closed allow-list and return the entries that were kept.
+
+    An entry that is neither an allowed file nor an allowed directory refuses - this is the rule
+    that stops a future Desktop build's new sidecar from being silently adopted into a revision.
+    """
+    allowed_files, allowed_dirs = set(files), set(dirs)
+    kept: dict[str, Path] = {}
+    for entry in _entries(walk, directory):
+        kind = _classify(walk, entry)
+        if kind == "excluded":
+            continue
+        expected = allowed_files if kind == "file" else allowed_dirs
+        if entry.name not in expected:
+            rel = walk.rel(entry)
+            raise _Refused(ENTRY_UNKNOWN, f"{rel} is not a supported {kind} entry", [rel])
+        kept[entry.name] = entry
+    return kept
+
+
+def _require(walk: _Walk, kept: dict[str, Path], names: Iterable[str], parent: Path) -> None:
+    """Refuse when a required entry is absent from a censused directory."""
+    for name in names:
+        if name not in kept:
+            rel = walk.rel(parent / name)
+            raise _Refused(ENTRY_MISSING, f"{rel} is required and absent", [rel])
+
+
+def _include_tree(walk: _Walk, directory: Path) -> None:
+    """Include every regular file under ``directory``, applying the same exclusion rules."""
+    for entry in _entries(walk, directory):
+        kind = _classify(walk, entry)
+        if kind == "excluded":
+            continue
+        if kind == "dir":
+            _include_tree(walk, entry)
+        else:
+            walk.include(entry)
+
+
+# --------------------------------------------------------------------------------------------
+# PBIP relation
+# --------------------------------------------------------------------------------------------
+
+
+def _artifact_report_paths(walk: _Walk, pbip: Path) -> list[str]:
+    """The report paths one `.pbip` declares, refusing any unknown artifact kind or odd path."""
+    rel = walk.rel(pbip)
+    document = _load_object(walk, pbip)
+    artifacts = document.get("artifacts")
+    if not isinstance(artifacts, list) or not artifacts:
+        raise _Refused(PBIP_MALFORMED, f"{rel} has no artifacts array", [rel])
+    paths: list[str] = []
+    for artifact in artifacts:
+        if not isinstance(artifact, dict) or sorted(artifact) != ["report"]:
+            raise _Refused(PBIP_MALFORMED, f"{rel} has an artifact that is not exactly one report", [rel])
+        report = artifact["report"]
+        if not isinstance(report, dict) or not isinstance(report.get("path"), str):
+            raise _Refused(PBIP_MALFORMED, f"{rel} has a report artifact without a string path", [rel])
+        paths.append(report["path"])
+    return paths
+
+
+def _relative_child(base: Path, spelling: str, code: str, token: str) -> Path:
+    """Resolve a declared relative path, refusing absolute, drive-shaped or backslash spellings."""
+    if not spelling or spelling != spelling.strip():
+        raise _Refused(code, f"{token} declares an empty or padded path", [token])
+    if "\\" in spelling or os.path.isabs(spelling) or ":" in spelling:
+        raise _Refused(code, f"{token} declares a non-portable path spelling", [token])
+    return base / spelling
+
+
+def _matching_pbip(walk: _Walk, root: Path, report_dir: Path) -> Path:
+    """The single `.pbip` in the fabric root that declares THIS report.
+
+    Every immediate `.pbip` is parsed, not just the first match: proving that exactly one project
+    claims this report is the whole point, and a malformed sibling would otherwise hide a second
+    claim.     A fabric root with no `.pbip` at all refuses - Power BI Desktop opens the `.pbip`, so a root
+    without one is not a local capture target. Matching is on the EXACT declared spelling: a
+    `.pbip` that names a differently-cased report is treated as declaring another report, because
+    the audit measured Desktop preserving whatever spelling it was opened with.
+    """
+    candidates: list[Path] = []
+    for entry in _entries(walk, root):
+        if entry.suffix.casefold() != PBIP_SUFFIX:
+            continue
+        kind = _classify(walk, entry)
+        if kind == "dir":
+            rel = walk.rel(entry)
+            raise _Refused(ENTRY_TYPE, f"{rel} is a directory, not a .pbip project file", [rel])
+        if kind == "file":
+            candidates.append(entry)
+    if not candidates:
+        raise _Refused(PBIP_ABSENT, "the fabric root holds no .pbip project file", [OPAQUE_ROOT])
+    target = _lexical(report_dir)
+    matches: list[Path] = []
+    for pbip in candidates:
+        rel = walk.rel(pbip)
+        declared = [
+            _relative_child(root, spelling, PBIP_MALFORMED, rel) for spelling in _artifact_report_paths(walk, pbip)
+        ]
+        hits = [path for path in declared if _lexical(path) == target]
+        if len(hits) > 1:
+            raise _Refused(PBIP_REPORT_AMBIGUOUS, f"{rel} declares this report more than once", [rel])
+        if hits:
+            matches.append(pbip)
+    if not matches:
+        raise _Refused(PBIP_REPORT_UNRELATED, "no .pbip in the fabric root declares this report", [OPAQUE_REPORT])
+    if len(matches) > 1:
+        raise _Refused(
+            PBIP_REPORT_AMBIGUOUS,
+            "more than one .pbip declares this report",
+            sorted(walk.rel(match) for match in matches),
+        )
+    # Keep only the matching project's bytes: a sibling project is not part of this revision.
+    for pbip in candidates:
+        if pbip != matches[0]:
+            walk.included.pop(walk.rel(pbip), None)
+            walk.exclude(pbip, "other-project")
+    return matches[0]
+
+
+# --------------------------------------------------------------------------------------------
+# Report definition census
+# --------------------------------------------------------------------------------------------
+
+
+def _page_order(walk: _Walk, pages_json: Path) -> tuple[list[str], str | None]:
+    """`pages.json` is the page-order authority; it must be a non-empty list of unique ids."""
+    rel = walk.rel(pages_json)
+    document = _load_object(walk, pages_json)
+    _reject_unknown_keys(walk, document, ("$schema", "pageOrder", "activePageName"), pages_json)
+    order = document.get("pageOrder")
+    if not isinstance(order, list) or not order:
+        raise _Refused(PAGE_ORDER_MALFORMED, f"{rel} has no non-empty pageOrder", [rel])
+    if any(not isinstance(name, str) or not name.strip() for name in order):
+        raise _Refused(PAGE_ORDER_MALFORMED, f"{rel} has a non-string pageOrder entry", [rel])
+    if len(set(order)) != len(order):
+        raise _Refused(PAGE_ORDER_MALFORMED, f"{rel} repeats a pageOrder entry", [rel])
+    active = document.get("activePageName")
+    if active is not None and (not isinstance(active, str) or active not in order):
+        raise _Refused(PAGE_ORDER_MALFORMED, f"{rel} names an activePageName outside pageOrder", [rel])
+    return list(order), active
+
+
+def _visuals(walk: _Walk, page_dir: Path, page_id: str) -> list[VisualCensus]:
+    """Census one page's `visuals/`. The folder is not identity; `visual.json.name` is."""
+    visuals_dir = page_dir / PAGE_DIR
+    if not visuals_dir.is_dir():
+        return []
+    censused: list[VisualCensus] = []
+    for entry in _entries(walk, visuals_dir):
+        kind = _classify(walk, entry)
+        if kind == "excluded":
+            continue
+        if kind != "dir":
+            rel = walk.rel(entry)
+            raise _Refused(ENTRY_UNKNOWN, f"{rel} is a file directly inside visuals/", [rel])
+        kept = _census_dir(walk, entry, (VISUAL_FILE,), ())
+        _require(walk, kept, (VISUAL_FILE,), entry)
+        document = _load_object(walk, kept[VISUAL_FILE])
+        censused.append(
+            VisualCensus(
+                page_id=page_id,
+                folder=entry.name,
+                document_id=_string(walk, document, "name", kept[VISUAL_FILE]),
+                file=walk.rel(kept[VISUAL_FILE]),
+            )
+        )
+    return censused
+
+
+def _page_directories(walk: _Walk, pages_dir: Path) -> dict[str, Path]:
+    """Every page directory under `definition/pages/`, refusing any other entry there.
+
+    Deliberately NOT expressed as an allow-list of the `pageOrder` names: a directory that is not in
+    `pageOrder` has to refuse as a page ORPHAN (with the page-order authority named), not as a
+    generic unknown entry, or the caller cannot tell a stale page from a stray file.
+    """
+    found: dict[str, Path] = {}
+    for entry in _entries(walk, pages_dir):
+        kind = _classify(walk, entry)
+        if kind == "excluded":
+            continue
+        if kind == "file":
+            if entry.name != "pages.json":
+                rel = walk.rel(entry)
+                raise _Refused(ENTRY_UNKNOWN, f"{rel} is not a supported file entry", [rel])
+            continue
+        found[entry.name] = entry
+    return found
+
+
+def _one_page(walk: _Walk, page_dir: Path, page_id: str) -> PageCensus:
+    """Census one page directory. The folder name IS the page document id (36/36 committed pages)."""
+    entries = _census_dir(walk, page_dir, (PAGE_FILE,), (PAGE_DIR,))
+    _require(walk, entries, (PAGE_FILE,), page_dir)
+    document = _load_object(walk, entries[PAGE_FILE])
+    document_id = _string(walk, document, "name", entries[PAGE_FILE])
+    if document_id != page_id:
+        rel = walk.rel(entries[PAGE_FILE])
+        raise _Refused(PAGE_ID_MISMATCH, f"{rel} names {document_id!r}, not its folder", [rel])
+    return PageCensus(
+        page_id=page_id,
+        folder=page_dir.name,
+        display_name=_string(walk, document, "displayName", entries[PAGE_FILE]),
+        file=walk.rel(entries[PAGE_FILE]),
+        visuals=tuple(_visuals(walk, page_dir, page_id)),
+    )
+
+
+def _pages(walk: _Walk, pages_dir: Path, order: list[str]) -> tuple[PageCensus, ...]:
+    """Census every page directory, requiring exact agreement with `pageOrder`."""
+    kept = _page_directories(walk, pages_dir)
+    missing = sorted(set(order) - set(kept))
+    if missing:
+        raise _Refused(PAGE_MISSING, f"pageOrder names {missing} with no page directory", missing)
+    orphan = sorted(set(kept) - set(order))
+    if orphan:
+        raise _Refused(PAGE_ORPHAN, f"page directories {orphan} are absent from pageOrder", orphan)
+    censused: list[PageCensus] = []
+    seen_visuals: dict[str, str] = {}
+    for page_id in order:
+        page = _one_page(walk, kept[page_id], page_id)
+        for visual in page.visuals:
+            if visual.document_id in seen_visuals:
+                raise _Refused(
+                    VISUAL_ID_DUPLICATE,
+                    f"visual document id {visual.document_id!r} appears twice in this report",
+                    sorted({seen_visuals[visual.document_id], visual.file}),
+                )
+            seen_visuals[visual.document_id] = visual.file
+        censused.append(page)
+    return tuple(censused)
+
+
+def _registered_paths(walk: _Walk, report_json: Path) -> list[str]:
+    """Registered-resource paths declared by `report.json`.
+
+    Only `RegisteredResources` packages are resolved on disk. `SharedResources` base themes
+    (`BaseThemes/CY24SU10.json` in 15 of 16 committed examples) ship inside Power BI and are
+    correctly absent from the report folder, so resolving them would refuse every real report.
+    """
+    rel = walk.rel(report_json)
+    document = _load_object(walk, report_json)
+    packages = document.get("resourcePackages", [])
+    if not isinstance(packages, list):
+        raise _Refused(RESOURCE_MALFORMED, f"{rel} has a non-list resourcePackages", [rel])
+    declared: list[str] = []
+    for package in packages:
+        if not isinstance(package, dict):
+            raise _Refused(RESOURCE_MALFORMED, f"{rel} has a non-object resource package", [rel])
+        if package.get("type") != REGISTERED_RESOURCES_DIR:
+            continue
+        items = package.get("items")
+        if not isinstance(items, list):
+            raise _Refused(RESOURCE_MALFORMED, f"{rel} has a resource package without items", [rel])
+        for item in items:
+            if not isinstance(item, dict) or not isinstance(item.get("path"), str):
+                raise _Refused(RESOURCE_MALFORMED, f"{rel} has a resource item without a string path", [rel])
+            declared.append(item["path"])
+    return declared
+
+
+def _static_resources(walk: _Walk, report_dir: Path, declared: list[str]) -> None:
+    """Include every committed static resource, and refuse a registration that resolves nowhere.
+
+    The asymmetry is deliberate. A registration with no file BREAKS the render, so it refuses. A file
+    with no registration does not, so it is included: its bytes still move the digest, which is what
+    makes an edit to an unregistered theme visible.
+    """
+    static_dir = report_dir / STATIC_RESOURCES_DIR
+    registered = static_dir / REGISTERED_RESOURCES_DIR
+    if static_dir.is_dir():
+        _census_dir(walk, static_dir, (), STATIC_RESOURCE_DIRS)
+        _include_tree(walk, static_dir)
+    for spelling in declared:
+        target = _relative_child(registered, spelling, RESOURCE_MALFORMED, "report.json")
+        rel = walk.rel(target)
+        if not target.is_file() or _is_reparse(target):
+            raise _Refused(RESOURCE_DANGLING, f"report.json registers {spelling!r}, which is not a file", [rel])
+
+
+# --------------------------------------------------------------------------------------------
+# Model binding and census
+# --------------------------------------------------------------------------------------------
+
+
+def _bound_model(walk: _Walk, root: Path, report_dir: Path, pbir: Path) -> tuple[Path, str]:
+    """The single local `byPath` model this report binds to, refusing every other binding shape."""
+    rel = walk.rel(pbir)
+    document = _load_object(walk, pbir)
+    _reject_unknown_keys(walk, document, ("$schema", "version", "datasetReference"), pbir)
+    reference = document.get("datasetReference")
+    if not isinstance(reference, dict) or not reference:
+        raise _Refused(BINDING_MALFORMED, f"{rel} has no datasetReference object", [rel])
+    if "byConnection" in reference:
+        raise _Refused(BINDING_REMOTE, f"{rel} binds byConnection, which is not a local capture target", [rel])
+    if sorted(reference) != ["byPath"]:
+        raise _Refused(BINDING_AMBIGUOUS, f"{rel} does not bind exactly one byPath", [rel])
+    by_path = reference["byPath"]
+    if not isinstance(by_path, dict) or sorted(by_path) != ["path"] or not isinstance(by_path["path"], str):
+        raise _Refused(BINDING_MALFORMED, f"{rel} has a malformed byPath", [rel])
+    spelling = by_path["path"]
+    candidate = _relative_child(report_dir, spelling, BINDING_MALFORMED, rel)
+    if _lexical(candidate) == _lexical(report_dir):
+        raise _Refused(MODEL_NOT_A_MODEL, f"{rel} binds the report directory as its model", [rel])
+    if not candidate.is_dir():
+        raise _Refused(MODEL_UNRESOLVED, f"{rel} binds a path that is not an existing directory", [rel])
+    if not candidate.name.endswith(MODEL_SUFFIX):
+        raise _Refused(MODEL_NOT_A_MODEL, f"{rel} binds a directory that is not a {MODEL_SUFFIX}", [rel])
+    _reject_uncontained(walk, root, candidate, MODEL_NOT_CONTAINED, OPAQUE_MODEL)
+    return candidate, spelling
+
+
+def _census_model(walk: _Walk, model_dir: Path) -> None:
+    """Include every deployable model definition byte; exclude local state by the named rules."""
+    top = _census_dir(walk, model_dir, MODEL_REQUIRED_FILES + MODEL_OPTIONAL_FILES, ("definition",))
+    _require(walk, top, MODEL_REQUIRED_FILES + ("definition",), model_dir)
+    for name in MODEL_REQUIRED_FILES + MODEL_OPTIONAL_FILES:
+        if name in top:
+            _load_object(walk, top[name])
+    definition = top["definition"]
+    allowed_files = MODEL_DEFINITION_REQUIRED + MODEL_DEFINITION_OPTIONAL
+    kept = _census_dir(walk, definition, allowed_files, MODEL_DEFINITION_DIRS)
+    _require(walk, kept, MODEL_DEFINITION_REQUIRED, definition)
+    for name, path in kept.items():
+        if name in MODEL_DEFINITION_DIRS:
+            for entry in _entries(walk, path):
+                kind = _classify(walk, entry)
+                if kind == "excluded":
+                    continue
+                if kind != "file" or not entry.name.endswith(".tmdl"):
+                    rel = walk.rel(entry)
+                    raise _Refused(ENTRY_UNKNOWN, f"{rel} is not a .tmdl file", [rel])
+                walk.include(entry)
+        else:
+            walk.include(path)
+
+
+# --------------------------------------------------------------------------------------------
+# Digest
+# --------------------------------------------------------------------------------------------
+
+
+def _framed(digest: Any, payload: bytes) -> None:
+    """Length-delimit every field so no concatenation of two fields can imitate another."""
+    digest.update(len(payload).to_bytes(8, "big"))
+    digest.update(payload)
+
+
+def revision_digest(files: Iterable[tuple[str, bytes]]) -> str:
+    """SHA-256 over the version tag plus every included path and its raw bytes, length-delimited.
+
+    Sorted on the UTF-8 bytes of the fabric-relative path, so the digest never depends on directory
+    enumeration order, and framed so that a path/content boundary cannot be shifted silently.
+    """
+    digest = hashlib.sha256()
+    _framed(digest, VERSION_TAG.encode("utf-8"))
+    for rel, data in sorted(files, key=lambda item: item[0].encode("utf-8")):
+        _framed(digest, rel.encode("utf-8"))
+        _framed(digest, data)
+    return digest.hexdigest()
+
+
+def _file_hashes(walk: _Walk) -> tuple[tuple[str, str], ...]:
+    """Per-file SHA-256, so a consumer can name WHICH file moved when a digest changes."""
+    return tuple(
+        (rel, hashlib.sha256(data).hexdigest())
+        for rel, data in sorted(walk.included.items(), key=lambda item: item[0].encode("utf-8"))
+    )
+
+
+# --------------------------------------------------------------------------------------------
+# Entry point
+# --------------------------------------------------------------------------------------------
+
+
+def _census_report_definition(
+    walk: _Walk, report_dir: Path, definition_dir: Path
+) -> tuple[list[str], tuple[PageCensus, ...]]:
+    """The report's `definition/` tree plus its static resources, in `pageOrder` authority order."""
+    definition = _census_dir(walk, definition_dir, DEFINITION_FILES, DEFINITION_DIRS)
+    _require(walk, definition, DEFINITION_FILES + DEFINITION_DIRS, definition_dir)
+    _load_object(walk, definition["version.json"])
+    _static_resources(walk, report_dir, _registered_paths(walk, definition["report.json"]))
+    order, _active = _page_order(walk, definition["pages"] / "pages.json")
+    return order, _pages(walk, definition["pages"], order)
+
+
+def _establish(walk: _Walk, root: Path, report_dir: Path) -> PbirRevision:
+    """The whole census, with every refusal raised as `_Refused` and caught by the caller."""
+    if not root.is_dir():
+        raise _Refused(ROOT_UNUSABLE, "the fabric root is not an existing directory", [OPAQUE_ROOT])
+    if not report_dir.is_dir():
+        raise _Refused(REPORT_UNUSABLE, "the report artifact is not an existing directory", [OPAQUE_REPORT])
+    if not report_dir.name.endswith(REPORT_SUFFIX):
+        raise _Refused(REPORT_UNUSABLE, f"the report artifact is not a {REPORT_SUFFIX} directory", [OPAQUE_REPORT])
+    report_rel = _reject_uncontained(walk, root, report_dir, REPORT_NOT_CONTAINED, OPAQUE_REPORT)
+
+    pbip = _matching_pbip(walk, root, report_dir)
+    top = _census_dir(walk, report_dir, REPORT_FILES, REPORT_DIRS)
+    _require(walk, top, REPORT_FILES + ("definition",), report_dir)
+    _load_object(walk, top[".platform"])
+    model_dir, binding = _bound_model(walk, root, report_dir, top["definition.pbir"])
+    order, pages = _census_report_definition(walk, report_dir, top["definition"])
+    _census_model(walk, model_dir)
+
+    return PbirRevision(
+        version=VERSION_TAG,
+        pbip=walk.rel(pbip),
+        report=report_rel,
+        model=walk.rel(model_dir),
+        model_binding=binding,
+        page_order=tuple(order),
+        pages=pages,
+        files=_file_hashes(walk),
+        excluded=tuple(sorted(walk.excluded)),
+        digest=revision_digest(walk.included.items()),
+    )
+
+
+def establish_revision(fabric_root: Path | str, report_dir: Path | str) -> PbirRevision | RevisionRefusal:
+    """Census one already-selected report under ``fabric_root`` and digest its revision.
+
+    Returns a :class:`PbirRevision` when every rule above holds, or a :class:`RevisionRefusal`
+    naming the first contradicted rule. It never raises for a bad tree, never repairs anything, and
+    never reads or writes outside ``fabric_root``.
+    """
+    root, report = Path(fabric_root), Path(report_dir)
+    walk = _Walk(root=root)
+    try:
+        return _establish(walk, root, report)
+    except _Refused as refusal:
+        return RevisionRefusal(code=refusal.code, detail=refusal.detail, evidence=refusal.evidence)
+
+
+def iter_included(revision: PbirRevision) -> Iterator[str]:
+    """The fabric-relative paths the revision covers, in digest order."""
+    for rel, _sha in revision.files:
+        yield rel

--- a/tests/test_pbir_revision.py
+++ b/tests/test_pbir_revision.py
@@ -1,0 +1,860 @@
+"""Controlled tests for `scripts/pbir_revision.py` - slice A1a of issue #363.
+
+The invariant under test: given an already-selected `fabric/` root and ONE report artifact, either
+produce a strict typed census plus a deterministic revision digest, or refuse with positive evidence.
+Nothing here touches Power BI Desktop, a PID, a screenshot, a receipt or a sign-off - those are later
+slices, and a test that reached for them would be testing the wrong thing.
+
+Three kinds of control run here:
+
+* **Corpus** - every committed report tree in this repo, judged against an EXACT expected verdict
+  table (`CORPUS`). A newly committed report shape fails this table rather than being adopted
+  silently, which is the point of a closed census.
+* **Positive** - a synthetic tree carrying one of every included entry type, so a mutation control
+  exists for each of them.
+* **Negative** - one control per refusal rule, each asserting the SPECIFIC code. A negative control
+  that merely asserts "not established" would pass for the wrong reason (this happened during
+  development: a fixture missing its `.pbip` refused as `pbip_absent` long before reaching the rule
+  it was written for).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from dataclasses import asdict
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+# ruff: noqa: E402  (the sys.path insert above must precede this import)
+# pylint: disable=wrong-import-position
+import pbir_revision as pbir
+
+# --------------------------------------------------------------------------------------------
+# Synthetic positive fixture: one of every entry type the census includes.
+# --------------------------------------------------------------------------------------------
+
+PAGE_ORDER = ["p_first", "p_second"]
+
+
+def _write(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if isinstance(payload, (dict, list)):
+        path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    else:
+        path.write_text(str(payload), encoding="utf-8")
+
+
+def _visual(name: str) -> dict[str, object]:
+    return {"$schema": "https://example.invalid/visualContainer/2.9.0/schema.json", "name": name}
+
+
+def _build(root: Path) -> tuple[Path, Path]:
+    """A complete, valid fabric root. Returns (fabric_root, report_dir).
+
+    The visual FOLDER names deliberately differ from the visual document ids, because 133 of the 869
+    committed example visuals do exactly that - a fixture where they matched would let a
+    folder-as-identity bug pass.
+    """
+    fabric = root / "fabric"
+    report = fabric / "Demo.Report"
+    model = fabric / "Demo.SemanticModel"
+    _write(fabric / "Demo.pbip", {"version": "1.0", "artifacts": [{"report": {"path": "Demo.Report"}}]})
+    _write(report / ".platform", {"metadata": {"type": "Report", "displayName": "Demo"}})
+    _write(
+        report / "definition.pbir",
+        {"version": "4.0", "datasetReference": {"byPath": {"path": "../Demo.SemanticModel"}}},
+    )
+    _write(report / "definition" / "version.json", {"version": "2.0.0"})
+    _write(
+        report / "definition" / "report.json",
+        {
+            "themeCollection": {},
+            "resourcePackages": [
+                {
+                    "name": "SharedResources",
+                    "type": "SharedResources",
+                    "items": [{"name": "CY24SU10", "path": "BaseThemes/CY24SU10.json", "type": "BaseTheme"}],
+                },
+                {
+                    "name": "RegisteredResources",
+                    "type": "RegisteredResources",
+                    "items": [{"name": "theme.json", "path": "theme.json", "type": "CustomTheme"}],
+                },
+            ],
+        },
+    )
+    _write(report / "StaticResources" / "RegisteredResources" / "theme.json", {"name": "DemoTheme"})
+    _write(report / "definition" / "pages" / "pages.json", {"pageOrder": PAGE_ORDER, "activePageName": "p_first"})
+    for index, page_id in enumerate(PAGE_ORDER):
+        page_dir = report / "definition" / "pages" / page_id
+        _write(page_dir / "page.json", {"name": page_id, "displayName": f"Page {index}", "height": 800, "width": 1400})
+        _write(page_dir / "visuals" / f"friendly-name-{index}" / "visual.json", _visual(f"v{index}0"))
+        _write(page_dir / "visuals" / f"another-{index}" / "visual.json", _visual(f"v{index}1"))
+    _write(model / ".platform", {"metadata": {"type": "SemanticModel", "displayName": "Demo"}})
+    _write(model / "definition.pbism", {"version": "4.2", "settings": {"qnaEnabled": True}})
+    _write(model / "definition" / "model.tmdl", "model Model\n")
+    _write(model / "definition" / "database.tmdl", "database Demo\n")
+    _write(model / "definition" / "relationships.tmdl", "relationship r1\n")
+    _write(model / "definition" / "expressions.tmdl", 'expression DataFolder = "x"\n')
+    _write(model / "definition" / "cultures" / "en-US.tmdl", "cultureInfo en-US\n")
+    _write(model / "definition" / "tables" / "Sales.tmdl", "table Sales\n")
+    return fabric, report
+
+
+@pytest.fixture(name="tree")
+def tree_fixture(tmp_path: Path) -> tuple[Path, Path]:
+    return _build(tmp_path)
+
+
+def _establish(tree: tuple[Path, Path]) -> pbir.PbirRevision:
+    result = pbir.establish_revision(*tree)
+    assert isinstance(result, pbir.PbirRevision), getattr(result, "detail", result)
+    return result
+
+
+def _refuse(tree: tuple[Path, Path]) -> pbir.RevisionRefusal:
+    result = pbir.establish_revision(*tree)
+    assert isinstance(result, pbir.RevisionRefusal), "expected a refusal, got an established revision"
+    return result
+
+
+def _append_one_byte(path: Path) -> None:
+    with path.open("ab") as handle:
+        handle.write(b" ")
+
+
+def _patch_json(path: Path, mutate) -> None:
+    document = json.loads(path.read_text(encoding="utf-8"))
+    mutate(document)
+    path.write_text(json.dumps(document, indent=2), encoding="utf-8")
+
+
+# --------------------------------------------------------------------------------------------
+# Positive control
+# --------------------------------------------------------------------------------------------
+
+
+def test_synthetic_tree_establishes_with_full_census(tree: tuple[Path, Path]) -> None:
+    revision = _establish(tree)
+    assert revision.version == pbir.VERSION_TAG
+    assert revision.pbip == "Demo.pbip"
+    assert revision.report == "Demo.Report"
+    assert revision.model == "Demo.SemanticModel"
+    assert revision.model_binding == "../Demo.SemanticModel"
+    assert revision.page_order == tuple(PAGE_ORDER)
+    assert [page.page_id for page in revision.pages] == PAGE_ORDER
+    assert revision.visual_count == 4
+    included = set(dict(revision.files))
+    assert included == {
+        "Demo.pbip",
+        "Demo.Report/.platform",
+        "Demo.Report/definition.pbir",
+        "Demo.Report/definition/report.json",
+        "Demo.Report/definition/version.json",
+        "Demo.Report/definition/pages/pages.json",
+        "Demo.Report/definition/pages/p_first/page.json",
+        "Demo.Report/definition/pages/p_first/visuals/another-0/visual.json",
+        "Demo.Report/definition/pages/p_first/visuals/friendly-name-0/visual.json",
+        "Demo.Report/definition/pages/p_second/page.json",
+        "Demo.Report/definition/pages/p_second/visuals/another-1/visual.json",
+        "Demo.Report/definition/pages/p_second/visuals/friendly-name-1/visual.json",
+        "Demo.Report/StaticResources/RegisteredResources/theme.json",
+        "Demo.SemanticModel/.platform",
+        "Demo.SemanticModel/definition.pbism",
+        "Demo.SemanticModel/definition/model.tmdl",
+        "Demo.SemanticModel/definition/database.tmdl",
+        "Demo.SemanticModel/definition/relationships.tmdl",
+        "Demo.SemanticModel/definition/expressions.tmdl",
+        "Demo.SemanticModel/definition/cultures/en-US.tmdl",
+        "Demo.SemanticModel/definition/tables/Sales.tmdl",
+    }
+
+
+def test_visual_folder_and_document_identity_are_recorded_separately(tree: tuple[Path, Path]) -> None:
+    """The folder is not the visual's identity - 133 of 869 committed examples prove it."""
+    revision = _establish(tree)
+    first = revision.pages[0].visuals[0]
+    assert first.folder == "another-0"
+    assert first.document_id == "v01"
+    assert first.file == "Demo.Report/definition/pages/p_first/visuals/another-0/visual.json"
+
+
+def test_a_page_with_no_visuals_directory_is_a_census_not_a_refusal(tree: tuple[Path, Path]) -> None:
+    """`fixtures/large-refresh` commits exactly this shape, so it must census rather than refuse."""
+    shutil.rmtree(tree[1] / "definition" / "pages" / "p_second" / "visuals")
+    revision = _establish(tree)
+    assert revision.pages[1].visuals == ()
+    assert revision.visual_count == 2
+
+
+def test_refusal_is_falsy_and_a_revision_is_truthy(tree: tuple[Path, Path]) -> None:
+    """`if revision:` must fail CLOSED - a refusal that reads as true is a fail-open consumer."""
+    assert bool(_establish(tree)) is True
+    (tree[1] / "definition" / "pages" / "p_first" / "page.json").unlink()
+    assert bool(_refuse(tree)) is False
+
+
+# --------------------------------------------------------------------------------------------
+# Determinism and order independence
+# --------------------------------------------------------------------------------------------
+
+
+def test_digest_is_stable_across_repeated_runs(tree: tuple[Path, Path]) -> None:
+    assert _establish(tree).digest == _establish(tree).digest
+
+
+def test_digest_is_independent_of_filesystem_enumeration_order(
+    tree: tuple[Path, Path], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A different `iterdir` order must not move the digest, the file list, or page/visual order."""
+    baseline = _establish(tree)
+    original = Path.iterdir
+    monkeypatch.setattr(Path, "iterdir", lambda self: iter(sorted(original(self), key=str, reverse=True)))
+    shuffled = _establish(tree)
+    assert shuffled.digest == baseline.digest
+    assert shuffled.files == baseline.files
+    assert shuffled.pages == baseline.pages
+
+
+def test_digest_covers_the_version_tag() -> None:
+    """The framing tag is part of the hash, so a future revision format cannot collide with v1."""
+    assert pbir.revision_digest([("a", b"x")]) != pbir.revision_digest([("a", b"x"), (pbir.VERSION_TAG, b"")])
+
+
+def test_revision_digest_sorts_its_own_input(tree: tuple[Path, Path]) -> None:
+    """Order independence has TWO layers and both must hold.
+
+    `_entries` normalises directory enumeration, and `revision_digest` sorts the file set it is
+    handed. Mutation testing caught this gap: with only the filesystem-level control, deleting the
+    sort inside `revision_digest` changed nothing, because the walk happened to insert in sorted
+    order anyway. A caller passing the same files in another order must still get one digest.
+    """
+    files = [(rel, rel.encode("utf-8")) for rel, _sha in _establish(tree).files]
+    assert pbir.revision_digest(files) == pbir.revision_digest(list(reversed(files)))
+
+
+def test_digest_framing_resists_a_path_content_boundary_shift() -> None:
+    """Without length delimiters these two file sets would hash identically."""
+    assert pbir.revision_digest([("ab", b"c")]) != pbir.revision_digest([("a", b"bc")])
+
+
+MUTABLE = [
+    "Demo.pbip",
+    "Demo.Report/.platform",
+    "Demo.Report/definition.pbir",
+    "Demo.Report/definition/report.json",
+    "Demo.Report/definition/version.json",
+    "Demo.Report/definition/pages/pages.json",
+    "Demo.Report/definition/pages/p_first/page.json",
+    "Demo.Report/definition/pages/p_first/visuals/another-0/visual.json",
+    "Demo.Report/StaticResources/RegisteredResources/theme.json",
+    "Demo.SemanticModel/.platform",
+    "Demo.SemanticModel/definition.pbism",
+    "Demo.SemanticModel/definition/model.tmdl",
+    "Demo.SemanticModel/definition/cultures/en-US.tmdl",
+    "Demo.SemanticModel/definition/tables/Sales.tmdl",
+]
+
+
+@pytest.mark.parametrize("relative", MUTABLE)
+def test_one_byte_change_in_any_included_file_moves_the_digest(tree: tuple[Path, Path], relative: str) -> None:
+    baseline = _establish(tree)
+    _append_one_byte(tree[0] / relative)
+    mutated = _establish(tree)
+    assert mutated.digest != baseline.digest
+    assert dict(mutated.files)[relative] != dict(baseline.files)[relative]
+
+
+def test_one_byte_change_in_a_committed_corpus_report_moves_the_digest(tmp_path: Path) -> None:
+    """The same control on a REAL committed tree, not only on the synthetic one."""
+    copied = tmp_path / "fabric"
+    shutil.copytree(REPO_ROOT / "fixtures" / "large-refresh" / "fabric", copied)
+    report = copied / "LargeRefresh.Report"
+    baseline = _establish((copied, report))
+    _append_one_byte(report / "definition" / "pages" / "largeRefreshPage" / "page.json")
+    assert _establish((copied, report)).digest != baseline.digest
+
+
+# --------------------------------------------------------------------------------------------
+# The explicit exclusion rule
+# --------------------------------------------------------------------------------------------
+
+
+def test_local_and_volatile_state_is_excluded_by_name_without_moving_the_digest(tree: tuple[Path, Path]) -> None:
+    """`.pbi/`, `TMDLScripts/` and volatile sidecars are machine state, not a portable revision."""
+    fabric, report = tree
+    baseline = _establish(tree)
+    _write(report / ".pbi" / "localSettings.json", {"local": True})
+    (report / ".pbi" / "cache.abf").write_bytes(b"\x00" * 32)
+    _write(fabric / "Demo.SemanticModel" / ".pbi" / "localSettings.json", {"local": True})
+    _write(fabric / "Demo.SemanticModel" / "TMDLScripts" / "Script 1.tmdl", "table Scratch\n")
+    _write(report / "definition" / "pages" / "p_first" / "page.json.tmp", "half written")
+    _write(report / "definition" / "report.json.autosave", "recovered")
+    _write(fabric / "Demo.SemanticModel" / "definition" / "model.tmdl.bak", "table Old\n")
+    (fabric / "Demo.SemanticModel" / "cache.abf").write_bytes(b"\x00" * 8)
+    _write(fabric / "~$Demo.pbip", "lock")
+    mutated = _establish(tree)
+    assert mutated.digest == baseline.digest
+    reasons = dict(mutated.excluded)
+    assert reasons["Demo.Report/.pbi"] == "local-desktop-state"
+    assert reasons["Demo.SemanticModel/.pbi"] == "local-desktop-state"
+    assert reasons["Demo.SemanticModel/TMDLScripts"] == "authoring-scratch"
+    for sidecar in (
+        "Demo.Report/definition/pages/p_first/page.json.tmp",
+        "Demo.Report/definition/report.json.autosave",
+        "Demo.SemanticModel/definition/model.tmdl.bak",
+        "Demo.SemanticModel/cache.abf",
+        "~$Demo.pbip",
+    ):
+        assert reasons[sidecar] == "volatile-sidecar", sidecar
+
+
+def test_a_sibling_pbip_project_is_recorded_as_excluded_not_hashed(tree: tuple[Path, Path]) -> None:
+    """Another project's bytes are not part of THIS report's revision, but must not vanish silently."""
+    fabric, _report = tree
+    baseline = _establish(tree)
+    _write(fabric / "Other.pbip", {"version": "1.0", "artifacts": [{"report": {"path": "Other.Report"}}]})
+    mutated = _establish(tree)
+    assert mutated.digest == baseline.digest
+    assert dict(mutated.excluded)["Other.pbip"] == "other-project"
+
+
+# --------------------------------------------------------------------------------------------
+# Negative controls - each asserts its OWN code
+# --------------------------------------------------------------------------------------------
+
+
+def test_missing_page_json_refuses(tree: tuple[Path, Path]) -> None:
+    (tree[1] / "definition" / "pages" / "p_first" / "page.json").unlink()
+    assert _refuse(tree).code == pbir.ENTRY_MISSING
+
+
+def test_missing_visual_json_refuses(tree: tuple[Path, Path]) -> None:
+    (tree[1] / "definition" / "pages" / "p_first" / "visuals" / "another-0" / "visual.json").unlink()
+    assert _refuse(tree).code == pbir.ENTRY_MISSING
+
+
+def test_page_order_naming_an_absent_page_refuses(tree: tuple[Path, Path]) -> None:
+    pages = tree[1] / "definition" / "pages" / "pages.json"
+    _patch_json(pages, lambda doc: doc["pageOrder"].append("p_ghost"))
+    refusal = _refuse(tree)
+    assert refusal.code == pbir.PAGE_MISSING
+    assert refusal.evidence == ("p_ghost",)
+
+
+def test_orphan_page_directory_refuses(tree: tuple[Path, Path]) -> None:
+    orphan = tree[1] / "definition" / "pages" / "p_orphan"
+    _write(orphan / "page.json", {"name": "p_orphan", "displayName": "Orphan"})
+    refusal = _refuse(tree)
+    assert refusal.code == pbir.PAGE_ORPHAN
+    assert refusal.evidence == ("p_orphan",)
+
+
+def test_page_document_id_disagreeing_with_its_folder_refuses(tree: tuple[Path, Path]) -> None:
+    page = tree[1] / "definition" / "pages" / "p_first" / "page.json"
+    _patch_json(page, lambda doc: doc.update({"name": "p_elsewhere"}))
+    assert _refuse(tree).code == pbir.PAGE_ID_MISMATCH
+
+
+def test_duplicate_page_id_in_page_order_refuses(tree: tuple[Path, Path]) -> None:
+    pages = tree[1] / "definition" / "pages" / "pages.json"
+    _patch_json(pages, lambda doc: doc.update({"pageOrder": ["p_first", "p_first"]}))
+    assert _refuse(tree).code == pbir.PAGE_ORDER_MALFORMED
+
+
+def test_active_page_outside_page_order_refuses(tree: tuple[Path, Path]) -> None:
+    pages = tree[1] / "definition" / "pages" / "pages.json"
+    _patch_json(pages, lambda doc: doc.update({"activePageName": "p_nowhere"}))
+    assert _refuse(tree).code == pbir.PAGE_ORDER_MALFORMED
+
+
+def test_duplicate_visual_document_id_across_pages_refuses(tree: tuple[Path, Path]) -> None:
+    """Uniqueness is report-wide: a per-page check passes this tree and is a real defect class."""
+    target = tree[1] / "definition" / "pages" / "p_second" / "visuals" / "another-1" / "visual.json"
+    _patch_json(target, lambda doc: doc.update({"name": "v01"}))
+    assert _refuse(tree).code == pbir.VISUAL_ID_DUPLICATE
+
+
+def test_empty_visual_document_id_refuses(tree: tuple[Path, Path]) -> None:
+    target = tree[1] / "definition" / "pages" / "p_first" / "visuals" / "another-0" / "visual.json"
+    _patch_json(target, lambda doc: doc.update({"name": "   "}))
+    assert _refuse(tree).code == pbir.JSON_TYPE
+
+
+def test_unknown_file_in_the_report_root_refuses(tree: tuple[Path, Path]) -> None:
+    _write(tree[1] / "mobileState.json", {"unknown": True})
+    assert _refuse(tree).code == pbir.ENTRY_UNKNOWN
+
+
+def test_unknown_directory_in_the_definition_refuses(tree: tuple[Path, Path]) -> None:
+    _write(tree[1] / "definition" / "bookmarks" / "b1.json", {"unknown": True})
+    assert _refuse(tree).code == pbir.ENTRY_UNKNOWN
+
+
+def test_unknown_file_beside_a_visual_refuses(tree: tuple[Path, Path]) -> None:
+    _write(tree[1] / "definition" / "pages" / "p_first" / "visuals" / "another-0" / "mobile.json", {})
+    assert _refuse(tree).code == pbir.ENTRY_UNKNOWN
+
+
+def test_loose_file_directly_inside_visuals_refuses(tree: tuple[Path, Path]) -> None:
+    _write(tree[1] / "definition" / "pages" / "p_first" / "visuals" / "stray.json", {})
+    assert _refuse(tree).code == pbir.ENTRY_UNKNOWN
+
+
+def test_unknown_model_definition_entry_refuses(tree: tuple[Path, Path]) -> None:
+    _write(tree[0] / "Demo.SemanticModel" / "definition" / "queryGroups.tmdl", "queryGroup x\n")
+    assert _refuse(tree).code == pbir.ENTRY_UNKNOWN
+
+
+def test_non_tmdl_file_in_a_model_object_folder_refuses(tree: tuple[Path, Path]) -> None:
+    _write(tree[0] / "Demo.SemanticModel" / "definition" / "tables" / "Sales.json", {})
+    assert _refuse(tree).code == pbir.ENTRY_UNKNOWN
+
+
+def test_missing_model_definition_refuses(tree: tuple[Path, Path]) -> None:
+    shutil.rmtree(tree[0] / "Demo.SemanticModel" / "definition")
+    assert _refuse(tree).code == pbir.ENTRY_MISSING
+
+
+def test_unknown_pages_metadata_key_refuses(tree: tuple[Path, Path]) -> None:
+    pages = tree[1] / "definition" / "pages" / "pages.json"
+    _patch_json(pages, lambda doc: doc.update({"futureField": 1}))
+    assert _refuse(tree).code == pbir.ENTRY_UNKNOWN
+
+
+def test_page_order_of_the_wrong_type_refuses(tree: tuple[Path, Path]) -> None:
+    pages = tree[1] / "definition" / "pages" / "pages.json"
+    _patch_json(pages, lambda doc: doc.update({"pageOrder": [{"name": "p_first"}, {"name": "p_second"}]}))
+    assert _refuse(tree).code == pbir.PAGE_ORDER_MALFORMED
+
+
+def test_duplicate_json_key_in_the_pbip_refuses(tree: tuple[Path, Path]) -> None:
+    """`json.load` keeps the last duplicate silently - two different readers would disagree."""
+    (tree[0] / "Demo.pbip").write_text(
+        '{"version": "1.0", "artifacts": [{"report": {"path": "Demo.Report"}}], "version": "9.9"}',
+        encoding="utf-8",
+    )
+    assert _refuse(tree).code == pbir.JSON_DUPLICATE_KEY
+
+
+def test_duplicate_json_key_in_the_pbir_refuses(tree: tuple[Path, Path]) -> None:
+    (tree[1] / "definition.pbir").write_text(
+        '{"datasetReference": {"byPath": {"path": "../Demo.SemanticModel"}},'
+        ' "datasetReference": {"byPath": {"path": "../Other.SemanticModel"}}}',
+        encoding="utf-8",
+    )
+    assert _refuse(tree).code == pbir.JSON_DUPLICATE_KEY
+
+
+def test_malformed_json_refuses(tree: tuple[Path, Path]) -> None:
+    (tree[1] / "definition" / "report.json").write_text('{"themeCollection":', encoding="utf-8")
+    assert _refuse(tree).code == pbir.JSON_MALFORMED
+
+
+def test_non_object_json_root_refuses(tree: tuple[Path, Path]) -> None:
+    (tree[1] / "definition" / "version.json").write_text("[]", encoding="utf-8")
+    assert _refuse(tree).code == pbir.JSON_TYPE
+
+
+def test_non_json_constant_refuses(tree: tuple[Path, Path]) -> None:
+    """`NaN`/`Infinity` are Python extensions, not JSON - Power BI would not round-trip them."""
+    (tree[1] / "definition" / "version.json").write_text('{"version": NaN}', encoding="utf-8")
+    assert _refuse(tree).code == pbir.JSON_MALFORMED
+
+
+def test_dangling_registered_resource_refuses(tree: tuple[Path, Path]) -> None:
+    (tree[1] / "StaticResources" / "RegisteredResources" / "theme.json").unlink()
+    assert _refuse(tree).code == pbir.RESOURCE_DANGLING
+
+
+def test_registered_resource_escaping_the_package_refuses(tree: tuple[Path, Path]) -> None:
+    report_json = tree[1] / "definition" / "report.json"
+    _patch_json(
+        report_json, lambda doc: doc["resourcePackages"][1]["items"][0].update({"path": "C:/themes/theme.json"})
+    )
+    assert _refuse(tree).code == pbir.RESOURCE_MALFORMED
+
+
+def test_unregistered_resource_file_is_included_rather_than_refused(tree: tuple[Path, Path]) -> None:
+    """A file with no registration cannot break the render, so its bytes are covered, not refused."""
+    baseline = _establish(tree)
+    _write(tree[1] / "StaticResources" / "RegisteredResources" / "spare.json", {"spare": True})
+    revision = _establish(tree)
+    assert "Demo.Report/StaticResources/RegisteredResources/spare.json" in dict(revision.files)
+    assert revision.digest != baseline.digest
+
+
+def test_unknown_static_resource_directory_refuses(tree: tuple[Path, Path]) -> None:
+    _write(tree[1] / "StaticResources" / "FutureResources" / "x.json", {})
+    assert _refuse(tree).code == pbir.ENTRY_UNKNOWN
+
+
+# --- model binding -----------------------------------------------------------------------------
+
+
+def test_byconnection_binding_refuses(tree: tuple[Path, Path]) -> None:
+    pbir_file = tree[1] / "definition.pbir"
+    _patch_json(pbir_file, lambda doc: doc.update({"datasetReference": {"byConnection": {"connectionString": "x"}}}))
+    assert _refuse(tree).code == pbir.BINDING_REMOTE
+
+
+def test_binding_carrying_both_bypath_and_byconnection_refuses(tree: tuple[Path, Path]) -> None:
+    pbir_file = tree[1] / "definition.pbir"
+    _patch_json(
+        pbir_file,
+        lambda doc: doc.update(
+            {"datasetReference": {"byPath": {"path": "../Demo.SemanticModel"}, "byConnection": {"c": "x"}}}
+        ),
+    )
+    assert _refuse(tree).code == pbir.BINDING_REMOTE
+
+
+def test_empty_dataset_reference_refuses(tree: tuple[Path, Path]) -> None:
+    _patch_json(tree[1] / "definition.pbir", lambda doc: doc.update({"datasetReference": {}}))
+    assert _refuse(tree).code == pbir.BINDING_MALFORMED
+
+
+def test_binding_to_a_missing_model_refuses(tree: tuple[Path, Path]) -> None:
+    shutil.rmtree(tree[0] / "Demo.SemanticModel")
+    assert _refuse(tree).code == pbir.MODEL_UNRESOLVED
+
+
+def test_binding_to_the_report_itself_refuses(tree: tuple[Path, Path]) -> None:
+    _patch_json(tree[1] / "definition.pbir", lambda doc: doc.update({"datasetReference": {"byPath": {"path": "."}}}))
+    assert _refuse(tree).code == pbir.MODEL_NOT_A_MODEL
+
+
+def test_binding_to_a_directory_that_is_not_a_semantic_model_refuses(tree: tuple[Path, Path]) -> None:
+    (tree[0] / "NotAModel").mkdir()
+    _patch_json(
+        tree[1] / "definition.pbir", lambda doc: doc.update({"datasetReference": {"byPath": {"path": "../NotAModel"}}})
+    )
+    assert _refuse(tree).code == pbir.MODEL_NOT_A_MODEL
+
+
+def test_binding_to_a_model_outside_the_fabric_root_refuses(tmp_path: Path) -> None:
+    fabric, report = _build(tmp_path)
+    outside = tmp_path / "shared" / "Demo.SemanticModel"
+    shutil.copytree(fabric / "Demo.SemanticModel", outside)
+    shutil.rmtree(fabric / "Demo.SemanticModel")
+    _patch_json(
+        report / "definition.pbir",
+        lambda doc: doc.update({"datasetReference": {"byPath": {"path": "../../shared/Demo.SemanticModel"}}}),
+    )
+    refusal = _refuse((fabric, report))
+    assert refusal.code == pbir.MODEL_NOT_CONTAINED
+    assert refusal.evidence == (pbir.OPAQUE_MODEL,)
+
+
+def test_backslash_binding_spelling_refuses(tree: tuple[Path, Path]) -> None:
+    _patch_json(
+        tree[1] / "definition.pbir",
+        lambda doc: doc.update({"datasetReference": {"byPath": {"path": "..\\Demo.SemanticModel"}}}),
+    )
+    assert _refuse(tree).code == pbir.BINDING_MALFORMED
+
+
+# --- pbip relation -----------------------------------------------------------------------------
+
+
+def test_fabric_root_without_a_pbip_refuses(tree: tuple[Path, Path]) -> None:
+    (tree[0] / "Demo.pbip").unlink()
+    refusal = _refuse(tree)
+    assert refusal.code == pbir.PBIP_ABSENT
+    assert refusal.evidence == (pbir.OPAQUE_ROOT,)
+
+
+def test_pbip_declaring_a_different_report_refuses(tree: tuple[Path, Path]) -> None:
+    _patch_json(tree[0] / "Demo.pbip", lambda doc: doc.update({"artifacts": [{"report": {"path": "Other.Report"}}]}))
+    assert _refuse(tree).code == pbir.PBIP_REPORT_UNRELATED
+
+
+def test_two_pbips_declaring_the_same_report_refuse(tree: tuple[Path, Path]) -> None:
+    _write(tree[0] / "Copy.pbip", {"version": "1.0", "artifacts": [{"report": {"path": "Demo.Report"}}]})
+    refusal = _refuse(tree)
+    assert refusal.code == pbir.PBIP_REPORT_AMBIGUOUS
+    assert refusal.evidence == ("Copy.pbip", "Demo.pbip")
+
+
+def test_a_directory_named_like_a_pbip_refuses(tree: tuple[Path, Path]) -> None:
+    """A `.pbip` that is a directory is not a project file, and must not be read as one."""
+    (tree[0] / "Fake.pbip").mkdir()
+    assert _refuse(tree).code == pbir.ENTRY_TYPE
+
+
+def test_pbip_with_an_unknown_artifact_kind_refuses(tree: tuple[Path, Path]) -> None:
+    _patch_json(tree[0] / "Demo.pbip", lambda doc: doc["artifacts"].append({"dataset": {"path": "Demo.SemanticModel"}}))
+    assert _refuse(tree).code == pbir.PBIP_MALFORMED
+
+
+def test_pbip_with_an_absolute_report_path_refuses(tree: tuple[Path, Path]) -> None:
+    _patch_json(
+        tree[0] / "Demo.pbip", lambda doc: doc.update({"artifacts": [{"report": {"path": "C:/x/Demo.Report"}}]})
+    )
+    assert _refuse(tree).code == pbir.PBIP_MALFORMED
+
+
+# --- caller-supplied targets --------------------------------------------------------------------
+
+
+def test_report_outside_the_fabric_root_refuses(tmp_path: Path) -> None:
+    fabric, report = _build(tmp_path)
+    elsewhere = tmp_path / "elsewhere"
+    shutil.copytree(report, elsewhere / "Demo.Report")
+    refusal = _refuse((fabric, elsewhere / "Demo.Report"))
+    assert refusal.code == pbir.REPORT_NOT_CONTAINED
+    assert refusal.evidence == (pbir.OPAQUE_REPORT,)
+
+
+def test_a_target_that_is_not_a_report_directory_refuses(tree: tuple[Path, Path]) -> None:
+    refusal = _refuse((tree[0], tree[0] / "Demo.SemanticModel"))
+    assert refusal.code == pbir.REPORT_UNUSABLE
+
+
+def test_a_missing_report_directory_refuses(tree: tuple[Path, Path]) -> None:
+    assert _refuse((tree[0], tree[0] / "Absent.Report")).code == pbir.REPORT_UNUSABLE
+
+
+def test_a_missing_fabric_root_refuses(tmp_path: Path) -> None:
+    refusal = _refuse((tmp_path / "nope", tmp_path / "nope" / "Demo.Report"))
+    assert refusal.code == pbir.ROOT_UNUSABLE
+
+
+# --- alias / reparse identity --------------------------------------------------------------------
+
+
+@pytest.mark.skipif(os.name != "nt", reason="case-insensitive path aliasing is a Windows behaviour")
+def test_case_aliased_report_spelling_refuses(tree: tuple[Path, Path]) -> None:
+    """A case alias opens the same directory but is not the canonical spelling.
+
+    The #363 A1 audit measured Desktop preserving the caller's case in `currentFilePath`, so a
+    census that silently canonicalised case would let two spellings claim one identity.
+    """
+    fabric, report = tree
+    aliased = fabric / (report.name.replace(pbir.REPORT_SUFFIX, "").upper() + pbir.REPORT_SUFFIX)
+    assert aliased.is_dir(), "the alias must open the same directory for this control to mean anything"
+    refusal = _refuse((fabric, aliased))
+    assert refusal.code == pbir.PATH_IDENTITY_MISMATCH
+
+
+@pytest.mark.skipif(os.name != "nt", reason="case-insensitive path aliasing is a Windows behaviour")
+def test_a_lowercased_report_suffix_is_not_accepted_as_a_report(tree: tuple[Path, Path]) -> None:
+    """The `.Report` suffix is matched exactly; a case-folded spelling is a different name."""
+    fabric, report = tree
+    refusal = _refuse((fabric, fabric / report.name.replace(pbir.REPORT_SUFFIX, ".report")))
+    assert refusal.code == pbir.REPORT_UNUSABLE
+
+
+def _make_junction(link: Path, target: Path) -> bool:
+    result = subprocess.run(
+        ["cmd", "/c", "mklink", "/J", str(link), str(target)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+@pytest.mark.skipif(os.name != "nt", reason="junctions are a Windows reparse point")
+def test_report_reached_through_a_junction_refuses(tmp_path: Path) -> None:
+    fabric, report = _build(tmp_path)
+    link = fabric / "Alias.Report"
+    if not _make_junction(link, report):
+        pytest.skip("mklink /J unavailable on this host")
+    refusal = _refuse((fabric, link))
+    assert refusal.code in {pbir.PATH_REPARSE, pbir.PATH_IDENTITY_MISMATCH}
+
+
+@pytest.mark.skipif(os.name != "nt", reason="junctions are a Windows reparse point")
+def test_a_junction_inside_the_report_refuses(tmp_path: Path) -> None:
+    fabric, report = _build(tmp_path)
+    real = report / "definition" / "pages" / "p_first" / "visuals" / "another-0"
+    link = report / "definition" / "pages" / "p_first" / "visuals" / "aliased"
+    if not _make_junction(link, real):
+        pytest.skip("mklink /J unavailable on this host")
+    assert _refuse((fabric, report)).code == pbir.PATH_REPARSE
+
+
+# --------------------------------------------------------------------------------------------
+# Privacy: nothing shareable may carry an absolute path
+# --------------------------------------------------------------------------------------------
+
+
+def _shareable_text(result: object) -> str:
+    return "\n".join([repr(result), json.dumps(asdict(result), default=str)])
+
+
+def test_an_established_revision_leaks_no_absolute_path(tree: tuple[Path, Path]) -> None:
+    text = _shareable_text(_establish(tree))
+    assert str(tree[0]) not in text
+    assert tree[0].drive.lower() not in text.lower() if tree[0].drive else True
+    assert str(tree[0].parent.name) not in text
+
+
+@pytest.mark.parametrize(
+    "break_it",
+    [
+        pytest.param(
+            lambda fabric, report: (report / "definition" / "pages" / "p_first" / "page.json").unlink(),
+            id="missing-page",
+        ),
+        pytest.param(lambda fabric, report: (fabric / "Demo.pbip").unlink(), id="pbip-absent"),
+        pytest.param(lambda fabric, report: shutil.rmtree(fabric / "Demo.SemanticModel"), id="model-unresolved"),
+        pytest.param(lambda fabric, report: _write(report / "mobileState.json", {}), id="unknown-entry"),
+    ],
+)
+def test_a_refusal_leaks_no_absolute_path(tmp_path: Path, break_it) -> None:
+    fabric, report = _build(tmp_path)
+    break_it(fabric, report)
+    text = _shareable_text(_refuse((fabric, report)))
+    assert str(fabric) not in text
+    assert tmp_path.name not in text
+
+
+# --------------------------------------------------------------------------------------------
+# Corpus control - every committed report tree, against an exact expected table
+# --------------------------------------------------------------------------------------------
+
+
+def _committed_reports() -> list[str]:
+    listed = subprocess.run(
+        ["git", "ls-files", "*definition.pbir"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.split()
+    return sorted(str(Path(rel).parent).replace(os.sep, "/") for rel in listed)
+
+
+ESTABLISHING = tuple(
+    f"examples/{slug}/fabric"
+    for slug in (
+        "airline-alliance-activity",
+        "broadway-stage-to-screen",
+        "eea-urban-adaptation",
+        "electricity-per-capita",
+        "fast-fashion-impact",
+        "health-tracker",
+        "interactive-resume",
+        "price-of-prosperity",
+        "quadruple-axis-charts",
+        "sales-commission-model",
+        "shipping-kpis",
+        "spiraling-satellites",
+        "superstore-sales-performance",
+        "tale-of-100-entrepreneurs",
+        "telecommunications-analytics",
+        "wind-energy-utilization",
+    )
+) + ("fixtures/large-refresh/fabric",)
+
+#: Gate fixtures that deliberately ship a partial tree with no `.pbip`. They are not capture targets:
+#: Power BI Desktop opens the `.pbip`, so a root without one cannot be one. Listed explicitly so a
+#: fixture gaining a `.pbip` has to be re-classified rather than silently changing verdict.
+REFUSING = {
+    "tests/fixtures/check-gates-dirty/pbip/Admin_Insights_Starter": pbir.PBIP_ABSENT,
+    "tests/fixtures/check-unit-brownfield-partial-pbip/pbip/Admin_Insights_Starter": pbir.PBIP_ABSENT,
+    "tests/fixtures/check-unit-brownfield-rearranged/PowerBI": pbir.PBIP_ABSENT,
+    "tests/fixtures/check-unit-clean-integration/pbip/Book": pbir.PBIP_ABSENT,
+    "tests/fixtures/shared-datasource/external-broken/workbooks/sales-wb/fabric": pbir.PBIP_ABSENT,
+    "tests/fixtures/shared-datasource/external-resolves/workbooks/sales-wb/fabric": pbir.PBIP_ABSENT,
+    "tests/fixtures/shared-datasource/model-local/fabric": pbir.PBIP_ABSENT,
+    "tests/fixtures/shared-datasource/no-model/fabric": pbir.PBIP_ABSENT,
+}
+
+
+def test_every_committed_report_is_classified() -> None:
+    """A newly committed report tree must be classified here, not adopted by silence."""
+    reports = _committed_reports()
+    roots = {str(Path(report).parent).replace(os.sep, "/") for report in reports}
+    assert roots == set(ESTABLISHING) | set(REFUSING)
+    assert len(reports) == 25
+
+
+@pytest.mark.parametrize("root", ESTABLISHING)
+def test_committed_production_trees_establish(root: str) -> None:
+    fabric = REPO_ROOT / root
+    report = next(path for path in sorted(fabric.iterdir()) if path.name.endswith(".Report"))
+    revision = _establish((fabric, report))
+    assert revision.page_order
+    assert len(revision.pages) == len(revision.page_order)
+    assert dict(revision.files)
+
+
+@pytest.mark.parametrize("root", sorted(REFUSING))
+def test_committed_gate_fixtures_refuse_for_their_named_reason(root: str) -> None:
+    fabric = REPO_ROOT / root
+    report = next(path for path in sorted(fabric.iterdir()) if path.name.endswith(".Report"))
+    assert _refuse((fabric, report)).code == REFUSING[root]
+
+
+def test_committed_examples_agree_with_the_measured_identity_semantics() -> None:
+    """Page folder IS the page id; visual folder is NOT the visual id - both measured on the corpus."""
+    folder_differs = 0
+    pages = 0
+    for root in ESTABLISHING:
+        fabric = REPO_ROOT / root
+        report = next(path for path in sorted(fabric.iterdir()) if path.name.endswith(".Report"))
+        revision = _establish((fabric, report))
+        for page in revision.pages:
+            pages += 1
+            assert page.folder == page.page_id
+            folder_differs += sum(1 for visual in page.visuals if visual.folder != visual.document_id)
+    assert pages == 37
+    assert folder_differs == 133
+
+
+# --- corpus-derived binding controls -------------------------------------------------------------
+
+
+def _with_pbip(source: Path, destination: Path, relative_fabric: str = "") -> tuple[Path, Path]:
+    """Copy a committed fixture tree and add the `.pbip` it omits, to reach the binding rules."""
+    shutil.copytree(source, destination)
+    fabric = destination / relative_fabric if relative_fabric else destination
+    report = next(path for path in sorted(fabric.iterdir()) if path.name.endswith(".Report"))
+    _write(fabric / "Sales.pbip", {"version": "1.0", "artifacts": [{"report": {"path": report.name}}]})
+    return fabric, report
+
+
+@pytest.mark.parametrize(
+    ("fixture", "relative_fabric", "expected"),
+    [
+        ("tests/fixtures/shared-datasource/model-local/fabric", "", None),
+        ("tests/fixtures/shared-datasource/no-model/fabric", "", pbir.BINDING_MALFORMED),
+        (
+            "tests/fixtures/shared-datasource/external-resolves",
+            "workbooks/sales-wb/fabric",
+            pbir.MODEL_NOT_CONTAINED,
+        ),
+        (
+            "tests/fixtures/shared-datasource/external-broken",
+            "workbooks/sales-wb/fabric",
+            pbir.MODEL_UNRESOLVED,
+        ),
+    ],
+)
+def test_committed_shared_datasource_shapes_route_to_the_right_binding_verdict(
+    tmp_path: Path, fixture: str, relative_fabric: str, expected: str | None
+) -> None:
+    """The shared-datasource fixtures are the repo's real binding corpus once given a `.pbip`.
+
+    `external-resolves` is the load-bearing one: the model EXISTS and the binding resolves, and it is
+    still refused, because it lives outside the fabric root the caller declared. A local capture
+    cannot be established from a root that does not contain its own model.
+    """
+    target = _with_pbip(REPO_ROOT / fixture, tmp_path / "copy", relative_fabric)
+    result = pbir.establish_revision(*target)
+    if expected is None:
+        assert isinstance(result, pbir.PbirRevision)
+    else:
+        assert isinstance(result, pbir.RevisionRefusal)
+        assert result.code == expected


### PR DESCRIPTION
Slice **A1a** of #363 and nothing else.

## Invariant

Given an already-selected local `fabric/` root and ONE report artifact, produce a strict typed
PBIR/model artifact census plus a deterministic revision digest, **or an explicit refusal**.

Out of scope by construction (later slices): package-manifest selection, Desktop/bridge/PID,
`reload`, screenshots, iterations, receipts, comparison, sign-off. This module has no live evidence,
so it can never claim Desktop LOADED these bytes - the independent A1 audit is explicit that a
disk-only check is not a loaded-revision oracle. Input is `(fabric_root, report_dir)` so A1b can
supply verified package roles later.

## API

```python
establish_revision(fabric_root, report_dir) -> PbirRevision | RevisionRefusal
```

`PbirRevision` carries `pbip/report/model/model_binding`, `page_order`, `pages` (each with folder,
document id, display name and visuals), a per-file SHA-256 map, the explicit `excluded` list with
reasons, and `digest`. `RevisionRefusal` carries a code, a detail and evidence. A refusal is
**falsy** and a revision **truthy**, so `if revision:` fails closed.

## Closed, not permissive

Every entry inside the report and the model is either **included**, **excluded by an explicit named
rule** (`.pbi/` local Desktop state, `TMDLScripts/` authoring scratch, volatile sidecars), or
**refused as unknown**. No `rglob("*")` anywhere.

The allow-lists are derived from the committed corpus, not assumed. Measured across
`examples/*/fabric` (16 reports, 36 pages, 869 visuals):

* page folder == `page.json.name` in **36/36** - the folder IS the page document id;
* visual folder != `visual.json.name` in **133/869** - the folder is NOT the visual id, so both are
  recorded and uniqueness is asserted **report-wide** on the document id;
* `fixtures/large-refresh` commits a page with **no** `visuals/`, so that is a census outcome
  (`visuals: ()`), not a refusal.

## Authority enforced

* `report_dir` contained under `fabric_root` **both lexically and resolved**, with no
  symlink/junction/reparse point on any component; a case alias refuses as `path_identity_mismatch`.
* Strict JSON everywhere it is load-bearing: duplicate keys, `NaN`/`Infinity` and non-object roots
  all refuse.
* Exactly one immediate `.pbip` declares this report (all are parsed, so a second claim cannot hide);
  zero -> `pbip_absent`, unrelated -> `pbip_report_unrelated`, two -> `pbip_report_ambiguous`.
* `definition.pbir` must hold exactly one **local, contained** `byPath` `.SemanticModel`;
  `byConnection`, zero/multiple bindings, dangling, report-target, escaping and backslash spellings
  all refuse.
* `pages.json.pageOrder` is the page-order authority; page directories must agree exactly
  (`page_missing` / `page_orphan`), `activePageName` must be a member.
* Report-level render bytes (`report.json`, `version.json`, pages metadata, `StaticResources`) and
  every deployable model definition byte (`.platform`, `definition.pbism`, TMDL/culture/
  relationships/expressions) are covered. A **dangling** registered resource refuses; an
  **unregistered** resource file is included instead, so its bytes still move the digest.
* Digest = SHA-256 over an explicit version tag plus length-delimited, sorted fabric-relative paths
  and raw bytes. Enumeration order cannot move it - proved at both layers.
* Every shareable field, refusal detail and evidence item is fabric-relative or an opaque token; no
  absolute path reaches `repr()`/`asdict()`.

## Controls (111 tests)

* **Corpus**: all 17 committed PBIP-bearing trees establish (**1231** files covered, 37 pages, 869
  visuals). The 8 committed gate fixtures with no `.pbip` refuse as `pbip_absent` - listed in an
  exact classification table, so a newly committed report shape must be classified rather than
  adopted by silence. The `shared-datasource` fixtures, given the `.pbip` they omit, are the real
  binding corpus: local -> establishes, absent model -> `model_unresolved`, resolvable-but-outside
  model -> `model_not_contained`, missing `datasetReference` -> `binding_malformed`.
* **Negative controls**, each asserting its OWN code: one-byte changes in `.pbip`/`definition.pbir`/
  report/page/visual/resource/`.platform`/`definition.pbism`/TMDL; missing `page.json`/`visual.json`;
  pageOrder mismatch/orphan/duplicate; duplicate page and visual document ids; wrong model target;
  `byConnection`; junction and case alias; unknown file/dir at every level; malformed types and
  duplicate JSON keys.
* **Mutation-tested**: 18 rule mutations applied to the module one at a time, **18/18 caught**, each
  by the test written for that rule. Two gaps this found and closed: the digest's own sort was
  unproven (the filesystem-level control was vacuous for it), and a `localSettings.json` name rule
  nothing exercised - removed rather than left as untested surface.

## Residuals

* A fabric root with **no** `.pbip` refuses. Desktop opens the `.pbip`, so such a root is not a local
  capture target - but it is why 8 committed gate fixtures refuse here.
* Unsupported-but-real shapes (`SharedResources/` on disk, `roles/`, `perspectives/`, bookmarks)
  refuse rather than being adopted. Widening is a deliberate edit with corpus evidence.
* `_is_reparse` answers `False` when `lstat` itself fails; the subsequent read/list then refuses.
* Disk-only: this proves what is on disk now, never that Desktop loaded it. That is A1b.

Refs #363. Draft - do not merge.
