### PR TITLE
fix: refuse an estate whose EMITTED tree breaks Desktop's path ceilings (Refs #564)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -162,6 +162,11 @@ EXPECTED_ENGINE_SKIP_REASONS_BY_NODEID: dict[str, str] = {
     "tests/test_harvest_download_watchdog.py::test_the_ceiling_constants_match_the_INSTALLED_engine": (
         "canonical engine not installed, so its constants cannot be read"
     ),
+    "tests/test_issue_194_long_pbir_path.py::test_the_emitted_long_case_stops_the_coordinator_before_its_first_"
+    "consumer": "deterministic tier not installed",
+    "tests/test_issue_194_long_pbir_path.py::test_the_emitted_short_control_passes_the_same_coordinator_gate": (
+        "deterministic tier not installed"
+    ),
     "tests/test_issue_194_long_pbir_path.py::test_the_engine_warning_is_asserted_only_where_it_was_established": (
         "deterministic tier not installed"
     ),

--- a/docs/windows-path-limits.md
+++ b/docs/windows-path-limits.md
@@ -359,6 +359,22 @@ because the right value depends on where the customer unpacks.
 (`docs/deterministic-tier-integration.md:414`) — though the estate bundle now has **66 files** past it.
 Pass `--ceiling 282` to test that budget.
 
+### Where `run_estate.py` applies this — the EMITTED tree, not only the projection
+
+The estate coordinator has always refused a run whose *projected* PBIR visual path breaks the ceiling,
+before conversion. That projection is fail-open by construction: it composes the canonical
+`pages/<id>/visuals/<id>` tail onto unit names knowable up front, and the path that actually breaches
+on the committed issue-194 repro is an **uncapped semantic-model table file** it never models —
+measured at **343 UTF-16 units** on canonical engine output, from a bundle whose projection passed.
+So `run_estate.py` also measures **what the engine really wrote**: immediately after the output receipt
+and baselines are recorded, and *before* provenance, handover slices, packaging, agent work or
+Desktop, it runs `check_path_ceiling.scan` (this module's walker and this page's 259/247 pair —
+nothing re-implemented) over the bundle, writes the report to `<bundle>/path-ceiling.json`, and returns
+`EXIT_PATH_CEILING` (10) when any emitted file, directory, or the walk itself says the tree is over the
+ceiling or cannot be assessed. The tight root budget stays **advisory** there, exactly as above. The
+output is **preserved as evidence** — never deleted, shortened or rewritten; permanent filename
+shortening is an upstream engine fix, and a refused bundle is what its report cites.
+
 ---
 
 ## 7. What the check deliberately does NOT do

--- a/docs/windows-path-limits.md
+++ b/docs/windows-path-limits.md
@@ -375,6 +375,14 @@ ceiling or cannot be assessed. The tight root budget stays **advisory** there, e
 output is **preserved as evidence** — never deleted, shortened or rewritten; permanent filename
 shortening is an upstream engine fix, and a refused bundle is what its report cites.
 
+That report is **published atomically** (serialize whole → per-process staging sibling → `os.replace`),
+so a full disk or an unserializable document cannot leave a truncated `path-ceiling.json` or destroy a
+previous trustworthy one; the refusal **outranks its own evidence**, so failing to persist the phase
+timings still exits 10; and both the report and the console line are **bundle-relative** —
+`<bundle>/pbip/…` — so a path-length report can be pasted into an upstream issue without carrying the
+run root, the account name or a customer folder with it. A path that cannot be *proven* inside the
+bundle is reported as an unassessable ordinal rather than echoed.
+
 ---
 
 ## 7. What the check deliberately does NOT do

--- a/scripts/run_estate.py
+++ b/scripts/run_estate.py
@@ -145,6 +145,7 @@ import argparse
 import json
 import logging
 import os
+import re
 import subprocess
 import sys
 import time
@@ -178,6 +179,7 @@ from check_path_ceiling import (
 )
 from check_path_ceiling import scan as scan_path_ceiling
 from engine_source import EngineNotFoundError, NonCanonicalEngineError, engine_provenance, resolve_engine
+from host_paths import discloses_host_location
 from manifest_scope import redact_host_paths
 from migration_bundle import ENGINE_RECEIPT, sha256_file, write_engine_receipt
 
@@ -225,6 +227,20 @@ SAFE_BUNDLE_ROOT = "<bundle>"
 #: echoed and never re-spelled as if it were relative: "I could not place this" is a different and
 #: honest answer, and echoing it is exactly the disclosure this transform exists to prevent.
 UNASSESSABLE_PATH = "<path-not-provably-inside-the-bundle-{index}>"
+
+#: The same answer for FREE-FORM text. A relative `--output` (`AcmeCorp-Confidential-FY26Q3\bundle`)
+#: names a customer as plainly as an absolute one and is invisible to every absolute-path predicate
+#: in this repo, so a message that cannot be proven free of a path keeps only its class and error
+#: code and is otherwise withheld under an ordinal.
+WITHHELD_DIAGNOSTIC = "<diagnostic-{index}-withheld: not provably free of a host path>"
+
+#: A whitespace-delimited token that still looks like a path, and a bare drive prefix.
+_SEPARATOR_TOKEN_RE = re.compile(r"\S*[\\/]\S*")
+_DRIVE_PREFIX_RE = re.compile(r"(?<![A-Za-z0-9])[A-Za-z]:")
+
+#: What may be kept from a withheld message: the leading exception class, and any error code.
+_DIAGNOSTIC_CLASS_RE = re.compile(r"^([A-Za-z_][A-Za-z0-9_.]*)\s*:")
+_DIAGNOSTIC_CODE_RE = re.compile(r"\b(errno|winerror)\b[\s:]*(-?\d+)", re.IGNORECASE)
 
 #: Where `scan()` records a single measured path, and where it records a list of them.
 _PATH_RECORD_KEYS = ("longest", "root_budget_binding")
@@ -776,16 +792,95 @@ def _ascii_path(value: str) -> str:
     return value.encode("ascii", "backslashreplace").decode("ascii")
 
 
-def _safe_diagnostic(exc: BaseException) -> str:
-    """`Type: message` for a log line, with any host location in the message redacted WHOLE.
+def _root_spellings(out_dir: Path) -> list[str]:
+    """Every spelling of THIS run's bundle root that could appear inside a diagnostic string.
 
-    An OS error message routinely embeds the path it failed on, which is the customer's absolute
-    path. `manifest_scope.redact_host_paths` is the repo's shipping redactor (built on
-    `host_paths.discloses_host_location`), so this asks the one question the rest of the repo asks
-    instead of inventing a second, weaker one.
+    An `--output` reaches an error message however the operator typed it, so the relative form, the
+    separator-normalised form and the canonical absolute form are all substituted - longest first,
+    so the absolute form is replaced before the relative substring inside it. Resolution is
+    best-effort: a root that cannot be resolved simply contributes fewer spellings, never an
+    exception, and anything left unproven is withheld by :func:`sanitize_diagnostic` anyway.
     """
-    cleaned, _hits = redact_host_paths(f"{type(exc).__name__}: {exc}")
-    return _ascii_path(str(cleaned))
+    raw = str(out_dir)
+    candidates = [raw, os.path.normpath(raw)]
+    try:
+        candidates.append(str(Path(raw).resolve()))
+    except (OSError, RuntimeError, ValueError):
+        pass
+    for candidate in list(candidates):
+        candidates.append(candidate.replace("\\", "/"))
+        candidates.append(candidate.replace("/", "\\"))
+    spellings = {candidate for candidate in candidates if candidate not in {"", ".", "/", "\\"}}
+    return sorted(spellings, key=len, reverse=True)
+
+
+def _is_shareable_diagnostic(text: str) -> bool:
+    """Whether free-form text can be PROVEN to carry no path except the bundle's own.
+
+    Two questions, and the second is the one the reviewer's reproduction needed: the repo's generic
+    predicate answers "is there an absolute host location in here", which a RELATIVE customer
+    directory passes untouched. So every whitespace-delimited token that still looks like a path -
+    it carries a separator, or a drive prefix - must already be rooted at the `<bundle>` marker.
+    Deliberately fail-closed: prose containing `and/or` is withheld rather than reasoned about.
+    """
+    if discloses_host_location(text):
+        return False
+    if any(SAFE_BUNDLE_ROOT not in token for token in _SEPARATOR_TOKEN_RE.findall(text)):
+        return False
+    return not _DRIVE_PREFIX_RE.search(text.replace(SAFE_BUNDLE_ROOT, ""))
+
+
+def _withheld_diagnostic(text: str, ordinal: int) -> str:
+    """What survives a message that could not be proven safe: class, error code, an ordinal.
+
+    Never the message. The class name and an `Errno`/`WinError` number are runtime facts about the
+    failure, carry no location, and are what makes the withheld line still actionable - "PermissionError
+    13" says what to check. Everything else is dropped rather than partially redacted, because a
+    partial redaction of free-form text is exactly the guess this correction exists to remove.
+    """
+    stripped = text.strip()
+    match = _DIAGNOSTIC_CLASS_RE.match(stripped)
+    parts = [match.group(1) if match else "diagnostic"]
+    parts += [f"{kind.title()} {number}" for kind, number in _DIAGNOSTIC_CODE_RE.findall(stripped)]
+    return f"{' '.join(parts)} {WITHHELD_DIAGNOSTIC.format(index=ordinal)}"
+
+
+def sanitize_diagnostic(text: object, spellings: list[str], ordinal: int) -> tuple[str, bool]:
+    """`(text safe to persist or print, was it withheld)` for one unstructured diagnostic string.
+
+    Order is the contract: the bundle root's own spellings are replaced with `<bundle>` FIRST - that
+    is the one root this process can prove, in whatever form the operator supplied it - and only the
+    remainder is judged. Generic host redaction still runs afterwards over the whole document
+    (`shareable_path_report`), so this narrows what reaches it rather than replacing it.
+    """
+    value = text if isinstance(text, str) else str(text)
+    for spelling in spellings:
+        value = re.sub(re.escape(spelling), SAFE_BUNDLE_ROOT, value, flags=re.IGNORECASE)
+    if _is_shareable_diagnostic(value):
+        return value, False
+    return _withheld_diagnostic(value, ordinal), True
+
+
+def _sanitized(text: object, spellings: list[str], withheld: list[str]) -> str:
+    """:func:`sanitize_diagnostic` with the run's withheld-ordinal counter threaded through it."""
+    value, was_withheld = sanitize_diagnostic(text, spellings, len(withheld) + 1)
+    if was_withheld:
+        withheld.append(value)
+    return value
+
+
+def _safe_diagnostic(exc: BaseException, out_dir: Path) -> str:
+    """A log line for one failure: the bundle root spelled `<bundle>`, anything unproven withheld.
+
+    ⚠️ Generic host-path detection only recognises ABSOLUTE locations, and a `--output` may be
+    RELATIVE - `AcmeCorp-Confidential-FY26Q3\\bundle` discloses a customer just as plainly and
+    survives every absolute-path predicate in this repo. So the bundle's own spellings are replaced
+    FIRST (that is the one root this call can prove), and only then is what remains judged; a
+    message that cannot be proven free of some other path keeps its class and error code and
+    nothing else.
+    """
+    text, _withheld = sanitize_diagnostic(f"{type(exc).__name__}: {exc}", _root_spellings(out_dir), 1)
+    return _ascii_path(text)
 
 
 def _bundle_relative(value: object, root: Path, unplaced: list[str]) -> str:
@@ -823,9 +918,13 @@ def shareable_path_report(report: dict, out_dir: Path) -> dict:
     because absolute length is exactly what Power BI Desktop counts.
     """
     root = Path(os.path.normpath(str(out_dir)))
+    spellings = _root_spellings(out_dir)
     unplaced: list[str] = []
+    withheld: list[str] = []
     shareable = dict(report)
     shareable["root"] = SAFE_BUNDLE_ROOT
+    if "scan_error" in shareable:
+        shareable["scan_error"] = _sanitized(shareable["scan_error"], spellings, withheld)
     for key in _PATH_RECORD_KEYS:
         record = shareable.get(key)
         if isinstance(record, dict):
@@ -837,7 +936,14 @@ def shareable_path_report(report: dict, out_dir: Path) -> dict:
                 dict(row, path=_bundle_relative(row.get("path"), root, unplaced)) if isinstance(row, dict) else row
                 for row in rows
             ]
+    shareable["unknown_paths"] = [
+        dict(row, reason=_sanitized(row["reason"], spellings, withheld))
+        if isinstance(row, dict) and "reason" in row
+        else row
+        for row in shareable.get("unknown_paths") or []
+    ]
     shareable["paths_not_placed"] = len(unplaced)
+    shareable["diagnostics_withheld"] = len(withheld)
     cleaned, redacted = redact_host_paths(shareable, prefix=PATH_CEILING_REPORT)
     cleaned["redacted_fields"] = sorted(redacted)
     return cleaned
@@ -893,7 +999,7 @@ def write_path_ceiling_report(out_dir: Path, report: dict) -> Path | None:
         os.replace(staging_path, final_path)
         swapped = True
     except (OSError, TypeError, ValueError) as exc:
-        log.warning("PATH CEILING: report not published (%s: %s)", type(exc).__name__, _safe_diagnostic(exc))
+        log.warning("PATH CEILING: report not published (%s)", _safe_diagnostic(exc, out_dir))
         return None
     finally:
         if not swapped:
@@ -1659,7 +1765,7 @@ def produce_and_gate_output(
         try:
             write_phase_record(args.output, phases)
         except (OSError, TypeError, ValueError) as exc:
-            log.warning("PATH CEILING: phase timings not persisted (%s)", _safe_diagnostic(exc))
+            log.warning("PATH CEILING: phase timings not persisted (%s)", _safe_diagnostic(exc, args.output))
         return report, EXIT_PATH_CEILING
     return report, EXIT_OK
 

--- a/scripts/run_estate.py
+++ b/scripts/run_estate.py
@@ -145,7 +145,6 @@ import argparse
 import json
 import logging
 import os
-import re
 import subprocess
 import sys
 import time
@@ -179,7 +178,6 @@ from check_path_ceiling import (
 )
 from check_path_ceiling import scan as scan_path_ceiling
 from engine_source import EngineNotFoundError, NonCanonicalEngineError, engine_provenance, resolve_engine
-from host_paths import discloses_host_location
 from manifest_scope import redact_host_paths
 from migration_bundle import ENGINE_RECEIPT, sha256_file, write_engine_receipt
 
@@ -228,19 +226,20 @@ SAFE_BUNDLE_ROOT = "<bundle>"
 #: honest answer, and echoing it is exactly the disclosure this transform exists to prevent.
 UNASSESSABLE_PATH = "<path-not-provably-inside-the-bundle-{index}>"
 
-#: The same answer for FREE-FORM text. A relative `--output` (`AcmeCorp-Confidential-FY26Q3\bundle`)
-#: names a customer as plainly as an absolute one and is invisible to every absolute-path predicate
-#: in this repo, so a message that cannot be proven free of a path keeps only its class and error
-#: code and is otherwise withheld under an ordinal.
-WITHHELD_DIAGNOSTIC = "<diagnostic-{index}-withheld: not provably free of a host path>"
+#: The same answer for a DIAGNOSTIC. Free-form text is not published or printed at all: a message
+#: is written by whatever raised it, so proving one carries no path means parsing prose, and the
+#: prefix-collision finding is what that costs (a root `…\bundle` "sanitised" a sibling
+#: `…\bundle-foreign` into `<bundle>-foreign`, inventing containment that does not exist). What is
+#: published instead is a stable code plus an ordinal, and - only for an exception this module
+#: caught itself - its class name and numeric code, read STRUCTURALLY off the object.
+SCAN_UNASSESSABLE_CODE = "scan-unassessable"
+UNKNOWN_PATH_CODE = "unknown-path-{index}"
 
-#: A whitespace-delimited token that still looks like a path, and a bare drive prefix.
-_SEPARATOR_TOKEN_RE = re.compile(r"\S*[\\/]\S*")
-_DRIVE_PREFIX_RE = re.compile(r"(?<![A-Za-z0-9])[A-Za-z]:")
-
-#: What may be kept from a withheld message: the leading exception class, and any error code.
-_DIAGNOSTIC_CLASS_RE = re.compile(r"^([A-Za-z_][A-Za-z0-9_.]*)\s*:")
-_DIAGNOSTIC_CODE_RE = re.compile(r"\b(errno|winerror)\b[\s:]*(-?\d+)", re.IGNORECASE)
+#: The operations this module may name in a log line. An allowlist, so a label is a constant of this
+#: file rather than anything derived from data.
+PUBLISH_REPORT_OPERATION = "publish-path-ceiling-report"
+WRITE_PHASE_RECORD_OPERATION = "write-phase-record"
+_ALLOWED_OPERATIONS = frozenset({PUBLISH_REPORT_OPERATION, WRITE_PHASE_RECORD_OPERATION})
 
 #: Where `scan()` records a single measured path, and where it records a list of them.
 _PATH_RECORD_KEYS = ("longest", "root_budget_binding")
@@ -792,95 +791,29 @@ def _ascii_path(value: str) -> str:
     return value.encode("ascii", "backslashreplace").decode("ascii")
 
 
-def _root_spellings(out_dir: Path) -> list[str]:
-    """Every spelling of THIS run's bundle root that could appear inside a diagnostic string.
+def _exception_facts(exc: BaseException) -> dict:
+    """The only things this module reports about an exception: class name and numeric codes.
 
-    An `--output` reaches an error message however the operator typed it, so the relative form, the
-    separator-normalised form and the canonical absolute form are all substituted - longest first,
-    so the absolute form is replaced before the relative substring inside it. Resolution is
-    best-effort: a root that cannot be resolved simply contributes fewer spellings, never an
-    exception, and anything left unproven is withheld by :func:`sanitize_diagnostic` anyway.
+    Read STRUCTURALLY off the object - never `str(exc)`, never a parse of it. A message belongs to
+    whoever raised it and routinely embeds the path it failed on; proving one carries no path means
+    reasoning about prose, which is precisely what the prefix-collision finding showed cannot be
+    done safely (a root `…\\bundle` rewrote a sibling `…\\bundle-foreign` into `<bundle>-foreign`).
+    A class name and an errno are runtime facts with no location in them, and they are enough to act
+    on: `PermissionError errno=13` says what to check.
     """
-    raw = str(out_dir)
-    candidates = [raw, os.path.normpath(raw)]
-    try:
-        candidates.append(str(Path(raw).resolve()))
-    except (OSError, RuntimeError, ValueError):
-        pass
-    for candidate in list(candidates):
-        candidates.append(candidate.replace("\\", "/"))
-        candidates.append(candidate.replace("/", "\\"))
-    spellings = {candidate for candidate in candidates if candidate not in {"", ".", "/", "\\"}}
-    return sorted(spellings, key=len, reverse=True)
+    facts: dict = {"class": type(exc).__name__}
+    for attribute in ("errno", "winerror"):
+        code = getattr(exc, attribute, None)
+        if isinstance(code, int):
+            facts[attribute] = code
+    return facts
 
 
-def _is_shareable_diagnostic(text: str) -> bool:
-    """Whether free-form text can be PROVEN to carry no path except the bundle's own.
-
-    Two questions, and the second is the one the reviewer's reproduction needed: the repo's generic
-    predicate answers "is there an absolute host location in here", which a RELATIVE customer
-    directory passes untouched. So every whitespace-delimited token that still looks like a path -
-    it carries a separator, or a drive prefix - must already be rooted at the `<bundle>` marker.
-    Deliberately fail-closed: prose containing `and/or` is withheld rather than reasoned about.
-    """
-    if discloses_host_location(text):
-        return False
-    if any(SAFE_BUNDLE_ROOT not in token for token in _SEPARATOR_TOKEN_RE.findall(text)):
-        return False
-    return not _DRIVE_PREFIX_RE.search(text.replace(SAFE_BUNDLE_ROOT, ""))
-
-
-def _withheld_diagnostic(text: str, ordinal: int) -> str:
-    """What survives a message that could not be proven safe: class, error code, an ordinal.
-
-    Never the message. The class name and an `Errno`/`WinError` number are runtime facts about the
-    failure, carry no location, and are what makes the withheld line still actionable - "PermissionError
-    13" says what to check. Everything else is dropped rather than partially redacted, because a
-    partial redaction of free-form text is exactly the guess this correction exists to remove.
-    """
-    stripped = text.strip()
-    match = _DIAGNOSTIC_CLASS_RE.match(stripped)
-    parts = [match.group(1) if match else "diagnostic"]
-    parts += [f"{kind.title()} {number}" for kind, number in _DIAGNOSTIC_CODE_RE.findall(stripped)]
-    return f"{' '.join(parts)} {WITHHELD_DIAGNOSTIC.format(index=ordinal)}"
-
-
-def sanitize_diagnostic(text: object, spellings: list[str], ordinal: int) -> tuple[str, bool]:
-    """`(text safe to persist or print, was it withheld)` for one unstructured diagnostic string.
-
-    Order is the contract: the bundle root's own spellings are replaced with `<bundle>` FIRST - that
-    is the one root this process can prove, in whatever form the operator supplied it - and only the
-    remainder is judged. Generic host redaction still runs afterwards over the whole document
-    (`shareable_path_report`), so this narrows what reaches it rather than replacing it.
-    """
-    value = text if isinstance(text, str) else str(text)
-    for spelling in spellings:
-        value = re.sub(re.escape(spelling), SAFE_BUNDLE_ROOT, value, flags=re.IGNORECASE)
-    if _is_shareable_diagnostic(value):
-        return value, False
-    return _withheld_diagnostic(value, ordinal), True
-
-
-def _sanitized(text: object, spellings: list[str], withheld: list[str]) -> str:
-    """:func:`sanitize_diagnostic` with the run's withheld-ordinal counter threaded through it."""
-    value, was_withheld = sanitize_diagnostic(text, spellings, len(withheld) + 1)
-    if was_withheld:
-        withheld.append(value)
-    return value
-
-
-def _safe_diagnostic(exc: BaseException, out_dir: Path) -> str:
-    """A log line for one failure: the bundle root spelled `<bundle>`, anything unproven withheld.
-
-    ⚠️ Generic host-path detection only recognises ABSOLUTE locations, and a `--output` may be
-    RELATIVE - `AcmeCorp-Confidential-FY26Q3\\bundle` discloses a customer just as plainly and
-    survives every absolute-path predicate in this repo. So the bundle's own spellings are replaced
-    FIRST (that is the one root this call can prove), and only then is what remains judged; a
-    message that cannot be proven free of some other path keeps its class and error code and
-    nothing else.
-    """
-    text, _withheld = sanitize_diagnostic(f"{type(exc).__name__}: {exc}", _root_spellings(out_dir), 1)
-    return _ascii_path(text)
+def _operation_failure(operation: str, exc: BaseException) -> str:
+    """One log line for a failure this module caught itself: allowlisted label, class, codes."""
+    label = operation if operation in _ALLOWED_OPERATIONS else "unlabelled-operation"
+    facts = _exception_facts(exc)
+    return " ".join([f"operation={label}"] + [f"{key}={value}" for key, value in facts.items()])
 
 
 def _bundle_relative(value: object, root: Path, unplaced: list[str]) -> str:
@@ -918,13 +851,9 @@ def shareable_path_report(report: dict, out_dir: Path) -> dict:
     because absolute length is exactly what Power BI Desktop counts.
     """
     root = Path(os.path.normpath(str(out_dir)))
-    spellings = _root_spellings(out_dir)
     unplaced: list[str] = []
-    withheld: list[str] = []
     shareable = dict(report)
     shareable["root"] = SAFE_BUNDLE_ROOT
-    if "scan_error" in shareable:
-        shareable["scan_error"] = _sanitized(shareable["scan_error"], spellings, withheld)
     for key in _PATH_RECORD_KEYS:
         record = shareable.get(key)
         if isinstance(record, dict):
@@ -936,14 +865,15 @@ def shareable_path_report(report: dict, out_dir: Path) -> dict:
                 dict(row, path=_bundle_relative(row.get("path"), root, unplaced)) if isinstance(row, dict) else row
                 for row in rows
             ]
+    # The walker's own `reason` is free-form text written by whatever raised it, so it is DROPPED
+    # rather than sanitized: what survives is the ordinal that identifies the row.
     shareable["unknown_paths"] = [
-        dict(row, reason=_sanitized(row["reason"], spellings, withheld))
-        if isinstance(row, dict) and "reason" in row
-        else row
-        for row in shareable.get("unknown_paths") or []
+        {"path": row.get("path"), "code": UNKNOWN_PATH_CODE.format(index=index)}
+        if isinstance(row, dict)
+        else {"code": UNKNOWN_PATH_CODE.format(index=index)}
+        for index, row in enumerate(shareable.get("unknown_paths") or [], start=1)
     ]
     shareable["paths_not_placed"] = len(unplaced)
-    shareable["diagnostics_withheld"] = len(withheld)
     cleaned, redacted = redact_host_paths(shareable, prefix=PATH_CEILING_REPORT)
     cleaned["redacted_fields"] = sorted(redacted)
     return cleaned
@@ -955,18 +885,17 @@ def scan_emitted_path_ceiling(out_dir: Path, limits: Limits | None = None) -> di
         return scan_path_ceiling(out_dir, limits or PATH_CEILING_LIMITS)
     except (OSError, RuntimeError, UnicodeError, ValueError) as exc:
         # `collect` already routes per-entry failures into `unknown_paths`; this is the walk itself
-        # failing outright. Reported in the SAME shape so the written report is readable either way.
-        # Raw here on purpose: `shareable_path_report` is the one place paths are made shareable, so
-        # pre-escaping the root would only stop it recognising the bundle it belongs to.
-        reason = f"{type(exc).__name__}: {exc}"
+        # failing outright. Reported as a CODE plus the exception's structural facts - never its
+        # message, which is written by whoever raised it and routinely quotes the path it failed on.
         return {
             "version": 1,
             "root": str(out_dir),
             "status": STATUS_UNKNOWN_PATHS,
-            "scan_error": reason,
+            "scan_error_code": SCAN_UNASSESSABLE_CODE,
+            "scan_error_facts": _exception_facts(exc),
             "counted": {"measured": 0, "files": 0, "directories": 0, "over_ceiling": 0, "unknown": 1},
             "worst_offenders": [],
-            "unknown_paths": [{"path": str(out_dir), "reason": reason}],
+            "unknown_paths": [{"path": str(out_dir)}],
         }
 
 
@@ -999,7 +928,7 @@ def write_path_ceiling_report(out_dir: Path, report: dict) -> Path | None:
         os.replace(staging_path, final_path)
         swapped = True
     except (OSError, TypeError, ValueError) as exc:
-        log.warning("PATH CEILING: report not published (%s)", _safe_diagnostic(exc, out_dir))
+        log.warning("PATH CEILING: report not published (%s)", _operation_failure(PUBLISH_REPORT_OPERATION, exc))
         return None
     finally:
         if not swapped:
@@ -1042,11 +971,13 @@ def path_ceiling_verdict(report: dict, written: Path | None) -> tuple[bool, str]
         )
     if report.get("status") == STATUS_UNKNOWN_PATHS:
         unknown = (report.get("unknown_paths") or [{}])[0]
-        reason = report.get("scan_error") or unknown.get("reason") or "no reason was recorded"
+        cause = report.get("scan_error_code") or unknown.get("code") or "no code was recorded"
+        facts = report.get("scan_error_facts") or {}
+        codes = "".join(f" {key}={value}" for key, value in facts.items())
         return False, (
             f"CANNOT ASSESS the emitted tree: {counted.get('unknown')} path(s) could not be "
-            f"measured - {reason} ({_ascii_path(str(unknown.get('path')))}). Unmeasurable is not "
-            f"clean, so nothing downstream may start from this tree.{where}{preserved}"
+            f"measured - {cause}{codes} ({_ascii_path(str(unknown.get('path')))}). Unmeasurable is "
+            f"not clean, so nothing downstream may start from this tree.{where}{preserved}"
         )
     if report.get("status") == STATUS_NO_PATHS:
         return False, (
@@ -1765,7 +1696,10 @@ def produce_and_gate_output(
         try:
             write_phase_record(args.output, phases)
         except (OSError, TypeError, ValueError) as exc:
-            log.warning("PATH CEILING: phase timings not persisted (%s)", _safe_diagnostic(exc, args.output))
+            log.warning(
+                "PATH CEILING: phase timings not persisted (%s)",
+                _operation_failure(WRITE_PHASE_RECORD_OPERATION, exc),
+            )
         return report, EXIT_PATH_CEILING
     return report, EXIT_OK
 

--- a/scripts/run_estate.py
+++ b/scripts/run_estate.py
@@ -82,7 +82,10 @@ things a conversation cannot be trusted to remember every time:
    consumer uses - immediately after the output is recorded and BEFORE provenance, handover slices,
    packaging, agents or Desktop. Over the ceiling, unmeasurable or unwalkable all return
    `EXIT_PATH_CEILING`; the output is preserved as evidence and never deleted or rewritten
-   (permanent filename shortening is an upstream engine fix).
+   (permanent filename shortening is an upstream engine fix). The verdict is published ATOMICALLY
+   (staging sibling + `os.replace`, so a failed write cannot destroy a previous report) and
+   SHAREABLE: what lands in `path-ceiling.json` and on the console is bundle-relative, carrying the
+   offending tail but never the run root, account or customer folder.
 
 Deliberately NOT here
 ---------------------
@@ -141,6 +144,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import subprocess
 import sys
 import time
@@ -174,6 +178,7 @@ from check_path_ceiling import (
 )
 from check_path_ceiling import scan as scan_path_ceiling
 from engine_source import EngineNotFoundError, NonCanonicalEngineError, engine_provenance, resolve_engine
+from manifest_scope import redact_host_paths
 from migration_bundle import ENGINE_RECEIPT, sha256_file, write_engine_receipt
 
 log = logging.getLogger("run_estate")
@@ -208,6 +213,22 @@ PATH_CEILING_REPORT = "path-ceiling.json"
 #: wherever the run happens. `min_root_budget` stays None, so the tight-root-budget number remains
 #: ADVISORY here - it is reported, never a refusal.
 PATH_CEILING_LIMITS = WINDOWS_LIMITS
+
+#: How a measured path is spelled once it leaves this process. The measurement itself keeps the
+#: absolute path (that is what Desktop counts), but a `path-ceiling.json` is shared upstream, pasted
+#: into an issue and read by an agent, so what is PERSISTED and PRINTED is bundle-relative: the
+#: refusal stays actionable (the offending tail is the whole point) while the run root - drive,
+#: account name, customer folder - never leaves the machine that measured it.
+SAFE_BUNDLE_ROOT = "<bundle>"
+
+#: A path the transform could not PROVE lies inside the bundle. It is reported as an ordinal, never
+#: echoed and never re-spelled as if it were relative: "I could not place this" is a different and
+#: honest answer, and echoing it is exactly the disclosure this transform exists to prevent.
+UNASSESSABLE_PATH = "<path-not-provably-inside-the-bundle-{index}>"
+
+#: Where `scan()` records a single measured path, and where it records a list of them.
+_PATH_RECORD_KEYS = ("longest", "root_budget_binding")
+_PATH_LIST_KEYS = ("worst_offenders", "near_ceiling_paths", "unknown_paths")
 VOLATILE_GENERATED_DIRS = {".pbi"}
 SCRATCH_DIRS = frozenset({"scratch", "_work", "_build", "_probe", "tmp", "temp", "_shots"})
 SCRATCH_INTENTS = frozenset(part.lstrip("._") for part in SCRATCH_DIRS)
@@ -755,6 +776,73 @@ def _ascii_path(value: str) -> str:
     return value.encode("ascii", "backslashreplace").decode("ascii")
 
 
+def _safe_diagnostic(exc: BaseException) -> str:
+    """`Type: message` for a log line, with any host location in the message redacted WHOLE.
+
+    An OS error message routinely embeds the path it failed on, which is the customer's absolute
+    path. `manifest_scope.redact_host_paths` is the repo's shipping redactor (built on
+    `host_paths.discloses_host_location`), so this asks the one question the rest of the repo asks
+    instead of inventing a second, weaker one.
+    """
+    cleaned, _hits = redact_host_paths(f"{type(exc).__name__}: {exc}")
+    return _ascii_path(str(cleaned))
+
+
+def _bundle_relative(value: object, root: Path, unplaced: list[str]) -> str:
+    """One measured path as `<bundle>/<tail>`, or an ordinal when containment cannot be PROVEN.
+
+    Purely lexical, and deliberately so: `Path.resolve()` on a UNC literal naming a host that does
+    not exist blocks on SMB name resolution (measured in `manifest_scope._inside_any`), and a path
+    that cannot be placed is unassessable regardless of what the filesystem would say.
+    """
+    text = value if isinstance(value, str) else str(value)
+    try:
+        candidate = Path(os.path.normpath(text))
+        if candidate.is_relative_to(root):
+            tail = candidate.relative_to(root).as_posix()
+            return SAFE_BUNDLE_ROOT if tail in {"", "."} else f"{SAFE_BUNDLE_ROOT}/{tail}"
+    except (OSError, ValueError):
+        pass
+    unplaced.append(text)
+    return UNASSESSABLE_PATH.format(index=len(unplaced))
+
+
+def shareable_path_report(report: dict, out_dir: Path) -> dict:
+    """The measurement as it may leave this machine: same numbers, no host location.
+
+    Two layers, and each closes what the other cannot:
+
+    * every field `scan()` fills with a measured path is rewritten bundle-relative, so the refusal
+      still names the offending tail (which IS the actionable part, and what an upstream report
+      needs) while the run root never appears;
+    * the whole document then goes through `manifest_scope.redact_host_paths`, the repo's
+      value-shaped shipping redactor, so a string this function does not know about - an OS error
+      message, an unknown-path reason, a future field - cannot carry a location past it either.
+
+    The measurement itself is untouched: `check_path_ceiling.scan` still measures absolute paths,
+    because absolute length is exactly what Power BI Desktop counts.
+    """
+    root = Path(os.path.normpath(str(out_dir)))
+    unplaced: list[str] = []
+    shareable = dict(report)
+    shareable["root"] = SAFE_BUNDLE_ROOT
+    for key in _PATH_RECORD_KEYS:
+        record = shareable.get(key)
+        if isinstance(record, dict):
+            shareable[key] = dict(record, path=_bundle_relative(record.get("path"), root, unplaced))
+    for key in _PATH_LIST_KEYS:
+        rows = shareable.get(key)
+        if isinstance(rows, list):
+            shareable[key] = [
+                dict(row, path=_bundle_relative(row.get("path"), root, unplaced)) if isinstance(row, dict) else row
+                for row in rows
+            ]
+    shareable["paths_not_placed"] = len(unplaced)
+    cleaned, redacted = redact_host_paths(shareable, prefix=PATH_CEILING_REPORT)
+    cleaned["redacted_fields"] = sorted(redacted)
+    return cleaned
+
+
 def scan_emitted_path_ceiling(out_dir: Path, limits: Limits | None = None) -> dict:
     """Measure the tree the engine ACTUALLY emitted. A failed measurement is never a clean one."""
     try:
@@ -762,6 +850,8 @@ def scan_emitted_path_ceiling(out_dir: Path, limits: Limits | None = None) -> di
     except (OSError, RuntimeError, UnicodeError, ValueError) as exc:
         # `collect` already routes per-entry failures into `unknown_paths`; this is the walk itself
         # failing outright. Reported in the SAME shape so the written report is readable either way.
+        # Raw here on purpose: `shareable_path_report` is the one place paths are made shareable, so
+        # pre-escaping the root would only stop it recognising the bundle it belongs to.
         reason = f"{type(exc).__name__}: {exc}"
         return {
             "version": 1,
@@ -770,25 +860,59 @@ def scan_emitted_path_ceiling(out_dir: Path, limits: Limits | None = None) -> di
             "scan_error": reason,
             "counted": {"measured": 0, "files": 0, "directories": 0, "over_ceiling": 0, "unknown": 1},
             "worst_offenders": [],
-            "unknown_paths": [{"path": _ascii_path(str(out_dir)), "reason": reason}],
+            "unknown_paths": [{"path": str(out_dir), "reason": reason}],
         }
 
 
 def write_path_ceiling_report(out_dir: Path, report: dict) -> Path | None:
-    """Persist the measurement beside the bundle it judges. Returns None if it could not be written."""
-    path = out_dir / PATH_CEILING_REPORT
+    """Publish the measurement beside the bundle it judges, ATOMICALLY. None if it was not written.
+
+    The order is the guarantee: the whole document is serialized to a string FIRST, then written to
+    a per-process staging sibling, flushed and fsynced, and only then `os.replace`d over the final
+    name. So a serialization error, a full disk or a torn write cannot leave a truncated
+    `path-ceiling.json` behind, and an existing report from a previous run stays byte-identical
+    rather than being destroyed by the very run that could not describe itself. On any failure only
+    THIS call's exact staging file is removed, best effort - never the report, never a sibling.
+
+    ⚠️ The pattern is deliberately the repo's existing one (`_abf._staged_image_write`,
+    `generated_edit_declarations._append_record`): unique-per-process staging name, `os.replace`,
+    staging removed when the swap did not happen. Neither is imported: `_append_record` is private
+    to another module, generates its own filename and injects its own `version`/`recorded_at` keys,
+    so its semantics do not fit publishing one named report - and `_abf` belongs to a skill bundle.
+    """
+    final_path = out_dir / PATH_CEILING_REPORT
+    staging_path = final_path.with_name(f"{final_path.name}.{os.getpid()}-{uuid.uuid4().hex}.tmp")
+    swapped = False
     try:
-        path.write_text(json.dumps(report, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+        # Serialize BEFORE touching the filesystem: a TypeError here must never have opened a file.
+        payload = json.dumps(report, indent=2, ensure_ascii=True) + "\n"
+        with open(staging_path, "w", encoding="utf-8", newline="\n") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(staging_path, final_path)
+        swapped = True
     except (OSError, TypeError, ValueError) as exc:
-        log.warning("PATH CEILING: report not written (%s: %s)", type(exc).__name__, exc)
+        log.warning("PATH CEILING: report not published (%s: %s)", type(exc).__name__, _safe_diagnostic(exc))
         return None
-    return path
+    finally:
+        if not swapped:
+            try:
+                staging_path.unlink()
+            except OSError:  # pragma: no cover - best effort by contract; the report is untouched
+                log.warning("PATH CEILING: staging file left behind: %s", staging_path.name)
+    return final_path
 
 
 def path_ceiling_verdict(report: dict, written: Path | None) -> tuple[bool, str]:
-    """Turn one measurement into (proceed, detail). Everything that is not clean refuses."""
+    """Turn one measurement into (proceed, detail). Everything that is not clean refuses.
+
+    ``report`` is the SHAREABLE view (:func:`shareable_path_report`), so every path this prints is
+    already bundle-relative. The report is named relatively too - the operator supplied ``--output``
+    and does not need it read back, while a console line is pasted into issues and chat.
+    """
     counted = report.get("counted") or {}
-    where = f" Report: {written}." if written else ""
+    where = f" Report: {SAFE_BUNDLE_ROOT}/{PATH_CEILING_REPORT}." if written else ""
     preserved = " The emitted output is PRESERVED as evidence - nothing was deleted or rewritten."
     if written is None:
         return False, (
@@ -838,9 +962,15 @@ def path_ceiling_verdict(report: dict, written: Path | None) -> tuple[bool, str]
 
 
 def check_emitted_path_ceiling(out_dir: Path, phases: list[dict], limits: Limits | None = None) -> tuple[bool, str]:
-    """Gate the ACTUAL engine output against Desktop's ceilings before anything consumes it."""
+    """Gate the ACTUAL engine output against Desktop's ceilings before anything consumes it.
+
+    The measurement is absolute (that is what Desktop counts); everything that LEAVES this call -
+    the published report and the printed verdict - is the bundle-relative, host-location-free view
+    built by :func:`shareable_path_report`.
+    """
     started = time.monotonic()
-    report = scan_emitted_path_ceiling(out_dir, limits)
+    measured = scan_emitted_path_ceiling(out_dir, limits)
+    report = shareable_path_report(measured, out_dir)
     written = write_path_ceiling_report(out_dir, report)
     proceed, detail = path_ceiling_verdict(report, written)
     phases.append(
@@ -1519,7 +1649,17 @@ def produce_and_gate_output(
     if not path_ok:
         # The timings are written even on a refusal, and they carry no later phase: the record IS
         # the evidence that nothing downstream started. The output tree itself is left untouched.
-        write_phase_record(args.output, phases)
+        #
+        # ⚠️ But the refusal OUTRANKS its own evidence. A bundle Power BI Desktop cannot open must
+        # still refuse when the timings cannot be persisted (a full disk, a read-only mount, an
+        # unserializable phase); returning EXIT_OK there - or letting the exception escape into the
+        # caller's traceback - would turn a path refusal into a run that continues or into a crash
+        # whose exit code says something else entirely. Only the write/serialization classes this
+        # repo already catches around a JSON write are absorbed; anything else still propagates.
+        try:
+            write_phase_record(args.output, phases)
+        except (OSError, TypeError, ValueError) as exc:
+            log.warning("PATH CEILING: phase timings not persisted (%s)", _safe_diagnostic(exc))
         return report, EXIT_PATH_CEILING
     return report, EXIT_OK
 

--- a/scripts/run_estate.py
+++ b/scripts/run_estate.py
@@ -72,6 +72,18 @@ things a conversation cannot be trusted to remember every time:
    prior full run already wrote), and `check_migration_progress.py` now tells the two cases apart -
    see its `NO_BASELINE_BY_DESIGN` state.
 
+8. **The pre-engine path projection is fail-open, so the EMITTED tree is measured too (issue #564).**
+   `preflight_estate_path_ceiling` projects the canonical PBIR visual tail onto names knowable before
+   conversion; the path that actually breaches on the committed issue-194 repro is an uncapped
+   SEMANTIC-MODEL table filename, which no pre-conversion projection here models. A bundle could
+   therefore pass the projection and still be one Power BI Desktop refuses to open, with every
+   signal green. `check_emitted_path_ceiling` measures what the engine really wrote - through
+   `check_path_ceiling.scan`, the same walker and the same measured 259/247 ceilings every other
+   consumer uses - immediately after the output is recorded and BEFORE provenance, handover slices,
+   packaging, agents or Desktop. Over the ceiling, unmeasurable or unwalkable all return
+   `EXIT_PATH_CEILING`; the output is preserved as evidence and never deleted or rewritten
+   (permanent filename shortening is an upstream engine fix).
+
 Deliberately NOT here
 ---------------------
 No migration logic. This never writes TMDL, never writes PBIR, never opens Power BI Desktop. It runs
@@ -150,7 +162,17 @@ from check_blank_placeholders import scan as scan_blank_placeholders
 from check_pbir_valid import REPORT_NAME as PBIR_VALID_REPORT
 from check_pbir_valid import render as render_pbir_valid
 from check_pbir_valid import scan as scan_pbir_validity
-from check_path_ceiling import DIR_CEILING, FILE_CEILING, utf16_len
+from check_path_ceiling import (
+    DIR_CEILING,
+    FILE_CEILING,
+    STATUS_NO_PATHS,
+    STATUS_OVER_CEILING,
+    STATUS_UNKNOWN_PATHS,
+    WINDOWS_LIMITS,
+    Limits,
+    utf16_len,
+)
+from check_path_ceiling import scan as scan_path_ceiling
 from engine_source import EngineNotFoundError, NonCanonicalEngineError, engine_provenance, resolve_engine
 from migration_bundle import ENGINE_RECEIPT, sha256_file, write_engine_receipt
 
@@ -174,6 +196,18 @@ EXIT_BUNDLE_REWRITE = 9
 EXIT_PATH_CEILING = 10
 GENERATED_ARTIFACTS_KEY = "generated_artifacts"
 SLICE_ONLY_COVERAGE = "slice_only_backfill"
+
+#: Where the post-engine path measurement lands inside the bundle, so a refusal is ATTRIBUTABLE to
+#: named paths rather than to a console line nobody kept. `path-ceiling.json` is the name this repo
+#: already uses for `check_path_ceiling.py --json` output (`check_unit.py` reads exactly that file),
+#: so the bundle carries one convention rather than a second private one.
+PATH_CEILING_REPORT = "path-ceiling.json"
+
+#: The MEASURED Desktop pair (259 file / 247 directory, UTF-16 code units), applied unconditionally:
+#: the question is "will the machine this bundle is shipped to open it", which is a Windows question
+#: wherever the run happens. `min_root_budget` stays None, so the tight-root-budget number remains
+#: ADVISORY here - it is reported, never a refusal.
+PATH_CEILING_LIMITS = WINDOWS_LIMITS
 VOLATILE_GENERATED_DIRS = {".pbi"}
 SCRATCH_DIRS = frozenset({"scratch", "_work", "_build", "_probe", "tmp", "temp", "_shots"})
 SCRATCH_INTENTS = frozenset(part.lstrip("._") for part in SCRATCH_DIRS)
@@ -681,6 +715,143 @@ def record_engine_output(out_dir: Path, report: dict | None, phases: list[dict],
     )
     log.info("ENGINE_OUTPUT_TREE: hashes -> %s", write_engine_output_tree(out_dir))
     write_receipt_phase(out_dir, phases, engine)
+
+
+# ---------------------------------------------------------------------------
+# The post-engine path-ceiling gate (issue #564)
+#
+# The pre-engine projection above (`preflight_estate_path_ceiling`) is a PROJECTION: it composes the
+# canonical PBIR visual tail onto unit names it can know BEFORE conversion. That is genuinely all it
+# can see, and it is fail-open by construction - measured on the committed issue-194 repro, the path
+# that actually breaches is a SEMANTIC-MODEL table file
+# (`<unit>.SemanticModel/definition/tables/<uncapped table name>`), which no pre-conversion
+# projection in this repo models. So an estate could pass the projection, emit a tree Power BI
+# Desktop cannot open, and hand it to packaging, agents and Desktop with every signal green.
+#
+# This gate answers the different question - "what did the engine ACTUALLY write?" - by measuring the
+# emitted tree with the SAME authority every other consumer uses (`check_path_ceiling.scan`, walker
+# and ceilings included; nothing here re-implements either). Python can write these paths, so the
+# tree exists; what must never happen is downstream work STARTING from it.
+#
+# Three rules, all deliberate:
+#   * it runs AFTER the engine's output is recorded (receipt + baselines) and BEFORE provenance,
+#     handover slices, packaging, agents and Desktop - so the refusal is early for consumers and
+#     late enough that the bundle still explains what built it;
+#   * where it cannot assess, it BLOCKS - an unreadable directory, an unmeasurable name, a walker
+#     failure or a tree with nothing in it is an indeterminate state, never a pass. That is the same
+#     rule the destructive-re-run barrier follows, for the same reason;
+#   * it NEVER deletes, shortens or rewrites the output. Permanent filename shortening belongs
+#     upstream in the engine; here the emitted tree is preserved as evidence for that report.
+# ---------------------------------------------------------------------------
+
+
+def _ascii_path(value: str) -> str:
+    """A console-safe rendering of a path that may carry astral or undecodable characters.
+
+    Output-only. The measurement itself is UTF-16 and belongs to `check_path_ceiling`; this exists
+    because a CP1252 console raises `UnicodeEncodeError` on the very paths a refusal has to name,
+    and a gate that crashes while printing its verdict has no verdict.
+    """
+    return value.encode("ascii", "backslashreplace").decode("ascii")
+
+
+def scan_emitted_path_ceiling(out_dir: Path, limits: Limits | None = None) -> dict:
+    """Measure the tree the engine ACTUALLY emitted. A failed measurement is never a clean one."""
+    try:
+        return scan_path_ceiling(out_dir, limits or PATH_CEILING_LIMITS)
+    except (OSError, RuntimeError, UnicodeError, ValueError) as exc:
+        # `collect` already routes per-entry failures into `unknown_paths`; this is the walk itself
+        # failing outright. Reported in the SAME shape so the written report is readable either way.
+        reason = f"{type(exc).__name__}: {exc}"
+        return {
+            "version": 1,
+            "root": str(out_dir),
+            "status": STATUS_UNKNOWN_PATHS,
+            "scan_error": reason,
+            "counted": {"measured": 0, "files": 0, "directories": 0, "over_ceiling": 0, "unknown": 1},
+            "worst_offenders": [],
+            "unknown_paths": [{"path": _ascii_path(str(out_dir)), "reason": reason}],
+        }
+
+
+def write_path_ceiling_report(out_dir: Path, report: dict) -> Path | None:
+    """Persist the measurement beside the bundle it judges. Returns None if it could not be written."""
+    path = out_dir / PATH_CEILING_REPORT
+    try:
+        path.write_text(json.dumps(report, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+    except (OSError, TypeError, ValueError) as exc:
+        log.warning("PATH CEILING: report not written (%s: %s)", type(exc).__name__, exc)
+        return None
+    return path
+
+
+def path_ceiling_verdict(report: dict, written: Path | None) -> tuple[bool, str]:
+    """Turn one measurement into (proceed, detail). Everything that is not clean refuses."""
+    counted = report.get("counted") or {}
+    where = f" Report: {written}." if written else ""
+    preserved = " The emitted output is PRESERVED as evidence - nothing was deleted or rewritten."
+    if written is None:
+        return False, (
+            "CANNOT ASSESS the emitted tree: its path-ceiling report could not be written into "
+            f"{report.get('root')}, so the verdict would not be attributable." + preserved
+        )
+    if report.get("status") == STATUS_OVER_CEILING:
+        offenders = report.get("worst_offenders") or []
+        binding = max(offenders, key=lambda record: record["length"] - record["ceiling"], default=None)
+        detail = (
+            f"binding {binding['kind']} is {binding['length']} UTF-16 units (ceiling "
+            f"{binding['ceiling']}): {_ascii_path(binding['path'])}"
+            if binding
+            else "no offender could be named"
+        )
+        return False, (
+            f"PATH CEILING: {counted.get('over_ceiling')} EMITTED path(s) exceed what Power BI "
+            f"Desktop will open - {detail}. LongPathsEnabled and \\\\?\\ prefixes do not make "
+            f"Desktop accept these paths, so nothing downstream may start from this tree.{where}"
+            f"{preserved} {_SHORT_ROOT_HINT}"
+        )
+    if report.get("status") == STATUS_UNKNOWN_PATHS:
+        unknown = (report.get("unknown_paths") or [{}])[0]
+        reason = report.get("scan_error") or unknown.get("reason") or "no reason was recorded"
+        return False, (
+            f"CANNOT ASSESS the emitted tree: {counted.get('unknown')} path(s) could not be "
+            f"measured - {reason} ({_ascii_path(str(unknown.get('path')))}). Unmeasurable is not "
+            f"clean, so nothing downstream may start from this tree.{where}{preserved}"
+        )
+    if report.get("status") == STATUS_NO_PATHS:
+        return False, (
+            f"CANNOT ASSESS the emitted tree: nothing was measured under {report.get('root')}. An "
+            f"output folder with no measurable path cannot be judged clean.{where}{preserved}"
+        )
+    advisory = ""
+    if report.get("root_budget_is_tight"):
+        advisory = (
+            f" ADVISORY: root budget {report.get('root_budget')} < "
+            f"{report.get('shipping_root_budget_advisory')} - this bundle tolerates only a short "
+            "installation root wherever it is shipped; not a refusal."
+        )
+    return True, (
+        f"PATH CEILING: {counted.get('measured')} emitted path(s) measured, none over Desktop's "
+        f"ceilings (file <= {report.get('file_ceiling')}, directory <= {report.get('dir_ceiling')})."
+        f"{where}{advisory}"
+    )
+
+
+def check_emitted_path_ceiling(out_dir: Path, phases: list[dict], limits: Limits | None = None) -> tuple[bool, str]:
+    """Gate the ACTUAL engine output against Desktop's ceilings before anything consumes it."""
+    started = time.monotonic()
+    report = scan_emitted_path_ceiling(out_dir, limits)
+    written = write_path_ceiling_report(out_dir, report)
+    proceed, detail = path_ceiling_verdict(report, written)
+    phases.append(
+        {
+            "phase": "path_ceiling",
+            "elapsed_sec": round(time.monotonic() - started, 1),
+            "status": report.get("status"),
+            "over_ceiling": (report.get("counted") or {}).get("over_ceiling"),
+        }
+    )
+    return proceed, detail
 
 
 # ---------------------------------------------------------------------------
@@ -1314,6 +1485,45 @@ def run_engine_phase(args: argparse.Namespace, engine: Path | None, phases: list
     return EXIT_OK
 
 
+def produce_and_gate_output(
+    args: argparse.Namespace, engine: Path | None, phases: list[dict]
+) -> tuple[dict | None, int]:
+    """Run the engine, baseline what it wrote, and refuse a tree nothing downstream may consume.
+
+    These three steps are ONE procedure, and the order is load-bearing in both directions:
+
+    * the baselines and receipt are recorded FIRST, so a bundle refused below still says what built
+      it - the receipt is exactly the evidence an upstream path-length report needs;
+    * the emitted tree is measured LAST, and before this function returns, so provenance, handover
+      slices, packaging, agent work and Desktop all sit behind it. The pre-engine projection cannot
+      see the paths the engine really writes (issue #564), so this is the only place where a bundle
+      Power BI Desktop refuses to open can still be stopped.
+
+    Returns ``(report, exit code)``; the report is None only when there was no output to read.
+    """
+    if not args.slice_only:
+        code = run_engine_phase(args, engine, phases)
+        if code != EXIT_OK:
+            # A failed engine has no output to judge, so nothing is measured and no path report is
+            # written - the engine's own verdict keeps precedence.
+            return None, code
+
+    report = read_report(args.output)
+    if not args.slice_only:
+        record_engine_output(args.output, report, phases, engine)
+    else:
+        backfill_slice_only_baseline(args.output, report, phases)
+
+    path_ok, path_detail = check_emitted_path_ceiling(args.output, phases)
+    print(path_detail)
+    if not path_ok:
+        # The timings are written even on a refusal, and they carry no later phase: the record IS
+        # the evidence that nothing downstream started. The output tree itself is left untouched.
+        write_phase_record(args.output, phases)
+        return report, EXIT_PATH_CEILING
+    return report, EXIT_OK
+
+
 class GateResults(NamedTuple):
     """Every independent verdict one estate run produces, in precedence order.
 
@@ -1415,17 +1625,10 @@ def main(argv: list[str] | None = None) -> int:
 
     record_bundle_rewrite_acknowledgement(rewrite)
 
-    # --- phase 1: the engine ------------------------------------------------------------------
-    if not args.slice_only:
-        code = run_engine_phase(args, engine, phases)
-        if code != EXIT_OK:
-            return code
-
-    report = read_report(args.output)
-    if not args.slice_only:
-        record_engine_output(args.output, report, phases, engine)
-    else:
-        backfill_slice_only_baseline(args.output, report, phases)
+    # --- phase 1 + 1a: the engine, its recorded output, and the ceilings that output must meet --
+    report, code = produce_and_gate_output(args, engine, phases)
+    if code != EXIT_OK:
+        return code
 
     # --- phase 1b: stamp where the inputs came from -------------------------------------------
     # The engine records the LOCAL half in input_manifest.json (name, size, sha256, staged path)

--- a/tests/test_expected_skips_gate.py
+++ b/tests/test_expected_skips_gate.py
@@ -416,7 +416,9 @@ def test_all_engine_dependent_tests_are_accounted_for() -> None:
     downloadable upstream long-path repro's A/B boundary controls and its root-length control),
     taking it to 33, and a 4th — the engine MAX_PATH warning's Windows-only provenance control,
     split out of the boundary test after both ubuntu engine jobs failed an unconditional
-    assertion — taking it to 34.
+    assertion — taking it to 34. Issue #564 then added the two coordinator controls that drive
+    `run_estate.py`'s post-engine path gate over the SAME emitted output (the long arm refused
+    before its first consumer, the short arm not refused), taking it to 36.
 
     The skip-reason classifier also treats the installed-engine-constants watchdog as engine-backed,
     so the engine jobs must run that one too instead of marking it NOT_CHECKED in the main job.

--- a/tests/test_issue_194_long_pbir_path.py
+++ b/tests/test_issue_194_long_pbir_path.py
@@ -31,6 +31,7 @@ import csv
 import hashlib
 import importlib.util
 import io
+import json
 import os
 import re
 import shutil
@@ -50,6 +51,7 @@ if str(SCRIPTS) not in sys.path:
 
 import engine_source  # noqa: E402  # pylint: disable=wrong-import-position
 import host_paths  # noqa: E402  # pylint: disable=wrong-import-position
+import run_estate  # noqa: E402  # pylint: disable=wrong-import-position
 
 FIXTURE = REPO / "fixtures" / "upstream-repros" / "issue-194-long-pbir-path"
 BUILDER = FIXTURE / "build_repro.py"
@@ -726,3 +728,94 @@ def test_the_short_control_stays_inside_both_ceilings_at_the_same_root(engine_ru
         f"the two cases emitted different structures ({short_case['files']}/{short_case['directories']} vs "
         f"{long_case['files']}/{long_case['directories']}); the A/B would then differ in more than names"
     )
+
+
+# -- engine-dependent: the coordinator refuses the REAL emitted tree (issue #564) ------------------
+#
+# `run_estate.py`'s PRE-conversion projection cannot see this: it composes the canonical PBIR visual
+# tail onto names knowable before conversion, and the offender the census above pins is a
+# semantic-model table file whose name the projection never models. These two tests therefore drive
+# the coordinator's POST-engine gate over the output the engine really wrote, reusing the session
+# fixture above so the engine runs no extra time.
+#
+# Both work on a COPY. The session fixture's tree is asserted on, entry by entry, by the tests above,
+# and a coordinator run writes its verdict into whatever bundle it judges - mutating the shared tree
+# would make those assertions order-dependent.
+
+
+def _copy_bundle(source: Path, base: Path, *, keep_root_length: bool) -> Path:
+    """Copy an emitted bundle so a coordinator run cannot mutate the shared session fixture.
+
+    ``keep_root_length`` pads the destination so the copy sits at a root at least as long as the
+    original: the verdict under test is a property of root + emitted tail, so a shorter destination
+    would quietly turn the long case legal and the test would pass for the wrong reason.
+    """
+    padding = measure_repro.utf16_len(str(source)) - measure_repro.utf16_len(str(base / "b"))
+    dest = base / ("b" + "d" * max(padding, 0)) if keep_root_length else base / "b"
+    shutil.copytree(source, dest)
+    return dest
+
+
+def _slice_only_run(bundle: Path, source_dir: Path, monkeypatch) -> tuple[int, list[Path]]:
+    """Run the coordinator over an EXISTING emitted bundle, with provenance as the sentinel.
+
+    ``--slice-only`` never invokes the engine (so the pre-conversion projection never runs, which is
+    the whole point here), while ``--input`` keeps the provenance stamp in the run - it is the first
+    consumer after the gate, so it is what proves the gate ran BEFORE anything downstream.
+    """
+    stamped: list[Path] = []
+    monkeypatch.setattr(run_estate, "stamp_inputs", lambda _input, out_dir: stamped.append(out_dir))
+    code = run_estate.main(["--slice-only", "--input", str(source_dir), "--output", str(bundle)])
+    return code, stamped
+
+
+@requires_engine
+def test_the_emitted_long_case_stops_the_coordinator_before_its_first_consumer(
+    engine_runs, tmp_path_factory: pytest.TempPathFactory, monkeypatch
+) -> None:
+    """The customer-visible #564 shape: engine exit 0, every gate green, a bundle Desktop cannot open."""
+    base = tmp_path_factory.mktemp("i194-gate-long")
+    bundle = _copy_bundle(engine_runs["cases"]["long"]["out_dir"], base, keep_root_length=True)
+    source = base / "in"
+    source.mkdir()
+    shutil.copy2(FIXTURE / LONG_ARCHIVE, source / LONG_ARCHIVE)
+
+    code, stamped = _slice_only_run(bundle, source, monkeypatch)
+
+    assert code == run_estate.EXIT_PATH_CEILING, (
+        f"the emitted tree was handed downstream on engine {engine_runs['version']}"
+    )
+    assert stamped == [], "provenance ran on a tree Power BI Desktop refuses to open"
+    report = json.loads((bundle / run_estate.PATH_CEILING_REPORT).read_text(encoding="utf-8"))
+    assert report["status"] == "over_ceiling"
+    offenders = report["worst_offenders"]
+    assert offenders, report
+    assert all(record["length"] > record["ceiling"] for record in offenders)
+    assert any(measure_repro.OFFENDER_FRAGMENT in record["path"].replace("\\", "/") for record in offenders), (
+        f"the offender moved off the semantic-model table file: {[record['path'] for record in offenders]}"
+    )
+    assert not (bundle / "handover").exists(), "handover slices were written from a refused tree"
+    assert (bundle / "report.json").is_file(), "the refused output must be preserved as evidence"
+
+
+@requires_engine
+def test_the_emitted_short_control_passes_the_same_coordinator_gate(
+    engine_runs, tmp_path_factory: pytest.TempPathFactory, monkeypatch
+) -> None:
+    """The false-positive control: the same command on the short arm must NOT stop at the path gate."""
+    base = tmp_path_factory.mktemp("i194-gate-short")
+    bundle = _copy_bundle(engine_runs["cases"]["short"]["out_dir"], base, keep_root_length=False)
+    source = base / "in"
+    source.mkdir()
+    shutil.copy2(FIXTURE / SHORT_ARCHIVE, source / SHORT_ARCHIVE)
+
+    code, stamped = _slice_only_run(bundle, source, monkeypatch)
+
+    report = json.loads((bundle / run_estate.PATH_CEILING_REPORT).read_text(encoding="utf-8"))
+    assert report["status"] == "ok", (
+        f"the short control measured {report['status']} at a {report['root_length']}-character root. "
+        "If its longest path is legal at a 22-unit root (asserted above) this means the RUNNER's "
+        "temporary directory is unusually long, not that the control regressed."
+    )
+    assert code != run_estate.EXIT_PATH_CEILING
+    assert stamped == [bundle], "the run stopped before provenance on a tree that is within the ceilings"

--- a/tests/test_run_estate.py
+++ b/tests/test_run_estate.py
@@ -7,6 +7,7 @@ defensible for that job. They are simply not safe for a CONSUMER, which is what 
 
 from __future__ import annotations
 
+import builtins
 import contextlib
 import io
 import json
@@ -27,6 +28,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
 import run_estate  # noqa: E402  # pylint: disable=wrong-import-position
 from check_path_ceiling import DIR_CEILING, FILE_CEILING, utf16_len  # noqa: E402
 from check_reference_readiness import engine_page_id  # noqa: E402
+from host_paths import discloses_host_location  # noqa: E402
 
 # These are imported ONLY to state ground truth for the composed CLI-evidence assertions below
 # (the reservation directory name, the manifest key, the verify state) - every actual allocation in
@@ -1934,7 +1936,15 @@ def test_an_over_ceiling_emitted_tree_refuses_before_any_consumer_sees_it(tmp_pa
     )
     assert match, f"the refusal did not name the binding path.\nprinted:\n{printed}"
     assert int(match.group("length")) > int(match.group("ceiling"))
-    assert Path(match.group("path")).exists(), "the refusal named a path that is not on disk"
+    named = match.group("path").rstrip(".")
+    assert named.startswith(f"{run_estate.SAFE_BUNDLE_ROOT}/"), (
+        f"the refusal named {named!r}, which is not the bundle-relative spelling"
+    )
+    tail = named[len(run_estate.SAFE_BUNDLE_ROOT) + 1 :]
+    assert (out / Path(tail)).is_file(), (
+        f"the refusal named {tail!r}, which is not a real path inside the bundle it judged"
+    )
+    assert str(out) not in printed and str(tmp_path) not in printed, "the refusal printed the absolute run root"
     assert stamped == [], "provenance ran on a tree Power BI Desktop cannot open"
     report = _path_report(out)
     assert report["status"] == "over_ceiling" and report["counted"]["over_ceiling"] >= 1
@@ -2155,3 +2165,211 @@ def test_a_tight_root_budget_is_reported_and_never_refuses() -> None:
     assert proceed is True, detail
     assert "ADVISORY: root budget 12" in detail, detail
     assert "not a refusal" in detail, detail
+
+
+# ---------------------------------------------------------------------------
+# The refusal's own evidence contract (blind-review findings on PR #587)
+#
+# Three properties of the REFUSAL, none of which is about path length:
+#   1. publishing the report is atomic - a failure cannot destroy a previous trustworthy one;
+#   2. exit 10 outranks its own evidence - failing to persist timings must not change the verdict;
+#   3. what is persisted and printed is SHAREABLE - bundle-relative, with no host location in it.
+# ---------------------------------------------------------------------------
+
+TRUSTWORTHY_REPORT = b'{"status": "ok", "written_by": "a previous run"}\n'
+
+#: A run root that is BOTH profile-shaped and carries a customer-identifying folder, so a leak of
+#: either half is detectable rather than inferred.
+SECRET_ACCOUNT = "j.doe"
+SECRET_FOLDER = "AcmeCorp-Confidential-FY26Q3"
+
+
+def _secret_rooted_bundle(tmp_path: Path) -> Path:
+    """A bundle whose ABSOLUTE path discloses an account name and a customer folder."""
+    out = tmp_path / "Users" / SECRET_ACCOUNT / SECRET_FOLDER / "bundle"
+    return _minimal_bundle(out)
+
+
+def _strings(payload) -> list[str]:
+    """Every string anywhere in a JSON document, keys included."""
+    if isinstance(payload, dict):
+        return [k for k in payload if isinstance(k, str)] + [s for v in payload.values() for s in _strings(v)]
+    if isinstance(payload, list):
+        return [s for v in payload for s in _strings(v)]
+    return [payload] if isinstance(payload, str) else []
+
+
+def _half_writing_open(monkeypatch, suffix: str = ".tmp") -> None:
+    """Make writes to `*<suffix>` fail after emitting half their bytes - a real partial write."""
+    real_open = builtins.open
+
+    class _HalfWriter:
+        def __init__(self, handle):
+            self._handle = handle
+
+        def write(self, text):
+            self._handle.write(text[: len(text) // 2])
+            raise OSError(28, "No space left on device")
+
+        def __getattr__(self, name):
+            return getattr(self._handle, name)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_exc):
+            self._handle.close()
+            return False
+
+    def _open(file, *args, **kwargs):
+        handle = real_open(file, *args, **kwargs)
+        return _HalfWriter(handle) if str(file).endswith(suffix) else handle
+
+    monkeypatch.setattr(builtins, "open", _open)
+
+
+def test_a_partial_write_leaves_the_previous_report_byte_identical(tmp_path: Path, monkeypatch) -> None:
+    """A full disk mid-write must not turn a trustworthy report into a truncated one."""
+    out = _minimal_bundle(tmp_path / "bundle")
+    previous = out / run_estate.PATH_CEILING_REPORT
+    previous.write_bytes(TRUSTWORTHY_REPORT)
+    _half_writing_open(monkeypatch)
+
+    written = run_estate.write_path_ceiling_report(out, {"status": "over_ceiling", "counted": {}})
+
+    assert written is None, "a partial write reported success"
+    assert previous.read_bytes() == TRUSTWORTHY_REPORT, "the previous report was destroyed by a failed write"
+    assert not list(out.glob("*.tmp")), "the staging file was left behind"
+
+
+def test_a_failed_swap_leaves_the_previous_report_byte_identical(tmp_path: Path, monkeypatch) -> None:
+    """The other half of atomicity: the write completed, the replace did not."""
+    out = _minimal_bundle(tmp_path / "bundle")
+    previous = out / run_estate.PATH_CEILING_REPORT
+    previous.write_bytes(TRUSTWORTHY_REPORT)
+
+    def _boom(*_args, **_kwargs):
+        raise OSError(13, "Permission denied")
+
+    monkeypatch.setattr(run_estate.os, "replace", _boom)
+
+    written = run_estate.write_path_ceiling_report(out, {"status": "over_ceiling", "counted": {}})
+
+    assert written is None
+    assert previous.read_bytes() == TRUSTWORTHY_REPORT
+    assert not list(out.glob("*.tmp")), "only this call's staging file may be removed, and it must be"
+
+
+def test_an_unserializable_report_never_opens_the_final_file(tmp_path: Path) -> None:
+    """Serialize FIRST: a document that cannot be rendered must not have truncated anything."""
+    out = _minimal_bundle(tmp_path / "bundle")
+    previous = out / run_estate.PATH_CEILING_REPORT
+    previous.write_bytes(TRUSTWORTHY_REPORT)
+
+    written = run_estate.write_path_ceiling_report(out, {"status": "ok", "when": object()})
+
+    assert written is None
+    assert previous.read_bytes() == TRUSTWORTHY_REPORT
+    assert not list(out.glob("*.tmp"))
+
+
+def test_a_path_refusal_survives_a_phase_record_failure(tmp_path: Path, monkeypatch) -> None:
+    """Exit 10 outranks its own evidence: unwritable timings are secondary to an unopenable bundle."""
+
+    def _boom(*_args, **_kwargs):
+        raise OSError(28, "No space left on device")
+
+    monkeypatch.setattr(run_estate, "write_phase_record", _boom)
+
+    code, printed, stamped, out = _emitted_run(tmp_path, monkeypatch, _ceilings(utf16_len(str(tmp_path)), 4096))
+
+    assert code == run_estate.EXIT_PATH_CEILING, printed
+    assert stamped == [], "provenance ran after a refusal whose timings could not be persisted"
+    assert not (out / "handover").exists(), "a later phase ran after the refusal"
+    assert not (out / "phase-timings.json").exists(), "the fixture did not actually block the write"
+
+
+def test_the_published_report_carries_no_host_location(tmp_path: Path, monkeypatch) -> None:
+    """The report is shared upstream, so the run root - account, customer folder - must not be in it."""
+    out = _secret_rooted_bundle(tmp_path)
+    monkeypatch.setattr(run_estate, "PATH_CEILING_LIMITS", _ceilings(utf16_len(str(tmp_path)), 4096))
+
+    proceed, detail = run_estate.check_emitted_path_ceiling(out, [])
+
+    assert proceed is False, detail
+    raw = (out / run_estate.PATH_CEILING_REPORT).read_text(encoding="utf-8")
+    payload = json.loads(raw)
+    assert SECRET_FOLDER not in raw and SECRET_ACCOUNT not in raw, "the report disclosed the run root"
+    assert str(out) not in raw
+    leaked = [value for value in _strings(payload) if discloses_host_location(value)]
+    assert leaked == [], f"the report carries host location(s): {leaked}"
+    assert payload["root"] == run_estate.SAFE_BUNDLE_ROOT
+    assert payload["worst_offenders"], payload
+    assert all(record["path"].startswith(f"{run_estate.SAFE_BUNDLE_ROOT}/") for record in payload["worst_offenders"])
+    assert any("pbip/Alpha" in record["path"] for record in payload["worst_offenders"]), (
+        "the relative tail was lost; the refusal has to stay actionable"
+    )
+
+
+def test_the_printed_refusal_carries_no_host_location(tmp_path: Path, monkeypatch) -> None:
+    """A console line is what gets pasted into an issue - it may not carry the customer's root.
+
+    ⚠️ The one drive-shaped string in the output is `_SHORT_ROOT_HINT`'s documented example command,
+    a CONSTANT of this repository shared with the pre-conversion refusal - not data from this run.
+    That is asserted directly rather than waved away, and everything else is judged strictly.
+    """
+    out = _secret_rooted_bundle(tmp_path)
+    monkeypatch.setattr(run_estate, "PATH_CEILING_LIMITS", _ceilings(utf16_len(str(tmp_path)), 4096))
+
+    _proceed, detail = run_estate.check_emitted_path_ceiling(out, [])
+
+    assert SECRET_FOLDER not in detail and SECRET_ACCOUNT not in detail, detail
+    assert str(out) not in detail and str(tmp_path) not in detail, detail
+    assert f"{run_estate.SAFE_BUNDLE_ROOT}/{run_estate.PATH_CEILING_REPORT}" in detail, (
+        "the report must be named relatively, not by its absolute path"
+    )
+    residue = detail.replace(run_estate._SHORT_ROOT_HINT, "")
+    assert not discloses_host_location(residue), residue
+
+
+def test_an_error_message_embedding_the_bundle_path_is_redacted_whole(tmp_path: Path, monkeypatch) -> None:
+    """An OS error routinely quotes the path it failed on - that path is the customer's."""
+    out = _secret_rooted_bundle(tmp_path)
+
+    def _boom(*_args, **_kwargs):
+        raise OSError(5, f"device is not ready: {out}")
+
+    monkeypatch.setattr(run_estate, "scan_path_ceiling", _boom)
+
+    proceed, detail = run_estate.check_emitted_path_ceiling(out, [])
+
+    assert proceed is False
+    raw = (out / run_estate.PATH_CEILING_REPORT).read_text(encoding="utf-8")
+    assert SECRET_FOLDER not in raw and SECRET_ACCOUNT not in raw, raw
+    assert SECRET_FOLDER not in detail and SECRET_ACCOUNT not in detail, detail
+    payload = json.loads(raw)
+    assert payload["redacted_fields"], "the closing redactor recorded no catch for a leaking error"
+    assert [value for value in _strings(payload) if discloses_host_location(value)] == []
+
+
+def test_a_path_outside_the_bundle_is_an_ordinal_not_an_echo(tmp_path: Path, monkeypatch) -> None:
+    """Containment that cannot be PROVEN is reported as unassessable, never echoed or faked relative."""
+    import check_path_ceiling  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
+
+    out = _minimal_bundle(tmp_path / "bundle")
+    foreign = tmp_path / "Users" / SECRET_ACCOUNT / SECRET_FOLDER / "elsewhere.json"
+    monkeypatch.setattr(
+        check_path_ceiling,
+        "collect",
+        lambda _root: ([], [{"path": str(foreign), "reason": "PermissionError: access is denied"}]),
+    )
+
+    proceed, detail = run_estate.check_emitted_path_ceiling(out, [])
+
+    assert proceed is False
+    raw = (out / run_estate.PATH_CEILING_REPORT).read_text(encoding="utf-8")
+    payload = json.loads(raw)
+    assert SECRET_FOLDER not in raw and SECRET_FOLDER not in detail, raw
+    assert payload["paths_not_placed"] == 1
+    assert payload["unknown_paths"][0]["path"] == run_estate.UNASSESSABLE_PATH.format(index=1)
+    assert "access is denied" in raw, "the reason itself was lost with the path"

--- a/tests/test_run_estate.py
+++ b/tests/test_run_estate.py
@@ -2008,10 +2008,15 @@ def test_a_walk_failure_cannot_report_a_clean_tree(tmp_path: Path, monkeypatch) 
         code = run_estate.main(_slice_only_argv(out))
 
     assert code == run_estate.EXIT_PATH_CEILING
-    assert "CANNOT ASSESS the emitted tree" in buffer.getvalue()
-    assert "device is not ready" in buffer.getvalue()
+    printed = buffer.getvalue()
+    assert "CANNOT ASSESS the emitted tree" in printed
+    assert run_estate.SCAN_UNASSESSABLE_CODE in printed and "class=OSError" in printed, printed
+    assert "device is not ready" not in printed, "a raw exception message was printed"
     report = _path_report(out)
-    assert report["status"] == "unknown_paths" and "OSError" in report["scan_error"]
+    assert report["status"] == "unknown_paths"
+    assert report["scan_error_code"] == run_estate.SCAN_UNASSESSABLE_CODE
+    assert report["scan_error_facts"]["class"] == "OSError" and report["scan_error_facts"]["errno"] == 5
+    assert "scan_error" not in report, "the free-form message is persisted again"
     assert not (out / "handover").exists(), "handover slices were written after a refusal"
 
 
@@ -2031,8 +2036,13 @@ def test_a_path_the_walker_could_not_measure_refuses(tmp_path: Path, monkeypatch
         code = run_estate.main(_slice_only_argv(out))
 
     assert code == run_estate.EXIT_PATH_CEILING
-    assert "access is denied" in buffer.getvalue(), buffer.getvalue()
-    assert _path_report(out)["status"] == "unknown_paths"
+    printed = buffer.getvalue()
+    assert run_estate.UNKNOWN_PATH_CODE.format(index=1) in printed, printed
+    assert "access is denied" not in printed, "the walker's free-form reason was printed"
+    report = _path_report(out)
+    assert report["status"] == "unknown_paths"
+    assert report["unknown_paths"][0]["code"] == run_estate.UNKNOWN_PATH_CODE.format(index=1)
+    assert "reason" not in report["unknown_paths"][0], "the free-form reason is persisted again"
 
 
 def test_an_output_tree_with_nothing_measurable_is_not_clean(tmp_path: Path) -> None:
@@ -2332,11 +2342,11 @@ def test_the_printed_refusal_carries_no_host_location(tmp_path: Path, monkeypatc
     assert not discloses_host_location(residue), residue
 
 
-def test_an_error_message_embedding_the_bundle_path_is_rewritten_not_echoed(tmp_path: Path, monkeypatch) -> None:
-    """An OS error routinely quotes the path it failed on - that path is the customer's.
+def test_an_error_message_embedding_the_bundle_path_is_never_persisted(tmp_path: Path, monkeypatch) -> None:
+    """An OS error routinely quotes the path it failed on - so its message is not published at all.
 
-    The bundle's own root is PROVEN, so it is rewritten to `<bundle>` rather than withheld: the
-    class, the errno and the failure text all survive, which is what makes the line worth keeping.
+    What survives is what can be read STRUCTURALLY off the exception: its class and its errno. There
+    is no rewriting step to get wrong, which is the whole point of the simplification.
     """
     out = _secret_rooted_bundle(tmp_path)
 
@@ -2351,10 +2361,11 @@ def test_an_error_message_embedding_the_bundle_path_is_rewritten_not_echoed(tmp_
     raw = (out / run_estate.PATH_CEILING_REPORT).read_text(encoding="utf-8")
     assert SECRET_FOLDER not in raw and SECRET_ACCOUNT not in raw, raw
     assert SECRET_FOLDER not in detail and SECRET_ACCOUNT not in detail, detail
+    assert "device is not ready" not in raw and "device is not ready" not in detail
     payload = json.loads(raw)
-    assert payload["diagnostics_withheld"] == 0, "a provable bundle root must be rewritten, not withheld"
-    assert run_estate.SAFE_BUNDLE_ROOT in payload["scan_error"], payload["scan_error"]
-    assert "device is not ready" in payload["scan_error"] and "OSError" in payload["scan_error"]
+    assert "scan_error" not in payload
+    assert payload["scan_error_code"] == run_estate.SCAN_UNASSESSABLE_CODE
+    assert payload["scan_error_facts"] == {"class": "OSError", "errno": 5}
     assert [value for value in _strings(payload) if discloses_host_location(value)] == []
 
 
@@ -2378,7 +2389,8 @@ def test_a_path_outside_the_bundle_is_an_ordinal_not_an_echo(tmp_path: Path, mon
     assert SECRET_FOLDER not in raw and SECRET_FOLDER not in detail, raw
     assert payload["paths_not_placed"] == 1
     assert payload["unknown_paths"][0]["path"] == run_estate.UNASSESSABLE_PATH.format(index=1)
-    assert "access is denied" in raw, "the reason itself was lost with the path"
+    assert payload["unknown_paths"][0]["code"] == run_estate.UNKNOWN_PATH_CODE.format(index=1)
+    assert "access is denied" not in raw, "the walker's free-form reason is persisted again"
 
 
 # ---------------------------------------------------------------------------
@@ -2400,7 +2412,10 @@ def _relative_bundle(monkeypatch, tmp_path: Path) -> Path:
 
 
 def test_a_relative_root_does_not_survive_in_the_persisted_scan_error(tmp_path: Path, monkeypatch) -> None:
-    """The reviewer's reproduction, on the report: a walk failure quoting a relative customer root."""
+    """The reviewer's reproduction, on the report: a walk failure quoting a relative customer root.
+
+    No rewriting: the message is not published at all. Its class and errno are.
+    """
     out = _relative_bundle(monkeypatch, tmp_path)
 
     def _boom(*_args, **_kwargs):
@@ -2415,8 +2430,9 @@ def test_a_relative_root_does_not_survive_in_the_persisted_scan_error(tmp_path: 
     payload = json.loads(raw)
     assert SECRET_FOLDER not in raw, raw
     assert SECRET_FOLDER not in detail, detail
-    assert run_estate.SAFE_BUNDLE_ROOT in payload["scan_error"]
-    assert "OSError" in payload["scan_error"] and "device is not ready" in payload["scan_error"]
+    assert "scan_error" not in payload, "a free-form message is persisted again"
+    assert payload["scan_error_code"] == run_estate.SCAN_UNASSESSABLE_CODE
+    assert payload["scan_error_facts"] == {"class": "OSError", "errno": 5}
 
 
 def test_a_relative_root_does_not_survive_in_an_unknown_path_reason(tmp_path: Path, monkeypatch) -> None:
@@ -2438,11 +2454,12 @@ def test_a_relative_root_does_not_survive_in_an_unknown_path_reason(tmp_path: Pa
     assert proceed is False
     raw = (out / run_estate.PATH_CEILING_REPORT).read_text(encoding="utf-8")
     payload = json.loads(raw)
-    reason = payload["unknown_paths"][0]["reason"]
+    row = payload["unknown_paths"][0]
     assert SECRET_FOLDER not in raw and SECRET_FOLDER not in detail, raw
-    assert f"{run_estate.SAFE_BUNDLE_ROOT}/pbip" in reason.replace("\\", "/"), reason
-    assert payload["unknown_paths"][0]["path"].startswith(run_estate.SAFE_BUNDLE_ROOT), payload["unknown_paths"]
-    assert "PermissionError" in reason
+    assert "reason" not in row, "the walker's free-form reason is persisted again"
+    assert row["code"] == run_estate.UNKNOWN_PATH_CODE.format(index=1)
+    # The structured half still names WHERE, because it was placed by true containment.
+    assert row["path"] == f"{run_estate.SAFE_BUNDLE_ROOT}/pbip", row
 
 
 def test_a_relative_root_does_not_survive_a_publication_failure_diagnostic(tmp_path: Path, monkeypatch, caplog) -> None:
@@ -2460,14 +2477,15 @@ def test_a_relative_root_does_not_survive_a_publication_failure_diagnostic(tmp_p
     assert written is None
     logged = "\n".join(record.getMessage() for record in caplog.records)
     assert SECRET_FOLDER not in logged, logged
-    assert run_estate.SAFE_BUNDLE_ROOT in logged, logged
-    assert "PermissionError" in logged and "Errno 13" in logged, (
-        f"the actionable class and error code were dropped with the path: {logged}"
+    assert "Permission denied" not in logged, "the exception's own message was logged"
+    assert f"operation={run_estate.PUBLISH_REPORT_OPERATION}" in logged, logged
+    assert "class=PermissionError" in logged and "errno=13" in logged, (
+        f"the actionable class and error code were dropped with the message: {logged}"
     )
 
 
-def test_a_foreign_relative_path_is_withheld_with_its_class_and_code(tmp_path: Path, monkeypatch) -> None:
-    """A path that is NOT the bundle cannot be proven safe, so the message goes - the facts stay."""
+def test_a_foreign_path_in_a_message_is_never_published_only_its_class_and_code(tmp_path: Path, monkeypatch) -> None:
+    """A path that is not the bundle's cannot be reasoned about - so no message is published at all."""
     out = _relative_bundle(monkeypatch, tmp_path)
 
     def _boom(*_args, **_kwargs):
@@ -2482,17 +2500,17 @@ def test_a_foreign_relative_path_is_withheld_with_its_class_and_code(tmp_path: P
     payload = json.loads(raw)
     assert "OtherCustomer" not in raw and "payroll" not in raw, raw
     assert "OtherCustomer" not in detail and "payroll" not in detail, detail
-    # Both unstructured fields carry the same offending text - `scan_error` and the walker's own
-    # reason - so both are withheld, each under its own ordinal.
-    assert payload["diagnostics_withheld"] == 2
-    assert payload["scan_error"].startswith("PermissionError"), payload["scan_error"]
-    assert "Errno 13" in payload["scan_error"], payload["scan_error"]
-    assert run_estate.WITHHELD_DIAGNOSTIC.format(index=1) in payload["scan_error"]
-    assert run_estate.WITHHELD_DIAGNOSTIC.format(index=2) in payload["unknown_paths"][0]["reason"]
+    assert "scan_error" not in payload
+    assert payload["scan_error_code"] == run_estate.SCAN_UNASSESSABLE_CODE
+    assert payload["scan_error_facts"] == {"class": "PermissionError", "errno": 13}
 
 
-def test_a_safe_message_keeps_its_text_class_and_code(tmp_path: Path, monkeypatch) -> None:
-    """The false-positive control: a message with no path at all must not be degraded."""
+def test_a_path_free_message_is_not_published_either(tmp_path: Path, monkeypatch) -> None:
+    """The control that used to justify keeping prose: even a harmless message is not published.
+
+    Its useful content survives structurally - `PermissionError`, `errno=13`, a stable code - which
+    is the whole trade this simplification makes: no parser, no rewriting, nothing to get wrong.
+    """
     out = _relative_bundle(monkeypatch, tmp_path)
 
     def _boom(*_args, **_kwargs):
@@ -2503,13 +2521,52 @@ def test_a_safe_message_keeps_its_text_class_and_code(tmp_path: Path, monkeypatc
     _proceed, detail = run_estate.check_emitted_path_ceiling(out, [])
 
     payload = json.loads((out / run_estate.PATH_CEILING_REPORT).read_text(encoding="utf-8"))
-    assert payload["diagnostics_withheld"] == 0, payload["scan_error"]
-    assert payload["scan_error"] == "OSError: [Errno 5] device is not ready", payload["scan_error"]
-    assert "device is not ready" in detail
+    assert "device is not ready" not in json.dumps(payload) and "device is not ready" not in detail
+    assert payload["scan_error_code"] == run_estate.SCAN_UNASSESSABLE_CODE
+    assert payload["scan_error_facts"] == {"class": "OSError", "errno": 5}
+    assert run_estate.SCAN_UNASSESSABLE_CODE in detail and "class=OSError" in detail
 
 
-def test_the_scan_verdict_and_structured_evidence_survive_sanitisation(tmp_path: Path, monkeypatch) -> None:
-    """Sanitising diagnostics must not weaken the verdict or the measured evidence beside it."""
+# -- the prefix collision that ended the substitution approach -------------------------------------
+#
+# A root of `…\bundle` shares a PREFIX with its siblings `…\bundle-foreign` and `…\bundle2`. Any
+# substring replacement rewrites those into `<bundle>-foreign` and `<bundle>2`, which reads as if
+# they were inside the bundle - inventing containment that does not exist, out of a customer path.
+# True path-component containment (`Path.is_relative_to`) refuses both, and there is no other path
+# handling left for a collision to reach.
+@pytest.mark.parametrize("sibling", ["bundle-foreign", "bundle2"])
+def test_a_prefix_sharing_sibling_is_never_read_as_inside_the_bundle(tmp_path: Path, monkeypatch, sibling: str) -> None:
+    import check_path_ceiling  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
+
+    out = _relative_bundle(monkeypatch, tmp_path)
+    foreign = out.parent / sibling / "payroll.twbx"
+    monkeypatch.setattr(
+        check_path_ceiling,
+        "collect",
+        lambda _root: ([], [{"path": str(foreign), "reason": f"PermissionError: cannot open {foreign}"}]),
+    )
+
+    proceed, detail = run_estate.check_emitted_path_ceiling(out, [])
+
+    assert proceed is False
+    raw = (out / run_estate.PATH_CEILING_REPORT).read_text(encoding="utf-8")
+    payload = json.loads(raw)
+    for text in (raw, detail):
+        assert sibling not in text, f"the sibling directory name leaked: {text}"
+        assert SECRET_FOLDER not in text, text
+        assert "payroll" not in text, text
+        assert f"{run_estate.SAFE_BUNDLE_ROOT}-" not in text and f"{run_estate.SAFE_BUNDLE_ROOT}2" not in text, (
+            "a prefix collision was rewritten as if it were inside the bundle"
+        )
+    assert payload["paths_not_placed"] == 1
+    assert payload["unknown_paths"][0]["path"] == run_estate.UNASSESSABLE_PATH.format(index=1)
+    assert payload["unknown_paths"][0]["code"] == run_estate.UNKNOWN_PATH_CODE.format(index=1)
+
+
+def test_the_scan_verdict_and_structured_evidence_survive_the_code_only_diagnostics(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Dropping free-form diagnostics must not weaken the verdict or the measured evidence beside it."""
     out = _relative_bundle(monkeypatch, tmp_path)
     monkeypatch.setattr(run_estate, "PATH_CEILING_LIMITS", _ceilings(1, 4096))
 
@@ -2519,7 +2576,7 @@ def test_the_scan_verdict_and_structured_evidence_survive_sanitisation(tmp_path:
     assert proceed is False
     assert payload["status"] == "over_ceiling"
     assert payload["counted"]["over_ceiling"] >= 1
-    assert payload["diagnostics_withheld"] == 0 and payload["paths_not_placed"] == 0
+    assert payload["paths_not_placed"] == 0
     offender = payload["worst_offenders"][0]
     assert offender["length"] > offender["ceiling"] and offender["kind"] in {"file", "directory"}
     assert offender["path"].startswith(f"{run_estate.SAFE_BUNDLE_ROOT}/")

--- a/tests/test_run_estate.py
+++ b/tests/test_run_estate.py
@@ -1854,3 +1854,304 @@ def test_a_dry_run_reports_the_refusal_and_never_writes_an_acknowledgement(tmp_p
     )
     assert calls == []
     assert not (out / run_estate.BUNDLE_REWRITE_RECORD).exists(), "a dry run must not write into the bundle"
+
+
+# ---------------------------------------------------------------------------
+# issue #564: the EMITTED tree, not the pre-conversion projection
+#
+# The projection above is fail-open by construction - it composes the canonical PBIR visual tail onto
+# names knowable BEFORE conversion, and the path that actually breaches on the committed issue-194
+# repro is an uncapped SEMANTIC-MODEL table filename it never models. These tests are about the
+# measurement of what the engine ACTUALLY wrote, and about WHERE it sits in the run: after the output
+# is recorded, before anything downstream consumes it.
+#
+# Long paths are never CREATED here, for the reason `tests/test_check_path_ceiling.py` states in its
+# own docstring: a stock Windows runner cannot create a 260-unit path at all, so the fixture rather
+# than the assertion would fail. A tight ceiling over a short tree walks the identical comparison
+# code. The shipped 259/247 pair is pinned separately, filesystem-free, below.
+# ---------------------------------------------------------------------------
+
+
+def _ceilings(file_ceiling: int, dir_ceiling: int) -> run_estate.Limits:
+    """Tight limits for a short tree - same code path, no unwritable fixture."""
+    return run_estate.Limits(file_ceiling=file_ceiling, dir_ceiling=dir_ceiling, warn_at=max(file_ceiling, 1) - 1)
+
+
+def _emitted_run(
+    tmp_path: Path,
+    monkeypatch,
+    limits: run_estate.Limits | None = None,
+) -> tuple[int, str, list[Path], Path]:
+    """A full run through `main` with the stand-in engine. Returns (code, stdout, provenance calls, bundle).
+
+    `stamp_inputs` is the SENTINEL: it is the first thing that runs after the gate, so a mutation that
+    deletes the gate or moves it later lets the sentinel fire on an over-ceiling tree.
+    """
+    _without_pbir_validator(monkeypatch)
+    engine = _versioned_engine(tmp_path / "engine", "2.339.0")
+    out = tmp_path / "bundle"
+    src = tmp_path / "src"
+    src.mkdir(exist_ok=True)
+    (src / "unit.twb").write_text("<workbook />", encoding="utf-8")
+    monkeypatch.setattr(run_estate, "run_engine", _bundle_engine())
+    stamped: list[Path] = []
+    monkeypatch.setattr(run_estate, "stamp_inputs", lambda _input, out_dir: stamped.append(out_dir))
+    if limits is not None:
+        monkeypatch.setattr(run_estate, "PATH_CEILING_LIMITS", limits)
+    buffer = io.StringIO()
+    with contextlib.redirect_stdout(buffer):
+        code = run_estate.main(_landing_argv(engine, src, out))
+    return code, buffer.getvalue(), stamped, out
+
+
+def _path_report(out: Path) -> dict:
+    return json.loads((out / run_estate.PATH_CEILING_REPORT).read_text(encoding="utf-8"))
+
+
+def _phase_names(out: Path) -> list[str]:
+    return [phase["phase"] for phase in json.loads((out / "phase-timings.json").read_text(encoding="utf-8"))["phases"]]
+
+
+def _minimal_bundle(out: Path) -> Path:
+    """A bundle with report.json and one conditional folder only - no semantic_models/, no data/."""
+    _write(out / "report.json", json.dumps(_report(workbooks=[_workbook("Alpha", "AlphaModel")])))
+    _write(out / "pbip" / "Alpha" / "Alpha.pbip", "{}")
+    return out
+
+
+def test_an_over_ceiling_emitted_tree_refuses_before_any_consumer_sees_it(tmp_path: Path, monkeypatch) -> None:
+    """THE issue-564 shape: the projection passed, the emitted tree is unopenable, everything was green.
+
+    The exit code is asserted last: it is the weakest signal. What matters is that the refusal names
+    the binding path and that the first downstream consumer never ran.
+    """
+    code, printed, stamped, out = _emitted_run(tmp_path, monkeypatch, _ceilings(utf16_len(str(tmp_path)), 4096))
+
+    assert "PATH CEILING:" in printed and "EMITTED path(s) exceed" in printed, printed
+    match = re.search(
+        r"binding (?P<kind>file|directory) is (?P<length>\d+) UTF-16 units \(ceiling (?P<ceiling>\d+)\): (?P<path>\S+)",
+        printed,
+    )
+    assert match, f"the refusal did not name the binding path.\nprinted:\n{printed}"
+    assert int(match.group("length")) > int(match.group("ceiling"))
+    assert Path(match.group("path")).exists(), "the refusal named a path that is not on disk"
+    assert stamped == [], "provenance ran on a tree Power BI Desktop cannot open"
+    report = _path_report(out)
+    assert report["status"] == "over_ceiling" and report["counted"]["over_ceiling"] >= 1
+    assert code == run_estate.EXIT_PATH_CEILING
+
+
+def test_a_clean_emitted_tree_continues_unchanged(tmp_path: Path, monkeypatch) -> None:
+    """The false-positive control: the SAME run at the real ceilings must reach every later phase."""
+    code, printed, stamped, out = _emitted_run(tmp_path, monkeypatch)
+
+    assert code == run_estate.EXIT_OK, printed
+    assert stamped == [out], "a clean tree must not stop the run"
+    assert _path_report(out)["status"] == "ok"
+    assert "none over Desktop" in printed, printed
+    assert {"provenance", "adjudicate", "slice_handovers"} <= set(_phase_names(out))
+
+
+def test_one_overlong_directory_refuses_even_when_every_file_is_legal(tmp_path: Path, monkeypatch) -> None:
+    """Measured in `check_path_ceiling`: an overlong DIRECTORY makes `git add` drop its contents at exit 0."""
+    code, printed, stamped, out = _emitted_run(tmp_path, monkeypatch, _ceilings(4096, utf16_len(str(tmp_path))))
+
+    assert "binding directory is" in printed, printed
+    assert stamped == [], "provenance ran on a tree whose directories git itself would silently drop"
+    report = _path_report(out)
+    assert {record["kind"] for record in report["worst_offenders"]} == {"directory"}
+    assert report["counted"]["over_ceiling"] == report["counted"]["directories"], (
+        "a file was counted as an offender in a directory-only fixture"
+    )
+    assert code == run_estate.EXIT_PATH_CEILING
+
+
+def test_the_emitted_measurement_counts_utf16_units_not_code_points(tmp_path: Path) -> None:
+    """A non-BMP character is 1 code point and 2 UTF-16 units - Desktop counts the second number."""
+    out = tmp_path / "bundle"
+    target = out / "pbip" / "x" / "visual\U0001f600.json"
+    _write(target)
+    units = utf16_len(str(target))
+    assert units == len(str(target)) + 1, "the fixture no longer carries a supplementary character"
+
+    refused, detail = run_estate.check_emitted_path_ceiling(out, [], _ceilings(units - 1, 4096))
+    assert refused is False, detail
+    assert "EMITTED path(s) exceed" in detail
+    passed, clean = run_estate.check_emitted_path_ceiling(out, [], _ceilings(units, 4096))
+    assert passed is True, clean
+
+
+def test_a_walk_failure_cannot_report_a_clean_tree(tmp_path: Path, monkeypatch) -> None:
+    """The walker raising outright is an indeterminate state, never a pass."""
+    out = _minimal_bundle(tmp_path / "bundle")
+
+    def _boom(*_args, **_kwargs):
+        raise OSError(5, "device is not ready")
+
+    monkeypatch.setattr(run_estate, "scan_path_ceiling", _boom)
+    monkeypatch.setattr(
+        run_estate, "stamp_inputs", lambda *_a, **_k: pytest.fail("provenance ran after a walk failure")
+    )
+
+    buffer = io.StringIO()
+    with contextlib.redirect_stdout(buffer):
+        code = run_estate.main(_slice_only_argv(out))
+
+    assert code == run_estate.EXIT_PATH_CEILING
+    assert "CANNOT ASSESS the emitted tree" in buffer.getvalue()
+    assert "device is not ready" in buffer.getvalue()
+    report = _path_report(out)
+    assert report["status"] == "unknown_paths" and "OSError" in report["scan_error"]
+    assert not (out / "handover").exists(), "handover slices were written after a refusal"
+
+
+def test_a_path_the_walker_could_not_measure_refuses(tmp_path: Path, monkeypatch) -> None:
+    """The walker's OWN unknown classification binds - this gate never re-decides it."""
+    import check_path_ceiling  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
+
+    out = _minimal_bundle(tmp_path / "bundle")
+    monkeypatch.setattr(
+        check_path_ceiling,
+        "collect",
+        lambda _root: ([], [{"path": str(out / "pbip"), "reason": "PermissionError: access is denied"}]),
+    )
+
+    buffer = io.StringIO()
+    with contextlib.redirect_stdout(buffer):
+        code = run_estate.main(_slice_only_argv(out))
+
+    assert code == run_estate.EXIT_PATH_CEILING
+    assert "access is denied" in buffer.getvalue(), buffer.getvalue()
+    assert _path_report(out)["status"] == "unknown_paths"
+
+
+def test_an_output_tree_with_nothing_measurable_is_not_clean(tmp_path: Path) -> None:
+    """`census` of nothing must not read as a pass (the same rule the issue-194 harness enforces)."""
+    empty = tmp_path / "out"
+    empty.mkdir()
+
+    proceed, detail = run_estate.check_emitted_path_ceiling(empty, [])
+
+    assert proceed is False
+    assert "nothing was measured" in detail, detail
+    assert _path_report(empty)["status"] == "no_paths"
+
+
+def test_a_bundle_without_the_conditional_engine_folders_is_clean(tmp_path: Path) -> None:
+    """`semantic_models/` and `data/` are conditional output - their absence is not a finding."""
+    out = _minimal_bundle(tmp_path / "bundle")
+
+    assert run_estate.main(_slice_only_argv(out)) == run_estate.EXIT_OK
+    assert _path_report(out)["status"] == "ok"
+    assert (out / "handover" / "Alpha.json").is_file()
+
+
+def test_slice_only_output_is_gated_too(tmp_path: Path, monkeypatch) -> None:
+    """`--slice-only` never runs the engine, but it hands an EXISTING tree downstream all the same."""
+    out = _minimal_bundle(tmp_path / "bundle")
+    monkeypatch.setattr(run_estate, "PATH_CEILING_LIMITS", _ceilings(utf16_len(str(tmp_path)), 4096))
+
+    buffer = io.StringIO()
+    with contextlib.redirect_stdout(buffer):
+        code = run_estate.main(_slice_only_argv(out))
+
+    assert code == run_estate.EXIT_PATH_CEILING
+    assert not (out / "handover").exists()
+    assert _phase_names(out) == ["slice_only_baseline_backfill", "path_ceiling"], (
+        "a slice-only refusal ran a phase it should not have"
+    )
+
+
+def test_the_phase_record_after_a_refusal_carries_no_later_phase(tmp_path: Path, monkeypatch) -> None:
+    """The timings ARE the evidence that nothing downstream started."""
+    _code, _printed, _stamped, out = _emitted_run(tmp_path, monkeypatch, _ceilings(utf16_len(str(tmp_path)), 4096))
+
+    names = _phase_names(out)
+    assert names[-1] == "path_ceiling", names
+    assert {"engine_run", "engine_receipt"} <= set(names), names
+    assert not {"provenance", "adjudicate", "slice_handovers"} & set(names), names
+
+
+def test_a_refusal_preserves_the_engine_output_and_what_built_it(tmp_path: Path, monkeypatch) -> None:
+    """Permanent shortening is an upstream fix - here the tree is EVIDENCE, so nothing is removed."""
+    code, _printed, _stamped, out = _emitted_run(tmp_path, monkeypatch, _ceilings(utf16_len(str(tmp_path)), 4096))
+
+    assert code == run_estate.EXIT_PATH_CEILING
+    assert (out / ORDERS_TMDL).read_text(encoding="utf-8") == "table Orders"
+    assert (out / REPORT_JSON).is_file() and (out / "pbip" / "WB" / "WB.pbip").is_file()
+    assert (out / run_estate.ENGINE_RECEIPT).is_file(), "the refused bundle can no longer say what built it"
+    manifest = json.loads((out / "input_manifest.json").read_text(encoding="utf-8"))
+    assert manifest[run_estate.GENERATED_ARTIFACTS_KEY]["files"], "the baseline was lost with the refusal"
+
+
+def test_an_engine_failure_keeps_its_precedence_and_writes_no_path_report(tmp_path: Path, monkeypatch) -> None:
+    """A failed engine has no output to judge - the path gate must not claim one."""
+    _without_pbir_validator(monkeypatch)
+    engine = _versioned_engine(tmp_path / "engine", "2.339.0")
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "unit.twb").write_text("<workbook />", encoding="utf-8")
+    out = tmp_path / "bundle"
+    monkeypatch.setattr(run_estate, "run_engine", lambda *_args: (1, "engine exploded"))
+    monkeypatch.setattr(run_estate, "PATH_CEILING_LIMITS", _ceilings(1, 1))
+
+    assert run_estate.main(_landing_argv(engine, src, out)) == run_estate.EXIT_ENGINE_FAILED
+    assert not (out / run_estate.PATH_CEILING_REPORT).exists()
+
+
+def test_no_path_report_is_written_when_there_is_no_output_to_measure(tmp_path: Path, monkeypatch) -> None:
+    """A bundle with no report.json fails loudly upstream of this gate, and leaves no verdict behind."""
+    out = tmp_path / "bundle"
+    out.mkdir()
+    monkeypatch.setattr(run_estate, "PATH_CEILING_LIMITS", _ceilings(1, 1))
+
+    with pytest.raises(FileNotFoundError):
+        run_estate.main(_slice_only_argv(out))
+
+    assert not (out / run_estate.PATH_CEILING_REPORT).exists()
+
+
+def test_a_verdict_that_cannot_be_recorded_is_not_a_pass(tmp_path: Path, monkeypatch) -> None:
+    """An unattributable verdict is an unassessable one: refuse rather than continue on hearsay."""
+    out = _minimal_bundle(tmp_path / "bundle")
+    monkeypatch.setattr(run_estate, "write_path_ceiling_report", lambda *_args: None)
+
+    buffer = io.StringIO()
+    with contextlib.redirect_stdout(buffer):
+        code = run_estate.main(_slice_only_argv(out))
+
+    assert code == run_estate.EXIT_PATH_CEILING
+    assert "could not be written" in buffer.getvalue()
+
+
+def test_the_gate_uses_the_measured_desktop_ceilings_and_keeps_the_root_budget_advisory() -> None:
+    """Filesystem-free pin: loosening the defaults, or promoting the advisory, has to fail here."""
+    assert run_estate.PATH_CEILING_LIMITS.file_ceiling == FILE_CEILING == 259
+    assert run_estate.PATH_CEILING_LIMITS.dir_ceiling == DIR_CEILING == 247
+    assert run_estate.PATH_CEILING_LIMITS.min_root_budget is None, (
+        "the tight portable root budget is ADVISORY here; gating on it is a different decision"
+    )
+
+
+def test_a_tight_root_budget_is_reported_and_never_refuses() -> None:
+    """The portable-budget advisory stays advisory - it is about WHERE a bundle lands, not this tree.
+
+    Driven through the verdict directly rather than through a fixture, because a tight root budget on
+    a CLEAN tree requires an absolute root under ~40 units, which no `tmp_path` on any runner has.
+    """
+    report = {
+        "status": "ok",
+        "root": "bundle",
+        "counted": {"measured": 4, "files": 2, "directories": 2, "over_ceiling": 0, "unknown": 0},
+        "file_ceiling": FILE_CEILING,
+        "dir_ceiling": DIR_CEILING,
+        "root_budget": 12,
+        "root_budget_is_tight": True,
+        "shipping_root_budget_advisory": 40,
+    }
+
+    proceed, detail = run_estate.path_ceiling_verdict(report, Path("bundle") / run_estate.PATH_CEILING_REPORT)
+
+    assert proceed is True, detail
+    assert "ADVISORY: root budget 12" in detail, detail
+    assert "not a refusal" in detail, detail

--- a/tests/test_run_estate.py
+++ b/tests/test_run_estate.py
@@ -2332,8 +2332,12 @@ def test_the_printed_refusal_carries_no_host_location(tmp_path: Path, monkeypatc
     assert not discloses_host_location(residue), residue
 
 
-def test_an_error_message_embedding_the_bundle_path_is_redacted_whole(tmp_path: Path, monkeypatch) -> None:
-    """An OS error routinely quotes the path it failed on - that path is the customer's."""
+def test_an_error_message_embedding_the_bundle_path_is_rewritten_not_echoed(tmp_path: Path, monkeypatch) -> None:
+    """An OS error routinely quotes the path it failed on - that path is the customer's.
+
+    The bundle's own root is PROVEN, so it is rewritten to `<bundle>` rather than withheld: the
+    class, the errno and the failure text all survive, which is what makes the line worth keeping.
+    """
     out = _secret_rooted_bundle(tmp_path)
 
     def _boom(*_args, **_kwargs):
@@ -2348,7 +2352,9 @@ def test_an_error_message_embedding_the_bundle_path_is_redacted_whole(tmp_path: 
     assert SECRET_FOLDER not in raw and SECRET_ACCOUNT not in raw, raw
     assert SECRET_FOLDER not in detail and SECRET_ACCOUNT not in detail, detail
     payload = json.loads(raw)
-    assert payload["redacted_fields"], "the closing redactor recorded no catch for a leaking error"
+    assert payload["diagnostics_withheld"] == 0, "a provable bundle root must be rewritten, not withheld"
+    assert run_estate.SAFE_BUNDLE_ROOT in payload["scan_error"], payload["scan_error"]
+    assert "device is not ready" in payload["scan_error"] and "OSError" in payload["scan_error"]
     assert [value for value in _strings(payload) if discloses_host_location(value)] == []
 
 
@@ -2373,3 +2379,148 @@ def test_a_path_outside_the_bundle_is_an_ordinal_not_an_echo(tmp_path: Path, mon
     assert payload["paths_not_placed"] == 1
     assert payload["unknown_paths"][0]["path"] == run_estate.UNASSESSABLE_PATH.format(index=1)
     assert "access is denied" in raw, "the reason itself was lost with the path"
+
+
+# ---------------------------------------------------------------------------
+# The RELATIVE root, reported by the same reviewer (PR #587)
+#
+# Generic host-path detection answers "is there an ABSOLUTE location in here". A `--output` that is
+# relative - `AcmeCorp-Confidential-FY26Q3\bundle` - names the customer just as plainly and walks
+# straight past every absolute predicate in this repo. Structured path evidence was already safe (it
+# is placed against the supplied root, relative or not); the unstructured strings beside it were not.
+# ---------------------------------------------------------------------------
+
+RELATIVE_ROOT = Path(SECRET_FOLDER) / "bundle"
+
+
+def _relative_bundle(monkeypatch, tmp_path: Path) -> Path:
+    """A bundle addressed by a RELATIVE, customer-named path, from inside `tmp_path`."""
+    monkeypatch.chdir(tmp_path)
+    return _minimal_bundle(Path(RELATIVE_ROOT))
+
+
+def test_a_relative_root_does_not_survive_in_the_persisted_scan_error(tmp_path: Path, monkeypatch) -> None:
+    """The reviewer's reproduction, on the report: a walk failure quoting a relative customer root."""
+    out = _relative_bundle(monkeypatch, tmp_path)
+
+    def _boom(*_args, **_kwargs):
+        raise OSError(5, f"device is not ready: {out}")
+
+    monkeypatch.setattr(run_estate, "scan_path_ceiling", _boom)
+
+    proceed, detail = run_estate.check_emitted_path_ceiling(out, [])
+
+    assert proceed is False
+    raw = (out / run_estate.PATH_CEILING_REPORT).read_text(encoding="utf-8")
+    payload = json.loads(raw)
+    assert SECRET_FOLDER not in raw, raw
+    assert SECRET_FOLDER not in detail, detail
+    assert run_estate.SAFE_BUNDLE_ROOT in payload["scan_error"]
+    assert "OSError" in payload["scan_error"] and "device is not ready" in payload["scan_error"]
+
+
+def test_a_relative_root_does_not_survive_in_an_unknown_path_reason(tmp_path: Path, monkeypatch) -> None:
+    """The same reproduction on the OTHER unstructured field the walker fills."""
+    import check_path_ceiling  # noqa: PLC0415  # pylint: disable=import-outside-toplevel
+
+    out = _relative_bundle(monkeypatch, tmp_path)
+    monkeypatch.setattr(
+        check_path_ceiling,
+        "collect",
+        lambda root: (
+            [],
+            [{"path": str(Path(root) / "pbip"), "reason": f"PermissionError: cannot open {Path(root) / 'pbip'}"}],
+        ),
+    )
+
+    proceed, detail = run_estate.check_emitted_path_ceiling(out, [])
+
+    assert proceed is False
+    raw = (out / run_estate.PATH_CEILING_REPORT).read_text(encoding="utf-8")
+    payload = json.loads(raw)
+    reason = payload["unknown_paths"][0]["reason"]
+    assert SECRET_FOLDER not in raw and SECRET_FOLDER not in detail, raw
+    assert f"{run_estate.SAFE_BUNDLE_ROOT}/pbip" in reason.replace("\\", "/"), reason
+    assert payload["unknown_paths"][0]["path"].startswith(run_estate.SAFE_BUNDLE_ROOT), payload["unknown_paths"]
+    assert "PermissionError" in reason
+
+
+def test_a_relative_root_does_not_survive_a_publication_failure_diagnostic(tmp_path: Path, monkeypatch, caplog) -> None:
+    """The third surface: the log line emitted when the report itself cannot be published."""
+    out = _relative_bundle(monkeypatch, tmp_path)
+
+    def _boom(*_args, **_kwargs):
+        raise OSError(13, f"Permission denied: {out / run_estate.PATH_CEILING_REPORT}")
+
+    monkeypatch.setattr(run_estate.os, "replace", _boom)
+
+    with caplog.at_level("WARNING", logger="run_estate"):
+        written = run_estate.write_path_ceiling_report(out, {"status": "ok", "counted": {}})
+
+    assert written is None
+    logged = "\n".join(record.getMessage() for record in caplog.records)
+    assert SECRET_FOLDER not in logged, logged
+    assert run_estate.SAFE_BUNDLE_ROOT in logged, logged
+    assert "PermissionError" in logged and "Errno 13" in logged, (
+        f"the actionable class and error code were dropped with the path: {logged}"
+    )
+
+
+def test_a_foreign_relative_path_is_withheld_with_its_class_and_code(tmp_path: Path, monkeypatch) -> None:
+    """A path that is NOT the bundle cannot be proven safe, so the message goes - the facts stay."""
+    out = _relative_bundle(monkeypatch, tmp_path)
+
+    def _boom(*_args, **_kwargs):
+        raise OSError(13, "cannot open OtherCustomer-Merger-Docs\\payroll.twbx")
+
+    monkeypatch.setattr(run_estate, "scan_path_ceiling", _boom)
+
+    proceed, detail = run_estate.check_emitted_path_ceiling(out, [])
+
+    assert proceed is False
+    raw = (out / run_estate.PATH_CEILING_REPORT).read_text(encoding="utf-8")
+    payload = json.loads(raw)
+    assert "OtherCustomer" not in raw and "payroll" not in raw, raw
+    assert "OtherCustomer" not in detail and "payroll" not in detail, detail
+    # Both unstructured fields carry the same offending text - `scan_error` and the walker's own
+    # reason - so both are withheld, each under its own ordinal.
+    assert payload["diagnostics_withheld"] == 2
+    assert payload["scan_error"].startswith("PermissionError"), payload["scan_error"]
+    assert "Errno 13" in payload["scan_error"], payload["scan_error"]
+    assert run_estate.WITHHELD_DIAGNOSTIC.format(index=1) in payload["scan_error"]
+    assert run_estate.WITHHELD_DIAGNOSTIC.format(index=2) in payload["unknown_paths"][0]["reason"]
+
+
+def test_a_safe_message_keeps_its_text_class_and_code(tmp_path: Path, monkeypatch) -> None:
+    """The false-positive control: a message with no path at all must not be degraded."""
+    out = _relative_bundle(monkeypatch, tmp_path)
+
+    def _boom(*_args, **_kwargs):
+        raise OSError(5, "device is not ready")
+
+    monkeypatch.setattr(run_estate, "scan_path_ceiling", _boom)
+
+    _proceed, detail = run_estate.check_emitted_path_ceiling(out, [])
+
+    payload = json.loads((out / run_estate.PATH_CEILING_REPORT).read_text(encoding="utf-8"))
+    assert payload["diagnostics_withheld"] == 0, payload["scan_error"]
+    assert payload["scan_error"] == "OSError: [Errno 5] device is not ready", payload["scan_error"]
+    assert "device is not ready" in detail
+
+
+def test_the_scan_verdict_and_structured_evidence_survive_sanitisation(tmp_path: Path, monkeypatch) -> None:
+    """Sanitising diagnostics must not weaken the verdict or the measured evidence beside it."""
+    out = _relative_bundle(monkeypatch, tmp_path)
+    monkeypatch.setattr(run_estate, "PATH_CEILING_LIMITS", _ceilings(1, 4096))
+
+    proceed, _detail = run_estate.check_emitted_path_ceiling(out, [])
+
+    payload = json.loads((out / run_estate.PATH_CEILING_REPORT).read_text(encoding="utf-8"))
+    assert proceed is False
+    assert payload["status"] == "over_ceiling"
+    assert payload["counted"]["over_ceiling"] >= 1
+    assert payload["diagnostics_withheld"] == 0 and payload["paths_not_placed"] == 0
+    offender = payload["worst_offenders"][0]
+    assert offender["length"] > offender["ceiling"] and offender["kind"] in {"file", "directory"}
+    assert offender["path"].startswith(f"{run_estate.SAFE_BUNDLE_ROOT}/")
+    assert (out / Path(offender["path"][len(run_estate.SAFE_BUNDLE_ROOT) + 1 :])).exists()


### PR DESCRIPTION
## What this is

The customer-ready mitigation for #564. `run_estate.py`'s pre-conversion path projection is
fail-open by construction — it composes the canonical PBIR `pages/<id>/visuals/<id>` tail onto unit
names knowable *before* conversion, and the path that actually breaches on the committed issue-194
repro is an **uncapped semantic-model table file** it never models. Measured on canonical engine
output in this branch's own test run:

```
PATH CEILING: 16 EMITTED path(s) exceed what Power BI Desktop will open - binding file is 343
UTF-16 units (ceiling 259): ...\pbip\Regional Sales Performance and Inventory Turnover Revie-
b52b9462\...-980f2851.SemanticModel\definition\tables\Regional Sales Performance and Inventory
Turnover FY2026 Q3 Detail Extract.csv.tmdl
```

Engine exit 0, projection passed, every gate green — and a bundle Desktop refuses to open handed on
to provenance, packaging, agents and Desktop. That is the customer-visible false clean.

## Invariant

After canonical engine output is recorded (`record_engine_output`, or the `--slice-only` baseline
backfill) and **before** provenance, handover slices, packaging, agent and Desktop work,
`check_emitted_path_ceiling` measures the **actual** emitted tree with the existing authority —
`check_path_ceiling.scan`, its walker and its measured 259/247 UTF-16 pair, nothing re-implemented —
and returns `EXIT_PATH_CEILING` (10) whenever any emitted file is over 259, any directory over 247,
or the tree cannot be assessed (unmeasurable path, walk failure, nothing measurable, or a verdict
that cannot be recorded). Clean continues unchanged.

* Python may still emit the tree; what must never happen is downstream work **starting** from it.
* Machine-readable report → `<bundle>/path-ceiling.json`, the name `check_unit.py` already reads, so
  the refusal is attributable to named paths.
* The tight portable root budget stays **advisory** (`min_root_budget` remains `None`).
* Engine-nonzero / missing-`report.json` precedence is unchanged, and no path report is written when
  there is no output.
* **Nothing is deleted, shortened or rewritten** — the emitted tree is preserved as evidence, and the
  phase record written on a refusal carries no later phase, so the timings themselves prove nothing
  downstream started. **Permanent filename shortening remains an upstream engine fix.**
* No acceptance flag, no warn-only bypass.

## Closed surface

`scripts/run_estate.py`; an import of (never a copy of) `scripts/check_path_ceiling.py`; direct
run-estate/path tests; one paragraph in `docs/windows-path-limits.md`. Plus two mechanical baseline
entries in `conftest.py` / `tests/test_expected_skips_gate.py` that the repo's expected-skips gate
*requires* for the two new engine-dependent tests — the gate fails without them.

No engine table names are modelled, no engine source inspected; `work_dirs`, `check_unit`,
`package_unit`, the credential gate, AGENTS and the personas are untouched. PRs #571/#584 are closed
and nothing from them is reused.

## Controls

Engine-backed (reusing the existing session fixture, so the engine runs no extra time):

* the **committed issue-194 long arm**, driven through the coordinator over real emitted output,
  refuses **before a mocked provenance sentinel**, names the semantic-model table file, writes no
  `handover/`, and leaves the output in place;
* the **short arm** passes the same gate and reaches provenance.

Engine-free, through `main`: over-ceiling refusal naming the binding path/length/ceiling; clean
control continuing to every later phase; one overlong **directory** with legal files; a
supplementary-plane name (UTF-16 units, not code points); a walker exception; a walker-reported
unmeasurable path; an empty tree; a conditional bundle with no `semantic_models/`; `--slice-only`;
phase timings excluding later phases after a refusal; receipt + baseline + artifacts preserved;
engine-failure precedence with no path report; no report when there is no output; the 259/247
defaults and the advisory-only root budget pinned filesystem-free.

**Mutation-tested by hand:** deleting the gate from the run fails **12** of these tests; moving it
after the provenance stamp fails **4** (including the real issue-194 control).

## Verification

* `pytest tests/test_run_estate.py tests/test_issue_194_long_pbir_path.py tests/test_check_path_ceiling.py`
  → 191 passed, 2 skipped (both pre-existing platform skips).
* Full suite → 6213 passed, 11 skipped, 2 failed — both failures
  (`tests/test_harvest_engine_gaps.py::test_unreadable_directory_does_not_fabricate_additions_beneath_it`,
  `::test_a_traversal_failure_that_cannot_be_located_suppresses_the_whole_pair`) reproduce on clean
  `bf4a79f1` with this branch stashed, so they are pre-existing and unrelated.
* `ruff format` / `ruff check` clean; `pylint scripts/run_estate.py conftest.py` **10.00/10**.

## Residuals

* The pre-conversion projection gap itself is **not** closed — this mitigates the customer-visible
  false clean, hence `Refs #564` rather than `Fixes`.
* Based on `bf4a79f1` as instructed; `origin/master` has since moved to `717d0edc`, which touches
  only `stamp_tableau_provenance.py` — no overlap with this diff.
* The two engine-backed controls run only where the canonical engine is installed (the repo's
  engine-integration job); the engine-free controls carry the mutation-killing weight.

Draft — do not merge.
