### PR TITLE
fix: classify a package target no-follow before any resolve or discovery (Refs #562)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -97,6 +97,7 @@ EXPECTED_EXACT_SKIP_REASONS: frozenset[str] = frozenset(
         "reproduces the WINDOWS half: Path resolves / against the current drive",
         "case-sensitive filesystem: 'FOO' and 'foo' are not the same deliverable",
         "canonical engine not installed, so its constants cannot be read",
+        "os.mkfifo is POSIX-only",
     }
 )
 

--- a/docs/migration-phases.md
+++ b/docs/migration-phases.md
@@ -216,6 +216,18 @@ evidence and never borrows omitted renders or double-matches against run-root ca
 `_runs/<NNN>-<slug>/oracle/`. An incomplete or failed package lacking `package-manifest.json` fails
 closed.
 
+⚠️ **The boundary is classified before anything is followed** (`bundle_corpus.classify_target`,
+issue #562). Placement is decided **lexically** — `packages/<Unit>` and `packages/<batch>/<Unit>` —
+and the marker is typed with a no-follow `lstat`, so a marker that is a symlink, junction, directory
+or special file is a **damaged** package, never an ordinary bundle, and never a reason to walk
+upward. `check_reference_readiness.py` refuses a damaged boundary with `CANNOT_ESTABLISH` (exit 3)
+before it resolves the root or discovers any source or evidence.
+
+⚠️ **Pass the real path, not an alias.** A supplied target that is itself a directory symlink or
+NTFS junction is refused the same way: following it would decide the boundary about a directory you
+never named. This is deliberate and fails **closed** — including for an ordinary, unpackaged bundle
+reached through an alias.
+
 ### The two gates
 
 | gate | question | verdicts |

--- a/docs/migration-phases.md
+++ b/docs/migration-phases.md
@@ -220,13 +220,22 @@ closed.
 issue #562). Placement is decided **lexically** — `packages/<Unit>` and `packages/<batch>/<Unit>` —
 and the marker is typed with a no-follow `lstat`, so a marker that is a symlink, junction, directory
 or special file is a **damaged** package, never an ordinary bundle, and never a reason to walk
-upward. `check_reference_readiness.py` refuses a damaged boundary with `CANNOT_ESTABLISH` (exit 3)
-before it resolves the root or discovers any source or evidence.
+upward. The **entry gate** refuses a damaged boundary with `CANNOT_ESTABLISH` (exit 3) before it
+resolves the root or discovers any source or evidence — in both its library entry (`scan`) and its
+CLI (`main`), which classifies before its own `is_dir`/`is_file` pre-checks.
 
 ⚠️ **Pass the real path, not an alias.** A supplied target that is itself a directory symlink or
 NTFS junction is refused the same way: following it would decide the boundary about a directory you
 never named. This is deliberate and fails **closed** — including for an ordinary, unpackaged bundle
 reached through an alias.
+
+❌ **The EXIT gate is NOT yet covered by that ordering, and this is a known blocking residual.**
+`check_unit.py`'s `_oracle_dirs()` reaches the shared walk through `_unit_dir()`, which calls
+`target.resolve()` **first** — so for a caller-supplied alias the classification happens on the
+already-resolved destination, which is precisely the substitution the classifier exists to refuse.
+The stop is therefore only reliable there for a real, un-aliased path. Closing it means classifying
+the **original** target before resolution, which is a separate follow-up to #562; do not read the
+entry gate's guarantee as covering `check_unit.py`.
 
 ### The two gates
 

--- a/scripts/bundle_corpus.py
+++ b/scripts/bundle_corpus.py
@@ -9,11 +9,272 @@ separate copies of the same filesystem-discovery rules. This module is the singl
 
 from __future__ import annotations
 
+import os
+import stat
 from collections.abc import Sequence
-from pathlib import Path
+from dataclasses import dataclass
+from pathlib import Path, PurePath
 
 #: A self-contained handover package writes this beside the unit (`scripts/package_unit.py`, #446).
 PACKAGE_MARKER = "package-manifest.json"
+
+#: The directory name that makes a target *lexically* package-shaped.
+PACKAGES_DIR = "packages"
+
+#: `FILE_ATTRIBUTE_REPARSE_POINT`. Named here because `stat` only exposes it on Windows builds, and
+#: this predicate has to give the same answer for a junction on either host.
+FILE_ATTRIBUTE_REPARSE_POINT = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x0400)
+
+# ---------------------------------------------------------------------------------------------
+# Package-target classification (issue #562, split prerequisite)
+# ---------------------------------------------------------------------------------------------
+#
+# ⚠️ **This runs BEFORE anything touches the filesystem in a following way.** The previous
+# classification asked `(target / PACKAGE_MARKER).is_file()` and `target.resolve()`, and both
+# DEREFERENCE: `is_file()` follows a marker symlink, so a package boundary could be declared by a
+# file living anywhere on the host, and `resolve()` follows a junction, so the *placement* question
+# ("am I under `packages/`?") was answered about the link's destination rather than about the path
+# the caller actually handed us. A boundary check that follows links is not a boundary check.
+#
+# So classification uses exactly two primitives - **no-follow `os.lstat`** of the supplied root and
+# of its root marker entry - plus **pure lexical** normalization of the supplied path. It never
+# calls `resolve`, `is_file`, `is_dir`, `exists` or `rglob`, never opens or reads a byte, and never
+# looks at a child other than the root marker entry.
+#
+# ⚠️ It is a **boundary classifier, not a manifest integrity verifier.** It answers "is this a
+# package boundary, and is that boundary intact enough to reason about?". It deliberately does NOT
+# parse the manifest, hash anything, or check declared contents - that is the next slice of #562.
+
+#: An ordinary, non-package target: a bundle root or an un-packaged unit. Legacy behaviour.
+TARGET_ORDINARY = "ordinary"
+#: A package boundary in good order: a regular, non-reparse `package-manifest.json` at the root.
+TARGET_PACKAGE = "package"
+#: Package-shaped or explicitly package, with a boundary that is missing, reparse, non-regular or
+#: unassessable. **Never non-package**, and never a reason to walk upward for evidence.
+TARGET_PACKAGE_DAMAGED = "damaged_package"
+#: The supplied root itself is a link/junction/reparse point, or could not be `lstat`-assessed.
+TARGET_UNSAFE_ROOT = "unsafe_root"
+
+#: Lexical placement of the supplied path.
+PLACEMENT_NONE = "none"
+PLACEMENT_FLAT = "flat"
+PLACEMENT_NESTED = "nested"
+
+#: Stable diagnostic codes. Consumers print these; they carry no host path and no file content.
+CODE_ORDINARY_TARGET = "ordinary_target"
+CODE_PACKAGE_BOUNDARY_OK = "package_boundary_ok"
+CODE_PACKAGE_MARKER_MISSING = "package_marker_missing"
+CODE_PACKAGE_MARKER_REPARSE = "package_marker_reparse"
+CODE_PACKAGE_MARKER_NOT_REGULAR = "package_marker_not_regular_file"
+CODE_PACKAGE_MARKER_UNASSESSABLE = "package_marker_unassessable"
+CODE_PACKAGE_ROOT_MISSING = "package_root_missing"
+CODE_PACKAGE_ROOT_NOT_DIRECTORY = "package_root_not_directory"
+CODE_TARGET_ROOT_REPARSE = "target_root_reparse"
+CODE_TARGET_ROOT_UNASSESSABLE = "target_root_unassessable"
+
+#: Generic, package-relative wording per code. **No supplied path, no marker bytes, ever**: these
+#: strings are printed into verdicts that get pasted into issues and shared with customers, and the
+#: supplied target can itself be a secret-bearing absolute path.
+_DETAILS = {
+    CODE_ORDINARY_TARGET: "not a package boundary",
+    CODE_PACKAGE_BOUNDARY_OK: f"package boundary declared by a regular {PACKAGE_MARKER}",
+    CODE_PACKAGE_MARKER_MISSING: (
+        f"the target is package-shaped but carries no {PACKAGE_MARKER}, so its boundary is "
+        "unproven - it is NOT treated as an ordinary bundle"
+    ),
+    CODE_PACKAGE_MARKER_REPARSE: (
+        f"{PACKAGE_MARKER} is a link/junction/reparse point, so the boundary would be declared by "
+        "bytes outside the package"
+    ),
+    CODE_PACKAGE_MARKER_NOT_REGULAR: (
+        f"{PACKAGE_MARKER} exists but is not a regular file (directory, FIFO, socket or device)"
+    ),
+    CODE_PACKAGE_MARKER_UNASSESSABLE: (
+        f"{PACKAGE_MARKER} could not be assessed without following it, so the boundary is unknown"
+    ),
+    CODE_PACKAGE_ROOT_MISSING: "the package-shaped target does not exist",
+    CODE_PACKAGE_ROOT_NOT_DIRECTORY: "the package-shaped target is not a directory",
+    CODE_TARGET_ROOT_REPARSE: (
+        "the supplied target is itself a link/junction/reparse point; this gate refuses to follow "
+        "a caller-supplied alias rather than classify the wrong directory"
+    ),
+    CODE_TARGET_ROOT_UNASSESSABLE: "the supplied target could not be assessed without following it",
+}
+
+
+@dataclass(frozen=True)
+class TargetClassification:
+    """What kind of boundary a caller-supplied target is, decided without dereferencing anything.
+
+    ``code`` and ``detail`` are the only strings a consumer may print: they are stable and generic.
+    ``unit_name`` is the normalized final path component - the same value a report already prints as
+    its unit - and never an absolute path.
+    """
+
+    kind: str
+    code: str
+    detail: str
+    placement: str
+    unit_name: str
+
+    @property
+    def is_package(self) -> bool:
+        """The bool :func:`is_package_target` projects. Damaged still counts as a package."""
+        return self.kind in (TARGET_PACKAGE, TARGET_PACKAGE_DAMAGED)
+
+    @property
+    def is_package_shaped(self) -> bool:
+        """Lexically under ``packages/`` (flat or nested), marker or no marker."""
+        return self.placement != PLACEMENT_NONE
+
+    @property
+    def declares_self_contained(self) -> bool:
+        """A regular, non-reparse root marker is present. A followed link is NOT a declaration."""
+        return self.kind == TARGET_PACKAGE
+
+    @property
+    def is_safe(self) -> bool:
+        """Whether a consumer may continue into resolve/discovery. ``unassessable`` is never safe."""
+        return self.kind in (TARGET_ORDINARY, TARGET_PACKAGE)
+
+    @property
+    def inherits_ancestor_evidence(self) -> bool:
+        """Only an ordinary target walks upward.
+
+        ⚠️ Damaged packages AND unsafe roots both stop the walk, for opposite-looking reasons that
+        are the same reason: neither has established where its boundary is, and inheriting evidence
+        is the fail-OPEN direction (it hands an agent renders nobody attributed to this unit).
+        """
+        return self.kind == TARGET_ORDINARY
+
+
+def _classification(kind: str, code: str, placement: str, unit_name: str) -> TargetClassification:
+    return TargetClassification(kind=kind, code=code, detail=_DETAILS[code], placement=placement, unit_name=unit_name)
+
+
+def normalized_parts(target: PurePath) -> tuple[str, ...]:
+    """The supplied path's components with ``.`` dropped and ``..`` collapsed **lexically**.
+
+    ⚠️ **Lexical, deliberately, and not equivalent to `resolve()`.** `resolve()` would answer the
+    placement question about a link's destination; the question is about the path the caller typed.
+    Two consequences, both tested:
+
+    * ``<...>/packages/../Unit`` normalizes to ``<...>/Unit`` and is therefore **NOT** package-shaped
+      - it cannot become a package by being spelled deceptively. (The previous `parent.parent.name`
+      check called it a *nested* package, because the literal parent component is ``..``.)
+    * ``<...>/packages/batch/../Unit`` normalizes to ``<...>/packages/Unit`` and IS flat-shaped.
+
+    ``..`` is never popped past an anchor, and a leading ``..`` on a relative path is preserved
+    rather than silently eaten.
+    """
+    parts = list(target.parts)
+    anchor_len = 1 if target.anchor and parts else 0
+    out = parts[:anchor_len]
+    for part in parts[anchor_len:]:
+        if part == ".":
+            continue
+        if part == "..":
+            if len(out) > anchor_len and out[-1] != "..":
+                out.pop()
+                continue
+            if anchor_len:  # `C:\..` is `C:\`: an absolute path cannot climb above its anchor
+                continue
+        out.append(part)
+    return tuple(out)
+
+
+def package_placement(target: PurePath) -> str:
+    """``flat`` for ``<...>/packages/<Unit>``, ``nested`` for ``<...>/packages/<batch>/<Unit>``.
+
+    Judged on :func:`normalized_parts` only - no filesystem access, and no resolved-parent
+    heuristic, so a target is package-shaped even when its marker is missing (which is exactly the
+    case that must not fall back to legacy bundle handling).
+    """
+    parts = normalized_parts(target)
+    if len(parts) >= 2 and parts[-2] == PACKAGES_DIR:
+        return PLACEMENT_FLAT
+    if len(parts) >= 3 and parts[-3] == PACKAGES_DIR:
+        return PLACEMENT_NESTED
+    return PLACEMENT_NONE
+
+
+def is_reparse_entry(info: os.stat_result) -> bool:
+    """Whether a no-follow ``lstat`` result describes a link, junction or other reparse point.
+
+    Both halves are load-bearing. ``S_ISLNK`` covers POSIX symlinks and the name-surrogate reparse
+    points Python reports as links; the Windows ``FILE_ATTRIBUTE_REPARSE_POINT`` bit covers the rest
+    - a junction, a mount point, or an app-execution alias - which are NOT symlinks and which
+    ``S_ISLNK`` alone would wave through.
+    """
+    if stat.S_ISLNK(info.st_mode):
+        return True
+    return bool(getattr(info, "st_file_attributes", 0) & FILE_ATTRIBUTE_REPARSE_POINT)
+
+
+def classify_target(target: Path) -> TargetClassification:
+    """Classify a caller-supplied target **before** any resolve, traversal or discovery.
+
+    Order is the invariant, not an implementation detail:
+
+    1. lexical placement (no syscall at all);
+    2. no-follow ``lstat`` of the **supplied root** - a link/junction/unassessable root is refused
+       here, before the marker is even looked for, so a root alias can never smuggle in a valid
+       package that lives somewhere else;
+    3. no-follow ``lstat`` of the **root marker entry** only.
+
+    ⚠️ **Fail-closed compatibility consequence, stated rather than hidden:** an *ordinary* bundle
+    reached through a directory symlink or junction alias now classifies ``unsafe_root`` and is
+    refused. That is intentional. The alternative is to follow it, which is the whole defect: a
+    boundary decided about a directory the caller did not name. Operators who alias a bundle path
+    should pass the real path; the refusal is loud, attributable and recoverable, where the
+    fail-open direction is silent.
+    """
+    placement = package_placement(target)
+    parts = normalized_parts(target)
+    unit_name = parts[-1] if parts else ""
+
+    try:
+        root_info = os.lstat(target)
+    except FileNotFoundError:
+        # Definitively absent, not ambiguous. Package-shaped means the boundary is gone; an ordinary
+        # missing path keeps legacy behaviour (a caller may be probing a path it has not built yet).
+        if placement != PLACEMENT_NONE:
+            return _classification(TARGET_PACKAGE_DAMAGED, CODE_PACKAGE_ROOT_MISSING, placement, unit_name)
+        return _classification(TARGET_ORDINARY, CODE_ORDINARY_TARGET, placement, unit_name)
+    except (OSError, ValueError):
+        # ⚠️ No exception-shaped success. "I could not tell whether this is a reparse point" is
+        # grouped with non-clean, never with clean, for EVERY placement - an unassessable ordinary
+        # root is exactly as unknown as an unassessable package one.
+        return _classification(TARGET_UNSAFE_ROOT, CODE_TARGET_ROOT_UNASSESSABLE, placement, unit_name)
+
+    if is_reparse_entry(root_info):
+        return _classification(TARGET_UNSAFE_ROOT, CODE_TARGET_ROOT_REPARSE, placement, unit_name)
+    if placement != PLACEMENT_NONE and not stat.S_ISDIR(root_info.st_mode):
+        return _classification(TARGET_PACKAGE_DAMAGED, CODE_PACKAGE_ROOT_NOT_DIRECTORY, placement, unit_name)
+
+    return _classify_marker(target, placement, unit_name)
+
+
+def _classify_marker(target: Path, placement: str, unit_name: str) -> TargetClassification:
+    """Classify the root marker entry of an already-cleared root, with a single no-follow ``lstat``."""
+    try:
+        marker_info = os.lstat(target / PACKAGE_MARKER)
+    except FileNotFoundError:
+        if placement != PLACEMENT_NONE:
+            return _classification(TARGET_PACKAGE_DAMAGED, CODE_PACKAGE_MARKER_MISSING, placement, unit_name)
+        return _classification(TARGET_ORDINARY, CODE_ORDINARY_TARGET, placement, unit_name)
+    except (OSError, ValueError):
+        # Ambiguous rather than absent: a marker may be sitting there declaring a package boundary
+        # we cannot read. Refusing is the fail-closed direction even outside `packages/`.
+        return _classification(TARGET_PACKAGE_DAMAGED, CODE_PACKAGE_MARKER_UNASSESSABLE, placement, unit_name)
+
+    if is_reparse_entry(marker_info):
+        return _classification(TARGET_PACKAGE_DAMAGED, CODE_PACKAGE_MARKER_REPARSE, placement, unit_name)
+    if not stat.S_ISREG(marker_info.st_mode):
+        return _classification(TARGET_PACKAGE_DAMAGED, CODE_PACKAGE_MARKER_NOT_REGULAR, placement, unit_name)
+    # A regular, non-reparse marker is an EXPLICIT package declaration wherever it sits, so a moved
+    # package outside `packages/` is still recognized.
+    return _classification(TARGET_PACKAGE, CODE_PACKAGE_BOUNDARY_OK, placement, unit_name)
 
 
 def is_self_contained(target: Path) -> bool:
@@ -37,33 +298,33 @@ def is_self_contained(target: Path) -> bool:
     ⚠️ Deliberately NOT "stop when the target has its own copy of this directory": a package that
     OMITTED a render because it could not attribute it would then pick that render up from the
     ancestor, undoing a fail-closed packaging decision at the consumer.
+
+    ⚠️ **A followed link is not a declaration.** This used to be ``(target / PACKAGE_MARKER).is_file()``,
+    which returns True for a marker symlink pointing anywhere on the host - so the package's boundary
+    could be declared by bytes outside the package. It is now the ``package`` projection of
+    :func:`classify_target`: a **regular, non-reparse** marker entry, judged by ``lstat``.
     """
-    return (target / PACKAGE_MARKER).is_file()
+    return classify_target(target).declares_self_contained
 
 
 def is_package_target(target: Path) -> bool:
     """Whether ``target`` is a package target (flat, nested, or explicitly marked).
+
+    The bool compatibility projection of :func:`classify_target` - kept because two gates and their
+    tests read it, but it is lossy on purpose: a caller that has to distinguish *intact* from
+    *damaged*, or that must refuse an unsafe root, calls :func:`classify_target` instead.
 
     A package-shaped target (flat ``.../packages/<Unit>`` or nested
     ``.../packages/<batch>/<Unit>``) must evaluate only its own local evidence and must not inherit
     ancestor evidence even if incomplete (missing ``package-manifest.json`` or local evidence).
     ``fabric/`` alone is not a package signal: ordinary migration units and bundle roots carry it
     too and still need to discover run-level evidence.
+
+    ⚠️ ``False`` here means "not a package", NOT "safe to walk upward" - an unsafe root is neither.
+    :func:`evidence_dirs` keys the walk on
+    :attr:`TargetClassification.inherits_ancestor_evidence`, never on this bool.
     """
-    if is_self_contained(target):
-        return True
-    try:
-        resolved = target.resolve()
-        parent = resolved.parent
-        if parent.name == "packages":
-            return True
-        if parent.parent.name == "packages":
-            return True
-    except (OSError, RuntimeError, ValueError):
-        pass
-    if target.parent.name == "packages" or target.parent.parent.name == "packages":
-        return True
-    return False
+    return classify_target(target).is_package
 
 
 def shipping_reports(root: Path) -> list[Path]:
@@ -125,13 +386,20 @@ def evidence_dirs(target: Path, names: Sequence[str], *, also: Sequence[Path] = 
     unit at `<bundle>/pbip/<Unit>/` could not inherit the run's flat capture at all in the exit gate.
     A shared rule that covers half the behaviour is two rules wearing one name.
 
-    The ancestor portion is skipped for a package target (:func:`is_package_target` /
-    :func:`is_self_contained`); the target itself, and any ``also`` root a caller adds, are always
-    searched. Results keep discovery order, are de-duplicated by resolved path, and are returned
-    unresolved so a caller still sees the spelling it passed in.
+    The ancestor portion is skipped for anything that is not an ordinary target
+    (:attr:`TargetClassification.inherits_ancestor_evidence`); the target itself, and any ``also``
+    root a caller adds, are always searched. Results keep discovery order, are de-duplicated by
+    resolved path, and are returned unresolved so a caller still sees the spelling it passed in.
+
+    ⚠️ **A DAMAGED package does not become a reason to walk upward.** Missing, reparse or
+    unassessable ``package-manifest.json`` under package placement stops the walk exactly as an
+    intact package does - the fail-open direction here hands an agent ancestor renders that nobody
+    attributed to this unit. An unsafe (link/junction/unassessable) root stops it too, for the same
+    reason: its boundary was never established.
     """
+    classification = classify_target(target)
     roots = [target, *also]
-    if not is_package_target(target):
+    if classification.inherits_ancestor_evidence:
         ancestor = target
         for _ in range(ANCESTOR_LEVELS):
             ancestor = ancestor.parent

--- a/scripts/bundle_corpus.py
+++ b/scripts/bundle_corpus.py
@@ -123,11 +123,6 @@ class TargetClassification:
         return self.kind in (TARGET_PACKAGE, TARGET_PACKAGE_DAMAGED)
 
     @property
-    def is_package_shaped(self) -> bool:
-        """Lexically under ``packages/`` (flat or nested), marker or no marker."""
-        return self.placement != PLACEMENT_NONE
-
-    @property
     def declares_self_contained(self) -> bool:
         """A regular, non-reparse root marker is present. A followed link is NOT a declaration."""
         return self.kind == TARGET_PACKAGE

--- a/scripts/bundle_corpus.py
+++ b/scripts/bundle_corpus.py
@@ -119,8 +119,17 @@ class TargetClassification:
 
     @property
     def is_package(self) -> bool:
-        """The bool :func:`is_package_target` projects. Damaged still counts as a package."""
-        return self.kind in (TARGET_PACKAGE, TARGET_PACKAGE_DAMAGED)
+        """The bool :func:`is_package_target` projects, defined **conservatively**.
+
+        ⚠️ It is ``True`` for everything that is not an ORDINARY target - intact package, damaged
+        package **and unsafe root alike** - because the only thing a caller can safely do with this
+        bool is decide whether to walk upward for ancestor evidence, and ``False`` is the fail-OPEN
+        answer. Round-1 review of PR #590: projecting an unsafe root as ``False`` made an
+        indeterminate boundary indistinguishable from a proven ordinary bundle, which is exactly the
+        confusion the classifier exists to remove. It is the strict complement of
+        :attr:`inherits_ancestor_evidence`, so a caller reading either one gets the same answer.
+        """
+        return self.kind != TARGET_ORDINARY
 
     @property
     def declares_self_contained(self) -> bool:
@@ -303,11 +312,12 @@ def is_self_contained(target: Path) -> bool:
 
 
 def is_package_target(target: Path) -> bool:
-    """Whether ``target`` is a package target (flat, nested, or explicitly marked).
+    """Whether ``target`` must be treated as a package boundary (flat, nested, or explicitly marked).
 
-    The bool compatibility projection of :func:`classify_target` - kept because two gates and their
-    tests read it, but it is lossy on purpose: a caller that has to distinguish *intact* from
-    *damaged*, or that must refuse an unsafe root, calls :func:`classify_target` instead.
+    The bool compatibility projection of :func:`classify_target`. **No production code reads it** -
+    :func:`evidence_dirs` keys the walk on
+    :attr:`TargetClassification.inherits_ancestor_evidence` - so it survives as a documented API for
+    callers that only ever needed the one bit, and it never resolves.
 
     A package-shaped target (flat ``.../packages/<Unit>`` or nested
     ``.../packages/<batch>/<Unit>``) must evaluate only its own local evidence and must not inherit
@@ -315,9 +325,10 @@ def is_package_target(target: Path) -> bool:
     ``fabric/`` alone is not a package signal: ordinary migration units and bundle roots carry it
     too and still need to discover run-level evidence.
 
-    ⚠️ ``False`` here means "not a package", NOT "safe to walk upward" - an unsafe root is neither.
-    :func:`evidence_dirs` keys the walk on
-    :attr:`TargetClassification.inherits_ancestor_evidence`, never on this bool.
+    ⚠️ **Conservative by construction:** damaged, unsafe and otherwise indeterminate boundaries all
+    project ``True``, because ``False`` is read as "ordinary, walk upward" and that is the fail-open
+    direction. ``False`` is reserved for a target *proven* ordinary. A caller that needs to tell an
+    intact package from a damaged one, or to refuse an unsafe root, calls :func:`classify_target`.
     """
     return classify_target(target).is_package
 

--- a/scripts/check_reference_readiness.py
+++ b/scripts/check_reference_readiness.py
@@ -67,7 +67,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 from xml.etree import ElementTree
-from bundle_corpus import evidence_dirs, shipping_reports
+from bundle_corpus import TargetClassification, classify_target, evidence_dirs, shipping_reports
 import object_identity as oid
 from object_identity import AMBIGUOUS
 from reference_evidence import (
@@ -883,6 +883,22 @@ def _collect_evidence(
     return ref_ok + orc_ok, ref_bad + orc_bad
 
 
+def _unsafe_target(root: Path, classification: TargetClassification) -> dict[str, Any]:
+    """The verdict for a target whose boundary could not be established without following a link.
+
+    ⚠️ The wording is the classifier's stable code plus its generic detail, and NOTHING else. The
+    supplied target can itself be a secret-bearing absolute path and the marker can hold customer
+    content; both would end up pasted into an issue. The unit label is the normalized final path
+    component, which every other verdict in this gate already prints.
+    """
+    unit = classification.unit_name or root.name or "target"
+    detail = (
+        f"{classification.code}: {classification.detail} - this gate refuses to fall back to "
+        "ordinary bundle handling and forms NO opinion, which is NOT a pass"
+    )
+    return _merge(root, [_cannot(unit, detail)], [], [])
+
+
 def scan(
     root: Path,
     *,
@@ -891,7 +907,22 @@ def scan(
     oracle_dir: Path | None = None,
     require_validation_grade: bool = False,
 ) -> dict[str, Any]:
-    """Assess every shipping report under ``root``."""
+    """Assess every shipping report under ``root``.
+
+    ⚠️ **Classification comes first, before ``resolve()`` and before any discovery.** The order is
+    the point (issue #562): ``resolve()`` follows a junction, so a caller-supplied alias would have
+    decided the package question about a directory the caller never named, and evidence/source
+    discovery would already have run against it. A package-shaped or explicitly-marked target whose
+    boundary is missing, reparse, non-regular or unassessable - and any root that is itself a
+    link/junction or cannot be ``lstat``-assessed - stops here as ``CANNOT_ESTABLISH``.
+
+    A **safe** package continues into the current behaviour completely unchanged. Proving that its
+    manifest still describes the bytes on disk is the next slice of #562; this is the boundary
+    classifier only.
+    """
+    classification = classify_target(root)
+    if not classification.is_safe:
+        return _unsafe_target(root, classification)
     root = root.resolve()
     evidence, rejected = _collect_evidence(root, reference_dir, oracle_dir)
     engine_report = _engine_report(root)

--- a/scripts/check_reference_readiness.py
+++ b/scripts/check_reference_readiness.py
@@ -1118,6 +1118,28 @@ def _render_page(page: dict[str, Any]) -> str:
     return f"{label}: ready [{page['grade']}] via {page['matched_by']}"
 
 
+def _prevalidate_targets(paths: list[Path]) -> dict[int, dict[str, Any]]:
+    """Classify every CLI target **before** any following check runs, keyed by position.
+
+    ⚠️ **The CLI had its own copy of the ordering defect** (round-1 review of PR #590). `scan()`
+    classified first, but `main()` reached it through `path.is_dir()`, which *follows*: a
+    package-shaped target whose boundary was missing or unassessable failed that check and left via
+    ``parser.error`` - **exit 2, with the supplied path echoed into the message** - so the typed
+    exit-3 refusal this gate exists to produce never happened, and a secret-bearing target was
+    printed on the way out. A gate whose entry point pre-checks in the following direction is not
+    protected by a guard further in.
+
+    Returns the generic refusal verdict for each unsafe target. An empty result means every target
+    classified safe and the caller may run the existing directory/source validation.
+    """
+    refusals: dict[int, dict[str, Any]] = {}
+    for index, path in enumerate(paths):
+        classification = classify_target(path)
+        if not classification.is_safe:
+            refusals[index] = _unsafe_target(path, classification)
+    return refusals
+
+
 def main(argv: list[str] | None = None) -> int:
     """CLI entry point."""
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -1137,21 +1159,29 @@ def main(argv: list[str] | None = None) -> int:
 
     if not args.paths:
         parser.error("give a bundle or migration-unit path")
-    for path in args.paths:
-        if not path.is_dir():
-            parser.error(f"{path} is not a directory")
-    if args.source is not None and not args.source.is_file():
-        parser.error(f"--source {args.source} is not a file")
+
+    refusals = _prevalidate_targets(args.paths)
+    if not refusals:
+        # ⚠️ Only reached once EVERY target classified safe. These are following checks - `is_dir()`
+        # and `is_file()` both dereference - and `parser.error` echoes the supplied path, so running
+        # them ahead of classification is what let a package-shaped target with no boundary exit 2
+        # with its own (possibly customer-bearing) path in the message instead of a typed exit 3.
+        for path in args.paths:
+            if not path.is_dir():
+                parser.error(f"{path} is not a directory")
+        if args.source is not None and not args.source.is_file():
+            parser.error(f"--source {args.source} is not a file")
 
     reports = [
-        scan(
+        refusals.get(index)
+        or scan(
             path,
             explicit_source=args.source,
             reference_dir=args.reference,
             oracle_dir=args.oracle,
             require_validation_grade=args.require_validation_grade,
         )
-        for path in args.paths
+        for index, path in enumerate(args.paths)
     ]
     merged = reports[0] if len(reports) == 1 else _merge_scans(reports)
     if args.json:

--- a/tests/test_bundle_corpus.py
+++ b/tests/test_bundle_corpus.py
@@ -337,9 +337,9 @@ def test_a_linked_root_is_refused_before_the_marker_is_even_looked_for(tmp_path:
     assert result.code == bundle_corpus.CODE_TARGET_ROOT_REPARSE
     assert not result.is_safe
     assert not result.inherits_ancestor_evidence
-    # The bool projection is honest: an unsafe root is not a package. The walk is stopped by
-    # `inherits_ancestor_evidence`, never by this bool.
-    assert bundle_corpus.is_package_target(alias) is False
+    # ⚠️ Round-1 review of #590: the bool projection is CONSERVATIVE, not "honest". An unsafe root
+    # is indeterminate, and `False` here is read as "ordinary, walk upward" - the fail-open answer.
+    assert bundle_corpus.is_package_target(alias) is True
 
 
 def test_an_ordinary_bundle_alias_fails_CLOSED_and_that_is_intentional(tmp_path: Path) -> None:
@@ -463,7 +463,12 @@ def test_diagnostics_never_echo_the_supplied_path_or_marker_bytes(tmp_path: Path
 
 
 def test_evidence_dirs_skips_ancestors_for_every_damaged_package_shape(tmp_path: Path) -> None:
-    """The shared authority both gates read: a damaged boundary is not a licence to walk up."""
+    """The shared walk: a damaged boundary is not a licence to walk up.
+
+    ⚠️ This exercises `evidence_dirs` directly. It is NOT a claim that `check_unit.py` is protected -
+    that gate reaches this walk through `_unit_dir()`, which resolves first (see the residual in
+    `docs/migration-phases.md`).
+    """
     run_root = tmp_path / "run"
     (run_root / "oracle").mkdir(parents=True)
     missing = run_root / "packages" / "NoMarker"
@@ -474,6 +479,63 @@ def test_evidence_dirs_skips_ancestors_for_every_damaged_package_shape(tmp_path:
     for target in (missing, dir_marker):
         assert bundle_corpus.classify_target(target).kind == bundle_corpus.TARGET_PACKAGE_DAMAGED
         assert bundle_corpus.evidence_dirs(target, ("oracle",)) == []
+
+
+@pytest.mark.parametrize("shape", [("packages", "Unit"), ("packages", "batch1", "Unit")])
+def test_the_bool_projection_never_calls_an_indeterminate_boundary_ordinary(
+    tmp_path: Path, monkeypatch, shape: tuple[str, ...]
+) -> None:
+    """Kills: projecting damaged/unsafe/unassessable boundaries as an ordinary ``False``.
+
+    Round-1 review of #590. ``False`` is read by a caller as "ordinary, walk upward", so it is the
+    fail-OPEN answer and must be reserved for a target *proven* ordinary. Flat and nested, missing /
+    permission-denied / reparse, root side and marker side.
+    """
+    base = tmp_path.joinpath("run", *shape)
+
+    missing_marker = base.with_name(base.name + "-missing")
+    missing_marker.mkdir(parents=True)
+
+    reparse_marker = base.with_name(base.name + "-reparse")
+    reparse_marker.mkdir(parents=True)
+    marker = reparse_marker / bundle_corpus.PACKAGE_MARKER
+    marker.write_text("{}\n", encoding="utf-8")
+
+    denied_root = base.with_name(base.name + "-denied-root")
+    denied_root.mkdir(parents=True)
+    denied_marker = base.with_name(base.name + "-denied-marker")
+    denied_marker.mkdir(parents=True)
+
+    real_lstat = os.lstat
+
+    def fake(path, *args, **kwargs):
+        if Path(path) == marker:
+            return _FakeStat(stat.S_IFREG | 0o666, bundle_corpus.FILE_ATTRIBUTE_REPARSE_POINT)
+        if Path(path) in (denied_root, denied_marker / bundle_corpus.PACKAGE_MARKER):
+            raise PermissionError(13, "denied")
+        return real_lstat(path, *args, **kwargs)
+
+    monkeypatch.setattr(bundle_corpus.os, "lstat", fake)
+
+    for target in (missing_marker, reparse_marker, denied_root, denied_marker):
+        classification = bundle_corpus.classify_target(target)
+        assert classification.kind != bundle_corpus.TARGET_ORDINARY
+        assert bundle_corpus.is_package_target(target) is True, classification.code
+        # The bool is the strict complement of the property the walk actually keys on, so a caller
+        # reading either one cannot be told two different things.
+        assert bundle_corpus.is_package_target(target) is not classification.inherits_ancestor_evidence
+
+
+def test_the_bool_projection_stays_false_for_a_target_proven_ordinary(tmp_path: Path) -> None:
+    """The vacuity control: a conservative projection that said True for everything is useless."""
+    unpackaged = tmp_path / "run" / "bundle" / "pbip" / "Unit"
+    unpackaged.mkdir(parents=True)
+    never_built = tmp_path / "run" / "bundle" / "pbip" / "NeverBuilt"
+
+    for target in (unpackaged, never_built):
+        assert bundle_corpus.classify_target(target).kind == bundle_corpus.TARGET_ORDINARY
+        assert bundle_corpus.is_package_target(target) is False
+        assert bundle_corpus.classify_target(target).inherits_ancestor_evidence is True
 
 
 def test_shipping_reports_use_pbip_not_engine_baseline(tmp_path: Path) -> None:

--- a/tests/test_bundle_corpus.py
+++ b/tests/test_bundle_corpus.py
@@ -29,15 +29,39 @@ import bundle_corpus  # noqa: E402  # pylint: disable=wrong-import-position
 _FOLLOWING_PRIMITIVES = ("resolve", "is_file", "is_dir", "exists", "rglob", "stat", "open")
 
 
+class _Followed(Exception):
+    """Raised at the exact call site where classification dereferenced the supplied path.
+
+    ⚠️ Deliberately NOT `AssertionError`, and deliberately caught inside the patched window (see
+    :func:`_classify_without_following`). `Path.exists` is patched here, and **pytest itself calls it
+    while formatting a failure traceback** - so letting the failure escape with the patch still
+    installed turns a genuine kill into an `INTERNALERROR`, which reports as infrastructure breakage
+    rather than as this test failing. Measured while mutation-testing this file's own controls.
+    """
+
+
 def _forbid_following(monkeypatch: pytest.MonkeyPatch) -> None:
     """Make every link-dereferencing `Path` primitive raise, plus `open`."""
 
     def boom(*_args: object, **_kwargs: object) -> object:
-        raise AssertionError("classification dereferenced the supplied path")
+        raise _Followed("classification dereferenced the supplied path")
 
     for name in _FOLLOWING_PRIMITIVES:
         monkeypatch.setattr(Path, name, boom, raising=True)
     monkeypatch.setattr("builtins.open", boom, raising=True)
+
+
+def _classify_without_following(
+    target: Path, monkeypatch: pytest.MonkeyPatch
+) -> tuple[bundle_corpus.TargetClassification | None, str]:
+    """Classify with every follower armed, then disarm before any assertion can escape."""
+    _forbid_following(monkeypatch)
+    try:
+        return bundle_corpus.classify_target(target), ""
+    except _Followed as exc:
+        return None, str(exc)
+    finally:
+        monkeypatch.undo()
 
 
 def _link_directory(link: Path, target: Path) -> None:
@@ -75,10 +99,11 @@ def _package(root: Path, *, marker: bool = True) -> Path:
 def test_classification_never_dereferences_the_supplied_path(tmp_path: Path, monkeypatch) -> None:
     """Kills: restoring `resolve()`/`is_file()` classification. Every follower raises here."""
     target = _package(tmp_path / "run" / "packages" / "Unit")
-    _forbid_following(monkeypatch)
 
-    result = bundle_corpus.classify_target(target)
+    result, followed = _classify_without_following(target, monkeypatch)
 
+    assert followed == "", followed
+    assert result is not None
     assert result.kind == bundle_corpus.TARGET_PACKAGE
     assert result.code == bundle_corpus.CODE_PACKAGE_BOUNDARY_OK
 

--- a/tests/test_bundle_corpus.py
+++ b/tests/test_bundle_corpus.py
@@ -2,12 +2,453 @@
 
 from __future__ import annotations
 
+import os
+import stat
+import subprocess
 import sys
 from pathlib import Path
+
+import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
 
 import bundle_corpus  # noqa: E402  # pylint: disable=wrong-import-position
+
+
+# ---------------------------------------------------------------------------------------------
+# Package-target classification (issue #562)
+# ---------------------------------------------------------------------------------------------
+#
+# The invariant under test: the boundary question is answered from LEXICAL placement plus a
+# no-follow `lstat` of the supplied root and its root marker entry - before any `resolve()`, any
+# child traversal and any source/evidence discovery. Every control below is independent: each names
+# one damaged/unsafe shape and asserts the specific classification it must produce.
+
+#: Every following primitive the classifier is forbidden to use. Patched to explode, not to count,
+#: so a violation is a hard failure at the exact call site rather than a soft assertion afterwards.
+_FOLLOWING_PRIMITIVES = ("resolve", "is_file", "is_dir", "exists", "rglob", "stat", "open")
+
+
+def _forbid_following(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make every link-dereferencing `Path` primitive raise, plus `open`."""
+
+    def boom(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("classification dereferenced the supplied path")
+
+    for name in _FOLLOWING_PRIMITIVES:
+        monkeypatch.setattr(Path, name, boom, raising=True)
+    monkeypatch.setattr("builtins.open", boom, raising=True)
+
+
+def _link_directory(link: Path, target: Path) -> None:
+    """A junction (Windows) or a directory symlink (POSIX) - a reparse point either way."""
+    link.parent.mkdir(parents=True, exist_ok=True)
+    if sys.platform == "win32":
+        completed = subprocess.run(  # noqa: S603
+            ["cmd", "/c", "mklink", "/J", str(link), str(target)], capture_output=True, check=False
+        )
+        if completed.returncode != 0:
+            pytest.skip(f"could not create junction: {completed.stderr.decode(errors='replace').strip()}")
+        return
+    try:
+        link.symlink_to(target, target_is_directory=True)
+    except (OSError, NotImplementedError):  # pragma: no cover - privilege-dependent
+        pytest.skip("this platform/account cannot create symlinks without elevation")
+
+
+def _link_file(link: Path, target: Path) -> None:
+    """A file symlink. Needs elevation on Windows, so it skips with the registered reason there."""
+    try:
+        link.symlink_to(target)
+    except (OSError, NotImplementedError):
+        pytest.skip("this platform/account cannot create symlinks without elevation")
+
+
+def _package(root: Path, *, marker: bool = True) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "fabric").mkdir(exist_ok=True)
+    if marker:
+        (root / bundle_corpus.PACKAGE_MARKER).write_text("{}\n", encoding="utf-8")
+    return root
+
+
+def test_classification_never_dereferences_the_supplied_path(tmp_path: Path, monkeypatch) -> None:
+    """Kills: restoring `resolve()`/`is_file()` classification. Every follower raises here."""
+    target = _package(tmp_path / "run" / "packages" / "Unit")
+    _forbid_following(monkeypatch)
+
+    result = bundle_corpus.classify_target(target)
+
+    assert result.kind == bundle_corpus.TARGET_PACKAGE
+    assert result.code == bundle_corpus.CODE_PACKAGE_BOUNDARY_OK
+
+
+@pytest.mark.parametrize(
+    ("spelling", "placement"),
+    [
+        (("run", "packages", "Unit"), bundle_corpus.PLACEMENT_FLAT),
+        (("run", "packages", "batch1", "Unit"), bundle_corpus.PLACEMENT_NESTED),
+        (("run", "bundle", "pbip", "Unit"), bundle_corpus.PLACEMENT_NONE),
+        (("run", "packages"), bundle_corpus.PLACEMENT_NONE),
+    ],
+)
+def test_placement_is_lexical_and_needs_no_filesystem(spelling: tuple[str, ...], placement: str) -> None:
+    """Flat and nested are recognized from the normalized components alone, marker or no marker."""
+    assert bundle_corpus.package_placement(Path("C:/root").joinpath(*spelling)) == placement
+
+
+def test_a_clean_flat_and_nested_package_classify_as_intact_packages(tmp_path: Path) -> None:
+    """Control: the ordinary good cases must stay clean, or the gate is unusable."""
+    flat = _package(tmp_path / "run" / "packages" / "Flat")
+    nested = _package(tmp_path / "run" / "packages" / "batch1" / "Nested")
+
+    for target, placement in ((flat, bundle_corpus.PLACEMENT_FLAT), (nested, bundle_corpus.PLACEMENT_NESTED)):
+        result = bundle_corpus.classify_target(target)
+        assert (result.kind, result.placement) == (bundle_corpus.TARGET_PACKAGE, placement)
+        assert result.is_safe and result.is_package and result.declares_self_contained
+        assert not result.inherits_ancestor_evidence
+
+
+def test_a_moved_package_with_a_regular_marker_outside_packages_is_still_recognized(tmp_path: Path) -> None:
+    """A regular, non-reparse marker is an explicit declaration wherever the package was moved to."""
+    moved = _package(tmp_path / "somewhere" / "else" / "Unit")
+
+    result = bundle_corpus.classify_target(moved)
+
+    assert result.kind == bundle_corpus.TARGET_PACKAGE
+    assert result.placement == bundle_corpus.PLACEMENT_NONE
+    assert bundle_corpus.is_package_target(moved) is True
+    assert bundle_corpus.is_self_contained(moved) is True
+
+
+def test_an_ordinary_unpackaged_unit_stays_non_package_and_keeps_ancestor_evidence(tmp_path: Path) -> None:
+    """Compatibility control: the un-packaged shape must be untouched by the classifier."""
+    run_root = tmp_path / "run"
+    target = run_root / "bundle" / "pbip" / "Unit"
+    target.mkdir(parents=True)
+    (run_root / "oracle").mkdir()
+
+    result = bundle_corpus.classify_target(target)
+
+    assert result.kind == bundle_corpus.TARGET_ORDINARY
+    assert result.is_safe and result.inherits_ancestor_evidence
+    assert bundle_corpus.is_package_target(target) is False
+    assert bundle_corpus.evidence_dirs(target, ("oracle",)) == [run_root / "oracle"]
+
+
+@pytest.mark.parametrize("spelling", [("packages", "Unit"), ("packages", "batch1", "Unit")])
+def test_a_package_shaped_target_with_no_marker_is_damaged_not_ordinary(
+    tmp_path: Path, spelling: tuple[str, ...]
+) -> None:
+    """Kills: turning a damaged package back into a non-package that falls into bundle handling."""
+    target = tmp_path.joinpath("run", *spelling)
+    target.mkdir(parents=True)
+
+    result = bundle_corpus.classify_target(target)
+
+    assert result.kind == bundle_corpus.TARGET_PACKAGE_DAMAGED
+    assert result.code == bundle_corpus.CODE_PACKAGE_MARKER_MISSING
+    assert result.is_package and not result.is_safe
+    assert not result.inherits_ancestor_evidence
+    assert not result.declares_self_contained
+
+
+def test_a_marker_that_is_a_directory_is_damaged_never_non_package(tmp_path: Path) -> None:
+    """`is_file()` says False for a directory marker, which the old code read as 'not a package'."""
+    target = tmp_path / "run" / "packages" / "Unit"
+    (target / bundle_corpus.PACKAGE_MARKER).mkdir(parents=True)
+
+    result = bundle_corpus.classify_target(target)
+
+    assert result.kind == bundle_corpus.TARGET_PACKAGE_DAMAGED
+    assert result.code == bundle_corpus.CODE_PACKAGE_MARKER_NOT_REGULAR
+    assert bundle_corpus.is_package_target(target) is True
+    assert bundle_corpus.is_self_contained(target) is False
+
+
+def test_a_marker_directory_outside_packages_is_damaged_rather_than_ordinary(tmp_path: Path) -> None:
+    """An ambiguous marker entry is refused wherever it sits, not only under `packages/`."""
+    target = tmp_path / "moved" / "Unit"
+    (target / bundle_corpus.PACKAGE_MARKER).mkdir(parents=True)
+
+    result = bundle_corpus.classify_target(target)
+
+    assert result.kind == bundle_corpus.TARGET_PACKAGE_DAMAGED
+    assert result.placement == bundle_corpus.PLACEMENT_NONE
+
+
+def test_a_symlinked_marker_is_damaged_and_the_boundary_is_never_declared_from_outside(tmp_path: Path) -> None:
+    """Kills: reading the marker with `is_file()`, which follows the link to bytes outside."""
+    outside = tmp_path / "outside" / "real-manifest.json"
+    outside.parent.mkdir(parents=True)
+    outside.write_text("{}\n", encoding="utf-8")
+    target = tmp_path / "run" / "packages" / "Unit"
+    target.mkdir(parents=True)
+    _link_file(target / bundle_corpus.PACKAGE_MARKER, outside)
+
+    result = bundle_corpus.classify_target(target)
+
+    assert result.kind == bundle_corpus.TARGET_PACKAGE_DAMAGED
+    assert result.code == bundle_corpus.CODE_PACKAGE_MARKER_REPARSE
+    assert bundle_corpus.is_self_contained(target) is False
+
+
+def test_a_broken_symlink_marker_is_damaged_rather_than_missing(tmp_path: Path) -> None:
+    """A dangling marker link is still a reparse point: `lstat` sees the link, not the void."""
+    target = tmp_path / "run" / "packages" / "Unit"
+    target.mkdir(parents=True)
+    _link_file(target / bundle_corpus.PACKAGE_MARKER, tmp_path / "never-existed.json")
+
+    result = bundle_corpus.classify_target(target)
+
+    assert result.kind == bundle_corpus.TARGET_PACKAGE_DAMAGED
+    assert result.code == bundle_corpus.CODE_PACKAGE_MARKER_REPARSE
+
+
+def test_a_junction_marker_is_damaged(tmp_path: Path) -> None:
+    """The Windows half of the reparse class: a junction is not a symlink to `S_ISLNK` alone."""
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    target = tmp_path / "run" / "packages" / "Unit"
+    target.mkdir(parents=True)
+    _link_directory(target / bundle_corpus.PACKAGE_MARKER, outside)
+
+    result = bundle_corpus.classify_target(target)
+
+    assert result.kind == bundle_corpus.TARGET_PACKAGE_DAMAGED
+    assert result.code in {
+        bundle_corpus.CODE_PACKAGE_MARKER_REPARSE,
+        bundle_corpus.CODE_PACKAGE_MARKER_NOT_REGULAR,
+    }
+
+
+class _FakeStat:
+    """A minimal `lstat` result. Both fields are exactly what :func:`is_reparse_entry` reads."""
+
+    def __init__(self, st_mode: int, st_file_attributes: int = 0) -> None:
+        self.st_mode = st_mode
+        self.st_file_attributes = st_file_attributes
+
+
+@pytest.mark.parametrize(
+    ("label", "info"),
+    [
+        ("posix symlink", _FakeStat(stat.S_IFLNK | 0o777)),
+        ("windows junction", _FakeStat(stat.S_IFREG | 0o666, bundle_corpus.FILE_ATTRIBUTE_REPARSE_POINT)),
+    ],
+)
+def test_a_reparse_marker_that_READS_as_a_regular_file_is_damaged(
+    tmp_path: Path, monkeypatch, label: str, info: _FakeStat
+) -> None:
+    """Kills: typing the marker with `is_file()`, which follows the link and says True.
+
+    ⚠️ **This is the control the real-link fixtures cannot supply on Windows.** A file symlink needs
+    elevation, and a junction can only point at a DIRECTORY - so on this host every creatable reparse
+    marker also fails `is_file()`, and an `is_file()`-based classifier survives them all. Here the
+    marker on disk IS a regular file and only the no-follow `lstat` reports the reparse, which is
+    precisely the discriminating case.
+
+    The junction row additionally kills an `S_ISLNK`-only predicate: its mode says regular file.
+    """
+    target = tmp_path / "run" / "packages" / "Unit"
+    target.mkdir(parents=True)
+    marker = target / bundle_corpus.PACKAGE_MARKER
+    marker.write_text("{}\n", encoding="utf-8")
+    assert marker.is_file(), "the fixture must be a following-visible regular file, or this is vacuous"
+    real_lstat = os.lstat
+
+    def fake(path, *args, **kwargs):
+        if Path(path) == marker:
+            return info
+        return real_lstat(path, *args, **kwargs)
+
+    monkeypatch.setattr(bundle_corpus.os, "lstat", fake)
+
+    result = bundle_corpus.classify_target(target)
+
+    assert result.kind == bundle_corpus.TARGET_PACKAGE_DAMAGED, label
+    assert result.code == bundle_corpus.CODE_PACKAGE_MARKER_REPARSE, label
+    assert bundle_corpus.is_self_contained(target) is False, label
+
+
+def test_the_reparse_predicate_covers_both_the_link_mode_and_the_windows_attribute() -> None:
+    """Both halves are load-bearing; either alone waves through half the reparse class."""
+    assert bundle_corpus.is_reparse_entry(_FakeStat(stat.S_IFLNK | 0o777)) is True
+    assert (
+        bundle_corpus.is_reparse_entry(_FakeStat(stat.S_IFREG | 0o666, bundle_corpus.FILE_ATTRIBUTE_REPARSE_POINT))
+        is True
+    )
+    assert bundle_corpus.is_reparse_entry(_FakeStat(stat.S_IFREG | 0o666)) is False
+    assert bundle_corpus.is_reparse_entry(_FakeStat(stat.S_IFDIR | 0o777)) is False
+    assert bundle_corpus.FILE_ATTRIBUTE_REPARSE_POINT == 0x0400
+
+
+@pytest.mark.skipif(not hasattr(os, "mkfifo"), reason="os.mkfifo is POSIX-only")
+def test_a_fifo_marker_is_damaged_and_is_never_opened(tmp_path: Path) -> None:
+    """A FIFO marker would BLOCK a reader forever; `lstat` types it without opening it."""
+    target = tmp_path / "run" / "packages" / "Unit"
+    target.mkdir(parents=True)
+    os.mkfifo(target / bundle_corpus.PACKAGE_MARKER)  # pylint: disable=no-member
+
+    result = bundle_corpus.classify_target(target)
+
+    assert result.kind == bundle_corpus.TARGET_PACKAGE_DAMAGED
+    assert result.code == bundle_corpus.CODE_PACKAGE_MARKER_NOT_REGULAR
+
+
+def test_a_linked_root_is_refused_before_the_marker_is_even_looked_for(tmp_path: Path) -> None:
+    """Kills: checking the marker before the root.
+
+    The link's destination holds a **valid** package, so a classifier that followed the alias would
+    happily report an intact boundary for a directory the caller never named.
+    """
+    destination = _package(tmp_path / "real" / "packages" / "Unit")
+    alias = tmp_path / "alias" / "packages" / "Unit"
+    _link_directory(alias, destination)
+
+    result = bundle_corpus.classify_target(alias)
+
+    assert result.kind == bundle_corpus.TARGET_UNSAFE_ROOT
+    assert result.code == bundle_corpus.CODE_TARGET_ROOT_REPARSE
+    assert not result.is_safe
+    assert not result.inherits_ancestor_evidence
+    # The bool projection is honest: an unsafe root is not a package. The walk is stopped by
+    # `inherits_ancestor_evidence`, never by this bool.
+    assert bundle_corpus.is_package_target(alias) is False
+
+
+def test_an_ordinary_bundle_alias_fails_CLOSED_and_that_is_intentional(tmp_path: Path) -> None:
+    """The documented compatibility cost: an aliased ORDINARY bundle is refused, not followed.
+
+    Stated rather than hidden. Following it is the defect (the boundary would be decided about a
+    directory the caller did not name); refusing it is loud, attributable and recoverable.
+    """
+    run_root = tmp_path / "run"
+    real = run_root / "bundle" / "pbip" / "Unit"
+    real.mkdir(parents=True)
+    (run_root / "oracle").mkdir()
+    alias = tmp_path / "alias-unit"
+    _link_directory(alias, real)
+
+    result = bundle_corpus.classify_target(alias)
+
+    assert result.kind == bundle_corpus.TARGET_UNSAFE_ROOT
+    assert not result.is_safe
+    assert bundle_corpus.evidence_dirs(alias, ("oracle",)) == [], "an unsafe root inherits nothing"
+    # The unaliased spelling keeps working, which is the recovery.
+    assert bundle_corpus.evidence_dirs(real, ("oracle",)) == [run_root / "oracle"]
+
+
+def test_an_unassessable_root_is_non_clean_and_never_exception_shaped_success(tmp_path: Path, monkeypatch) -> None:
+    """A permission/OS error on the root `lstat` may not be swallowed into 'ordinary'."""
+    target = tmp_path / "run" / "packages" / "Unit"
+    target.mkdir(parents=True)
+    real_lstat = os.lstat
+
+    def deny(path, *args, **kwargs):
+        if Path(path) == target:
+            raise PermissionError(13, "denied")
+        return real_lstat(path, *args, **kwargs)
+
+    monkeypatch.setattr(bundle_corpus.os, "lstat", deny)
+
+    result = bundle_corpus.classify_target(target)
+
+    assert result.kind == bundle_corpus.TARGET_UNSAFE_ROOT
+    assert result.code == bundle_corpus.CODE_TARGET_ROOT_UNASSESSABLE
+    assert not result.is_safe
+
+
+def test_an_unassessable_marker_under_package_placement_is_damaged(tmp_path: Path, monkeypatch) -> None:
+    """'I could not tell whether a marker is there' is grouped with non-clean, never with clean."""
+    target = tmp_path / "run" / "packages" / "Unit"
+    target.mkdir(parents=True)
+    marker = target / bundle_corpus.PACKAGE_MARKER
+    real_lstat = os.lstat
+
+    def deny(path, *args, **kwargs):
+        if Path(path) == marker:
+            raise PermissionError(13, "denied")
+        return real_lstat(path, *args, **kwargs)
+
+    monkeypatch.setattr(bundle_corpus.os, "lstat", deny)
+
+    result = bundle_corpus.classify_target(target)
+
+    assert result.kind == bundle_corpus.TARGET_PACKAGE_DAMAGED
+    assert result.code == bundle_corpus.CODE_PACKAGE_MARKER_UNASSESSABLE
+    assert not result.is_safe
+
+
+def test_a_missing_ordinary_root_stays_ordinary_but_a_missing_package_root_is_damaged(tmp_path: Path) -> None:
+    """Absent is not ambiguous - but an absent package BOUNDARY still is not a bundle."""
+    ordinary = bundle_corpus.classify_target(tmp_path / "bundle" / "pbip" / "NeverBuilt")
+    packaged = bundle_corpus.classify_target(tmp_path / "run" / "packages" / "NeverBuilt")
+
+    assert ordinary.kind == bundle_corpus.TARGET_ORDINARY
+    assert packaged.kind == bundle_corpus.TARGET_PACKAGE_DAMAGED
+    assert packaged.code == bundle_corpus.CODE_PACKAGE_ROOT_MISSING
+
+
+def test_a_package_shaped_root_that_is_a_regular_file_is_damaged(tmp_path: Path) -> None:
+    """A package boundary has to be a directory; a file wearing the name is not one."""
+    target = tmp_path / "run" / "packages" / "Unit"
+    target.parent.mkdir(parents=True)
+    target.write_text("not a package\n", encoding="utf-8")
+
+    result = bundle_corpus.classify_target(target)
+
+    assert result.kind == bundle_corpus.TARGET_PACKAGE_DAMAGED
+    assert result.code == bundle_corpus.CODE_PACKAGE_ROOT_NOT_DIRECTORY
+
+
+def test_a_deceptive_dot_dot_spelling_cannot_become_a_package_and_normalizes_lexically() -> None:
+    """`packages/../Unit` is `Unit`. Defined lexically, so no dereference can change the answer.
+
+    ⚠️ This is a deliberate behaviour change: the previous `parent.parent.name` check read the
+    literal `..` component and called this a NESTED package.
+    """
+    deceptive = Path("C:/run/packages/../Unit")
+    assert bundle_corpus.normalized_parts(deceptive)[-2:] == ("run", "Unit")
+    assert "packages" not in bundle_corpus.normalized_parts(deceptive)
+    assert bundle_corpus.package_placement(deceptive) == bundle_corpus.PLACEMENT_NONE
+
+    # ...while a `..` INSIDE the package shape collapses to the flat shape it really is.
+    assert bundle_corpus.package_placement(Path("C:/run/packages/batch1/../Unit")) == bundle_corpus.PLACEMENT_FLAT
+    # A relative path may not eat its own leading `..`.
+    assert bundle_corpus.normalized_parts(Path("../packages/Unit")) == ("..", "packages", "Unit")
+    assert bundle_corpus.package_placement(Path("../packages/Unit")) == bundle_corpus.PLACEMENT_FLAT
+
+
+def test_diagnostics_never_echo_the_supplied_path_or_marker_bytes(tmp_path: Path) -> None:
+    """Codes and wording are stable and generic: these strings get pasted into shared verdicts."""
+    secret = tmp_path / "customer-secret-server" / "packages" / "Unit"
+    marker = secret / bundle_corpus.PACKAGE_MARKER
+    marker.mkdir(parents=True)
+    (marker / "SECRET-TOKEN.txt").write_text("SECRET-TOKEN\n", encoding="utf-8")
+
+    result = bundle_corpus.classify_target(secret)
+    missing = bundle_corpus.classify_target(tmp_path / "customer-secret-server" / "packages" / "Other")
+
+    assert result.code == bundle_corpus.CODE_PACKAGE_MARKER_NOT_REGULAR
+    for classification in (result, missing):
+        assert "customer-secret-server" not in classification.detail
+        assert str(tmp_path) not in classification.detail
+        assert "SECRET-TOKEN" not in classification.detail
+
+
+def test_evidence_dirs_skips_ancestors_for_every_damaged_package_shape(tmp_path: Path) -> None:
+    """The shared authority both gates read: a damaged boundary is not a licence to walk up."""
+    run_root = tmp_path / "run"
+    (run_root / "oracle").mkdir(parents=True)
+    missing = run_root / "packages" / "NoMarker"
+    missing.mkdir(parents=True)
+    dir_marker = run_root / "packages" / "DirMarker"
+    (dir_marker / bundle_corpus.PACKAGE_MARKER).mkdir(parents=True)
+
+    for target in (missing, dir_marker):
+        assert bundle_corpus.classify_target(target).kind == bundle_corpus.TARGET_PACKAGE_DAMAGED
+        assert bundle_corpus.evidence_dirs(target, ("oracle",)) == []
 
 
 def test_shipping_reports_use_pbip_not_engine_baseline(tmp_path: Path) -> None:

--- a/tests/test_check_reference_readiness.py
+++ b/tests/test_check_reference_readiness.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import hashlib
 import json
 import struct
+import subprocess
 import sys
 import zlib
 from pathlib import Path
@@ -31,6 +32,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
 
+import bundle_corpus  # noqa: E402  # pylint: disable=wrong-import-position
 import check_reference_readiness as crr  # noqa: E402  # pylint: disable=wrong-import-position
 
 # Page ids observed in the real engine bundle
@@ -1345,3 +1347,174 @@ def test_every_integer_counter_survives_a_merge_by_construction(tmp_path: Path) 
     assert unsummed == set(), f"a counter silently dropped on merge: {sorted(unsummed)}"
     # `bool` is an `int` subclass, so the conjunction must NOT have been tallied into 2.
     assert merged["all_evidence_validation_grade"] in (True, False)
+
+
+# --------------------------------------------------------------------------------------------
+# Package-boundary classification runs BEFORE resolve and before any discovery (issue #562)
+# --------------------------------------------------------------------------------------------
+
+
+def _link_directory(link: Path, target: Path) -> None:
+    """A junction (Windows) or a directory symlink (POSIX) - a reparse point either way."""
+    link.parent.mkdir(parents=True, exist_ok=True)
+    if sys.platform == "win32":
+        completed = subprocess.run(  # noqa: S603
+            ["cmd", "/c", "mklink", "/J", str(link), str(target)], capture_output=True, check=False
+        )
+        if completed.returncode != 0:
+            pytest.skip(f"could not create junction: {completed.stderr.decode(errors='replace').strip()}")
+        return
+    try:
+        link.symlink_to(target, target_is_directory=True)
+    except (OSError, NotImplementedError):  # pragma: no cover - privilege-dependent
+        pytest.skip("this platform/account cannot create symlinks without elevation")
+
+
+def _forbid_discovery(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Explode on every step `scan` must not reach for an unsafe target.
+
+    `Path.resolve` is included deliberately: the ORDER is the invariant. `resolve()` follows a
+    junction, so classifying after it would already have answered the boundary question about a
+    directory the caller never named.
+    """
+
+    def boom(*_args: object, **_kwargs: object) -> object:
+        raise AssertionError("scan continued past an unsafe package classification")
+
+    monkeypatch.setattr(Path, "resolve", boom)
+    monkeypatch.setattr(crr, "_collect_evidence", boom)
+    monkeypatch.setattr(crr, "_engine_report", boom)
+    monkeypatch.setattr(crr, "shipping_reports", boom)
+    monkeypatch.setattr(crr, "resolve_source", boom)
+
+
+def test_a_package_shaped_target_with_no_marker_blocks_before_resolve_and_discovery(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Flat placement, missing boundary: CANNOT_ESTABLISH, and nothing downstream may fire."""
+    unit = tmp_path / "run" / "packages" / "Minimal"
+    (unit / "fabric").mkdir(parents=True)
+    _forbid_discovery(monkeypatch)
+
+    report = crr.scan(unit)
+
+    assert report["status"] == crr.STATUS_CANNOT_ESTABLISH
+    assert report["units_cannot_establish"] == 1
+    assert report["pages_expected"] == 0
+    assert bundle_corpus.CODE_PACKAGE_MARKER_MISSING in report["units"][0]["detail"]
+
+
+def test_a_nested_package_shaped_target_with_no_marker_blocks_too(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The nested `<...>/packages/<batch>/<Unit>` spelling is the same boundary claim."""
+    unit = tmp_path / "run" / "packages" / "batch1" / "Minimal"
+    (unit / "fabric").mkdir(parents=True)
+    _forbid_discovery(monkeypatch)
+
+    report = crr.scan(unit)
+
+    assert report["status"] == crr.STATUS_CANNOT_ESTABLISH
+    assert bundle_corpus.CODE_PACKAGE_MARKER_MISSING in report["units"][0]["detail"]
+
+
+def test_a_marker_that_is_a_directory_blocks_before_anything_reads_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A non-regular marker is damaged, never non-package - so it never falls back to bundle handling."""
+    unit = tmp_path / "run" / "packages" / "Minimal"
+    (unit / bundle_corpus.PACKAGE_MARKER).mkdir(parents=True)
+    _forbid_discovery(monkeypatch)
+
+    report = crr.scan(unit)
+
+    assert report["status"] == crr.STATUS_CANNOT_ESTABLISH
+    assert bundle_corpus.CODE_PACKAGE_MARKER_NOT_REGULAR in report["units"][0]["detail"]
+
+
+def test_a_linked_root_blocks_even_when_its_destination_is_a_valid_package(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The strongest control: following the alias would have reported an INTACT boundary."""
+    destination = tmp_path / "real" / "packages" / "Minimal"
+    (destination / "fabric").mkdir(parents=True)
+    (destination / bundle_corpus.PACKAGE_MARKER).write_text("{}\n", encoding="utf-8")
+    alias = tmp_path / "alias" / "packages" / "Minimal"
+    _link_directory(alias, destination)
+    _forbid_discovery(monkeypatch)
+
+    report = crr.scan(alias)
+
+    assert report["status"] == crr.STATUS_CANNOT_ESTABLISH
+    assert bundle_corpus.CODE_TARGET_ROOT_REPARSE in report["units"][0]["detail"]
+
+
+def test_an_aliased_ORDINARY_bundle_fails_closed_and_the_real_path_still_works(tmp_path: Path) -> None:
+    """The documented compatibility cost of refusing a caller-supplied root alias.
+
+    Fail-closed by choice: the operator passes the real path, which is loud and recoverable. The
+    fail-open alternative decides a boundary about a directory nobody named.
+    """
+    bundle = tmp_path / "run" / "bundle"
+    bundle.mkdir(parents=True)
+    (tmp_path / "run" / "assets").mkdir()
+    build_unit(bundle, "Minimal", worksheets=["Revenue"])
+    write_oracle(bundle, [{"view_name": "Revenue", "view_type": "worksheet", "workbook_luid": UNIT_LUID}])
+    alias = tmp_path / "alias-bundle"
+    _link_directory(alias, bundle)
+
+    assert crr.main([str(alias), "--quiet"]) == crr.EXIT_CANNOT_ESTABLISH
+    assert crr.main([str(bundle), "--quiet"]) == crr.EXIT_OK
+
+
+def test_an_unassessable_root_blocks_rather_than_reading_as_an_ordinary_bundle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No exception-shaped success: an lstat error is non-clean, not 'ordinary'."""
+    unit = tmp_path / "run" / "packages" / "Minimal"
+    (unit / "fabric").mkdir(parents=True)
+    real_lstat = bundle_corpus.os.lstat
+
+    def deny(path, *args, **kwargs):
+        if Path(path) == unit:
+            raise PermissionError(13, "denied")
+        return real_lstat(path, *args, **kwargs)
+
+    monkeypatch.setattr(bundle_corpus.os, "lstat", deny)
+    _forbid_discovery(monkeypatch)
+
+    report = crr.scan(unit)
+
+    assert report["status"] == crr.STATUS_CANNOT_ESTABLISH
+    assert bundle_corpus.CODE_TARGET_ROOT_UNASSESSABLE in report["units"][0]["detail"]
+
+
+def test_the_refusal_detail_carries_a_stable_code_and_no_host_path(tmp_path: Path) -> None:
+    """These verdicts get pasted into issues; the supplied target can be secret-bearing."""
+    unit = tmp_path / "customer-secret-server" / "packages" / "Minimal"
+    (unit / "fabric").mkdir(parents=True)
+
+    detail = crr.scan(unit)["units"][0]["detail"]
+
+    assert bundle_corpus.CODE_PACKAGE_MARKER_MISSING in detail
+    assert "customer-secret-server" not in detail
+    assert str(tmp_path) not in detail
+
+
+def test_a_SAFE_package_continues_into_the_current_behaviour_unchanged(tmp_path: Path) -> None:
+    """The classifier is a precondition, not a new verdict: an intact package still reports READY.
+
+    ⚠️ This is the vacuity control for every block above. Without it, classifying EVERYTHING as
+    unsafe would satisfy them all.
+    """
+    unit = tmp_path / "run" / "packages" / "Minimal"
+    unit.mkdir(parents=True)
+    (tmp_path / "run" / "packages" / "assets").mkdir()
+    build_unit(unit, "Minimal", worksheets=["Revenue"])
+    write_oracle(unit, [{"view_name": "Revenue", "view_type": "worksheet", "workbook_luid": UNIT_LUID}])
+    (unit / bundle_corpus.PACKAGE_MARKER).write_text("{}\n", encoding="utf-8")
+
+    report = crr.scan(unit)
+
+    assert report["status"] == crr.STATUS_READY
+    assert report["pages_ready"] == report["pages_expected"] == 1

--- a/tests/test_check_reference_readiness.py
+++ b/tests/test_check_reference_readiness.py
@@ -1413,6 +1413,110 @@ def _scan_forbidding_discovery(unit: Path, monkeypatch: pytest.MonkeyPatch) -> t
         monkeypatch.undo()
 
 
+def _main_forbidding_following(argv: list[str], monkeypatch: pytest.MonkeyPatch) -> tuple[int | None, str]:
+    """Run the CLI with every FOLLOWING pre-check armed, disarming before anything is asserted.
+
+    ⚠️ `is_dir()` and `is_file()` are the CLI's own pre-checks and both dereference, so arming them
+    is what proves the ORDER: a refusal that comes back while they are still armed cannot have
+    consulted them. Same sentinel discipline as :func:`_scan_forbidding_discovery` - pytest formats
+    tracebacks with these very primitives.
+    """
+
+    def boom(*_args: object, **_kwargs: object) -> object:
+        raise _Continued("main ran a following pre-check before classifying the target")
+
+    monkeypatch.setattr(Path, "is_dir", boom)
+    monkeypatch.setattr(Path, "is_file", boom)
+    monkeypatch.setattr(Path, "resolve", boom)
+    try:
+        return crr.main(argv), ""
+    except _Continued as exc:
+        return None, str(exc)
+    finally:
+        monkeypatch.undo()
+
+
+@pytest.mark.parametrize("spelling", [("packages", "Minimal"), ("packages", "batch1", "Minimal")])
+def test_main_refuses_a_missing_package_shaped_root_with_the_typed_exit_instead_of_argparse(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, spelling: tuple[str, ...]
+) -> None:
+    """Kills: pre-checking with `is_dir()` before classifying.
+
+    The CLI used to reach `path.is_dir()` first, so a package-shaped root with no boundary left via
+    `parser.error` - **exit 2, with the supplied path echoed** - instead of the typed exit 3.
+    """
+    unit = tmp_path.joinpath("run", *spelling)
+
+    code, followed = _main_forbidding_following([str(unit), "--quiet"], monkeypatch)
+
+    assert followed == "", followed
+    assert code == crr.EXIT_CANNOT_ESTABLISH
+
+
+def test_main_refuses_an_unassessable_package_shaped_root_with_the_typed_exit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An lstat error is indeterminate, so it is exit 3 - never argparse's exit 2, never a pass."""
+    unit = tmp_path / "run" / "packages" / "Minimal"
+    (unit / "fabric").mkdir(parents=True)
+    real_lstat = bundle_corpus.os.lstat
+
+    def deny(path, *args, **kwargs):
+        if Path(path) == unit:
+            raise PermissionError(13, "denied")
+        return real_lstat(path, *args, **kwargs)
+
+    monkeypatch.setattr(bundle_corpus.os, "lstat", deny)
+
+    code, followed = _main_forbidding_following([str(unit), "--quiet"], monkeypatch)
+
+    assert followed == "", followed
+    assert code == crr.EXIT_CANNOT_ESTABLISH
+
+
+def test_main_refuses_an_unsafe_root_alias_before_its_own_pre_checks(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An aliased root is refused by classification, not by a pre-check that would have followed it."""
+    destination = tmp_path / "real" / "packages" / "Minimal"
+    (destination / "fabric").mkdir(parents=True)
+    (destination / bundle_corpus.PACKAGE_MARKER).write_text("{}\n", encoding="utf-8")
+    alias = tmp_path / "alias" / "packages" / "Minimal"
+    _link_directory(alias, destination)
+
+    code, followed = _main_forbidding_following([str(alias), "--quiet"], monkeypatch)
+
+    assert followed == "", followed
+    assert code == crr.EXIT_CANNOT_ESTABLISH
+
+
+def test_main_prints_the_stable_code_and_no_supplied_path_for_a_refused_target(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The rendered CLI verdict is what gets pasted into an issue; the target can be secret-bearing."""
+    unit = tmp_path / "customer-secret-server" / "packages" / "Minimal"
+
+    code = crr.main([str(unit)])
+    printed = capsys.readouterr().out
+
+    assert code == crr.EXIT_CANNOT_ESTABLISH
+    assert bundle_corpus.CODE_PACKAGE_ROOT_MISSING in printed
+    assert "customer-secret-server" not in printed
+    assert str(tmp_path) not in printed
+
+
+def test_main_keeps_argparses_verdict_for_an_ORDINARY_missing_path(tmp_path: Path) -> None:
+    """Compatibility control: only a package-shaped or unsafe target is diverted.
+
+    ⚠️ Without this, classifying everything as refusable would satisfy the controls above while
+    silently swallowing the ordinary typo case that argparse is right to reject.
+    """
+    with pytest.raises(SystemExit) as exit_info:
+        crr.main([str(tmp_path / "run" / "bundle" / "NeverBuilt"), "--quiet"])
+
+    assert exit_info.value.code == 2
+
+
 def test_a_package_shaped_target_with_no_marker_blocks_before_resolve_and_discovery(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_check_reference_readiness.py
+++ b/tests/test_check_reference_readiness.py
@@ -1354,6 +1354,14 @@ def test_every_integer_counter_survives_a_merge_by_construction(tmp_path: Path) 
 # --------------------------------------------------------------------------------------------
 
 
+class _Continued(Exception):
+    """Raised at the exact call site where `scan` continued past an unsafe classification.
+
+    Deliberately not `AssertionError`: it is caught inside the patched window so the patches are
+    undone before pytest formats anything (see :func:`_scan_forbidding_discovery`).
+    """
+
+
 def _link_directory(link: Path, target: Path) -> None:
     """A junction (Windows) or a directory symlink (POSIX) - a reparse point either way."""
     link.parent.mkdir(parents=True, exist_ok=True)
@@ -1379,7 +1387,7 @@ def _forbid_discovery(monkeypatch: pytest.MonkeyPatch) -> None:
     """
 
     def boom(*_args: object, **_kwargs: object) -> object:
-        raise AssertionError("scan continued past an unsafe package classification")
+        raise _Continued("scan continued past an unsafe package classification")
 
     monkeypatch.setattr(Path, "resolve", boom)
     monkeypatch.setattr(crr, "_collect_evidence", boom)
@@ -1388,16 +1396,34 @@ def _forbid_discovery(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(crr, "resolve_source", boom)
 
 
+def _scan_forbidding_discovery(unit: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[dict | None, str]:
+    """Scan with every downstream step armed, then disarm before any assertion can escape.
+
+    ⚠️ `Path.resolve` is patched globally and **pytest uses it while formatting a failure
+    traceback**, so a kill that escaped the patched window would surface as an `INTERNALERROR` -
+    infrastructure breakage rather than this test failing. Measured while mutation-testing these
+    controls; the sentinel is caught here and the patches are undone before anything is asserted.
+    """
+    _forbid_discovery(monkeypatch)
+    try:
+        return crr.scan(unit), ""
+    except _Continued as exc:
+        return None, str(exc)
+    finally:
+        monkeypatch.undo()
+
+
 def test_a_package_shaped_target_with_no_marker_blocks_before_resolve_and_discovery(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Flat placement, missing boundary: CANNOT_ESTABLISH, and nothing downstream may fire."""
     unit = tmp_path / "run" / "packages" / "Minimal"
     (unit / "fabric").mkdir(parents=True)
-    _forbid_discovery(monkeypatch)
 
-    report = crr.scan(unit)
+    report, continued = _scan_forbidding_discovery(unit, monkeypatch)
 
+    assert continued == "", continued
+    assert report is not None
     assert report["status"] == crr.STATUS_CANNOT_ESTABLISH
     assert report["units_cannot_establish"] == 1
     assert report["pages_expected"] == 0
@@ -1410,10 +1436,11 @@ def test_a_nested_package_shaped_target_with_no_marker_blocks_too(
     """The nested `<...>/packages/<batch>/<Unit>` spelling is the same boundary claim."""
     unit = tmp_path / "run" / "packages" / "batch1" / "Minimal"
     (unit / "fabric").mkdir(parents=True)
-    _forbid_discovery(monkeypatch)
 
-    report = crr.scan(unit)
+    report, continued = _scan_forbidding_discovery(unit, monkeypatch)
 
+    assert continued == "", continued
+    assert report is not None
     assert report["status"] == crr.STATUS_CANNOT_ESTABLISH
     assert bundle_corpus.CODE_PACKAGE_MARKER_MISSING in report["units"][0]["detail"]
 
@@ -1424,10 +1451,11 @@ def test_a_marker_that_is_a_directory_blocks_before_anything_reads_it(
     """A non-regular marker is damaged, never non-package - so it never falls back to bundle handling."""
     unit = tmp_path / "run" / "packages" / "Minimal"
     (unit / bundle_corpus.PACKAGE_MARKER).mkdir(parents=True)
-    _forbid_discovery(monkeypatch)
 
-    report = crr.scan(unit)
+    report, continued = _scan_forbidding_discovery(unit, monkeypatch)
 
+    assert continued == "", continued
+    assert report is not None
     assert report["status"] == crr.STATUS_CANNOT_ESTABLISH
     assert bundle_corpus.CODE_PACKAGE_MARKER_NOT_REGULAR in report["units"][0]["detail"]
 
@@ -1441,10 +1469,11 @@ def test_a_linked_root_blocks_even_when_its_destination_is_a_valid_package(
     (destination / bundle_corpus.PACKAGE_MARKER).write_text("{}\n", encoding="utf-8")
     alias = tmp_path / "alias" / "packages" / "Minimal"
     _link_directory(alias, destination)
-    _forbid_discovery(monkeypatch)
 
-    report = crr.scan(alias)
+    report, continued = _scan_forbidding_discovery(alias, monkeypatch)
 
+    assert continued == "", continued
+    assert report is not None
     assert report["status"] == crr.STATUS_CANNOT_ESTABLISH
     assert bundle_corpus.CODE_TARGET_ROOT_REPARSE in report["units"][0]["detail"]
 
@@ -1481,10 +1510,11 @@ def test_an_unassessable_root_blocks_rather_than_reading_as_an_ordinary_bundle(
         return real_lstat(path, *args, **kwargs)
 
     monkeypatch.setattr(bundle_corpus.os, "lstat", deny)
-    _forbid_discovery(monkeypatch)
 
-    report = crr.scan(unit)
+    report, continued = _scan_forbidding_discovery(unit, monkeypatch)
 
+    assert continued == "", continued
+    assert report is not None
     assert report["status"] == crr.STATUS_CANNOT_ESTABLISH
     assert bundle_corpus.CODE_TARGET_ROOT_UNASSESSABLE in report["units"][0]["detail"]
 

--- a/tests/test_package_unit_gates.py
+++ b/tests/test_package_unit_gates.py
@@ -554,12 +554,16 @@ def test_incomplete_flat_package_without_manifest_fails_closed_when_ancestor_evi
     (unit / "package-manifest.json").unlink()
     shutil.rmtree(unit / "oracle")
 
-    # Entry gate refuses ancestor evidence: reports blind pages rather than READY
+    # Entry gate refuses ancestor evidence. ⚠️ The refusal SHAPE changed with #562: the damaged
+    # boundary is now classified before the root is resolved and before any discovery runs, so the
+    # gate forms no opinion at all instead of reporting the unit's pages as blind. Both are exit 3;
+    # the new one additionally proves discovery never happened.
     code, payload = _readiness(unit, tmp_path)
-    assert code in {1, 3}
-    assert payload["status"] in {"FINDINGS", "CANNOT_ESTABLISH"}
+    assert (code, payload["status"]) == (3, "CANNOT_ESTABLISH")
     assert payload["pages_ready"] == 0
-    assert payload["pages_blind"] == len(objects)
+    assert payload["pages_expected"] == 0, f"classification must precede the {len(objects)}-page expectation"
+    assert payload["evidence_records"] == 0, "no ancestor evidence may be collected for a damaged package"
+    assert "package_marker_missing" in payload["units"][0]["detail"]
 
     # Exit gate refuses ancestor evidence: oracle-coverage is NOT_CHECKED with 0 evidence
     coverage = check_unit.check_oracle_coverage(unit, None, None)
@@ -589,10 +593,11 @@ def test_incomplete_nested_package_without_manifest_fails_closed_when_ancestor_e
     shutil.rmtree(unit / "oracle")
 
     code, payload = _readiness(unit, tmp_path)
-    assert code in {1, 3}
-    assert payload["status"] in {"FINDINGS", "CANNOT_ESTABLISH"}
+    assert (code, payload["status"]) == (3, "CANNOT_ESTABLISH")
     assert payload["pages_ready"] == 0
-    assert payload["pages_blind"] == len(objects)
+    assert payload["pages_expected"] == 0, f"classification must precede the {len(objects)}-page expectation"
+    assert payload["evidence_records"] == 0, "no ancestor evidence may be collected for a damaged package"
+    assert "package_marker_missing" in payload["units"][0]["detail"]
 
     coverage = check_unit.check_oracle_coverage(unit, None, None)
     assert coverage["status"] == check_unit.STATUS_NOT_CHECKED

--- a/tests/test_package_unit_gates.py
+++ b/tests/test_package_unit_gates.py
@@ -554,10 +554,11 @@ def test_incomplete_flat_package_without_manifest_fails_closed_when_ancestor_evi
     (unit / "package-manifest.json").unlink()
     shutil.rmtree(unit / "oracle")
 
-    # Entry gate refuses ancestor evidence. ⚠️ The refusal SHAPE changed with #562: the damaged
-    # boundary is now classified before the root is resolved and before any discovery runs, so the
-    # gate forms no opinion at all instead of reporting the unit's pages as blind. Both are exit 3;
-    # the new one additionally proves discovery never happened.
+    # ENTRY GATE ONLY. ⚠️ The refusal SHAPE changed with #562: the damaged boundary is classified
+    # before the root is resolved and before any discovery runs, so the gate forms no opinion at all
+    # instead of reporting the unit's pages as blind. Both are exit 3; the new one additionally
+    # proves discovery never happened. This says NOTHING about the exit gate below - see
+    # `docs/migration-phases.md` for the residual that keeps `check_unit` out of #590's claim.
     code, payload = _readiness(unit, tmp_path)
     assert (code, payload["status"]) == (3, "CANNOT_ESTABLISH")
     assert payload["pages_ready"] == 0
@@ -565,7 +566,8 @@ def test_incomplete_flat_package_without_manifest_fails_closed_when_ancestor_evi
     assert payload["evidence_records"] == 0, "no ancestor evidence may be collected for a damaged package"
     assert "package_marker_missing" in payload["units"][0]["detail"]
 
-    # Exit gate refuses ancestor evidence: oracle-coverage is NOT_CHECKED with 0 evidence
+    # Exit gate refuses ancestor evidence: oracle-coverage is NOT_CHECKED with 0 evidence.
+    # ⚠️ Pre-existing behaviour on a REAL (un-aliased) path, unchanged and unclaimed by #562.
     coverage = check_unit.check_oracle_coverage(unit, None, None)
     assert coverage["status"] == check_unit.STATUS_NOT_CHECKED
     assert coverage["visual_present"] == 0
@@ -592,6 +594,7 @@ def test_incomplete_nested_package_without_manifest_fails_closed_when_ancestor_e
     (unit / "package-manifest.json").unlink()
     shutil.rmtree(unit / "oracle")
 
+    # ENTRY GATE ONLY - the exit-gate assertions below are pre-existing and unclaimed by #562.
     code, payload = _readiness(unit, tmp_path)
     assert (code, payload["status"]) == (3, "CANNOT_ESTABLISH")
     assert payload["pages_ready"] == 0


### PR DESCRIPTION
Refs #562

Recovered from uncommitted pre-reboot work in a worktree; **not** a re-do and not a copy of the
closed #586, which remains evidence only. Commit `473b1cf5` is a preservation checkpoint of the
exact recovered tree (verified byte-for-byte against the forensic snapshot before anything was
edited) — a checkpoint, not an approval.

**Round-1 review corrections are in `f4425f97`.** Two in-scope fixes and one descope; see
*Round-1 corrections* below.

## The claim — shared classifier + ENTRY gate only

Classify the caller-supplied target **before** any `Path.resolve()`, child traversal,
source/evidence discovery or ancestor walk, using only:

* **lexical** flat (`<...>/packages/<Unit>`) / nested (`<...>/packages/<batch>/<Unit>`) placement, and
* a **no-follow `os.lstat`** of the supplied root and of its root marker entry.

Both old primitives dereferenced: `(target / PACKAGE_MARKER).is_file()` follows a marker symlink, so
a package boundary could be declared by bytes anywhere on the host; `target.resolve()` follows a
junction, so the placement question was answered about a link's destination rather than about the
path the caller typed. A boundary check that follows links is not a boundary check.

**Fail-closed direction:** a missing marker under package placement, a root/marker
symlink/junction/reparse point, a non-regular marker, or an unassessable package-shaped root can
never fall into legacy bundle handling and never borrows ancestor evidence. A moved target with a
regular, non-reparse root marker is an **explicit** package wherever it sits.

**One authority.** `is_package_target`, `is_self_contained`, `evidence_dirs` and
`check_reference_readiness` (both `scan` and now `main`) consume `classify_target`. No new consumer
and no second authority surface.

**Diagnostics** are stable codes plus generic, package-relative wording. `render()` prints status,
unit label and detail — never the supplied path. (The `--json` payload's `target` field is the
universal, pre-existing field every verdict carries; unchanged here.)

## Round-1 corrections (`f4425f97`)

**1 — CLI prevalidation.** `scan()` classified first, but `main()` reached it through
`path.is_dir()`, which *follows*. A package-shaped root with a missing or unassessable boundary
failed that pre-check and left via `parser.error` — **exit 2, with the supplied path echoed** —
instead of the typed exit 3. Classification now runs first per target (`_prevalidate_targets`); the
existing directory/source validation runs only once **every** target classified safe or ordinary. An
ordinary missing path keeps argparse's exit 2 unchanged.

**2 — Conservative bool projection.** `TargetClassification.is_package` projected an unsafe or
indeterminate boundary as `False`, which a caller reads as "ordinary, walk upward" — the fail-open
answer. It is now the strict complement of `inherits_ancestor_evidence`: anything not *proven*
ORDINARY is package-like, and `False` is reserved for a target proven ordinary. **No production code
reads the bool** — `evidence_dirs` keys the walk on the typed property — so this is a compatibility
API hardened, not control flow moved.

**3 — Descoped, not widened.** `scripts/check_unit.py` is **untouched** in this PR (verified: `git
diff 84184101 -- scripts/check_unit.py` is empty).

## ❌ Blocking residual — the EXIT gate is NOT covered

`check_unit.py`'s `_oracle_dirs()` reaches the shared walk through `_unit_dir()`, which calls
`target.resolve()` **first**. For a caller-supplied alias the classification therefore happens on the
already-resolved destination — precisely the substitution the classifier exists to refuse. The
ancestor stop is reliable there only for a real, un-aliased path. Closing it means classifying the
**original** target before resolution, and that is a **separate follow-up to #562**.

This is recorded in `docs/migration-phases.md`, and the exit-gate wording in the docs and tests was
corrected rather than patched: `tests/test_package_unit_gates.py`'s changed assertions are now
explicitly labelled ENTRY GATE ONLY (its exit-gate assertions are pre-existing master lines, on a
real un-aliased path, unchanged and unclaimed here), and
`test_evidence_dirs_skips_ancestors_for_every_damaged_package_shape` states that it exercises
`evidence_dirs` directly and is not a `check_unit` claim.

**#590 claims the shared classifier and the entry gate. Nothing else.**

## Deliberate, documented compatibility cost

An **ordinary** bundle reached through a directory symlink or NTFS junction now classifies
`unsafe_root` and is refused. Following it is the defect (a boundary decided about a directory the
caller never named); refusing it is loud, attributable and recoverable — pass the real path. Pinned
by a test that also proves the un-aliased spelling still returns `EXIT_OK`.

Also deliberate: `packages/../Unit` normalizes lexically to `Unit` and is **not** package-shaped. The
previous `parent.parent.name` check read the literal `..` component and called it a nested package.

## What this is NOT

Out of scope, and no code here touches them: manifest JSON parsing, hashes, declared file-set
verification, semantic roles/LUID/source resolution, working lifecycle, and
`package_unit` / `check_unit` / promotion. This is the boundary classifier plus the entry gate.

## Verification

**Mutation controls** (scratch, gitignored, **not shipped** — no new framework): **18 mutations, 17
caught** by the specific test written to kill each, no-op control survives, baseline restored,
exit 0. Both round-1 defects are reproduced verbatim as mutations: `is_package` projecting an unsafe
root as `False`, and `main()` pre-checking with `is_dir()` before classifying. Also covered: a
vacuously-`True` projection, a refusal that echoes the supplied path, a CLI that never refuses,
restoring `resolve()` placement and normalization, `is_file()` marker typing, an `S_ISLNK`-only
reparse predicate, dropping `S_ISREG`, marker-before-root, damaged→non-package,
damaged→walks-upward, classify-after-`resolve()` in `scan`, both exception-shaped successes, a
missing package root read as ordinary, and `is_self_contained` following the marker again.

⚠️ **A defect the mutation run found in the controls themselves.** The runner initially scored a kill
from a non-zero exit; tightened to require a *reported failure*, it immediately exposed that
`_forbid_following` patches `Path.exists` globally and **pytest calls it while formatting a failure
traceback**, so a genuine kill surfaced as `INTERNALERROR`. Both guards now raise a private sentinel
caught inside the patched window, with patches undone before anything is asserted.

**Tests** (Windows, Python 3.11.9): `test_bundle_corpus.py`, `test_check_reference_readiness.py`,
`test_package_unit_gates.py`, `test_check_unit.py`, `test_package_unit.py`,
`test_expected_skips_gate.py` → **551 passed, 4 skipped**. Capability gates
(`test_agent_capabilities.py`, `test_dirty_gate_snapshots.py`, `test_tableau_render_capability.py`)
→ 74 passed.

**Lint / gates, by exit code:** `ruff format --check` and `ruff check` over
`conftest.py scripts tests .github/skills` → 0; `pylint scripts` → 0 (10.00/10); `pylint conftest.py`
→ 0; `check_navigation_index.py` → 0; `set_data_folder.py --check` → 0;
`check_agent_capabilities.py` → 0.

## File census vs master (`9f53a385`)

| file | +/− |
|---|---|
| `conftest.py` | +1 |
| `docs/migration-phases.md` | +21 |
| `scripts/bundle_corpus.py` | +318 |
| `scripts/check_reference_readiness.py` | +79 |
| `tests/test_bundle_corpus.py` | +528 |
| `tests/test_check_reference_readiness.py` | +307 |
| `tests/test_package_unit_gates.py` | +24 |
| **total** | **7 files, 1239 insertions, 39 deletions** |

`scripts/check_unit.py`: **not in this PR.**

## Other residuals — stated, not hidden

* **3 platform skips**, all registered in `conftest.py`'s expected-skip gate: 2 file-symlink fixtures
  (Windows needs elevation) and the POSIX-only FIFO marker. The Windows half of the reparse class is
  covered anyway by a real junction fixture plus a fake-`lstat` control whose marker **is** a regular
  file on disk — the discriminating case a junction cannot supply.
* `evidence_dirs` still scans the **target itself** and any `also` root for an unsafe root; only the
  **ancestor** walk is stopped. Unchanged legacy behaviour, outside this claim — the entry gate
  refuses an unsafe root before `evidence_dirs` is reached at all.
* The refusal-shape change is pinned in `test_package_unit_gates.py`: an incomplete package now
  reports `CANNOT_ESTABLISH` with `pages_expected == 0` instead of listing its pages as blind. Both
  are exit 3; the new one additionally proves discovery never ran.

Draft, and **not self-reviewed** — please review the diff without this description.
