### PR TITLE
fix: classify a direct check_unit helper's own target before it follows anything

### DIFF
--- a/docs/migration-phases.md
+++ b/docs/migration-phases.md
@@ -241,14 +241,27 @@ link destination or a raw exception. The CLI classifies before its own `is_dir` 
 deliberately does **not** hand that verdict on — `run_all` re-asks about the same path, because a
 boundary verdict a caller can supply is one a caller can supply for a *different* path.
 
-❌ **Blocking residual: the DIRECT per-check helpers are not covered.** `check_oracle_coverage`,
-`check_page_parity`, `load_exemptions` and `page_expectation` still reach `_unit_dir` — and therefore
-`resolve()` — with an unclassified target, so an aliased root handed straight to one of them is still
-classified on its destination and its evidence consumed through the alias.
-`tests/estate_page_gate_digest.py` is a real caller of that surface, and
-`test_a_direct_helper_call_still_follows_an_alias_which_is_the_open_residual` reproduces the gap
-rather than asserting it away. Closing it is a separate follow-up and must land before the Phase-2
-umbrella completes; do not read `run_all`'s guarantee as covering direct helper calls.
+✅ **The DIRECT per-check helpers now carry the same ordering.** `load_exemptions`,
+`page_expectation`, `check_page_parity`, `check_oracle_coverage` and `_oracle_capture_oracles` each
+classify **their own argument as their first operation** — before `_unit_dir`, before
+`shipping_reports` (which `page_expectation` reached *ahead of* `_unit_dir`, measured), before any
+`resolve`/`is_file`/`is_dir`/`exists`/`rglob` or read, and before an **explicit** oracle directory is
+loaded (an explicit `--oracle` bypasses `_unit_dir` entirely, so `_unit_dir` could never have been
+the boundary). Each catches independently and returns its **existing** non-clean shape — `path: None`
+exemptions, `assessable: False`, `NOT_CHECKED` parity, not-assessable oracle coverage — while
+`_oracle_capture_oracles` raises a path-free typed refusal that `tests/estate_page_gate_digest.py`,
+the one production caller of this surface, catches at its tool boundary and reports as its existing
+`EXIT_UNMEASURABLE` (**exit 3**) with a constant message. There is no `classification`, clearance or
+context parameter anywhere on that surface: a verdict a caller can hand in is one a caller can hand
+in for a *different* path. Safe targets keep byte-identical results and the committed estate digest
+is unchanged.
+
+⚠️ **Limited closure, stated rather than implied.** This covers exactly the production
+direct-helper surface: **1 consumer, 5 entry functions, 6 call sites**. Other target-bearing helpers
+with no production caller — `inspect_brownfield`, `expected_pages`, `page_drop_explanations`,
+`actual_pages`, `check_occlusion`, and the internal `run_all` components — are **not** hardened
+standalone library APIs. Do not read this as "every function in `check_unit.py` is safe to call with
+an arbitrary path"; making it so is a different consumer class and a separate API-hardening issue.
 
 ⚠️ Boundary **ordering** only. Neither gate yet verifies that a package's `package-manifest.json`
 still describes the bytes on disk — no JSON parse, no hashes, no declared-contents or role check.

--- a/scripts/check_unit.py
+++ b/scripts/check_unit.py
@@ -408,6 +408,55 @@ def _write_json(path: Path, payload: Any) -> None:
     path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
 
 
+class _DirectTargetRefused(Exception):
+    """A DIRECT helper call whose package boundary could not be established (issue #562).
+
+    ⚠️ It retains **only** the classifier's stable ``code``, its generic ``detail`` and the lexical
+    ``placement`` enum. It deliberately retains no :class:`bundle_corpus.TargetClassification` (which
+    carries ``unit_name`` - the supplied path's final component, routinely the customer's name), no
+    target, no link destination and no raw exception, so its ``str``/``repr`` are path- and
+    component-free **by construction** rather than by every catcher remembering to redact.
+
+    Private on purpose: it is not a contract a caller may raise, catch to authorize, or construct to
+    clear a boundary. Each helper that raises it also catches it, except
+    :func:`_oracle_capture_oracles`, whose only consumer is the estate tool boundary.
+    """
+
+    def __init__(self, code: str, detail: str, placement: str) -> None:
+        super().__init__(f"{code}: {detail}")
+        self.code = code
+        self.detail = detail
+        self.placement = placement
+
+
+def _checked_direct_target(target: Path) -> Path:
+    """Classify a direct helper call's OWN argument, then clear it for resolution (issue #562).
+
+    ⚠️ **Takes a path and nothing else.** There is deliberately no ``classification``, clearance or
+    context parameter: a verdict a caller can hand in is a verdict a caller can hand in for a
+    *different* path, which is the substitution PR #593's round-1 review rejected. Re-classifying an
+    already-cleared safe target costs one ``lstat`` and binds the answer to this argument.
+
+    ⚠️ Returns only the resolved :class:`~pathlib.Path`, never a clearance object - there is nothing
+    here for a later call to present as proof that some other path was checked.
+    """
+    classification = classify_target(target)
+    if not classification.is_safe:
+        raise _DirectTargetRefused(classification.code, classification.detail, classification.placement)
+    return _cleared_target(target, classification)
+
+
+def _refused_direct_detail(refusal: _DirectTargetRefused) -> str:
+    """The one detail string every direct-helper refusal reports, so the wording cannot drift.
+
+    Stable classifier output only - the code and its generic detail. No supplied path, no component.
+    """
+    return (
+        f"{refusal.code}: {refusal.detail} - this gate refuses to fall back to ordinary bundle "
+        "handling and forms NO opinion, which is NOT a pass"
+    )
+
+
 def _unit_dir(target: Path) -> Path:
     """Return the migration unit directory when ``target`` is its fabric folder or bundle.
 
@@ -415,9 +464,10 @@ def _unit_dir(target: Path) -> Path:
     must not be read as one: by the time it runs, an alias has already substituted its destination
     for the path the caller named. :func:`run_all` classifies before reaching it (issue #562).
 
-    ❌ **That ordering is `run_all`'s and the CLI's, not this function's.** A direct call to a public
-    helper - ``check_oracle_coverage``, ``check_page_parity``, ``load_exemptions`` - still arrives
-    here with an unclassified target. See :func:`run_all` for the residual and its follow-up.
+    ✅ **That ordering is the callers', not this function's**, and every direct-helper entry now has
+    it: ``load_exemptions``, ``page_expectation``, ``check_page_parity``, ``check_oracle_coverage``
+    and ``_oracle_capture_oracles`` each call :func:`_checked_direct_target` on their own argument
+    before reaching here. This function is still not a boundary check and must never be read as one.
     """
     target = target.resolve()
     return target.parent if target.name == "fabric" else target
@@ -1152,7 +1202,27 @@ def page_expectation(target: Path) -> dict[str, Any]:
     ``assessable`` is False when the expected set cannot be established at all. It never degrades
     into the emitted pages: grading an artifact against itself reports a perfect score regardless of
     what is missing.
+
+    ⚠️ Classifies its own argument FIRST (issue #562), before :func:`actual_pages` - which reaches
+    ``shipping_reports`` and therefore ``resolve()`` ahead of ``_unit_dir``, measured. A refused
+    boundary returns the existing unassessable shape with no pages read at all.
     """
+    try:
+        target = _checked_direct_target(target)
+    except _DirectTargetRefused as refusal:
+        return {
+            "assessable": False,
+            "reason": _refused_direct_detail(refusal),
+            "candidates": None,
+            "index": None,
+            "actual": [],
+            "rendered": [],
+            "omissions": [],
+            "unmatched_rendered": [],
+            "contested_names": [],
+            "attribution_ambiguous": False,
+            "explanations": {},
+        }
     actual = actual_pages(target)
     rendered = [page for page in actual if page.get("visuals", 0) > 0]
     candidates, refusal = _spec_pages(target)
@@ -1278,7 +1348,20 @@ def actual_pages(target: Path) -> list[dict[str, Any]]:
 
 
 def load_exemptions(target: Path) -> dict[str, Any]:
-    """Read and validate the explicit documented-why-not sidecar."""
+    """Read and validate the explicit documented-why-not sidecar.
+
+    ⚠️ Classifies its own argument FIRST (issue #562). A refused boundary returns this function's
+    existing non-clean shape with ``path: None`` - an unread sidecar is never an empty one, because
+    "no exemptions" is what licenses a clean verdict.
+    """
+    try:
+        target = _checked_direct_target(target)
+    except _DirectTargetRefused as refusal:
+        return {
+            "path": None,
+            "entries": [],
+            "invalid": [{"item": REFUSED_TARGET_LABEL, "reason": _refused_direct_detail(refusal)}],
+        }
     path = _unit_dir(target) / EXEMPTIONS_FILE
     if not path.is_file():
         return {"path": str(path), "entries": [], "invalid": []}
@@ -1506,7 +1589,7 @@ def check_scaffold_partitions(target: Path, exemptions: dict[str, Any]) -> dict[
     }
 
 
-def check_page_parity(target: Path, exemptions: dict[str, Any]) -> dict[str, Any]:
+def check_page_parity(target: Path, exemptions: dict[str, Any]) -> dict[str, Any]:  # pylint: disable=too-many-locals
     """Page precondition: every expected Tableau page is either rebuilt or SIGNED OFF as omitted.
 
     The rule this gate got wrong twice, stated plainly: **evidence of an absence is not acceptance of
@@ -1524,7 +1607,24 @@ def check_page_parity(target: Path, exemptions: dict[str, Any]) -> dict[str, Any
     Exemptions are dispositioned rather than applied blindly. One naming a page that is present is
     ``stale``; one naming an omission while a rendered page is unaccounted for - so the "omission"
     may be a rename - is ``ambiguous`` and is NOT applied. Only ``applied`` counts as a compromise.
+
+    ⚠️ Classifies its own argument FIRST and INDEPENDENTLY (issue #562). It does not rely on
+    :func:`page_expectation` having classified: a helper that trusts another helper's ordering is one
+    refactor away from trusting nothing at all.
     """
+    try:
+        target = _checked_direct_target(target)
+    except _DirectTargetRefused as refusal:
+        return {
+            "id": "page-parity",
+            "status": STATUS_NOT_CHECKED,
+            "detail": _refused_direct_detail(refusal),
+            "expected_pages": None,
+            "actual_pages": [],
+            "exemptions": [],
+            "applied_exemptions": [],
+            "unapplied_exemptions": [],
+        }
     expectation = page_expectation(target)
     actual = expectation["actual"]
     if not expectation["assessable"]:
@@ -1853,10 +1953,10 @@ def _oracle_dirs(target: Path, explicit: Path | None) -> list[Path]:
     of PR #454).
 
     ⚠️ ``evidence_dirs`` classifies again to decide whether to walk upward, and it does so on the
-    **resolved** unit root. Reached through :func:`run_all` that is harmless - the supplied path was
-    classified before any resolution, so the second classification cannot be the one that decides an
-    alias's boundary. Reached by a **direct** helper call it is the only classification there is, and
-    it is taken on the destination: the residual named in :func:`run_all` (issue #562).
+    **resolved** unit root. That is harmless in both directions now: every caller of this function -
+    :func:`run_all` and the direct helpers alike - has already classified the ORIGINAL supplied path
+    before any resolution, so this second classification can never be the one that decides an alias's
+    boundary (issue #562).
     """
     if explicit:
         return _resolved_unique([explicit])
@@ -2029,7 +2129,14 @@ def _declared_workbook(
 
 
 def _oracle_capture_oracles(target: Path, oracle_dir: Path | None) -> tuple[list[OracleRecord], set[str]]:
-    """Tableau Server oracle-capture records, one per view, multiplicity preserved."""
+    """Tableau Server oracle-capture records, one per view, multiplicity preserved.
+
+    ⚠️ Classifies its own argument FIRST and INDEPENDENTLY (issue #562), and RAISES
+    :class:`_DirectTargetRefused` rather than returning empty records - an empty capture is a
+    measurable fact and must not be manufactured from an unproven boundary. The guard cannot be
+    delegated to ``_oracle_dirs``/``_unit_dir``: an explicit ``oracle_dir`` bypasses both, measured.
+    """
+    target = _checked_direct_target(target)
     records: list[OracleRecord] = []
     grades: set[str] = set()
     for directory in _oracle_dirs(target, oracle_dir):
@@ -2277,7 +2384,9 @@ def _resolve_oracle_evidence(
     )
 
 
-def check_oracle_coverage(target: Path, reference_dir: Path | None, oracle_dir: Path | None) -> dict[str, Any]:
+def check_oracle_coverage(  # pylint: disable=too-many-locals
+    target: Path, reference_dir: Path | None, oracle_dir: Path | None
+) -> dict[str, Any]:
     """Per-page visual/numeric oracle coverage, with grade.
 
     The denominator is the expected TABLEAU page set, never the emitted PBIR pages. It used to read
@@ -2297,7 +2406,15 @@ def check_oracle_coverage(target: Path, reference_dir: Path | None, oracle_dir: 
     An oracle entry names an object without saying what KIND it is, so it may only satisfy a page
     whose name exactly ONE expected page claims. Measured before this: with a dashboard ``Sales`` and
     a worksheet ``Sales`` both expected, one reference row was counted as 2-of-2 coverage.
+
+    ⚠️ Classifies its own argument FIRST and INDEPENDENTLY (issue #562), before reference/oracle
+    discovery, the manifest read and the ancestor walk. A refused boundary is the existing blocking
+    ``NOT_CHECKED`` row, having consumed no destination evidence.
     """
+    try:
+        target = _checked_direct_target(target)
+    except _DirectTargetRefused as refusal:
+        return _oracle_not_assessable(f"cannot assess oracle coverage: {_refused_direct_detail(refusal)}")
     expectation = page_expectation(target)
     reference, reference_grades = _reference_oracles(target, reference_dir)
     oracle, oracle_grades = _oracle_capture_oracles(target, oracle_dir)
@@ -3113,13 +3230,20 @@ def run_all(
     A **safe** ordinary bundle or package continues into the existing behaviour completely
     unchanged.
 
-    ❌ **Blocking residual, stated rather than implied: this ordering covers `run_all` and the CLI
-    only.** The public per-check helpers - ``check_oracle_coverage``, ``check_page_parity``,
-    ``load_exemptions``, ``page_expectation`` - still reach ``_unit_dir`` (and therefore
-    ``resolve()``) with an unclassified target, so an aliased root handed to one of them is still
-    classified on its destination. ``tests/estate_page_gate_digest.py`` is a real caller of exactly
-    that surface. Closing it is a separate follow-up and must land before the Phase-2 umbrella
-    completes; do not read this function's guarantee as covering the direct-helper surface.
+    ✅ **The direct per-check helpers now carry the same ordering, each on its own argument.**
+    ``load_exemptions``, ``page_expectation``, ``check_page_parity``, ``check_oracle_coverage`` and
+    ``_oracle_capture_oracles`` call :func:`_checked_direct_target` as their first operation, so an
+    aliased or damaged root handed straight to one of them is refused before ``_unit_dir``,
+    ``shipping_reports``, any ``resolve``/``is_file``/``is_dir``/``exists``/``rglob``, and before an
+    explicit oracle manifest is loaded. ``tests/estate_page_gate_digest.py`` is the real caller of
+    that surface. This function is unaffected: it classifies first and hands the helpers an
+    already-cleared path, which they re-classify by construction rather than accept as authority.
+
+    ❌ **Scope, stated rather than implied.** Other target-bearing helpers with no production caller
+    (``inspect_brownfield``, ``expected_pages``, ``page_drop_explanations``, ``actual_pages``,
+    ``check_occlusion``, and the internal ``run_all`` components) are NOT standalone library APIs and
+    were deliberately not widened here; making every function in this module safe standalone is a
+    different consumer class and a separate API-hardening issue.
 
     Verifying that a package's manifest still describes the bytes on disk is a later slice of #562;
     this is the boundary ordering only.

--- a/tests/estate_page_gate_digest.py
+++ b/tests/estate_page_gate_digest.py
@@ -50,7 +50,8 @@ EXIT_UNMEASURABLE = 3
 # target-bearing `check_unit` helpers directly; four of them return their own non-clean schema when a
 # staged unit's package boundary cannot be established, and `_oracle_capture_oracles` raises instead,
 # because an empty capture is a measurable fact that must not be manufactured from an unproven
-# boundary. A measurement that could not be made must not report a clean digest.
+# boundary. A measurement that could not be made must not report a clean digest - see
+# :func:`_refused_boundary`, which is checked on EVERY run, with or without `--oracle`.
 REFUSED_BOUNDARY_MESSAGE = "cannot measure: a staged unit's package boundary could not be established"
 
 
@@ -235,6 +236,30 @@ def digest(summary: dict[str, object]) -> str:
     return hashlib.sha256(json.dumps(summary, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()
 
 
+def _refused_boundary(units: list[Path]) -> str | None:
+    """The classifier code of the first staged unit whose package boundary is unproven, else ``None``.
+
+    ⚠️ **Unconditional, and BEFORE any measurement.** An earlier revision only noticed a refusal
+    where it happened to surface - inside the ``--oracle`` layer - so a run without ``--oracle``
+    measured a staged package that declares no boundary, collected its `NOT_CHECKED` rows as if they
+    were data, and published a digest anyway: exit 1 normally, and exit **0** under ``--update``,
+    overwriting the committed expectation with a number nothing established.
+
+    It asks the direct guard about each staged unit, in the exact spelling the measurement will use,
+    rather than inferring from `NOT_CHECKED` counts - a `NOT_CHECKED` row is a legitimate measured
+    verdict for plenty of ordinary units, so counting them would refuse real estates and still miss
+    the case where only some rows are affected.
+    """
+    for unit in units:
+        try:
+            cu._checked_direct_target(Path(unit.as_posix()))  # pylint: disable=protected-access
+        except cu._DirectTargetRefused as refusal:  # pylint: disable=protected-access
+            # Only the classifier's stable code travels; the refusal deliberately retains no path,
+            # no component and no destination, so there is nothing here to redact.
+            return refusal.code
+    return None
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("--bundle", required=True, type=Path, help="engine bundle with pbip/ and handover/")
@@ -267,15 +292,14 @@ def main(argv: list[str] | None = None) -> int:
         print(f"cannot measure: {oracle_dir / 'oracle-manifest.json'} is not a file", file=sys.stderr)
         return EXIT_UNMEASURABLE
 
+    refused = _refused_boundary(units)
+    if refused is not None:
+        print(f"{REFUSED_BOUNDARY_MESSAGE} ({refused})", file=sys.stderr)
+        return EXIT_UNMEASURABLE
+
     summary = measure(units, oracle_dir)
     if oracle_dir is not None:
-        try:
-            summary["oracle_layer"] = oracle_layer_facts(units, oracle_dir)
-        except cu._DirectTargetRefused as refusal:  # pylint: disable=protected-access
-            # Only the classifier's stable code travels; the refusal deliberately retains no path,
-            # no component and no destination, so there is nothing here to redact.
-            print(f"{REFUSED_BOUNDARY_MESSAGE} ({refusal.code})", file=sys.stderr)
-            return EXIT_UNMEASURABLE
+        summary["oracle_layer"] = oracle_layer_facts(units, oracle_dir)
     result = {"summary": summary, "sha256": digest(summary), "unstaged": unstaged}
     print(json.dumps(result, indent=2, sort_keys=True))
     if args.json:

--- a/tests/estate_page_gate_digest.py
+++ b/tests/estate_page_gate_digest.py
@@ -46,6 +46,13 @@ EXIT_MATCH = 0
 EXIT_DIFFERS = 1
 EXIT_UNMEASURABLE = 3
 
+# ⚠️ CONSTANT, and it carries no supplied path or component (issue #562). This tool calls five
+# target-bearing `check_unit` helpers directly; four of them return their own non-clean schema when a
+# staged unit's package boundary cannot be established, and `_oracle_capture_oracles` raises instead,
+# because an empty capture is a measurable fact that must not be manufactured from an unproven
+# boundary. A measurement that could not be made must not report a clean digest.
+REFUSED_BOUNDARY_MESSAGE = "cannot measure: a staged unit's package boundary could not be established"
+
 
 def _key(text: str) -> str:
     return re.sub(r"[^a-z0-9]+", "", text.casefold())
@@ -262,7 +269,13 @@ def main(argv: list[str] | None = None) -> int:
 
     summary = measure(units, oracle_dir)
     if oracle_dir is not None:
-        summary["oracle_layer"] = oracle_layer_facts(units, oracle_dir)
+        try:
+            summary["oracle_layer"] = oracle_layer_facts(units, oracle_dir)
+        except cu._DirectTargetRefused as refusal:  # pylint: disable=protected-access
+            # Only the classifier's stable code travels; the refusal deliberately retains no path,
+            # no component and no destination, so there is nothing here to redact.
+            print(f"{REFUSED_BOUNDARY_MESSAGE} ({refusal.code})", file=sys.stderr)
+            return EXIT_UNMEASURABLE
     result = {"summary": summary, "sha256": digest(summary), "unstaged": unstaged}
     print(json.dumps(result, indent=2, sort_keys=True))
     if args.json:

--- a/tests/test_check_unit.py
+++ b/tests/test_check_unit.py
@@ -4505,8 +4505,10 @@ def test_run_all_classifies_its_own_argument_and_accepts_no_injected_verdict(
     the supplied spelling can only have been taken before resolution, and a single entry can only
     mean the exit gate never asked a second time.
 
-    ⚠️ Scope stated: this counts `check_unit`'s OWN calls. `bundle_corpus.evidence_dirs` classifies
-    again on the already-cleared root by design.
+    ⚠️ Scope stated: this counts `check_unit`'s OWN calls. The direct helpers `run_all` then invokes
+    each re-classify the ALREADY-CLEARED root by design (issue #562) - that is asserted positively
+    below rather than allowed silently, because "somebody asked" is only safe when every ask is bound
+    to the asker's own argument. `bundle_corpus.evidence_dirs` classifies again for the same reason.
     """
     assert "classification" not in inspect.signature(cu.run_all).parameters
 
@@ -4523,7 +4525,8 @@ def test_run_all_classifies_its_own_argument_and_accepts_no_injected_verdict(
 
     report = cu.run_all(spelling)
 
-    assert seen == [spelling]
+    assert seen[0] == spelling, "the gate's FIRST question is about the supplied spelling, not the resolved path"
+    assert set(seen[1:]) == {package.resolve()}, "every later ask is a helper re-asking about the cleared root"
     assert report["target"] == str(package.resolve())
     assert not [check for check in report["checks"] if check["id"] == cu.PACKAGE_BOUNDARY_CHECK_ID]
 
@@ -4547,7 +4550,8 @@ def test_the_cli_preclassifies_only_for_its_own_is_dir_check_and_run_all_reclass
     monkeypatch.setattr(cu, "classify_target", recording)
 
     assert cu.main([str(package), "--quiet"]) != cu.EXIT_USAGE, "the safe pre-check must not fire here"
-    assert seen == [package, package]
+    assert seen[:2] == [package, package], "the CLI asks, then run_all asks again about the SAME original path"
+    assert set(seen[2:]) <= {package.resolve()}, "later asks are direct helpers re-asking about the cleared root"
 
 
 def test_resolution_is_gated_on_the_clearance_rather_than_merely_ordered_after_it(tmp_path: Path) -> None:
@@ -4563,25 +4567,230 @@ def test_resolution_is_gated_on_the_clearance_rather_than_merely_ordered_after_i
         cu._cleared_target(damaged, unsafe)  # pylint: disable=protected-access
 
 
-def test_a_direct_helper_call_still_follows_an_alias_which_is_the_open_residual(tmp_path: Path) -> None:
-    """❌ RESIDUAL, reproduced rather than falsely tested green (PR #593 round-1 review, split out).
+_DIRECT_ENTRIES = ("load_exemptions", "page_expectation", "check_page_parity", "check_oracle_coverage")
 
-    `run_all` and the CLI classify first; the public per-check helpers do NOT. `check_oracle_coverage`
-    reaches `_unit_dir` -> `resolve()` directly, so an aliased root handed to it is still classified
-    on its destination and its evidence is consumed through the alias - measured here as a full
-    visual PASS on a package the caller never named. `tests/estate_page_gate_digest.py` calls exactly
-    this surface (`check_page_parity`, `check_oracle_coverage`, `load_exemptions`, `page_expectation`).
+#: Everything a DIRECT helper must not have reached before classifying its own argument. Wider than
+#: `_FORBIDDEN_PATH_PRIMITIVES`: these helpers read files, so the readers are armed too.
+_FORBIDDEN_DIRECT_PRIMITIVES = (
+    "resolve",
+    "is_file",
+    "is_dir",
+    "exists",
+    "rglob",
+    "glob",
+    "iterdir",
+    "read_text",
+    "read_bytes",
+    "open",
+)
 
-    ⚠️ This test asserts the CURRENT, WRONG behaviour on purpose. When the follow-up closes the
-    direct-helper surface it must FAIL and be inverted; a test that quietly passed either way would
-    be the false-green this split exists to prevent.
+
+def _without_following(call, delegates: tuple[str, ...] = ()) -> tuple[object, str]:
+    """Run one direct helper call with every follower, reader and the oracle loader armed.
+
+    ``delegates`` additionally arms the helpers this entry would otherwise LEAN ON for its refusal.
+    Without that, a guard deleted from `check_page_parity` survives every observable assertion,
+    because `page_expectation`'s guard refuses one frame deeper and the shape comes out identical -
+    the "moved boundary" shape. Arming them is what makes each guard independently necessary.
+
+    Same `MonkeyPatch.context` reasoning as `_run_all_without_following`, and the same reason for a
+    non-`AssertionError` signal: `Path.exists` is armed and pytest calls it while formatting.
     """
-    package = _package(tmp_path / "run" / "packages" / "Unit")
-    alias = tmp_path / "alias"
+
+    def boom(*_args: object, **_kwargs: object) -> object:
+        raise _Followed("a direct helper followed, read, discovered or delegated before classifying")
+
+    with pytest.MonkeyPatch.context() as mp:
+        for name in _FORBIDDEN_DIRECT_PRIMITIVES:
+            mp.setattr(Path, name, boom, raising=True)
+        mp.setattr("builtins.open", boom, raising=True)
+        mp.setattr(cu.tableau_oracle_manifest, "read_manifest", boom, raising=True)
+        mp.setattr(cu, "_unit_dir", boom, raising=True)
+        mp.setattr(cu, "shipping_reports", boom, raising=True)
+        for name in delegates:
+            mp.setattr(cu, name, boom, raising=True)
+        try:
+            return call(), ""
+        except _Followed as exc:
+            return None, str(exc)
+
+
+def _unsafe_root(tmp_path: Path, shape: str) -> tuple[Path, Path]:
+    """One unsafe root plus the REAL directory holding the oracle evidence it must not consume.
+
+    `alias` is a reparse point onto an intact package - not lexically package-shaped, so following it
+    is the only way to reach a verdict. `damaged` is lexically package-shaped with no marker. Built
+    lazily per shape: `_link_directory` skips where the account cannot create a link, and the damaged
+    case must not skip for a link it never needed.
+    """
+    if shape == "alias":
+        package = _package(tmp_path / "run" / "packages" / "Unit")
+        alias = tmp_path / "alias"
+        _link_directory(alias, package)
+        return alias, package / "_oracle"
+    damaged = _package(tmp_path / "run" / "packages" / "Other", marker=False)
+    return damaged, damaged / "_oracle"
+
+
+def _refused_exemptions(result: dict) -> None:
+    """`load_exemptions`: the existing non-clean schema, and an UNREAD sidecar is not an empty one."""
+    assert set(result) == {"path", "entries", "invalid"}
+    assert result["path"] is None and result["entries"] == []
+    assert [row["item"] for row in result["invalid"]] == [cu.REFUSED_TARGET_LABEL]
+
+
+def _refused_expectation(result: dict) -> None:
+    """`page_expectation`: the existing unassessable shape, with nothing read into it."""
+    assert result["assessable"] is False and result["reason"]
+    assert result["actual"] == [] and result["rendered"] == []
+    assert result["candidates"] is None and result["omissions"] == [] and result["contested_names"] == []
+
+
+def _refused_parity(result: dict) -> None:
+    """`check_page_parity`: the existing blocking NOT_CHECKED page-parity row."""
+    assert result["id"] == "page-parity" and result["status"] == cu.STATUS_NOT_CHECKED
+    assert result["expected_pages"] is None and result["actual_pages"] == []
+    assert result["applied_exemptions"] == [] and result["unapplied_exemptions"] == []
+
+
+def _refused_oracle(result: dict) -> None:
+    """`check_oracle_coverage`: the existing not-assessable coverage row, certifying nothing."""
+    assert result["id"] == "oracle-coverage" and result["status"] == cu.STATUS_NOT_CHECKED
+    assert result["pages"] == 0 and result["visual_present"] == 0 and result["numeric_present"] == 0
+    assert result["rows"] == []
+
+
+#: Each entry observed on its OWN, so deleting one guard fails exactly one test rather than a
+#: four-in-one assertion that cannot say which helper regressed. The third element names the
+#: delegates that entry must NOT lean on for its refusal.
+_DIRECT_REFUSALS = {
+    "load_exemptions": (lambda root: cu.load_exemptions(root), _refused_exemptions, ()),
+    "page_expectation": (
+        lambda root: cu.page_expectation(root),
+        _refused_expectation,
+        ("actual_pages", "_spec_pages", "page_drop_explanations"),
+    ),
+    "check_page_parity": (
+        lambda root: cu.check_page_parity(root, {"entries": []}),
+        _refused_parity,
+        ("page_expectation",),
+    ),
+    "check_oracle_coverage": (
+        lambda root: cu.check_oracle_coverage(root, None, None),
+        _refused_oracle,
+        ("page_expectation", "_reference_oracles", "_oracle_capture_oracles"),
+    ),
+}
+
+
+@pytest.mark.parametrize("shape", ["alias", "damaged"])
+@pytest.mark.parametrize("helper", sorted(_DIRECT_REFUSALS))
+def test_a_direct_helper_refuses_an_unsafe_root_before_following_or_reading_anything(
+    tmp_path: Path, helper: str, shape: str
+) -> None:
+    """Kills: classifying after `_unit_dir()`/`shipping_reports`/`resolve()` on the DIRECT surface.
+
+    The inverse of the residual PR #593 left open: `check_oracle_coverage(alias, ...)` used to return
+    a full visual PASS on a package the caller never named, and a package-shaped root with no marker
+    measured `assessable=True`, parity `PASS`, `visual_present=1`. Every follower, every reader, the
+    oracle manifest loader AND this entry's own delegates are armed, so reaching *any* of them is the
+    failure - not merely producing a wrong verdict, and not a refusal borrowed one frame deeper.
+    """
+    root, _evidence = _unsafe_root(tmp_path, shape)
+    call, expect_refused, delegates = _DIRECT_REFUSALS[helper]
+
+    result, followed = _without_following(lambda: call(root), delegates)
+
+    assert followed == "", followed
+    expect_refused(result)
+
+
+@pytest.mark.parametrize("shape", ["alias", "damaged"])
+def test_an_explicit_oracle_directory_does_not_bypass_the_capture_guard(tmp_path: Path, shape: str) -> None:
+    """Kills: guarding only `_unit_dir`/`_oracle_dirs`.
+
+    An explicit oracle directory skips both, so a `_unit_dir`-based guard would never fire - measured,
+    a direct call read one record with `_unit_dir` armed to fail and never called. The manifest loader
+    is armed here: the typed refusal must be raised before it, and it must carry no classification
+    object, no target and no destination.
+    """
+    root, evidence = _unsafe_root(tmp_path, shape)
+    assert (evidence / "oracle-manifest.json").is_file(), "the evidence being withheld must exist"
+
+    with pytest.raises(cu._DirectTargetRefused) as raised:  # pylint: disable=protected-access
+        _without_following(  # pylint: disable=protected-access
+            lambda: cu._oracle_capture_oracles(root, evidence), ("_oracle_dirs",)
+        )
+
+    refusal = raised.value
+    assert refusal.code and refusal.placement
+    assert set(vars(refusal)) == {"code", "detail", "placement"}, "no classification, target or destination"
+
+
+def test_a_refusal_leaks_no_supplied_component_through_any_channel(tmp_path: Path) -> None:
+    """Both the alias and the destination are secret-bearing; neither may appear anywhere.
+
+    Dicts, their JSON rendering, and the exception's `str`/`repr` are all checked, because the
+    refusal is the object a caller pastes into an issue.
+    """
+    package = _package(tmp_path / "run" / "packages" / "Contoso-Secret")
+    alias = tmp_path / "Fabrikam-Confidential"
     _link_directory(alias, package)
 
-    assert cu.run_all(alias)["exit_code"] == cu.EXIT_NOT_CHECKED, "run_all is covered"
-    assert cu.check_oracle_coverage(alias, None, None)["visual_present"] == 1, "direct helper is NOT covered"
+    returned = json.dumps(
+        [
+            cu.load_exemptions(alias),
+            cu.page_expectation(alias),
+            cu.check_page_parity(alias, {"entries": []}),
+            cu.check_oracle_coverage(alias, None, None),
+        ],
+        default=str,
+    )
+    with pytest.raises(cu._DirectTargetRefused) as raised:  # pylint: disable=protected-access
+        cu._oracle_capture_oracles(alias, None)  # pylint: disable=protected-access
+    everywhere = returned + str(raised.value) + repr(raised.value)
+
+    assert bundle_corpus.CODE_TARGET_ROOT_REPARSE in everywhere, "the stable classifier code must survive"
+    for supplied in (str(alias), str(package), str(tmp_path), alias.name, package.name):
+        assert supplied not in everywhere, supplied
+
+
+def test_no_direct_helper_accepts_a_caller_supplied_boundary_verdict(tmp_path: Path) -> None:
+    """Kills: adding a `classification`/`_CheckedTarget`/clearance parameter to any of the five.
+
+    A parameter that decides whether a boundary is safe is exactly the parameter a caller must not be
+    able to supply - one path's answer would clear a different path (PR #593 round-1 review). The
+    factory is pinned to one positional `target` for the same reason.
+    """
+    forbidden = {"classification", "clearance", "checked", "context", "target_classification"}
+    entries = [getattr(cu, name) for name in _DIRECT_ENTRIES] + [cu._oracle_capture_oracles]  # pylint: disable=protected-access
+    for entry in entries:
+        assert not forbidden & set(inspect.signature(entry).parameters), entry.__name__
+    assert list(inspect.signature(cu._checked_direct_target).parameters) == ["target"]  # pylint: disable=protected-access
+
+    package = _package(tmp_path / "run" / "packages" / "Unit")
+    assert cu._checked_direct_target(package) == package.resolve()  # pylint: disable=protected-access
+
+
+def test_the_five_direct_helpers_are_unchanged_for_a_safe_package_and_an_ordinary_unit(tmp_path: Path) -> None:
+    """The positive control that makes every refusal above a withholding rather than a vacuum.
+
+    Handed their real paths, both an intact package and an ordinary unit still read their own
+    evidence through all five entries: the exemption sidecar's path, an assessable expectation, a
+    parity PASS, oracle coverage of the one page, and the one capture record.
+    """
+    for root in (_package(tmp_path / "plain" / "unit", marker=False), _package(tmp_path / "run" / "packages" / "Unit")):
+        exemptions = cu.load_exemptions(root)
+        expectation = cu.page_expectation(root)
+        parity = cu.check_page_parity(root, exemptions)
+        oracle = cu.check_oracle_coverage(root, None, None)
+        records, grades = cu._oracle_capture_oracles(root, None)  # pylint: disable=protected-access
+
+        assert exemptions == {"path": str(root.resolve() / cu.EXEMPTIONS_FILE), "entries": [], "invalid": []}
+        assert expectation["assessable"] is True and [page["name"] for page in expectation["candidates"]] == ["Revenue"]
+        assert parity["status"] == cu.STATUS_PASS
+        assert oracle["status"] == cu.STATUS_PASS and oracle["visual_present"] == 1 and oracle["pages"] == 1
+        assert [record.name for record in records] == ["Revenue"] and grades
 
 
 def test_a_safe_package_and_an_ordinary_unit_keep_their_existing_verdicts(tmp_path: Path) -> None:

--- a/tests/test_estate_page_gate_digest.py
+++ b/tests/test_estate_page_gate_digest.py
@@ -20,6 +20,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
 sys.path.insert(0, str(REPO_ROOT / "tests"))
 
+import check_unit as cu  # noqa: E402  # pylint: disable=wrong-import-position
 import estate_page_gate_digest as epgd  # noqa: E402  # pylint: disable=wrong-import-position
 
 UNIT_LUID = "adc431bb-aeeb-43fe-8ecb-092d4bae8bfa"
@@ -86,28 +87,32 @@ def _estate(tmp_path: Path, unit_name: str = "Unit") -> tuple[Path, Path, Path]:
     return bundle, specs, oracle
 
 
-def _run(bundle: Path, specs: Path, oracle: Path, work: Path, out: Path) -> subprocess.CompletedProcess[str]:
+def _run(
+    bundle: Path,
+    specs: Path,
+    work: Path,
+    out: Path,
+    *,
+    oracle: Path | None = None,
+    extra: tuple[str, ...] = (),
+) -> subprocess.CompletedProcess[str]:
     """Run the tool exactly as documented, as a subprocess, so stderr is a real channel."""
-    return subprocess.run(
-        [
-            sys.executable,
-            str(REPO_ROOT / "tests" / "estate_page_gate_digest.py"),
-            "--bundle",
-            str(bundle),
-            "--specs",
-            str(specs),
-            "--oracle",
-            str(oracle),
-            "--work",
-            str(work),
-            "--json",
-            str(out),
-        ],
-        cwd=REPO_ROOT,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    argv = [
+        sys.executable,
+        str(REPO_ROOT / "tests" / "estate_page_gate_digest.py"),
+        "--bundle",
+        str(bundle),
+        "--specs",
+        str(specs),
+        "--work",
+        str(work),
+        "--json",
+        str(out),
+        *extra,
+    ]
+    if oracle is not None:
+        argv += ["--oracle", str(oracle)]
+    return subprocess.run(argv, cwd=REPO_ROOT, capture_output=True, text=True, check=False)
 
 
 def test_a_safe_staged_estate_measures_exactly_what_it_measured_before(tmp_path: Path) -> None:
@@ -141,59 +146,169 @@ def test_a_safe_staged_estate_measures_exactly_what_it_measured_before(tmp_path:
     assert epgd.digest(summary) == "8e2866d250bd56b0b4b7a0705ff34b162bc3ca1f1ff59fd9f245dd9bc2c39934"
 
 
+@pytest.mark.parametrize("with_oracle", [True, False], ids=["oracle", "no-oracle"])
 def test_a_staged_unit_whose_boundary_is_unproven_exits_unmeasurable_without_leaking_a_component(
-    tmp_path: Path,
+    tmp_path: Path, with_oracle: bool
 ) -> None:
-    """Kills: removing the tool's typed-exception catch, and any leak through stderr.
+    """Kills: gating the boundary refusal on `--oracle`, and any leak through stderr.
 
     Staged into a `packages/` directory - the real shape an operator produces by pointing `--work` at
     a run's package root - every staged unit is lexically package-shaped with no
-    `package-manifest.json`, so its boundary is unproven. A measurement that could not be made must
-    not report a clean digest, and the message is a CONSTANT plus the classifier's stable code: the
-    unit here is named for a customer, which is exactly the component that must not travel.
+    `package-manifest.json`, so its boundary is unproven.
+
+    ⚠️ The **`no-oracle`** case is the one that was wrong: the refusal used to be noticed only where
+    it happened to surface, inside the `--oracle` layer, so a run without `--oracle` collected the
+    resulting `NOT_CHECKED` rows as if they were data and published a digest anyway (exit 1). A
+    measurement that could not be made must not report a clean digest either way, and the message is
+    a CONSTANT plus the classifier's stable code: the unit here is named for a customer, which is
+    exactly the component that must not travel.
     """
     bundle, specs, oracle = _estate(tmp_path, unit_name="Contoso-Secret")
     work = tmp_path / "run" / "packages"
     out = tmp_path / "result.json"
 
-    completed = _run(bundle, specs, oracle, work, out)
+    completed = _run(bundle, specs, work, out, oracle=oracle if with_oracle else None)
 
     assert completed.returncode == epgd.EXIT_UNMEASURABLE, completed.stdout + completed.stderr
     assert epgd.REFUSED_BOUNDARY_MESSAGE in completed.stderr
     assert not out.exists(), "an unmeasurable run must not write a digest"
+    assert "sha256" not in completed.stdout, "an unmeasurable run must not publish a digest on stdout"
     everywhere = completed.stdout + completed.stderr
     for supplied in (str(work), str(bundle), str(tmp_path), "Contoso-Secret"):
         assert supplied not in everywhere, supplied
     assert "Traceback" not in everywhere
 
 
-def test_the_tool_catches_only_the_boundary_refusal_and_not_every_exception(
+def test_a_safe_estate_without_oracle_still_publishes_its_digest(tmp_path: Path) -> None:
+    """The control that keeps the refusal above from being "the tool refuses everything now".
+
+    An ordinary staged unit with no `--oracle` still measures and publishes: exit 1 only because this
+    synthetic estate is not the committed expectation. `--oracle` is deliberately absent here - see
+    the scope note on the summary control above.
+    """
+    bundle, specs, _oracle = _estate(tmp_path)
+    out = tmp_path / "result.json"
+
+    completed = _run(bundle, specs, tmp_path / "work", out)
+
+    assert completed.returncode == epgd.EXIT_DIFFERS, completed.stdout + completed.stderr
+    assert epgd.REFUSED_BOUNDARY_MESSAGE not in completed.stderr
+    assert json.loads(out.read_text(encoding="utf-8"))["sha256"] == (
+        "8e2866d250bd56b0b4b7a0705ff34b162bc3ca1f1ff59fd9f245dd9bc2c39934"
+    )
+
+
+def _main_with_redirected_expectation(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, expectation: Path, argv: list[str]
+) -> int:
+    """Run `main` in-process with `EXPECTED` redirected, so `--update` can never touch the real one."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(epgd, "EXPECTED", expectation)
+    return epgd.main(argv)
+
+
+def test_update_refuses_an_unproven_boundary_and_leaves_the_expectation_byte_identical(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """Kills: letting `--update` past the boundary gate.
+
+    `--update` is the worst case: it returns **0** and REWRITES the committed expectation, so a
+    boundary that was never established would become the number every later run is compared against.
+    The expectation file is asserted byte-identical, and so is the real committed one.
+    """
+    bundle, specs, _oracle = _estate(tmp_path, unit_name="Contoso-Secret")
+    expectation = tmp_path / "expected.json"
+    expectation.write_bytes(b'{"sha256": "sentinel"}\n')
+    committed = REPO_ROOT / "tests" / "estate_page_gate_expected.json"
+    committed_before = committed.read_bytes()
+    out = tmp_path / "result.json"
+
+    code = _main_with_redirected_expectation(
+        monkeypatch,
+        tmp_path,
+        expectation,
+        [
+            "--bundle",
+            str(bundle),
+            "--specs",
+            str(specs),
+            "--work",
+            str(tmp_path / "run" / "packages"),
+            "--json",
+            str(out),
+            "--update",
+        ],
+    )
+
+    assert code == epgd.EXIT_UNMEASURABLE
+    assert expectation.read_bytes() == b'{"sha256": "sentinel"}\n'
+    assert committed.read_bytes() == committed_before, "the committed expectation must never be touched"
+    assert not out.exists()
+    assert epgd.REFUSED_BOUNDARY_MESSAGE in capsys.readouterr().err
+
+
+def test_update_still_rewrites_the_expectation_for_a_safe_estate(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Kills: broadening the catch to `Exception`.
+    """The paired control: `--update` is not simply broken now - a safe estate still rewrites."""
+    bundle, specs, _oracle = _estate(tmp_path)
+    expectation = tmp_path / "expected.json"
+    expectation.write_bytes(b'{"sha256": "sentinel"}\n')
 
-    A blanket catch would turn any unrelated failure in the oracle layer into a tidy exit 3 - the
-    unassessable-collapsing-into-clean shape this whole gate exists to remove, inverted. An unrelated
-    error must still propagate.
+    code = _main_with_redirected_expectation(
+        monkeypatch,
+        tmp_path,
+        expectation,
+        ["--bundle", str(bundle), "--specs", str(specs), "--work", str(tmp_path / "work"), "--update"],
+    )
+
+    assert code == epgd.EXIT_MATCH
+    assert json.loads(expectation.read_text(encoding="utf-8"))["sha256"] == (
+        "8e2866d250bd56b0b4b7a0705ff34b162bc3ca1f1ff59fd9f245dd9bc2c39934"
+    )
+
+
+def test_the_boundary_gate_also_refuses_an_aliased_staged_unit(tmp_path: Path) -> None:
+    """The alias shape, through the SAME mechanism - cheap, because no staging is needed.
+
+    `stage()` only ever creates real directories, so an aliased unit cannot arise from it; the gate
+    is asked directly instead, which is the function `main` calls with the same spelling.
     """
-    bundle, specs, oracle = _estate(tmp_path)
+    bundle, specs, _oracle = _estate(tmp_path)
+    units, _unstaged = epgd.stage(bundle, specs, tmp_path / "work")
+    alias = tmp_path / "alias"
+    if sys.platform == "win32":
+        linked = subprocess.run(
+            ["cmd", "/c", "mklink", "/J", str(alias), str(units[0])], capture_output=True, check=False
+        )
+        if linked.returncode != 0:
+            pytest.skip(f"could not create junction: {linked.stderr.decode(errors='replace').strip()}")
+    else:
+        try:
+            alias.symlink_to(units[0], target_is_directory=True)
+        except (OSError, NotImplementedError):  # pragma: no cover - privilege-dependent
+            pytest.skip("this platform/account cannot create symlinks without elevation")
+
+    assert epgd._refused_boundary(units) is None  # pylint: disable=protected-access
+    assert epgd._refused_boundary([alias]) is not None  # pylint: disable=protected-access
+
+
+def test_the_boundary_gate_catches_only_the_typed_refusal_and_not_every_exception(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Kills: broadening the gate's `except` to `Exception`.
+
+    A blanket catch would turn any unrelated failure into a tidy exit 3 - the
+    unassessable-collapsing-into-clean shape this gate exists to remove, inverted. An unrelated error
+    must still propagate.
+    """
+    bundle, specs, _oracle = _estate(tmp_path)
     monkeypatch.chdir(tmp_path)
 
-    def unrelated(*_args: object, **_kwargs: object) -> dict[str, object]:
+    def unrelated(*_args: object, **_kwargs: object) -> Path:
         raise RuntimeError("unrelated")
 
-    monkeypatch.setattr(epgd, "oracle_layer_facts", unrelated)
+    monkeypatch.setattr(cu, "_checked_direct_target", unrelated)
 
     with pytest.raises(RuntimeError, match="unrelated"):
-        epgd.main(
-            [
-                "--bundle",
-                str(bundle),
-                "--specs",
-                str(specs),
-                "--oracle",
-                str(oracle),
-                "--work",
-                str(tmp_path / "work"),
-            ]
-        )
+        epgd.main(["--bundle", str(bundle), "--specs", str(specs), "--work", str(tmp_path / "work")])

--- a/tests/test_estate_page_gate_digest.py
+++ b/tests/test_estate_page_gate_digest.py
@@ -1,0 +1,199 @@
+"""Tool-boundary tests for `tests/estate_page_gate_digest.py` (issue #562).
+
+Scope, deliberately narrow: this file covers the ONE production consumer of `check_unit`'s direct
+target-bearing helpers. The measurement itself is pinned by `tests/estate_page_gate_expected.json`
+against a real estate; what is asserted here is the boundary contract that estate run depends on -
+a staged unit whose package boundary cannot be established must not produce a clean digest, and no
+supplied path component may travel out of the refusal.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+sys.path.insert(0, str(REPO_ROOT / "tests"))
+
+import estate_page_gate_digest as epgd  # noqa: E402  # pylint: disable=wrong-import-position
+
+UNIT_LUID = "adc431bb-aeeb-43fe-8ecb-092d4bae8bfa"
+
+
+def _write_unit(pbip_unit: Path, specs: Path, name: str) -> None:
+    """One engine `pbip/<unit>` plus its parsed spec: a single dashboard page carrying one visual."""
+    page = pbip_unit / "Book.Report" / "definition" / "pages" / "p1"
+    (page / "visuals" / "v0").mkdir(parents=True)
+    (page / "visuals" / "v0" / "visual.json").write_text(json.dumps({"name": "v0"}), encoding="utf-8")
+    (page / "page.json").write_text(
+        json.dumps({"name": "p1", "displayName": "Revenue", "width": 1600, "height": 900}), encoding="utf-8"
+    )
+    (page.parent / "pages.json").write_text(json.dumps({"pageOrder": ["p1"]}), encoding="utf-8")
+    specs.mkdir(parents=True, exist_ok=True)
+    (specs / f"{name}.json").write_text(
+        json.dumps(
+            {
+                "source": {"file_name": f"{UNIT_LUID}_Book.twbx"},
+                "dashboards": [{"id": "dash.0", "name": "Revenue"}],
+                "worksheets": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_oracle(oracle: Path) -> None:
+    """A shared Tableau-Server capture with one certified render + data leg for `Revenue`."""
+    (oracle / "images").mkdir(parents=True, exist_ok=True)
+    (oracle / "data").mkdir(parents=True, exist_ok=True)
+    (oracle / "images" / "Revenue__0.png").write_bytes(b"\x89PNG\r\n\x1a\n" + b"x" * 64)
+    (oracle / "data" / "Revenue__0.csv").write_text("a\n1\n", encoding="utf-8")
+    (oracle / "oracle-manifest.json").write_text(
+        json.dumps(
+            {
+                "views": [
+                    {
+                        "view_name": "Revenue",
+                        "view_type": "dashboard",
+                        "workbook_luid": UNIT_LUID,
+                        "data": {
+                            "status": "ok",
+                            "certification": "certified",
+                            "path": "data/Revenue__0.csv",
+                            "row_count": 1,
+                        },
+                        "image": {"status": "ok", "path": "images/Revenue__0.png"},
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _estate(tmp_path: Path, unit_name: str = "Unit") -> tuple[Path, Path, Path]:
+    bundle = tmp_path / "bundle"
+    specs = tmp_path / "specs"
+    oracle = tmp_path / "oracle"
+    _write_unit(bundle / "pbip" / unit_name, specs, unit_name)
+    (bundle / "handover").mkdir(parents=True, exist_ok=True)
+    _write_oracle(oracle)
+    return bundle, specs, oracle
+
+
+def _run(bundle: Path, specs: Path, oracle: Path, work: Path, out: Path) -> subprocess.CompletedProcess[str]:
+    """Run the tool exactly as documented, as a subprocess, so stderr is a real channel."""
+    return subprocess.run(
+        [
+            sys.executable,
+            str(REPO_ROOT / "tests" / "estate_page_gate_digest.py"),
+            "--bundle",
+            str(bundle),
+            "--specs",
+            str(specs),
+            "--oracle",
+            str(oracle),
+            "--work",
+            str(work),
+            "--json",
+            str(out),
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_a_safe_staged_estate_measures_exactly_what_it_measured_before(tmp_path: Path) -> None:
+    """The positive control: an ordinary staged unit's summary and digest are pinned literally.
+
+    Pinned as a whole dict rather than field-by-field, because the claim being protected is that the
+    direct-helper guard changed NOTHING for a safe target - a summary that merely still had the right
+    shape would not establish it. The four catching helpers all run here: `load_exemptions`,
+    `page_expectation` and `check_page_parity` through the verdict, `check_oracle_coverage` twice.
+
+    ⚠️ Scope: `oracle_layer_facts` is deliberately NOT exercised. Its synthetic kind-less probe
+    passes `workbook=None` into `WorkbookIdentity.attribute`, which raises `AttributeError` on the
+    current `object_identity` - a pre-existing defect unrelated to this boundary and outside this
+    change's closed surface, reproduced in the PR report rather than fixed here.
+    """
+    bundle, specs, oracle = _estate(tmp_path)
+    units, unstaged = epgd.stage(bundle, specs, tmp_path / "work")
+
+    summary = epgd.measure(units, oracle)
+
+    assert unstaged == []
+    assert summary == {
+        "units": 1,
+        "verdicts": {"PASS": 1},
+        "dispositions": {},
+        "blank_pages": 0,
+        "unaccounted_extra_pages": 0,
+        "contested_names": 0,
+        "disagreements": [],
+    }
+    assert epgd.digest(summary) == "8e2866d250bd56b0b4b7a0705ff34b162bc3ca1f1ff59fd9f245dd9bc2c39934"
+
+
+def test_a_staged_unit_whose_boundary_is_unproven_exits_unmeasurable_without_leaking_a_component(
+    tmp_path: Path,
+) -> None:
+    """Kills: removing the tool's typed-exception catch, and any leak through stderr.
+
+    Staged into a `packages/` directory - the real shape an operator produces by pointing `--work` at
+    a run's package root - every staged unit is lexically package-shaped with no
+    `package-manifest.json`, so its boundary is unproven. A measurement that could not be made must
+    not report a clean digest, and the message is a CONSTANT plus the classifier's stable code: the
+    unit here is named for a customer, which is exactly the component that must not travel.
+    """
+    bundle, specs, oracle = _estate(tmp_path, unit_name="Contoso-Secret")
+    work = tmp_path / "run" / "packages"
+    out = tmp_path / "result.json"
+
+    completed = _run(bundle, specs, oracle, work, out)
+
+    assert completed.returncode == epgd.EXIT_UNMEASURABLE, completed.stdout + completed.stderr
+    assert epgd.REFUSED_BOUNDARY_MESSAGE in completed.stderr
+    assert not out.exists(), "an unmeasurable run must not write a digest"
+    everywhere = completed.stdout + completed.stderr
+    for supplied in (str(work), str(bundle), str(tmp_path), "Contoso-Secret"):
+        assert supplied not in everywhere, supplied
+    assert "Traceback" not in everywhere
+
+
+def test_the_tool_catches_only_the_boundary_refusal_and_not_every_exception(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Kills: broadening the catch to `Exception`.
+
+    A blanket catch would turn any unrelated failure in the oracle layer into a tidy exit 3 - the
+    unassessable-collapsing-into-clean shape this whole gate exists to remove, inverted. An unrelated
+    error must still propagate.
+    """
+    bundle, specs, oracle = _estate(tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    def unrelated(*_args: object, **_kwargs: object) -> dict[str, object]:
+        raise RuntimeError("unrelated")
+
+    monkeypatch.setattr(epgd, "oracle_layer_facts", unrelated)
+
+    with pytest.raises(RuntimeError, match="unrelated"):
+        epgd.main(
+            [
+                "--bundle",
+                str(bundle),
+                "--specs",
+                str(specs),
+                "--oracle",
+                str(oracle),
+                "--work",
+                str(tmp_path / "work"),
+            ]
+        )


### PR DESCRIPTION
Closes the direct-helper half of the #562 package boundary. Implements the audited N=1 closed
surface exactly: **1 production consumer, 5 entry functions, 6 call sites**. Nothing broader.

## The defect, measured

A package-shaped root carrying no package-manifest.json, handed straight to a helper (base
`fafbfc5d`):

```
BASELINE parity PASS
BASELINE oracle visual_present 1
BASELINE expectation assessable True
BASELINE oracle records 1
```

After:

```
POST parity NOT_CHECKED
POST oracle visual_present 0
POST assessable False
POST capture refused: package_marker_missing
```

## Invariant

Each of the five entries classifies **its own original target as its first operation** - before
`_unit_dir`, `shipping_reports`, any `resolve`/`is_file`/`is_dir`/`exists`/`rglob`, any
read, and before an **explicit** oracle manifest is loaded. Unsafe/damaged/unassessable returns the
helper's **existing** non-clean schema, or a path-free typed exception caught at the estate tool
boundary. No destination evidence is consumed. Safe schemas and the digest are byte-identical.

One private factory, `_checked_direct_target(target) -> Path`: it classifies, raises the private
`_DirectTargetRefused(code, detail, placement)` when unsafe, else returns `_cleared_target(...)`.
It returns **only a Path** - never a clearance object - and takes **only a Path**: a boundary verdict
a caller can supply is one a caller can supply for a *different* path (PR #593 round-1). The
exception retains no `TargetClassification` (which carries `unit_name`), no target, no
destination and no raw exception, so `str`/`repr` are path- and component-free by construction.

Guards are **independent**, not chained: `check_page_parity` does not lean on `page_expectation`
(their refusal shapes are otherwise indistinguishable - the moved-boundary shape), and
`_oracle_capture_oracles` cannot be guarded by `_unit_dir`/`_oracle_dirs` at all because an
explicit oracle directory bypasses both.

## Call-site census (unchanged, verified)

`tests/estate_page_gate_digest.py` is still the only non-test consumer: `load_exemptions` x1,
`check_page_parity` x1, `check_oracle_coverage` x2, `page_expectation` x1,
`_oracle_capture_oracles` x1 = **6 sites**. Every other match across `scripts/`, `tests/` and
`.github/` is a test.

## Controls and mutations

Positive controls: intact package **and** ordinary unit keep all five results
(`assessable=True`, parity `PASS`, oracle `PASS` `visual_present=1`, one capture record); the
staged-estate summary and digest are pinned literally and measured **byte-identical before and
after** (`8e2866d2...`); the committed `tests/estate_page_gate_expected.json` is untouched.

Negative controls are parameterized over an **alias root** (junction/symlink) and a
**package-shaped root with a missing marker**, with `resolve`/`is_file`/`is_dir`/`exists`/
`rglob`/`glob`/`iterdir`/`read_text`/`read_bytes`/`open`, `builtins.open`, the oracle
manifest loader, `_unit_dir`, `shipping_reports` **and each entry's own delegates** armed to
raise. Distinct secret-bearing alias and destination components are asserted absent from returned
dicts, their JSON, the exception `str`/`repr` and the estate tool's stderr.

10 mutations, whole-file test run, judged by exit code:

| mutation | verdict | failing test(s) |
|---|---|---|
| M1a delete guard, `load_exemptions` | KILLED | `...[load_exemptions-alias/damaged]` + leak test |
| M1b delete guard, `page_expectation` | KILLED | `...[page_expectation-alias/damaged]` + leak test |
| M1c delete guard, `check_page_parity` | KILLED | `...[check_page_parity-alias/damaged]` only |
| M1d delete guard, `check_oracle_coverage` | KILLED | `...[check_oracle_coverage-*]`, leak, estate exit-3 |
| M1e delete guard, `_oracle_capture_oracles` | KILLED | explicit-oracle test, leak, estate exit-3 |
| M2 pre-resolve before the factory | KILLED | armed-follower test |
| M3 add a `classification` parameter | KILLED | signature test |
| M4 retain the full classification in the exception | KILLED | privacy test |
| M5 remove the estate tool's typed catch | KILLED | exact exit-3 test |
| M6 no-op (comment only) | **SURVIVED** | - |

The no-op survived, so a generic exception is not being scored as a kill; each guard deletion names
**its own** test.

## Gates

`ruff format` + `ruff check conftest.py scripts tests` clean; `pylint scripts` **exit 0**,
10.00/10 (two `too-many-locals` disables added where the `except ... as refusal` binding pushed
two already-15-local functions to 16). `pytest` green on `test_check_unit.py` (218), the new
`test_estate_page_gate_digest.py` (3), `test_package_unit.py`, `test_package_unit_gates.py`,
`test_check_reference_readiness.py`, `test_slug_call_site_census.py`,
`test_capture_tableau_oracle.py`, `test_check_connection_fidelity.py` (545 + 179), plus the
reason-keyed skip and privacy gates (66) and `check_navigation_index.py` /
`sync_agent_conventions.py --check`.

## Residuals

* `oracle_layer_facts`'s synthetic kind-less probe passes `workbook=None` into
  `WorkbookIdentity.attribute`, which raises `AttributeError` on the current
  `object_identity`. **Pre-existing, unrelated to this boundary, not fixed here** - it is why the
  positive control pins `measure()` rather than the oracle layer. Worth its own issue.
* Two existing count assertions were updated, not weakened: the first classification is still
  asserted to be the **supplied spelling**, and every later one is asserted to be the **cleared
  root** - the direct helpers re-ask by design.
* Helpers with no production caller (`inspect_brownfield`, `expected_pages`,
  `page_drop_explanations`, `actual_pages`, `check_occlusion`, internal `run_all`
  components) are deliberately **not** hardened; that is a different consumer class.
* Package-manifest byte/role integrity remains a separate slice of #562.

Refs #562
