### PR TITLE
feat: separate package construction from dispatch readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ _runs/<NNN>-<slug>/                     ◀── PHASE 1  collect & convert  (g
 │   │   └── oracle-manifest.json
 │   ├── report.json  source-provenance.json   gate input, and source-to-LUID attribution
 │   ├── engine-output-receipt.json            which engine version built this      (67 of 67)
-│   └── package-manifest.json               what was packaged, and every omission with its reason
+│   └── package-manifest.json               what was assembled, and every omission with its reason
 │
 ├── deliverables/                           customer-facing outputs — never committed
 └── scratch/                                the ONLY subdir that is safe to delete

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ _runs/<NNN>-<slug>/                     ◀── PHASE 1  collect & convert  (g
 │   ├── data/                                 materialised extract rows
 │   └── engine-output-receipt.json            which engine version built this, and from where
 │
-├── packages/<Unit>/                    ◀── PHASE 2  one self-contained folder per unit
+├── packages/<Unit>/                    ◀── PHASE 2  one diagnostic folder per unit
 │   ├── README.md  handover.md              start here — the gate commands, pre-scoped
 │   ├── migration-spec.json                 the parsed source                    (64 of 67)
 │   ├── fabric/                             the packaged copy of bundle/pbip/    (62 of 67)
@@ -276,9 +276,10 @@ migration order), `assets/` (the downloads), `bundle/` (the engine's conversion 
 
 **2. Package for the agent** → `_runs/<NNN>-<slug>/packages/<Unit>/`
 
-[`scripts/package_unit.py`](scripts/package_unit.py) emits one self-contained folder per migration
-unit — source, engine output, handover queue and reference evidence together — which **both gates
-accept with no flags**. The command targets the `packages/` directory itself; nested
+[`scripts/package_unit.py`](scripts/package_unit.py) emits one diagnostic folder per migration
+unit which **both gates accept with no flags**. Source, rows, engine output, handover and reference
+evidence are copied when available; omissions remain explicit in `package-manifest.json`. The
+command targets the `packages/` directory itself; nested
 `packages/<batch>/<Unit>/` remains supported for compatibility, not as the default.
 
 **3. Ship** → `migrations/{workbooks,datasources}/<slug>/fabric/`

--- a/docs/migration-phases.md
+++ b/docs/migration-phases.md
@@ -26,7 +26,7 @@ The pipeline has three locations, and the direction is one-way:
             │  PHASE 2 — package for the agent  (scripts/package_unit.py)
             ▼
    _runs/<NNN>-<slug>/packages/<Unit>/
-       one self-contained folder per migration unit; BOTH gates accept it with NO flags
+       one diagnostic folder per migration unit; BOTH gates accept it with NO flags
             │            entry gate: check_reference_readiness.py   (ready / blind)
             │            exit  gate: check_unit.py                  (is this unit done?)
             │
@@ -145,7 +145,8 @@ baseline reads as "large diff, do not re-run" (issue #274, #359).
 ## Phase 2 — package for the agent
 
 [`scripts/package_unit.py`](../scripts/package_unit.py) (issues #446 / #451) assembles **one
-self-contained folder per migration unit that both gates accept with NO flags.**
+diagnostic folder per migration unit that both gates accept with NO flags.** Source, imported rows,
+engine output, handover and reference evidence are conditional; the manifest names every omission.
 
 That "no flags" property is the entire point. Before it, the three things an agent needs lived in
 four naming schemes across two trees — the engine keys `pbip/`, `reports/` and `handover/` by
@@ -242,7 +243,7 @@ package (*"Promoting FROM the package is settled (#460)"*, `scripts/promote_unit
 and again under the swap. The shared-conventions `working copy` row's *"agents edit `pbip/`"* governs the window **before**
 packaging; after it, work in the package. See phase 3 below for the promotion mechanics.
 
-### Where `packages/` goes, and the self-contained marker
+### Where `packages/` goes, and the package-boundary marker
 
 ```powershell
 python scripts\package_unit.py --bundle _runs\<NNN>-<slug>\bundle `
@@ -256,8 +257,8 @@ python scripts\check_unit.py                _runs\<NNN>-<slug>\packages\<Unit>
 `--out` directly targets `_runs/<NNN>-<slug>/packages` (flat layout, creating `packages/<Unit>/`).
 Optional nested batch folders (`packages/<batch>/<Unit>/`) remain supported for compatibility.
 
-Completed packages carry `package-manifest.json` (`bundle_corpus.is_self_contained`), which
-declares that the package carries its own evidence and stops the ancestor walk in both gates
+Constructed packages carry `package-manifest.json` (`bundle_corpus.is_self_contained`), which
+marks the package boundary and stops the ancestor walk in both gates
 (`check_reference_readiness.py` and `check_unit.py`). The package matches only its own scoped oracle
 evidence and never borrows omitted renders or double-matches against run-root captures at
 `_runs/<NNN>-<slug>/oracle/`. An incomplete or failed package lacking `package-manifest.json` fails

--- a/docs/migration-phases.md
+++ b/docs/migration-phases.md
@@ -177,7 +177,7 @@ Per-unit layout (authoritative list: `package_unit.py`'s module docstring):
         dashboard/{images,data}/<Object>.<ext>
         worksheet/{images,data}/<Object>.<ext>
         unknown/{images,data}/<Object>.<ext>
-    package-manifest.json        what was packaged, and every omission with its reason
+    package-manifest.json        what was assembled, and every omission with its reason
     README.md
 ```
 

--- a/docs/reference-readiness.md
+++ b/docs/reference-readiness.md
@@ -464,8 +464,10 @@ than silently selecting a new baseline.
 ⚠️ This is **not** the final START_READY consumer. `check_reference_readiness.py` does not yet fold
 the projection. Construction success, its internal S2 `START_READY`, and reference `READY` do not
 authorize Phase-2 dispatch or clear a credential gate. Handover, README and packaging output expose
-the actual closed data state and this pending step. `packaged`/`self_contained` keep their original
-construction/containment meanings.
+the actual closed data state and this pending step. `construction_status = "ASSEMBLED"` means only
+that a diagnostic package directory was constructed; `has_engine_working_copy` and `self_contained`
+remain separate limitations. `dispatch_readiness.status = "NOT_EVALUATED"` is explicit until #622
+and the final #562 consumer establish the later decision.
 
 See [credential gate](credential-gate.md#package-data-access-projection) for gate-root, provider and
 scope limits. The final consumer remains a separate PR; S1 stays byte authority, not a semantic

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -235,6 +235,12 @@ Totals always use the original requested denominator, and any BLOCKED request ma
 nonzero while preserving ASSEMBLED siblings. A missing working copy, non-self-contained package,
 unbound data path or absent oracle remains ASSEMBLED diagnostic output.
 
+The legacy ordered `units` / `failed` / `refused` / `unaccounted` JSON buckets and their totals
+remain present, explicitly marked `construction_only`; `construction` is the single ASSEMBLED /
+BLOCKED projection over them. `units` and its projection preserve provider-first publication order.
+The legacy manifest `packaged` boolean remains an engine-working-copy indicator only, with adjacent
+`packaged_semantics`; it is not a success label.
+
 **ASSEMBLED is never START_READY.** Output records dispatch readiness as unavailable and
 `NOT_EVALUATED`; #622 and the final #562 consumer own that later decision. The command creates no
 dispatch authorization and does not call or reimplement `check_reference_readiness.py`.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -222,6 +222,23 @@ and credential containment checks run before assembly. Unsafe text is refused wi
 redacting or echoing it. Datasource resolution retains the unique selecting input-manifest row with
 its walked path and validates that row's basename/path/digest; ambiguous rows or candidates refuse.
 
+### Construction status (#614)
+
+This section supersedes the legacy exit/status vocabulary embedded in the long `package_unit.py`
+catalog row above; its historical construction, containment and attribution evidence remains valid.
+
+`package_unit.py` is inherently assembly-only before #622. `--assemble-only` is an explicit alias
+and status marker for that existing behavior, not a second construction path. Human output, the
+batch JSON and every package manifest use **ASSEMBLED** only when a diagnostic package directory was
+constructed; failures, edit refusals, unassessable inputs and unattempted requests are **BLOCKED**.
+Totals always use the original requested denominator, and any BLOCKED request makes the command
+nonzero while preserving ASSEMBLED siblings. A missing working copy, non-self-contained package,
+unbound data path or absent oracle remains ASSEMBLED diagnostic output.
+
+**ASSEMBLED is never START_READY.** Output records dispatch readiness as unavailable and
+`NOT_EVALUATED`; #622 and the final #562 consumer own that later decision. The command creates no
+dispatch authorization and does not call or reimplement `check_reference_readiness.py`.
+
 `package_role_identity.py` re-runs no-follow S1 at the S2 entry seam rather than trusting an earlier
 clearance. It strictly reads identity JSON, preserves every dependency row, requires S2-clean
 providers and checks actual PBIR bindings to complete declared model roles. Evidence consumers receive
@@ -272,8 +289,9 @@ connection and valid dependency; malformed/additional direct legs never disappea
 No probe/audit/gate writes or scope downgrade.
 
 ❌ **Producer-only:** the final `check_reference_readiness.py` START_READY data consumer is pending.
-Construction exit 0, reference `READY`, `packaged` and `self_contained` are not data authorization.
-Handover/README/output make this explicit. Model-only authorization stays unvalidated and cannot be
+Construction `ASSEMBLED`, reference `READY`, `has_engine_working_copy` and `self_contained` are not
+data authorization. Handover/README/output record dispatch readiness as unavailable and not
+evaluated. Model-only authorization stays unvalidated and cannot be
 inherited by a report; published-plus-direct mixtures and recursive inheritance remain non-accepted.
 Details and residuals: [credential gate](../docs/credential-gate.md#package-data-access-projection).
 

--- a/scripts/package_unit.py
+++ b/scripts/package_unit.py
@@ -1,9 +1,9 @@
 """
-purpose: assemble ONE self-contained, no-flags handover package per migration unit (report or datasource).
+purpose: assemble ONE diagnostic, no-flags handover package per migration unit (report or datasource).
 usage:   python scripts/package_unit.py --bundle <bundle> --out <dir> [--unit NAME ...]
                                         [--oracle <dir>] [--assets <dir>] [--brief <file>]
                                         [--gate-root <original-root>] [--provider-package <root> ...]
-                                        [--json <file>] [--quiet]
+                                        [--assemble-only] [--json <file>] [--quiet]
 
 Issue #446: the three things an agent needs to start one report all exist and NOTHING assembles them.
 They live in four naming schemes across two trees - the engine keys `pbip/`, `reports/` and
@@ -121,28 +121,20 @@ render leg.
 
 Exit codes
 ----------
-| 0 | every requested unit was packaged, engine output included, and every source its model names is
-      IN the package |
-| 1 | at least one unit has NO engine working copy under `pbip/`. It is still packaged - the source,
-      the reference and the engine's own handover slice are all there - but there is nothing to build
-      on, and `check_reference_readiness.py` reports it as a finding rather than a pass. |
+| 0 | every requested unit was ASSEMBLED: a diagnostic package directory was constructed. This says
+      nothing about self-containment, binding, reference coverage or START_READY. |
+| 1 | legacy `EXIT_NO_WORKING_COPY`, retained for import compatibility but no longer emitted: a
+      successfully constructed diagnostic package is ASSEMBLED even when it has no working copy. |
 | 2 | usage error (argparse), including an `--out` too deep for the paths this bundle would produce.
       Every unit is measured against `check_path_ceiling.py`'s ceilings BEFORE any is assembled, and
-      the refusal names the path, its length, the ceiling and how many characters `--out` must lose.
-      Nothing is packaged: a shorter `--out` moves every unit, so a partial estate would be redone
-      anyway (#476). |
+      the refusal names the path, its length, the ceiling and how many characters `--out` must lose. |
 | 3 | at least one requested unit already has a package carrying EDITS, and this packager replaces a
-      package whole. Those units were left untouched; every other requested unit was still packaged.
+      package whole. Those units were left untouched; every other requested unit was still attempted.
       `--discard-package-edits` overwrites them deliberately. |
-| 4 | at least one unit is NOT SELF-CONTAINED - it ships without something it names: a source its
-      model reads (the bytes could not be copied, or a literal could not be classified), or the
-      semantic model its report's `definition.pbir` `byPath` points at. The package is still written
-      (it carries everything else) but it is not complete. Ranked above 1 because 1 is already
-      visible in every gate's verdict while this is not: a model missing its rows loads, validates
-      and passes `check_datamodel.py`, and `powerbi-report-author validate` returns `errorCount: 0`
-      for a `byPath` naming a model that exists nowhere. |
+| 4 | legacy `EXIT_NOT_SELF_CONTAINED`, retained for import compatibility but no longer emitted: a
+      successfully constructed diagnostic package remains ASSEMBLED and carries this limitation. |
 | 5 | at least one unit hit a CONTRADICTION this packager refuses to ship past, or RAISED while it
-      was being packaged, and NOTHING was written for it: a source whose bytes do not match the
+      was being assembled, and NOTHING was written for it: a source whose bytes do not match the
       digest `input_manifest.json` declares, a unit name that would write outside `--out`, a host
       path that could not be contained in the model, or any other exception (issue #478's field
       failure was `shutil.Error: [WinError 3]`). Every OTHER requested unit was still attempted. |
@@ -164,19 +156,20 @@ comprehension over `sorted(units)`, and every alphabetically later unit was **ne
 never reported** - the operator could not tell *"not packaged"* from *"packaged and fine"* without
 diffing directories by hand. Every requested unit is now attempted deterministically (datasources
 first, then workbooks; sorted within each phase),
-a raise is caught per unit and carried in `--json` under `failed[]` with its traceback, and the run
+a raise is caught per unit and carried in `--json` under `blocked[]` with its traceback, and the run
 still exits 5.
 
-Every requested unit lands in EXACTLY ONE bucket - `units[]` (attempted), `failed[]` or `refused[]` -
-and `unaccounted[]` names any that did not, in either direction. The totals are measured against the
+Every requested unit lands in EXACTLY ONE construction state - `assembled[]` or `blocked[]` - and
+`accounting_findings[]` names any raw-bucket contradiction. The totals are measured against the
 REQUEST, never against whatever survived it: a unit that raised before it could be recorded anywhere
-would otherwise shrink the denominator and read as a clean run of a smaller estate.
+would otherwise shrink the denominator and read as a clean run of a smaller estate. The raw local
+lists still separate results, failures and edit refusals so existing continuation and exit-code
+precedence stay intact; the JSON folds them into the two construction states.
 
-An oracle omission INSIDE a package is not exit 1, 4 or 6: a unit whose oracle genuinely has no
-render for a page is the negative control, and it must package successfully and still report that
-page BLIND. A missing, absent or truncated oracle is therefore explicitly NOT an unassessable input;
-the entry gate reports it, correctly, at exit 1 FINDINGS. Exit 4 is about what the package itself
-promises to carry, nothing else.
+An oracle omission INSIDE a package does not BLOCK assembly: a unit whose oracle genuinely has no
+render for a page is the negative control, and it must still produce a diagnostic package whose page
+is BLIND. A missing, absent or truncated oracle is therefore explicitly NOT an unassessable
+construction input; the later entry gate owns that evidence verdict.
 """
 
 # Packaging, the evidence walk, path containment and the CLI deliberately live together: this module
@@ -207,7 +200,7 @@ import sys
 import time
 import traceback
 import uuid
-from collections import Counter
+from collections import Counter, defaultdict
 from collections.abc import Callable, Sequence
 from copy import deepcopy
 from functools import partial
@@ -398,10 +391,16 @@ MANIFEST_NAME = "package-manifest.json"
 #: Markdown file a package happens to carry.
 BRIEF_NAME = "migration-brief.md"
 DATA_ACCESS_NAME = "data-access.json"
-DATA_ACCESS_PENDING = (
-    "Final START_READY data-access consumer pending: package construction and reference READY do not "
-    "authorize Phase-2 dispatch or clear the credential gate."
+ASSEMBLY_MODE = "ASSEMBLE_ONLY"
+STATUS_ASSEMBLED = "ASSEMBLED"
+STATUS_BLOCKED = "BLOCKED"
+DISPATCH_READINESS_NOT_EVALUATED = "NOT_EVALUATED"
+NOT_START_READY_NOTICE = (
+    "NOT START_READY: dispatch readiness is unavailable and was not evaluated; #622 and the final "
+    "#562 consumer own that decision. Package construction and reference READY do not authorize "
+    "Phase-2 dispatch or clear the credential gate."
 )
+DATA_ACCESS_PENDING = NOT_START_READY_NOTICE
 
 #: Refuse to copy a single source larger than this, rather than silently turning a handover folder
 #: into a data lake. Measured on estate run 408 the largest referenced extract is 1.33 MB and the
@@ -505,7 +504,7 @@ class UnassessableInput(PackagingError):
         self.traceback = _safe_traceback(error) if error is not None else None
         safe_reasons = [_sanitize_diagnostic(reason) for reason in reasons]
         super().__init__(
-            f"cannot assess {unit}: " + "; ".join(safe_reasons) + ". Nothing was packaged for it - a package "
+            f"cannot assess {unit}: " + "; ".join(safe_reasons) + ". No package was produced for it - a package "
             "built from input that could not be read would carry a verdict nobody can stand behind."
         )
 
@@ -584,7 +583,7 @@ class UnitCrashed(PackagingError):
     because those are the operator ending the run rather than a unit failing.
 
     It is a :class:`PackagingError` so it travels the path every other per-unit refusal already
-    travels - `failed[]`, the `FAIL` line, `EXIT_UNIT_FAILED` - rather than opening a second one.
+    travels - `blocked[]`, the `BLOCKED` line, `EXIT_UNIT_FAILED` - rather than opening a second one.
     The original exception and its traceback are kept, because "a unit raised" without the traceback
     is not a defect report anyone can act on.
     """
@@ -594,8 +593,8 @@ class UnitCrashed(PackagingError):
         self.label = _error_label(error)
         self.traceback = _safe_traceback(error)
         super().__init__(
-            f"packaging {unit} FAILED and nothing was written for it ({self.label}: {_one_line(error)}). "
-            "Every other requested unit was still attempted; see the traceback in --json under failed[]."
+            f"assembly of {unit} FAILED and nothing was written for it ({self.label}: {_one_line(error)}). "
+            "Every other requested unit was still attempted; see the traceback in --json under blocked[]."
         )
 
 
@@ -3400,8 +3399,8 @@ def _refuse_surviving_staging(unit: str, staging: Path) -> None:
         )
         return
     raise PackagingError(
-        f"packaged {unit}, but its staging directory {staging} could not be removed ({left}). The package "
-        "itself is complete on disk; this unit is reported failed because a staging directory that "
+        f"construction of {unit} finished, but its staging directory {staging} could not be removed ({left}). "
+        "The diagnostic package itself is complete on disk; this unit is BLOCKED because a staging directory that "
         "outlives its build is what a later build would silently assemble into."
     )
 
@@ -4234,7 +4233,10 @@ def _assemble_unit(  # pylint: disable=too-many-locals,too-many-arguments,too-ma
         "unit": unit,
         "kind": kind,
         "engine": ((receipt or {}).get("engine") or {}).get("version"),
-        "packaged": report_name is not None or model_name is not None,
+        "mode": ASSEMBLY_MODE,
+        "construction_status": STATUS_ASSEMBLED,
+        "has_engine_working_copy": report_name is not None or model_name is not None,
+        "dispatch_readiness": _dispatch_readiness(),
         "self_contained": bool(data_sources["self_contained"] and binding["resolves_in_package"]),
         "artifacts": {
             "migration_spec": spec,
@@ -4293,11 +4295,11 @@ def _run_totals(
 ) -> list[str]:
     """The lines after the per-unit list: every state that must not be inferred from a silence."""
     lines: list[str] = []
-    starved = sorted(result["unit"] for result in results if not result["packaged"])
+    starved = sorted(result["unit"] for result in results if not result["has_engine_working_copy"])
     if starved:
         lines.append(
-            f"WARN: {len(starved)} unit(s) have NO engine working copy under pbip/ - packaged for their "
-            f"source, reference and handover only, with nothing to build on: {', '.join(starved)}"
+            f"WARN: {len(starved)} ASSEMBLED unit(s) have NO engine working copy under pbip/. Their "
+            f"diagnostic packages carry source, reference and handover only: {', '.join(starved)}"
         )
     if refused:
         lines.append(
@@ -4308,7 +4310,7 @@ def _run_totals(
     if unassessable:
         lines.append(
             f"CANNOT ASSESS: {len(unassessable)} unit(s) had an input that exists but could not be read, "
-            "so nothing was packaged for them - this is neither a clean nor a failed verdict: "
+            "so no package was produced for them - this is neither a clean nor a failed verdict: "
             f"{', '.join(unassessable)}"
         )
     hard = sorted(_failed_unit(item) for item in failed if not isinstance(item, UnassessableInput))
@@ -4334,14 +4336,37 @@ def _run_totals(
     return lines
 
 
-def render(
+def _dispatch_readiness() -> dict[str, str]:
+    """The only readiness statement construction is allowed to make before #622."""
+    return {
+        "availability": "UNAVAILABLE",
+        "status": DISPATCH_READINESS_NOT_EVALUATED,
+        "message": NOT_START_READY_NOTICE,
+    }
+
+
+def _mode(explicit: bool) -> dict[str, Any]:
+    """Describe the command's one behavior; the flag is an explicit alias, not a second path."""
+    return {
+        "name": ASSEMBLY_MODE,
+        "explicit": explicit,
+        "description": (
+            "This command is inherently construction-only before #622; --assemble-only makes that "
+            "existing behavior explicit and does not authorize dispatch."
+        ),
+    }
+
+
+def render(  # pylint: disable=too-many-arguments
     results: list[dict[str, Any]],
     out_root: Path,
     refused: list[PackageEditsRefused] | None = None,
     failed: list[PackagingError] | None = None,
     requested: list[str] | None = None,
+    *,
+    assemble_only_explicit: bool = False,
 ) -> str:
-    """The human verdict: one line per unit, then the totals that make an omission visible.
+    """The human construction verdict: one line per requested unit, then exact-denominator totals.
 
     ``requested`` is the units the operator ASKED for. It is passed rather than inferred so the
     totals are measured against the REQUEST, not against whatever survived it: a unit that vanished
@@ -4350,46 +4375,46 @@ def render(
     """
     refused, failed = refused or [], failed or []
     requested = list(requested) if requested is not None else _bucketed_units(results, failed, refused)
-    lines = [f"package_unit: {len(requested)} unit(s) -> {out_root}"]
-    lines += [_unit_line(result) for result in sorted(results, key=lambda item: item["unit"])]
-    for refusal in sorted(refused, key=lambda item: item.unit):
-        lines.append(f"  KEPT {refusal.unit} - not repackaged, the existing package carries edits")
-    for failure in sorted(failed, key=_failed_unit):
-        label = "CANT" if isinstance(failure, UnassessableInput) else "FAIL"
-        lines.append(f"  {label} {_failed_unit(failure)} - NOT packaged: {_one_line(failure)}")
-    gaps = partition_gaps(requested, results, failed, refused)
-    for gap in gaps:
-        lines.append(f"  GAP  {gap['unit']} - {gap['reason']}")
-    packaged = sum(1 for result in results if result["packaged"])
+    assembled, blocked, gaps = construction_outcomes(requested, results, failed, refused)
+    mode_note = "explicit --assemble-only" if assemble_only_explicit else "current default"
+    lines = [
+        f"package_unit: {len(requested)} requested unit(s) -> {out_root}",
+        f"mode: {ASSEMBLY_MODE} ({mode_note}; construction only)",
+    ]
+    lines += [_unit_line(result) for result in sorted(assembled, key=lambda item: item["unit"])]
+    lines += [_blocked_line(row) for row in sorted(blocked, key=lambda item: item["unit"])]
     with_oracle = sum(1 for result in results if result["oracle"].get("objects"))
-    lines.append(f"packaged {packaged}/{len(requested)}; {with_oracle} carry oracle evidence")
-    lines.append(
-        f"{len(requested)} requested = {len(results)} attempted + {len(failed)} failed + {len(refused)} kept"
-        + (f" + {len(gaps)} UNACCOUNTED" if gaps else "")
-    )
+    lines.append(f"ASSEMBLED: {len(assembled)}/{len(requested)} ({with_oracle} carry oracle evidence)")
+    lines.append(f"BLOCKED: {len(blocked)}/{len(requested)}")
+    lines.append(f"{len(requested)} requested = {len(assembled)} ASSEMBLED + {len(blocked)} BLOCKED")
     lines.extend(_run_totals(results, refused, failed))
     if gaps:
         lines.append(
-            f"UNACCOUNTED: {len(gaps)} requested unit(s) reached no outcome bucket or more than one, so "
-            "what happened to them is unknown and this run is NOT clean: "
+            f"ACCOUNTING FINDINGS: {len(gaps)} raw outcome contradiction(s); this run is NOT clean: "
             + "; ".join(f"{gap['unit']} ({gap['state']})" for gap in gaps)
         )
-    lines.append(DATA_ACCESS_PENDING)
+    lines.append(NOT_START_READY_NOTICE)
     return "\n".join(lines)
 
 
 def _unit_line(result: dict[str, Any]) -> str:
-    """The summary line for one ATTEMPTED unit - `OK` or `MISS`, never a failure (those are `FAIL`)."""
+    """The summary line for one successfully constructed diagnostic package."""
     oracle = result["oracle"]
     objects = oracle.get("objects") or []
     untyped = sum(1 for obj in objects if obj["view_type"] == KIND_UNKNOWN)
     detail = f"{len(objects)} oracle object(s) via {oracle.get('route')}" if objects else "no oracle evidence"
+    working_copy = "engine working copy present" if result["has_engine_working_copy"] else "no engine working copy"
     return (
-        f"  {'OK  ' if result['packaged'] else 'MISS'} {result['unit']} [{result['kind']}] - {detail}"
+        f"  {STATUS_ASSEMBLED} {result['unit']} [{result['kind']}] - {working_copy}; {detail}"
         + (f", {untyped} untyped" if untyped else "")
         + (f"; {len(result['notes'])} note(s)" if result["notes"] else "")
         + "".join(f"\n    {note}" for note in result["notes"] if note.startswith("DATA_ACCESS "))
     )
+
+
+def _blocked_line(row: dict[str, Any]) -> str:
+    """One named construction refusal/failure, never a readiness verdict."""
+    return f"  {STATUS_BLOCKED} {row['unit']} [{row['blocker']}] - {_one_line(row['reason'])}"
 
 
 def _failed_unit(failure: PackagingError) -> str:
@@ -4439,6 +4464,73 @@ def partition_gaps(
         for unit in sorted(set(counted) - asked)
     ]
     return gaps
+
+
+def _refusal_block(refusal: PackageEditsRefused) -> dict[str, Any]:
+    """Fold an edit-preservation refusal into the construction-only BLOCKED vocabulary."""
+    detail = refusal.reason or (
+        f"{len(refusal.changed)} existing package file(s) differ from the recorded assembly: "
+        + ", ".join(refusal.changed[:5])
+        + (" ..." if len(refusal.changed) > 5 else "")
+    )
+    return {
+        "unit": refusal.unit,
+        "construction_status": STATUS_BLOCKED,
+        "blocker": "PACKAGE_EDITS_REFUSED",
+        "reason": detail,
+        "changed": refusal.changed,
+    }
+
+
+def _failure_block(failure: PackagingError) -> dict[str, Any]:
+    """Fold a modelled/unexpected failure into BLOCKED without losing its diagnostic."""
+    return {
+        "unit": _failed_unit(failure),
+        "construction_status": STATUS_BLOCKED,
+        "blocker": "UNASSESSABLE_INPUT" if isinstance(failure, UnassessableInput) else "CONSTRUCTION_FAILED",
+        "reason": _sanitize_diagnostic(str(failure)),
+        "traceback": getattr(failure, "traceback", None),
+    }
+
+
+def construction_outcomes(
+    requested: list[str],
+    results: list[dict[str, Any]],
+    failed: list[PackagingError],
+    refused: list[PackageEditsRefused],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, str]]]:
+    """Fold raw continuation buckets into exactly one construction state per requested unit."""
+    buckets: dict[str, list[tuple[str, dict[str, Any]]]] = defaultdict(list)
+    for result in results:
+        buckets[result["unit"]].append((STATUS_ASSEMBLED, result))
+    for failure in failed:
+        block = _failure_block(failure)
+        buckets[block["unit"]].append((STATUS_BLOCKED, block))
+    for refusal in refused:
+        block = _refusal_block(refusal)
+        buckets[block["unit"]].append((STATUS_BLOCKED, block))
+
+    gaps = partition_gaps(requested, results, failed, refused)
+    assembled: list[dict[str, Any]] = []
+    blocked: list[dict[str, Any]] = []
+    for unit in requested:
+        outcomes = buckets.get(unit, [])
+        if len(outcomes) == 1 and outcomes[0][0] == STATUS_ASSEMBLED:
+            assembled.append(outcomes[0][1])
+            continue
+        if len(outcomes) == 1:
+            blocked.append(outcomes[0][1])
+            continue
+        gap = next((item for item in gaps if item["unit"] == unit), None)
+        blocked.append(
+            {
+                "unit": unit,
+                "construction_status": STATUS_BLOCKED,
+                "blocker": "UNATTEMPTED" if not outcomes else "ACCOUNTING_ERROR",
+                "reason": (gap or {}).get("reason", "requested unit has contradictory construction outcomes"),
+            }
+        )
+    return assembled, blocked, gaps
 
 
 def _package_each(  # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals
@@ -4498,7 +4590,7 @@ def _package_each(  # pylint: disable=too-many-arguments,too-many-positional-arg
                 discard_edits=discard_edits,
             )
             results.append(result)
-            if result["kind"] == KIND_DATASOURCE and result["packaged"]:
+            if result["kind"] == KIND_DATASOURCE and result["has_engine_working_copy"]:
                 providers.append(out_root / unit)
         except PackageEditsRefused as refusal:
             print(_sanitize_diagnostic(str(refusal)), file=sys.stderr)
@@ -4563,21 +4655,28 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="overwrite an existing package even though it carries edits made since it was written",
     )
+    parser.add_argument(
+        "--assemble-only",
+        action="store_true",
+        help=(
+            "explicit alias/status marker for this command's current and only behavior: construct "
+            "diagnostic packages without evaluating or authorizing dispatch readiness"
+        ),
+    )
     return parser
 
 
-def _refuse_zero_units(bundle: Path, out_root: Path, json_path: Path | None) -> int:
+def _refuse_zero_units(bundle: Path, out_root: Path, json_path: Path | None, *, assemble_only_explicit: bool) -> int:
     """The verdict for a bundle that names no units at all.
 
-    ⚠️ **`packaged 0/0` at exit 0 is TRUE and useless**, and it is the shape a caller reads as "the
-    estate is packaged" - measured on this branch. The emptiness is a fact about the BUNDLE rather
-    than about the command line, so it gets the cannot-assess code rather than argparse's 2, and the
-    `--json` envelope is still written so an automated caller has a record of the refusal.
+    A zero denominator cannot establish construction status. The emptiness is a fact about the
+    BUNDLE rather than about the command line, so it gets the cannot-assess code rather than
+    argparse's 2, and the `--json` envelope is still written so an automated caller has a record.
     """
     print(
         f"cannot assess {bundle}: its report.json lists no workbooks or datasources and it has no "
-        "pbip/ working copies, so there is nothing to package and 'packaged 0/0' would read as "
-        "success. Point --bundle at an engine run, or check that report.json parsed.",
+        "pbip/ working copies, so there is no requested construction denominator. Point --bundle "
+        f"at an engine run, or check that report.json parsed. {NOT_START_READY_NOTICE}",
         file=sys.stderr,
     )
     if json_path:
@@ -4587,11 +4686,13 @@ def _refuse_zero_units(bundle: Path, out_root: Path, json_path: Path | None) -> 
                 "id": "package-unit",
                 "bundle": str(bundle),
                 "out": str(out_root),
+                "mode": _mode(assemble_only_explicit),
+                "dispatch_readiness": _dispatch_readiness(),
                 "requested": [],
-                "units": [],
-                "refused": [],
-                "failed": [],
-                "unaccounted": [],
+                "totals": {"requested": 0, "assembled": 0, "blocked": 0},
+                "assembled": [],
+                "blocked": [],
+                "accounting_findings": [],
                 "cannot_assess": ["the bundle names no units"],
             },
         )
@@ -4599,30 +4700,30 @@ def _refuse_zero_units(bundle: Path, out_root: Path, json_path: Path | None) -> 
 
 
 def _run_verdict(
-    results: list[dict[str, Any]],
+    blocked: list[dict[str, Any]],
     refused: list[PackageEditsRefused],
     failed: list[PackagingError],
     gaps: list[dict[str, str]] | None = None,
 ) -> int:
-    """The run's exit code, worst first.
+    """The run's exit code, worst first; content limitations do not change construction status.
 
     The two "nothing was written" states rank ABOVE every verdict about content: a verdict computed
-    from input that could not be read, or reported alongside a unit that never got packaged at all,
+    from input that could not be read, or reported alongside a unit that never got assembled at all,
     is the fail-open shape this ordering exists to make impossible.
 
     ⚠️ **An UNACCOUNTED unit ranks with cannot-assess, at the top.** A requested unit that reached no
     outcome bucket is not "fine" and it is not "failed" - nobody knows what happened to it, which is
     the same third state, and it must never be able to leave a run clean (#478).
     """
+    if not blocked and not gaps:
+        return EXIT_OK
     if gaps or any(isinstance(failure, UnassessableInput) for failure in failed):
         return EXIT_CANNOT_ASSESS
     if failed:
         return EXIT_UNIT_FAILED
     if refused:
         return EXIT_EDITS_REFUSED
-    if any(not result.get("self_contained", True) for result in results):
-        return EXIT_NOT_SELF_CONTAINED
-    return EXIT_OK if all(result["packaged"] for result in results) else EXIT_NO_WORKING_COPY
+    return EXIT_UNIT_FAILED
 
 
 def _measure_unit_budgets(
@@ -4701,7 +4802,7 @@ def main(argv: list[str] | None = None) -> int:  # pylint: disable=too-many-loca
 
     out_root = _prepare_out(args.out)
     if not units:
-        return _refuse_zero_units(bundle, out_root, args.json)
+        return _refuse_zero_units(bundle, out_root, args.json, assemble_only_explicit=args.assemble_only)
 
     # The denominator stays sorted by name even though assembly publishes datasources first.
     requested = sorted(units)
@@ -4725,6 +4826,7 @@ def main(argv: list[str] | None = None) -> int:  # pylint: disable=too-many-loca
         provider_packages=_external_providers(args.provider_package, out_root, requested),
     )
     gaps = partition_gaps(requested, results, failed, refused)
+    assembled, blocked, accounting_findings = construction_outcomes(requested, results, failed, refused)
 
     payload = {
         "id": "package-unit",
@@ -4732,30 +4834,17 @@ def main(argv: list[str] | None = None) -> int:  # pylint: disable=too-many-loca
         "out": str(out_root),
         "oracle": str(oracle_dir) if oracle_dir else None,
         "assets": str(assets_dir) if assets_dir else None,
+        "mode": _mode(args.assemble_only),
+        "dispatch_readiness": _dispatch_readiness(),
         "requested": requested,
         "totals": {
             "requested": len(requested),
-            "units": len(results),
-            "failed": len(failed),
-            "refused": len(refused),
-            "unaccounted": len(gaps),
+            "assembled": len(assembled),
+            "blocked": len(blocked),
         },
-        "units": results,
-        "refused": [
-            {"unit": refusal.unit, "changed": refusal.changed, "reason": refusal.reason} for refusal in refused
-        ],
-        "failed": [
-            {
-                "unit": _failed_unit(failure),
-                "state": "cannot_assess" if isinstance(failure, UnassessableInput) else "unit_failed",
-                "reason": _sanitize_diagnostic(str(failure)),
-                # Only a crash carries one: the modelled refusals ARE their reason, while "a unit
-                # raised" without the traceback is not a defect report anyone can act on (#478).
-                "traceback": getattr(failure, "traceback", None),
-            }
-            for failure in failed
-        ],
-        "unaccounted": gaps,
+        "assembled": assembled,
+        "blocked": blocked,
+        "accounting_findings": accounting_findings,
         # The relocation number, per unit, travelling WITH the report: how long a Windows root each
         # package still tolerates. Nothing downstream re-measures it, and it is the one figure that
         # says whether a package that is valid here will open where a customer unpacks it.
@@ -4764,8 +4853,19 @@ def main(argv: list[str] | None = None) -> int:  # pylint: disable=too-many-loca
     if args.json:
         write_json(args.json, payload)
     if not args.quiet:
-        print(render(results, out_root, refused, failed, requested))
-    return _run_verdict(results, refused, failed, gaps)
+        print(
+            render(
+                results,
+                out_root,
+                refused,
+                failed,
+                requested,
+                assemble_only_explicit=args.assemble_only,
+            )
+        )
+    elif args.assemble_only:
+        print(NOT_START_READY_NOTICE)
+    return _run_verdict(blocked, refused, failed, gaps)
 
 
 if __name__ == "__main__":

--- a/scripts/package_unit.py
+++ b/scripts/package_unit.py
@@ -658,10 +658,17 @@ class InterruptedUnit(PackagingError):
 class AssemblyInterrupted(KeyboardInterrupt):
     """A handled operator interruption carrying only observed swap state."""
 
-    def __init__(self, *, published: bool, rollback_failed: bool = False) -> None:
+    def __init__(
+        self,
+        *,
+        published: bool,
+        rollback_failed: bool = False,
+        secondary_code: str | None = None,
+    ) -> None:
         super().__init__()
         self.published = published
         self.rollback_failed = rollback_failed
+        self.secondary_code = secondary_code
         self.unit: str | None = None
         self.result: dict[str, Any] | None = None
         self.reason_code = "assembly_interrupted_after_publish" if published else "assembly_interrupted_before_publish"
@@ -3499,39 +3506,54 @@ def package_unit(  # pylint: disable=too-many-arguments,too-many-locals
             "Remove it and re-run that unit."
         )
     result: dict[str, Any] | None = None
+    candidate_manifest_sha256: str | None = None
+    publication_started = False
     try:
-        result, verify_staged = _assemble_unit(
-            bundle,
-            unit,
-            staging,
+        try:
+            result, verify_staged = _assemble_unit(
+                bundle,
+                unit,
+                staging,
+                final=final,
+                oracle_dir=oracle_dir,
+                assets_dir=assets_dir,
+                brief=prepared_brief,
+                gate_root=gate_root,
+                provider_packages=_external_providers(provider_packages, out_root, [unit]),
+            )
+            assert_assembled_fits(unit, staging, final, out_root, limits)
+            candidate_manifest_sha256 = sha256_of(staging / MANIFEST_NAME)
+            if candidate_manifest_sha256 is None:
+                raise PackagingError("candidate_manifest_unreadable")
+            publication_started = True
+            replace_dir(
+                staging,
+                final,
+                verify=None if discard_edits else partial(_refuse_if_edited, unit),
+                verify_staged=verify_staged,
+            )
+        except OSError as failure:
+            refusal = _assembly_refusal(unit, failure)
+            if refusal is None:
+                raise
+            raise refusal from failure
+        finally:
+            _refuse_surviving_staging(unit, staging, final)
+        if result is None:
+            raise PackagingError("assembly_result_missing")
+        return result
+    except KeyboardInterrupt as error:
+        interruption = _publication_interruption(
+            error,
             final=final,
-            oracle_dir=oracle_dir,
-            assets_dir=assets_dir,
-            brief=prepared_brief,
-            gate_root=gate_root,
-            provider_packages=_external_providers(provider_packages, out_root, [unit]),
+            staging=staging,
+            candidate_manifest_sha256=candidate_manifest_sha256,
+            publication_started=publication_started,
         )
-        assert_assembled_fits(unit, staging, final, out_root, limits)
-        replace_dir(
-            staging,
-            final,
-            verify=None if discard_edits else partial(_refuse_if_edited, unit),
-            verify_staged=verify_staged,
-        )
-    except AssemblyInterrupted as interruption:
         interruption.unit = unit
         interruption.result = result if interruption.published and result is not None else None
-        raise
-    except OSError as failure:
-        refusal = _assembly_refusal(unit, failure)
-        if refusal is None:
-            raise
-        raise refusal from failure
-    finally:
-        _refuse_surviving_staging(unit, staging, final)
-    if result is None:
-        raise PackagingError("assembly_result_missing")
-    return result
+        cause = error.__cause__ if isinstance(error, AssemblyInterrupted) and error.__cause__ is not None else error
+        raise interruption from cause
 
 
 def _refuse_surviving_staging(unit: str, staging: Path, final: Path) -> None:
@@ -3750,8 +3772,85 @@ def replace_dir(
                 rollback_failed = True
                 error.add_note("package rollback failed during swap recovery")
         if isinstance(error, KeyboardInterrupt):
-            raise AssemblyInterrupted(published=published, rollback_failed=rollback_failed) from error
+            raise AssemblyInterrupted(
+                published=published,
+                rollback_failed=rollback_failed,
+                secondary_code="rollback_failed" if rollback_failed else None,
+            ) from error
         raise
+
+
+def _valid_published_package(final: Path, candidate_manifest_sha256: str | None) -> bool:
+    """Whether ``final`` is the exact assembled candidate and its manifest still verifies."""
+    if candidate_manifest_sha256 is None:
+        return False
+    if sha256_of(final / MANIFEST_NAME) != candidate_manifest_sha256:
+        return False
+    try:
+        return final.is_dir() and pri.verify_s1(final).integrity.is_clean
+    except Exception:  # pylint: disable=broad-exception-caught
+        return False
+
+
+def _make_scratch_nondiscoverable(root: Path, role: str) -> str | None:
+    """Remove reserved scratch, or at least remove its package-discovery marker."""
+    try:
+        residue = _discard_scratch(root)
+    except BaseException:  # pylint: disable=broad-exception-caught
+        residue = "cleanup interrupted"
+    if not root.exists():
+        return None
+    manifest = root / MANIFEST_NAME
+    if not manifest.is_file():
+        return f"{role}_cleanup_incomplete"
+    try:
+        manifest.unlink()
+        return f"{role}_cleanup_incomplete_manifest_removed"
+    except OSError:
+        hidden = manifest.with_name(f".{MANIFEST_NAME}.retired")
+        try:
+            _rename_retrying(manifest, hidden)
+        except OSError:
+            return f"{role}_manifest_still_discoverable"
+        return f"{role}_cleanup_incomplete_manifest_hidden"
+    finally:
+        del residue
+
+
+def _publication_interruption(
+    error: KeyboardInterrupt,
+    *,
+    final: Path,
+    staging: Path,
+    candidate_manifest_sha256: str | None,
+    publication_started: bool,
+) -> AssemblyInterrupted:
+    """Resolve an interrupt from verified final/scratch state, then close package discovery."""
+    prior = error if isinstance(error, AssemblyInterrupted) else None
+    prior_refused_publication = prior is not None and not prior.published
+    published = (
+        publication_started
+        and not prior_refused_publication
+        and not staging.exists()
+        and _valid_published_package(final, candidate_manifest_sha256)
+    )
+    secondary_code = prior.secondary_code if prior is not None else None
+    if published:
+        retired = retired_dir(final)
+        cleanup_code = _make_scratch_nondiscoverable(retired, "retired")
+        secondary_code = cleanup_code or secondary_code
+        published = (
+            _valid_published_package(final, candidate_manifest_sha256)
+            and not (staging / MANIFEST_NAME).is_file()
+            and not (retired / MANIFEST_NAME).is_file()
+        )
+        if not published and secondary_code is None:
+            secondary_code = "publication_state_unverified"
+    return AssemblyInterrupted(
+        published=published,
+        rollback_failed=bool(prior and prior.rollback_failed),
+        secondary_code=secondary_code,
+    )
 
 
 #: Windows denies a directory rename while anything still holds a handle inside it, and a scanner
@@ -5120,6 +5219,7 @@ def main(argv: list[str] | None = None) -> int:  # pylint: disable=too-many-loca
                 "reason_code": interruption.reason_code,
                 "published": interruption.published,
                 "rollback_failed": interruption.rollback_failed,
+                "secondary_code": interruption.secondary_code,
             }
             if interruption is not None
             else None

--- a/scripts/package_unit.py
+++ b/scripts/package_unit.py
@@ -13,7 +13,8 @@ So `check_reference_readiness.py` and `check_unit.py` both need `--source`/`--or
 cannot be derived from the unit path, and getting one wrong reads as "this unit is broken" rather
 than "you did not tell me where the workbook is".
 
-This script emits a folder both gates accept with NO flags:
+This script emits a diagnostic folder both gates accept with NO flags. Entries below are conditional;
+`package-manifest.json` records what was present and every omission:
 
     <out>/<Unit>/
         migration-spec.json          <- parse_tableau.py; check_unit.py's expected page set (#443)
@@ -30,7 +31,7 @@ This script emits a folder both gates accept with NO flags:
             dashboard/{images,data}/<Object>.<ext>   <- SINGULAR: the directory is object_identity's
             worksheet/{images,data}/<Object>.<ext>      KIND_* value verbatim, never a pluralised copy
             unknown/{images,data}/<Object>.<ext>     <- carried but MARKED, never filed as either kind
-        package-manifest.json        <- what was packaged, and every omission with its reason
+        package-manifest.json        <- what was assembled, and every omission with its reason
         data-access.json             <- strict S1-covered authority projection, never a gate clear
         README.md
 
@@ -156,15 +157,14 @@ comprehension over `sorted(units)`, and every alphabetically later unit was **ne
 never reported** - the operator could not tell *"not packaged"* from *"packaged and fine"* without
 diffing directories by hand. Every requested unit is now attempted deterministically (datasources
 first, then workbooks; sorted within each phase),
-a raise is caught per unit and carried in `--json` under `blocked[]` with its traceback, and the run
-still exits 5.
+a raise is caught per unit and carried in the compatibility `failed[]` bucket with a stable
+reason code and code-owned traceback frames; `construction.blocked[]` projects its status, and the
+run still exits 5.
 
-Every requested unit lands in EXACTLY ONE construction state - `assembled[]` or `blocked[]` - and
-`accounting_findings[]` names any raw-bucket contradiction. The totals are measured against the
-REQUEST, never against whatever survived it: a unit that raised before it could be recorded anywhere
-would otherwise shrink the denominator and read as a clean run of a smaller estate. The raw local
-lists still separate results, failures and edit refusals so existing continuation and exit-code
-precedence stay intact; the JSON folds them into the two construction states.
+The ordered compatibility buckets remain `units[]`, `failed[]`, `refused[]` and `unaccounted[]`.
+`construction` is the ONE ASSEMBLED/BLOCKED projection over them. Its totals are measured against
+the REQUEST, never against whatever survived it: a unit that raised before it could be recorded
+anywhere would otherwise shrink the denominator and read as a clean run of a smaller estate.
 
 An oracle omission INSIDE a package does not BLOCK assembly: a unit whose oracle genuinely has no
 render for a page is the negative control, and it must still produce a diagnostic package whose page
@@ -200,7 +200,7 @@ import sys
 import time
 import traceback
 import uuid
-from collections import Counter, defaultdict
+from collections import Counter
 from collections.abc import Callable, Sequence
 from copy import deepcopy
 from functools import partial
@@ -432,6 +432,17 @@ _MAX_ERROR_LINE = 200
 KIND_WORKBOOK = "workbook"
 KIND_DATASOURCE = "datasource"
 KIND_UNCLASSIFIED = "unclassified"
+IDENTITY_ENGINE_KIND_COLLISION = "engine_kind_collision"
+IDENTITY_ENGINE_DUPLICATE = "duplicate_engine_identity"
+IDENTITY_REQUEST_DUPLICATE = "duplicate_requested_identity"
+IDENTITY_DESTINATION_ALIAS = "destination_alias"
+_IDENTITY_REASON_ORDER = (
+    IDENTITY_ENGINE_KIND_COLLISION,
+    IDENTITY_ENGINE_DUPLICATE,
+    IDENTITY_REQUEST_DUPLICATE,
+    IDENTITY_DESTINATION_ALIAS,
+)
+_REASON_CODE_RE = re.compile(r"^[a-z][a-z0-9_]*$")
 
 
 class PackagingError(RuntimeError):
@@ -450,6 +461,12 @@ class PackagingError(RuntimeError):
     """
 
     unit: str | None = None
+    reason_code = "construction_failed"
+
+    def __init__(self, message: str = "", *, reason_code: str | None = None) -> None:
+        default = type(self).reason_code
+        self.reason_code = reason_code or (message if _REASON_CODE_RE.fullmatch(message) else default)
+        super().__init__(message)
 
 
 class PackageEditsRefused(PackagingError):
@@ -458,6 +475,8 @@ class PackageEditsRefused(PackagingError):
     Carries the changed paths (or the reason they could not be established) so the CLI can name them
     rather than saying "something changed".
     """
+
+    reason_code = "package_edits_refused"
 
     def __init__(self, unit: str, package: Path, changed: list[str], reason: str | None) -> None:
         self.unit, self.package, self.changed, self.reason = unit, package, changed, reason
@@ -479,6 +498,8 @@ class PackagePathTooLong(PackagingError):
     limit and no remedy. Carries the measured :class:`PathBudget` so the message can name all three.
     """
 
+    reason_code = "path_budget_exceeded"
+
     def __init__(self, budget: PathBudget) -> None:
         self.budget = budget
         super().__init__(render_path_budget(budget))
@@ -499,8 +520,11 @@ class UnassessableInput(PackagingError):
     replaced by one built from input nobody could read.
     """
 
+    reason_code = "unassessable_input"
+
     def __init__(self, unit: str, reasons: list[str], error: BaseException | None = None) -> None:
         self.unit, self.reasons = unit, reasons
+        self.exception_class = _error_label(error) if error is not None else None
         self.traceback = _safe_traceback(error) if error is not None else None
         safe_reasons = [_sanitize_diagnostic(reason) for reason in reasons]
         super().__init__(
@@ -522,6 +546,8 @@ class UnsafeUnitName(PackagingError):
     name that matches nothing in the bundle, and every later join - handover slice, oracle
     attribution, `promote_unit.py`'s manifest kind - is keyed by that name.
     """
+
+    reason_code = "unsafe_unit_name"
 
     def __init__(self, unit: str, reason: str) -> None:
         self.unit, self.reason = unit, reason
@@ -562,14 +588,14 @@ def _safe_frame_name(filename: str) -> str:
 
 
 def _safe_traceback(error: BaseException) -> str:
-    """Render actionable traceback frames while applying the shipped-artifact path rule to text."""
+    """Render code-owned frame identities, never exception text, URLs, queries or credentials."""
     lines = ["Traceback (most recent call last):"]
     for frame in traceback.extract_tb(error.__traceback__):
         lines.append(f'  File "{_safe_frame_name(frame.filename)}", line {frame.lineno}, in {frame.name}')
-        if frame.line:
-            lines.append(f"    {_sanitize_diagnostic(frame.line.strip())}")
-    lines.append(f"{_error_label(error)}: {_one_line(error)}")
-    lines.extend(_sanitize_diagnostic(note) for note in getattr(error, "__notes__", ()))
+    lines.append(f"exception_class={_error_label(error)}")
+    notes = getattr(error, "__notes__", ())
+    if notes:
+        lines.append(f"diagnostic_notes_withheld={len(notes)}")
     return "\n".join(lines) + "\n"
 
 
@@ -583,19 +609,62 @@ class UnitCrashed(PackagingError):
     because those are the operator ending the run rather than a unit failing.
 
     It is a :class:`PackagingError` so it travels the path every other per-unit refusal already
-    travels - `blocked[]`, the `BLOCKED` line, `EXIT_UNIT_FAILED` - rather than opening a second one.
-    The original exception and its traceback are kept, because "a unit raised" without the traceback
-    is not a defect report anyone can act on.
+    travels - `failed[]`, `construction.blocked[]`, `EXIT_UNIT_FAILED` - rather than opening a second one.
+    Only its stable class and code-owned frame identities are persisted. Exception messages can carry
+    endpoint URLs, query strings or credentials, so they are never copied into JSON or console text.
     """
+
+    reason_code = "unit_exception"
 
     def __init__(self, unit: str, error: BaseException) -> None:
         self.unit, self.error = unit, error
-        self.label = _error_label(error)
+        self.exception_class = _error_label(error)
+        self.label = self.exception_class
         self.traceback = _safe_traceback(error)
         super().__init__(
-            f"assembly of {unit} FAILED and nothing was written for it ({self.label}: {_one_line(error)}). "
-            "Every other requested unit was still attempted; see the traceback in --json under blocked[]."
+            f"assembly of {unit} failed (reason_code={self.reason_code}, "
+            f"exception_class={self.exception_class}). "
+            "Every other requested unit was still attempted; see the stable traceback in --json under failed[]."
         )
+
+
+class IdentityBlocked(PackagingError):
+    """A requested identity cannot select one unique package destination."""
+
+    reason_code = "identity_collision"
+
+    def __init__(self, unit: str, reason_codes: Sequence[str]) -> None:
+        self.unit = unit
+        self.reason_codes = tuple(reason_codes)
+        super().__init__(
+            f"construction identity blocked (reason_codes={','.join(self.reason_codes)})",
+            reason_code=self.reason_codes[0],
+        )
+
+
+class InterruptedUnit(PackagingError):
+    """The operator interrupted this unit before its package was published."""
+
+    reason_code = "assembly_interrupted_before_publish"
+
+    def __init__(self, unit: str, *, rollback_failed: bool) -> None:
+        self.unit = unit
+        self.rollback_failed = rollback_failed
+        self.exception_class = "builtins.KeyboardInterrupt"
+        self.traceback = None
+        super().__init__(f"assembly of {unit} was interrupted before publication (reason_code={self.reason_code})")
+
+
+class AssemblyInterrupted(KeyboardInterrupt):
+    """A handled operator interruption carrying only observed swap state."""
+
+    def __init__(self, *, published: bool, rollback_failed: bool = False) -> None:
+        super().__init__()
+        self.published = published
+        self.rollback_failed = rollback_failed
+        self.unit: str | None = None
+        self.result: dict[str, Any] | None = None
+        self.reason_code = "assembly_interrupted_after_publish" if published else "assembly_interrupted_before_publish"
 
 
 # --------------------------------------------------------------------------------------------
@@ -710,6 +779,84 @@ def bundle_units(bundle: Path) -> list[str]:
     pbip = bundle / "pbip"
     folders = [path.name for path in pbip.iterdir() if path.is_dir()] if pbip.is_dir() else []
     return sorted(set(folders) | set(workbooks) | set(datasources))
+
+
+def bundle_unit_occurrences(bundle: Path) -> list[str]:
+    """Every engine identity occurrence plus one row for each working-copy-only unit."""
+    engine_report = read_json(bundle / "report.json")
+    workbooks, datasources = engine_unit_names(engine_report)
+    named = set(workbooks) | set(datasources)
+    pbip = bundle / "pbip"
+    extras = (
+        sorted(path.name for path in pbip.iterdir() if path.is_dir() and path.name not in named)
+        if pbip.is_dir()
+        else []
+    )
+    return [*workbooks, *datasources, *extras]
+
+
+def _destination_identity(out_root: Path, unit: str) -> str:
+    """A Windows-filesystem canonical key for one already-validated package destination."""
+    destination = assert_package_destination(out_root, unit).resolve()
+    parent = str(PureWindowsPath(str(destination.parent))).casefold()
+    leaf_name = destination.name.rstrip(" .").casefold()
+    return f"{parent}\\{leaf_name}"
+
+
+def _aliased_unit_names(units: set[str], out_root: Path) -> set[str]:
+    """Names that select one Windows-canonical destination despite differing exactly."""
+    canonical_names: dict[str, set[str]] = {}
+    for unit in units:
+        try:
+            key = _destination_identity(out_root, unit)
+        except PackagingError:
+            continue
+        canonical_names.setdefault(key, set()).add(unit)
+    return {unit for names in canonical_names.values() if len(names) > 1 for unit in names}
+
+
+def _identity_preflight(  # pylint: disable=too-many-locals
+    requested: list[str],
+    workbooks: list[str],
+    datasources: list[str],
+    known_units: list[str],
+    out_root: Path,
+) -> tuple[list[str], list[PackagingError]]:
+    """Block every ambiguous occurrence before output creation, budgeting or assembly."""
+    request_counts = Counter(requested)
+    workbook_counts = Counter(workbooks)
+    datasource_counts = Counter(datasources)
+    reason_codes: list[set[str]] = [set() for _ in requested]
+    direct_failures: dict[int, PackagingError] = {}
+    aliased_names = _aliased_unit_names(set(requested) | set(known_units), out_root)
+
+    for index, unit in enumerate(requested):
+        if workbook_counts[unit] and datasource_counts[unit]:
+            reason_codes[index].add(IDENTITY_ENGINE_KIND_COLLISION)
+        if workbook_counts[unit] > 1 or datasource_counts[unit] > 1:
+            reason_codes[index].add(IDENTITY_ENGINE_DUPLICATE)
+        if request_counts[unit] > 1:
+            reason_codes[index].add(IDENTITY_REQUEST_DUPLICATE)
+        if unit in aliased_names:
+            reason_codes[index].add(IDENTITY_DESTINATION_ALIAS)
+        try:
+            _destination_identity(out_root, unit)
+        except PackagingError as failure:
+            failure.unit = unit
+            direct_failures[index] = failure
+
+    packageable: list[str] = []
+    failures: list[PackagingError] = []
+    for index, unit in enumerate(requested):
+        if index in direct_failures:
+            failures.append(direct_failures[index])
+            continue
+        if reason_codes[index]:
+            ordered = [code for code in _IDENTITY_REASON_ORDER if code in reason_codes[index]]
+            failures.append(IdentityBlocked(unit, ordered))
+            continue
+        packageable.append(unit)
+    return packageable, failures
 
 
 # --------------------------------------------------------------------------------------------
@@ -1707,10 +1854,11 @@ README = """# {unit}
 
 {data_access_pending}
 
-Handover package for one migration unit ({kind}). It carries its own rows, its own reference and its
-own source - but it is **not bound to a location**, so do this FIRST, wherever this folder now is,
-before opening the model. Then the two gates, each of which takes THIS FOLDER'S PATH as its only
-argument - a bare unit name is a usage error, never a verdict (exit 2 from
+Diagnostic handover package for one migration unit ({kind}). It may carry imported rows, reference
+evidence, source bytes and engine output; `package-manifest.json` names what is present and every
+omission. If it carries a location placeholder it is **not bound to a location**, so do this FIRST,
+wherever this folder now is, before opening the model. Then the two gates, each of which takes THIS
+FOLDER'S PATH as its only argument - a bare unit name is a usage error, never a verdict (exit 2 from
 `check_reference_readiness.py`, exit 64 from `check_unit.py`, both with a message on stderr):
 
     python scripts/set_data_folder.py --package <path-to-this-folder>
@@ -1743,7 +1891,7 @@ expected set is every dashboard PLUS every worksheet not placed on one.
 | `report.json` | **gate input, and readable.** The engine's classification of THIS unit - workbook vs datasource - which is what earns a datasource-only unit `NOT_APPLICABLE` instead of a finding. Scoped to this unit. |
 | `source-provenance.json` | **gate input.** The only trusted route from this package's asset to a Tableau workbook LUID, keyed by the asset's sha256; `origin.match` decides whether a render can be trusted - see UNFIXABLE below. An entry ships only when attribution was NOT refused (`scope.suppressed_reason`). |
 | `engine-output-receipt.json` | **read `engine.version` when a result looks wrong** - it establishes which engine built this, so version drift stays checkable months later. Install paths are not shipped. |
-| `package-manifest.json` | what was packaged, and every omission with its reason. Its `contents.files` digest is how a re-run knows this package has been edited and refuses to overwrite it. |
+| `package-manifest.json` | what was assembled, and every omission with its reason. Its `contents.files` digest is how a re-run knows this package has been edited and refuses to overwrite it. |
 
 `oracle/` images are **layout/text grade only**: a capture is taken in the view's default state with
 no `?vf_` filter pinning, so a visual PASS signed off on one alone is overstated, and it is no claim
@@ -3350,6 +3498,7 @@ def package_unit(  # pylint: disable=too-many-arguments,too-many-locals
             f"inherit whatever an earlier build left there and still be reported as a success ({residue}). "
             "Remove it and re-run that unit."
         )
+    result: dict[str, Any] | None = None
     try:
         result, verify_staged = _assemble_unit(
             bundle,
@@ -3369,17 +3518,23 @@ def package_unit(  # pylint: disable=too-many-arguments,too-many-locals
             verify=None if discard_edits else partial(_refuse_if_edited, unit),
             verify_staged=verify_staged,
         )
+    except AssemblyInterrupted as interruption:
+        interruption.unit = unit
+        interruption.result = result if interruption.published and result is not None else None
+        raise
     except OSError as failure:
         refusal = _assembly_refusal(unit, failure)
         if refusal is None:
             raise
         raise refusal from failure
     finally:
-        _refuse_surviving_staging(unit, staging)
+        _refuse_surviving_staging(unit, staging, final)
+    if result is None:
+        raise PackagingError("assembly_result_missing")
     return result
 
 
-def _refuse_surviving_staging(unit: str, staging: Path) -> None:
+def _refuse_surviving_staging(unit: str, staging: Path, final: Path) -> None:
     """Remove ``staging`` on the way out, and refuse to call the unit clean if it is still there.
 
     ⚠️ **Never raises over an exception that is already propagating.** An exception raised out of a
@@ -3398,10 +3553,17 @@ def _refuse_surviving_staging(unit: str, staging: Path) -> None:
             file=sys.stderr,
         )
         return
+    if final.is_dir():
+        print(
+            _sanitize_diagnostic(
+                f"WARN: staging {staging} survived after {unit} was published; the package is ASSEMBLED, "
+                "and the residue will block its next construction attempt"
+            ),
+            file=sys.stderr,
+        )
+        return
     raise PackagingError(
-        f"construction of {unit} finished, but its staging directory {staging} could not be removed ({left}). "
-        "The diagnostic package itself is complete on disk; this unit is BLOCKED because a staging directory that "
-        "outlives its build is what a later build would silently assemble into."
+        f"construction of {unit} failed to remove its staging directory ({left}), and no package was published"
     )
 
 
@@ -3565,21 +3727,31 @@ def replace_dir(
     """
     final.parent.mkdir(parents=True, exist_ok=True)
     retired = retired_dir(final) if final.exists() else None
-    if retired is not None:
-        _discard_scratch(retired)
-        _rename_retrying(final, retired)
-    swapped = False
+    publish_armed = False
     try:
+        if retired is not None:
+            _discard_scratch(retired)
+            _rename_retrying(final, retired)
         if retired is not None and verify is not None:
             verify(retired)
         verify_staged()
+        publish_armed = True
         _rename_retrying(staged, final)
-        swapped = True
-    finally:
-        if not swapped and retired is not None:
-            _rename_retrying(retired, final)
-    if retired is not None:
-        _discard_scratch(retired)
+        if retired is not None:
+            _discard_scratch(retired)
+        publish_armed = False
+    except BaseException as error:  # pylint: disable=broad-exception-caught
+        published = publish_armed and final.is_dir() and not staged.exists()
+        rollback_failed = False
+        if not published and retired is not None and retired.exists() and not final.exists():
+            try:
+                _rename_retrying(retired, final)
+            except BaseException:  # pylint: disable=broad-exception-caught
+                rollback_failed = True
+                error.add_note("package rollback failed during swap recovery")
+        if isinstance(error, KeyboardInterrupt):
+            raise AssemblyInterrupted(published=published, rollback_failed=rollback_failed) from error
+        raise
 
 
 #: Windows denies a directory rename while anything still holds a handle inside it, and a scanner
@@ -4229,13 +4401,16 @@ def _assemble_unit(  # pylint: disable=too-many-locals,too-many-arguments,too-ma
             "this package, so it opens with no model; promote the model this report shares and rewrite "
             "byPath, or repackage the unit that owns it"
         )
+    has_engine_working_copy = report_name is not None or model_name is not None
     result = {
         "unit": unit,
         "kind": kind,
         "engine": ((receipt or {}).get("engine") or {}).get("version"),
         "mode": ASSEMBLY_MODE,
         "construction_status": STATUS_ASSEMBLED,
-        "has_engine_working_copy": report_name is not None or model_name is not None,
+        "packaged": has_engine_working_copy,
+        "packaged_semantics": "legacy engine-working-copy indicator; not construction or dispatch readiness",
+        "has_engine_working_copy": has_engine_working_copy,
         "dispatch_readiness": _dispatch_readiness(),
         "self_contained": bool(data_sources["self_contained"] and binding["resolves_in_package"]),
         "artifacts": {
@@ -4357,7 +4532,7 @@ def _mode(explicit: bool) -> dict[str, Any]:
     }
 
 
-def render(  # pylint: disable=too-many-arguments
+def render(  # pylint: disable=too-many-arguments,too-many-locals
     results: list[dict[str, Any]],
     out_root: Path,
     refused: list[PackageEditsRefused] | None = None,
@@ -4365,6 +4540,7 @@ def render(  # pylint: disable=too-many-arguments
     requested: list[str] | None = None,
     *,
     assemble_only_explicit: bool = False,
+    interruption: AssemblyInterrupted | None = None,
 ) -> str:
     """The human construction verdict: one line per requested unit, then exact-denominator totals.
 
@@ -4375,19 +4551,33 @@ def render(  # pylint: disable=too-many-arguments
     """
     refused, failed = refused or [], failed or []
     requested = list(requested) if requested is not None else _bucketed_units(results, failed, refused)
-    assembled, blocked, gaps = construction_outcomes(requested, results, failed, refused)
+    gaps = partition_gaps(requested, results, failed, refused)
+    failed_rows = [_failure_row(failure) for failure in failed]
+    refused_rows = [_refusal_row(item) for item in refused]
+    construction = construction_status_projection(requested, results, failed_rows, refused_rows, gaps)
+    assembled_counts = Counter(row["unit"] for row in construction["assembled"])
     mode_note = "explicit --assemble-only" if assemble_only_explicit else "current default"
     lines = [
         f"package_unit: {len(requested)} requested unit(s) -> {out_root}",
         f"mode: {ASSEMBLY_MODE} ({mode_note}; construction only)",
     ]
-    lines += [_unit_line(result) for result in sorted(assembled, key=lambda item: item["unit"])]
-    lines += [_blocked_line(row) for row in sorted(blocked, key=lambda item: item["unit"])]
+    for result in results:
+        if assembled_counts[result["unit"]]:
+            lines.append(_unit_line(result))
+            assembled_counts[result["unit"]] -= 1
+    lines += [_blocked_line(row) for row in construction["blocked"]]
     with_oracle = sum(1 for result in results if result["oracle"].get("objects"))
-    lines.append(f"ASSEMBLED: {len(assembled)}/{len(requested)} ({with_oracle} carry oracle evidence)")
-    lines.append(f"BLOCKED: {len(blocked)}/{len(requested)}")
-    lines.append(f"{len(requested)} requested = {len(assembled)} ASSEMBLED + {len(blocked)} BLOCKED")
+    totals = construction["totals"]
+    lines.append(f"ASSEMBLED: {totals['assembled']}/{totals['requested']} ({with_oracle} carry oracle evidence)")
+    lines.append(f"BLOCKED: {totals['blocked']}/{totals['requested']}")
+    lines.append(f"{totals['requested']} requested = {totals['assembled']} ASSEMBLED + {totals['blocked']} BLOCKED")
     lines.extend(_run_totals(results, refused, failed))
+    if interruption is not None:
+        publication = "the current package was published" if interruption.published else "no package was published"
+        lines.append(
+            f"INTERRUPTED: {interruption.unit or '?'} ({interruption.reason_code}); {publication}. "
+            "The command stopped and its result is nonzero."
+        )
     if gaps:
         lines.append(
             f"ACCOUNTING FINDINGS: {len(gaps)} raw outcome contradiction(s); this run is NOT clean: "
@@ -4414,7 +4604,7 @@ def _unit_line(result: dict[str, Any]) -> str:
 
 def _blocked_line(row: dict[str, Any]) -> str:
     """One named construction refusal/failure, never a readiness verdict."""
-    return f"  {STATUS_BLOCKED} {row['unit']} [{row['blocker']}] - {_one_line(row['reason'])}"
+    return f"  {STATUS_BLOCKED} {row['unit']} [{row['reason_code']}] - {row['reason']}"
 
 
 def _failed_unit(failure: PackagingError) -> str:
@@ -4448,26 +4638,32 @@ def partition_gaps(
     estate, and a unit recorded twice inflates it.
     """
     counted = Counter(_bucketed_units(results, failed, refused))
-    asked = set(requested)
-    gaps = [
-        {"unit": unit, "state": "not_attempted", "reason": "requested but recorded in no outcome bucket"}
-        for unit in sorted(asked)
-        if not counted[unit]
-    ]
-    gaps += [
-        {"unit": unit, "state": "recorded_twice", "reason": f"recorded in {count} buckets"}
-        for unit, count in sorted(counted.items())
-        if count > 1
-    ]
-    gaps += [
-        {"unit": unit, "state": "never_requested", "reason": "recorded although it was never requested"}
-        for unit in sorted(set(counted) - asked)
-    ]
+    asked = Counter(requested)
+    gaps: list[dict[str, str]] = []
+    for unit in sorted(set(asked) | set(counted)):
+        if counted[unit] < asked[unit]:
+            gaps.extend(
+                {
+                    "unit": unit,
+                    "state": "not_attempted",
+                    "reason": "requested occurrence recorded in no outcome bucket",
+                }
+                for _ in range(asked[unit] - counted[unit])
+            )
+        elif counted[unit] > asked[unit]:
+            state = "never_requested" if not asked[unit] else "recorded_too_many"
+            gaps.append(
+                {
+                    "unit": unit,
+                    "state": state,
+                    "reason": f"requested {asked[unit]} time(s) but recorded {counted[unit]} outcome(s)",
+                }
+            )
     return gaps
 
 
-def _refusal_block(refusal: PackageEditsRefused) -> dict[str, Any]:
-    """Fold an edit-preservation refusal into the construction-only BLOCKED vocabulary."""
+def _refusal_row(refusal: PackageEditsRefused) -> dict[str, Any]:
+    """The compatibility-safe legacy refusal row."""
     detail = refusal.reason or (
         f"{len(refusal.changed)} existing package file(s) differ from the recorded assembly: "
         + ", ".join(refusal.changed[:5])
@@ -4475,62 +4671,94 @@ def _refusal_block(refusal: PackageEditsRefused) -> dict[str, Any]:
     )
     return {
         "unit": refusal.unit,
-        "construction_status": STATUS_BLOCKED,
-        "blocker": "PACKAGE_EDITS_REFUSED",
+        "reason_code": refusal.reason_code,
         "reason": detail,
         "changed": refusal.changed,
     }
 
 
-def _failure_block(failure: PackagingError) -> dict[str, Any]:
-    """Fold a modelled/unexpected failure into BLOCKED without losing its diagnostic."""
+def _failure_reason(failure: PackagingError) -> str:
+    """A stable, non-sensitive explanation for persisted construction failure rows."""
+    reasons = (
+        (UnassessableInput, "a required construction input could not be assessed"),
+        (IdentityBlocked, "the requested identity does not select one unique package destination"),
+        (InterruptedUnit, "the operator interrupted construction before publication"),
+        (PackagePathTooLong, "the package destination exceeds the measured path ceiling"),
+        (UnsafeUnitName, "the unit name cannot select a safe package destination"),
+        (UnitCrashed, "the unit raised an unexpected exception during construction"),
+    )
+    return next((reason for kind, reason in reasons if isinstance(failure, kind)), "construction failed")
+
+
+def _failure_row(failure: PackagingError) -> dict[str, Any]:
+    """The compatibility-safe legacy failure row: stable codes/classes, never exception text."""
     return {
         "unit": _failed_unit(failure),
-        "construction_status": STATUS_BLOCKED,
-        "blocker": "UNASSESSABLE_INPUT" if isinstance(failure, UnassessableInput) else "CONSTRUCTION_FAILED",
-        "reason": _sanitize_diagnostic(str(failure)),
+        "state": "cannot_assess" if isinstance(failure, UnassessableInput) else "unit_failed",
+        "reason_code": failure.reason_code,
+        "reason": _failure_reason(failure),
+        "exception_class": getattr(failure, "exception_class", _error_label(failure)),
         "traceback": getattr(failure, "traceback", None),
     }
 
 
-def construction_outcomes(
+def construction_status_projection(
     requested: list[str],
     results: list[dict[str, Any]],
-    failed: list[PackagingError],
-    refused: list[PackageEditsRefused],
-) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[dict[str, str]]]:
-    """Fold raw continuation buckets into exactly one construction state per requested unit."""
-    buckets: dict[str, list[tuple[str, dict[str, Any]]]] = defaultdict(list)
-    for result in results:
-        buckets[result["unit"]].append((STATUS_ASSEMBLED, result))
-    for failure in failed:
-        block = _failure_block(failure)
-        buckets[block["unit"]].append((STATUS_BLOCKED, block))
-    for refusal in refused:
-        block = _refusal_block(refusal)
-        buckets[block["unit"]].append((STATUS_BLOCKED, block))
-
-    gaps = partition_gaps(requested, results, failed, refused)
-    assembled: list[dict[str, Any]] = []
-    blocked: list[dict[str, Any]] = []
+    failed_rows: list[dict[str, Any]],
+    refused_rows: list[dict[str, Any]],
+    gaps: list[dict[str, str]],
+) -> dict[str, Any]:
+    """One construction-only projection over the ordered compatibility buckets."""
+    asked = Counter(requested)
+    observed = Counter(
+        [result["unit"] for result in results]
+        + [row["unit"] for row in failed_rows]
+        + [row["unit"] for row in refused_rows]
+    )
+    mismatched = {unit for unit in set(asked) | set(observed) if asked[unit] != observed[unit]}
+    assembled = [
+        {
+            "unit": result["unit"],
+            "status": STATUS_ASSEMBLED,
+            "has_engine_working_copy": result["has_engine_working_copy"],
+            "self_contained": result.get("self_contained", True),
+        }
+        for result in results
+        if result["unit"] in asked and result["unit"] not in mismatched
+    ]
+    blocked = [
+        {
+            "unit": row["unit"],
+            "status": STATUS_BLOCKED,
+            "reason_code": row["reason_code"],
+            "reason": row["reason"],
+        }
+        for row in [*failed_rows, *refused_rows]
+        if row["unit"] in asked and row["unit"] not in mismatched
+    ]
     for unit in requested:
-        outcomes = buckets.get(unit, [])
-        if len(outcomes) == 1 and outcomes[0][0] == STATUS_ASSEMBLED:
-            assembled.append(outcomes[0][1])
-            continue
-        if len(outcomes) == 1:
-            blocked.append(outcomes[0][1])
-            continue
-        gap = next((item for item in gaps if item["unit"] == unit), None)
-        blocked.append(
-            {
-                "unit": unit,
-                "construction_status": STATUS_BLOCKED,
-                "blocker": "UNATTEMPTED" if not outcomes else "ACCOUNTING_ERROR",
-                "reason": (gap or {}).get("reason", "requested unit has contradictory construction outcomes"),
-            }
-        )
-    return assembled, blocked, gaps
+        if unit in mismatched:
+            blocked.append(
+                {
+                    "unit": unit,
+                    "status": STATUS_BLOCKED,
+                    "reason_code": "outcome_accounting_mismatch",
+                    "reason": "the requested occurrence did not reach exactly one construction bucket",
+                }
+            )
+    return {
+        "schema": "package-construction/v1",
+        "scope": "construction_only",
+        "assembled": assembled,
+        "blocked": blocked,
+        "accounting_findings": gaps,
+        "totals": {
+            "requested": len(requested),
+            "assembled": len(assembled),
+            "blocked": len(blocked),
+        },
+    }
 
 
 def _package_each(  # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals
@@ -4568,11 +4796,9 @@ def _package_each(  # pylint: disable=too-many-arguments,too-many-positional-arg
     `PackagingError` at all: the blast radius of ANY exception must be one unit, and a narrower
     clause leaves the next unforeseen type free to abort the batch again. It is wrapped in
     :class:`UnitCrashed` so it travels the path the modelled refusals already travel, with the
-    traceback kept. `BaseException` - `KeyboardInterrupt`, `SystemExit` - still passes through,
-    because that is the operator ending the run rather than a unit failing.
+    safe traceback kept. `SystemExit` still passes through. `KeyboardInterrupt` is handled only
+    long enough to publish truthful JSON, then stops the batch with a nonzero result.
     """
-    if brief is not None and len(units) != 1:
-        raise PackagingError("brief_requires_one_unit")
     workbooks, datasources = engine_unit_names(read_json(bundle / "report.json"))
     ordered = sorted(units, key=lambda unit: (unit_kind(unit, workbooks, datasources) != KIND_DATASOURCE, unit))
     providers = list(_external_providers(provider_packages, out_root, units))
@@ -4592,6 +4818,19 @@ def _package_each(  # pylint: disable=too-many-arguments,too-many-positional-arg
             results.append(result)
             if result["kind"] == KIND_DATASOURCE and result["has_engine_working_copy"]:
                 providers.append(out_root / unit)
+        except AssemblyInterrupted as interruption:
+            interruption.unit = unit
+            if interruption.published and interruption.result is not None:
+                results.append(interruption.result)
+            elif failed is not None:
+                failed.append(InterruptedUnit(unit, rollback_failed=interruption.rollback_failed))
+            raise
+        except KeyboardInterrupt as error:
+            interruption = AssemblyInterrupted(published=False)
+            interruption.unit = unit
+            if failed is not None:
+                failed.append(InterruptedUnit(unit, rollback_failed=False))
+            raise interruption from error
         except PackageEditsRefused as refusal:
             print(_sanitize_diagnostic(str(refusal)), file=sys.stderr)
             refused.append(refusal)
@@ -4680,6 +4919,7 @@ def _refuse_zero_units(bundle: Path, out_root: Path, json_path: Path | None, *, 
         file=sys.stderr,
     )
     if json_path:
+        construction = construction_status_projection([], [], [], [], [])
         write_json(
             json_path,
             {
@@ -4689,10 +4929,20 @@ def _refuse_zero_units(bundle: Path, out_root: Path, json_path: Path | None, *, 
                 "mode": _mode(assemble_only_explicit),
                 "dispatch_readiness": _dispatch_readiness(),
                 "requested": [],
-                "totals": {"requested": 0, "assembled": 0, "blocked": 0},
-                "assembled": [],
-                "blocked": [],
-                "accounting_findings": [],
+                "legacy_bucket_semantics": "construction_only; never dispatch readiness",
+                "totals": {
+                    "requested": 0,
+                    "units": 0,
+                    "failed": 0,
+                    "refused": 0,
+                    "unaccounted": 0,
+                    **construction["totals"],
+                },
+                "units": [],
+                "failed": [],
+                "refused": [],
+                "unaccounted": [],
+                "construction": construction,
                 "cannot_assess": ["the bundle names no units"],
             },
         )
@@ -4700,10 +4950,10 @@ def _refuse_zero_units(bundle: Path, out_root: Path, json_path: Path | None, *, 
 
 
 def _run_verdict(
-    blocked: list[dict[str, Any]],
     refused: list[PackageEditsRefused],
     failed: list[PackagingError],
     gaps: list[dict[str, str]] | None = None,
+    interruption: AssemblyInterrupted | None = None,
 ) -> int:
     """The run's exit code, worst first; content limitations do not change construction status.
 
@@ -4715,9 +4965,9 @@ def _run_verdict(
     outcome bucket is not "fine" and it is not "failed" - nobody knows what happened to it, which is
     the same third state, and it must never be able to leave a run clean (#478).
     """
-    if not blocked and not gaps:
+    if not failed and not refused and not gaps and interruption is None:
         return EXIT_OK
-    if gaps or any(isinstance(failure, UnassessableInput) for failure in failed):
+    if interruption is not None or gaps or any(isinstance(failure, UnassessableInput) for failure in failed):
         return EXIT_CANNOT_ASSESS
     if failed:
         return EXIT_UNIT_FAILED
@@ -4792,41 +5042,53 @@ def main(argv: list[str] | None = None) -> int:  # pylint: disable=too-many-loca
         # otherwise write a whole estate of packages that all silently lack the brief.
         parser.error("--brief must be a readable file")
 
+    engine_report = read_json(bundle / "report.json")
+    workbooks, datasources = engine_unit_names(engine_report)
     available = bundle_units(bundle)
-    units = args.unit or available
+    units = list(args.unit) if args.unit else bundle_unit_occurrences(bundle)
     if args.brief is not None and len(units) != 1:
         parser.error("--brief requires exactly one unit; package each unit with its own brief")
     unknown = [unit for unit in units if unit not in available]
     if unknown:
         parser.error(f"the bundle's report.json and pbip/ know nothing of: {', '.join(sorted(unknown))}")
 
-    out_root = _prepare_out(args.out)
     if not units:
+        out_root = _prepare_out(args.out)
         return _refuse_zero_units(bundle, out_root, args.json, assemble_only_explicit=args.assemble_only)
 
     # The denominator stays sorted by name even though assembly publishes datasources first.
     requested = sorted(units)
+    packageable, identity_failures = _identity_preflight(
+        requested, workbooks, datasources, available, args.out.resolve()
+    )
+    out_root = _prepare_out(args.out)
     results: list[dict[str, Any]] = []
     refused: list[PackageEditsRefused] = []
-    failed: list[PackagingError] = []
-    packageable, budgets = _measure_unit_budgets(bundle, requested, out_root, assets_dir, failed)
+    failed: list[PackagingError] = list(identity_failures)
+    packageable, budgets = _measure_unit_budgets(bundle, packageable, out_root, assets_dir, failed)
     _warn_shipping(budgets)
-    _package_each(
-        packageable,
-        bundle,
-        out_root,
-        oracle_dir,
-        assets_dir,
-        args.discard_package_edits,
-        results,
-        refused,
-        failed,
-        brief=args.brief.resolve() if args.brief else None,
-        gate_root=args.gate_root,
-        provider_packages=_external_providers(args.provider_package, out_root, requested),
-    )
+    interruption: AssemblyInterrupted | None = None
+    try:
+        _package_each(
+            packageable,
+            bundle,
+            out_root,
+            oracle_dir,
+            assets_dir,
+            args.discard_package_edits,
+            results,
+            refused,
+            failed,
+            brief=args.brief.resolve() if args.brief else None,
+            gate_root=args.gate_root,
+            provider_packages=_external_providers(args.provider_package, out_root, requested),
+        )
+    except AssemblyInterrupted as error:
+        interruption = error
     gaps = partition_gaps(requested, results, failed, refused)
-    assembled, blocked, accounting_findings = construction_outcomes(requested, results, failed, refused)
+    failed_rows = [_failure_row(failure) for failure in failed]
+    refused_rows = [_refusal_row(item) for item in refused]
+    construction = construction_status_projection(requested, results, failed_rows, refused_rows, gaps)
 
     payload = {
         "id": "package-unit",
@@ -4837,14 +5099,31 @@ def main(argv: list[str] | None = None) -> int:  # pylint: disable=too-many-loca
         "mode": _mode(args.assemble_only),
         "dispatch_readiness": _dispatch_readiness(),
         "requested": requested,
+        "legacy_bucket_semantics": "construction_only; never dispatch readiness",
         "totals": {
             "requested": len(requested),
-            "assembled": len(assembled),
-            "blocked": len(blocked),
+            "units": len(results),
+            "failed": len(failed_rows),
+            "refused": len(refused_rows),
+            "unaccounted": len(gaps),
+            "assembled": construction["totals"]["assembled"],
+            "blocked": construction["totals"]["blocked"],
         },
-        "assembled": assembled,
-        "blocked": blocked,
-        "accounting_findings": accounting_findings,
+        "units": results,
+        "failed": failed_rows,
+        "refused": refused_rows,
+        "unaccounted": gaps,
+        "construction": construction,
+        "interruption": (
+            {
+                "unit": interruption.unit,
+                "reason_code": interruption.reason_code,
+                "published": interruption.published,
+                "rollback_failed": interruption.rollback_failed,
+            }
+            if interruption is not None
+            else None
+        ),
         # The relocation number, per unit, travelling WITH the report: how long a Windows root each
         # package still tolerates. Nothing downstream re-measures it, and it is the one figure that
         # says whether a package that is valid here will open where a customer unpacks it.
@@ -4861,11 +5140,12 @@ def main(argv: list[str] | None = None) -> int:  # pylint: disable=too-many-loca
                 failed,
                 requested,
                 assemble_only_explicit=args.assemble_only,
+                interruption=interruption,
             )
         )
     elif args.assemble_only:
         print(NOT_START_READY_NOTICE)
-    return _run_verdict(blocked, refused, failed, gaps)
+    return _run_verdict(refused, failed, gaps, interruption)
 
 
 if __name__ == "__main__":

--- a/tests/mutate_package_unit.py
+++ b/tests/mutate_package_unit.py
@@ -846,8 +846,8 @@ MUTATIONS: list[tuple[str, Path, str, str, list[str]]] = [
     (
         "#478: stop measuring the buckets against the request, so a lost unit is never named",
         PACKAGER,
-        "    counted = Counter(_bucketed_units(results, failed, refused))",
-        "    counted = Counter(requested)",
+        "    asked = Counter(requested)",
+        "    asked = Counter(_bucketed_units(results, failed, refused))",
         [
             "test_an_unaccounted_unit_is_reported_and_cannot_exit_zero",
             "test_a_requested_unit_in_no_bucket_is_named_rather_than_counted_clean",
@@ -856,8 +856,8 @@ MUTATIONS: list[tuple[str, Path, str, str, list[str]]] = [
     (
         "#478: let an unaccounted unit leave the run clean",
         PACKAGER,
-        "    if gaps or any(isinstance(failure, UnassessableInput) for failure in failed):",
-        "    if any(isinstance(failure, UnassessableInput) for failure in failed):",
+        "    if interruption is not None or gaps or any(isinstance(failure, UnassessableInput) for failure in failed):",
+        "    if interruption is not None or any(isinstance(failure, UnassessableInput) for failure in failed):",
         ["test_an_unaccounted_unit_is_reported_and_cannot_exit_zero"],
     ),
     (
@@ -871,21 +871,21 @@ MUTATIONS: list[tuple[str, Path, str, str, list[str]]] = [
     (
         "#614: shrink the requested denominator to the units that assembled",
         PACKAGER,
-        '            "requested": len(requested),',
-        '            "requested": len(assembled),',
+        '        "totals": {\n            "requested": len(requested),\n            "assembled": len(assembled),',
+        '        "totals": {\n            "requested": len(assembled),\n            "assembled": len(assembled),',
         ["test_eleven_of_fourteen_keeps_the_original_denominator_and_names_every_blocker"],
     ),
     (
         "#614: classify a successfully constructed package as BLOCKED",
         PACKAGER,
-        "        if len(outcomes) == 1 and outcomes[0][0] == STATUS_ASSEMBLED:",
-        "        if len(outcomes) == 1 and outcomes[0][0] == STATUS_BLOCKED:",
+        '            "status": STATUS_ASSEMBLED,\n            "has_engine_working_copy": result["has_engine_working_copy"],',
+        '            "status": STATUS_BLOCKED,\n            "has_engine_working_copy": result["has_engine_working_copy"],',
         ["test_eleven_of_fourteen_keeps_the_original_denominator_and_names_every_blocker"],
     ),
     (
         "#614: let a partial batch exit zero",
         PACKAGER,
-        "    if not blocked and not gaps:\n        return EXIT_OK",
+        "    if not failed and not refused and not gaps and interruption is None:\n        return EXIT_OK",
         "    if True:\n        return EXIT_OK  # noqa",
         ["test_eleven_of_fourteen_keeps_the_original_denominator_and_names_every_blocker"],
     ),

--- a/tests/mutate_package_unit.py
+++ b/tests/mutate_package_unit.py
@@ -890,6 +890,13 @@ MUTATIONS: list[tuple[str, Path, str, str, list[str]]] = [
         ["test_eleven_of_fourteen_keeps_the_original_denominator_and_names_every_blocker"],
     ),
     (
+        "#614: leave the retired package manifest discoverable after publish interruption",
+        PACKAGER,
+        '        cleanup_code = _make_scratch_nondiscoverable(retired, "retired")',
+        "        cleanup_code = None  # noqa",
+        ["test_post_rename_line_interrupt_hides_retired_manifest_before_reporting_status"],
+    ),
+    (
         "#478: restore rmtree(ignore_errors=True), so a staging tree that survived is assembled into",
         PACKAGER,
         "    reason: str | None = None\n    for attempt in range(_SCRATCH_CLEAR_ATTEMPTS):",

--- a/tests/mutate_package_unit.py
+++ b/tests/mutate_package_unit.py
@@ -867,6 +867,28 @@ MUTATIONS: list[tuple[str, Path, str, str, list[str]]] = [
         "    requested = _bucketed_units(results, failed, refused)",
         ["test_an_unaccounted_unit_is_reported_and_cannot_exit_zero"],
     ),
+    # ---- #614: construction status is not dispatch readiness -----------------------------------
+    (
+        "#614: shrink the requested denominator to the units that assembled",
+        PACKAGER,
+        '            "requested": len(requested),',
+        '            "requested": len(assembled),',
+        ["test_eleven_of_fourteen_keeps_the_original_denominator_and_names_every_blocker"],
+    ),
+    (
+        "#614: classify a successfully constructed package as BLOCKED",
+        PACKAGER,
+        "        if len(outcomes) == 1 and outcomes[0][0] == STATUS_ASSEMBLED:",
+        "        if len(outcomes) == 1 and outcomes[0][0] == STATUS_BLOCKED:",
+        ["test_eleven_of_fourteen_keeps_the_original_denominator_and_names_every_blocker"],
+    ),
+    (
+        "#614: let a partial batch exit zero",
+        PACKAGER,
+        "    if not blocked and not gaps:\n        return EXIT_OK",
+        "    if True:\n        return EXIT_OK  # noqa",
+        ["test_eleven_of_fourteen_keeps_the_original_denominator_and_names_every_blocker"],
+    ),
     (
         "#478: restore rmtree(ignore_errors=True), so a staging tree that survived is assembled into",
         PACKAGER,
@@ -890,11 +912,11 @@ MUTATIONS: list[tuple[str, Path, str, str, list[str]]] = [
         ["test_a_residue_found_while_a_unit_is_already_failing_does_not_replace_the_root_cause"],
     ),
     (
-        f"{NEGATIVE_CONTROL} (#478): a comment-only edit inside the batch loop",
+        f"{NEGATIVE_CONTROL} (#614): a comment-only edit beside the status report",
         PACKAGER,
-        '            # Only a crash carries one: the modelled refusals ARE their reason, while "a unit',
-        '            # (control) Only a crash carries one: the modelled refusals ARE their reason, while "a unit',
-        ["test_one_unit_raising_does_not_stop_the_units_after_it"],
+        "        # The relocation number, per unit, travelling WITH the report: how long a Windows root each",
+        "        # (control) The relocation number, per unit, travelling WITH the report: how long a Windows root each",
+        ["test_eleven_of_fourteen_keeps_the_original_denominator_and_names_every_blocker"],
     ),
 ]
 

--- a/tests/test_package_unit.py
+++ b/tests/test_package_unit.py
@@ -3367,7 +3367,8 @@ def test_a_unit_with_no_engine_working_copy_is_still_assembled_and_reported(tmp_
     code = pkg.main(["--bundle", str(bundle), "--out", str(_out(tmp_path)), "--quiet"])
     manifest = json.loads((_out(tmp_path) / "Never_Emitted" / "package-manifest.json").read_text(encoding="utf-8"))
     assert manifest["construction_status"] == pkg.STATUS_ASSEMBLED
-    assert manifest["has_engine_working_copy"] is False
+    assert manifest["packaged"] is manifest["has_engine_working_copy"] is False
+    assert "not construction or dispatch readiness" in manifest["packaged_semantics"]
     assert manifest["dispatch_readiness"]["status"] == pkg.DISPATCH_READINESS_NOT_EVALUATED
     assert code == pkg.EXIT_OK
 
@@ -3381,7 +3382,8 @@ def test_packaging_every_emitted_unit_exits_zero(tmp_path: Path) -> None:
     record = json.loads((package / pkg.MANIFEST_NAME).read_text(encoding="utf-8"))
     assert record["construction_status"] == pkg.STATUS_ASSEMBLED
     assert record["dispatch_readiness"] == EXPECTED_DISPATCH_READINESS
-    assert "packaged" not in record
+    assert record["packaged"] is record["has_engine_working_copy"] is True
+    assert "legacy engine-working-copy indicator" in record["packaged_semantics"]
     assert pkg.discover_dir(bundle, ("oracle", "_oracle")) == oracle.resolve()
     assert (package / "oracle" / "oracle-manifest.json").is_file()
 
@@ -3431,17 +3433,20 @@ def test_assemble_only_is_an_explicit_alias_for_the_existing_construction_behavi
     assert explicit_report["mode"]["explicit"] is True
     assert default_report["dispatch_readiness"] == EXPECTED_DISPATCH_READINESS
     assert explicit_report["dispatch_readiness"] == EXPECTED_DISPATCH_READINESS
-    assert (
-        default_report["totals"]
-        == explicit_report["totals"]
-        == {
-            "requested": 1,
-            "assembled": 1,
-            "blocked": 0,
-        }
-    )
+    assert default_report["totals"] == explicit_report["totals"]
+    assert default_report["totals"] == {
+        "requested": 1,
+        "units": 1,
+        "failed": 0,
+        "refused": 0,
+        "unaccounted": 0,
+        "assembled": 1,
+        "blocked": 0,
+    }
+    assert default_report["construction"]["totals"] == {"requested": 1, "assembled": 1, "blocked": 0}
+    assert default_report["legacy_bucket_semantics"] == "construction_only; never dispatch readiness"
     for report_path in (default_json, explicit_json):
-        assert '"packaged":' not in report_path.read_text(encoding="utf-8")
+        assert '"status": "packaged"' not in report_path.read_text(encoding="utf-8").casefold()
 
     default_package = default_out / UNIT
     explicit_package = explicit_out / UNIT
@@ -3463,6 +3468,115 @@ def test_an_unknown_unit_is_a_usage_error_not_an_empty_package(tmp_path: Path) -
         pkg.main(["--bundle", str(bundle), "--out", str(_out(tmp_path)), "--unit", "Nope", "--quiet"])
     assert excinfo.value.code == 2
     assert not (_out(tmp_path) / "Nope").exists()
+
+
+@pytest.mark.parametrize(
+    ("variant", "reason_code", "expected_requested"),
+    [
+        ("repeated-request", pkg.IDENTITY_REQUEST_DUPLICATE, [UNIT, UNIT]),
+        ("duplicate-engine-row", pkg.IDENTITY_ENGINE_DUPLICATE, [UNIT, UNIT]),
+        ("workbook-datasource-collision", pkg.IDENTITY_ENGINE_KIND_COLLISION, [UNIT, UNIT]),
+        ("windows-destination-alias", pkg.IDENTITY_DESTINATION_ALIAS, [UNIT, UNIT.lower()]),
+    ],
+)
+def test_ambiguous_unit_identities_block_every_occurrence_before_budget_or_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    variant: str,
+    reason_code: str,
+    expected_requested: list[str],
+) -> None:
+    """Exact duplicates and Windows-canonical aliases never compete for one package directory."""
+    bundle, _oracle = _bundle(tmp_path)
+    selected: list[str] = []
+    if variant == "repeated-request":
+        selected = [UNIT, UNIT]
+    elif variant == "duplicate-engine-row":
+        write_engine_report(bundle, workbooks=[UNIT, UNIT])
+    elif variant == "workbook-datasource-collision":
+        write_engine_report(bundle, workbooks=[UNIT], datasources=[UNIT])
+    else:
+        write_engine_report(bundle, workbooks=[UNIT, UNIT.lower()])
+
+    def budget_must_not_run(*_args: object, **_kwargs: object) -> pkg.PathBudget:
+        pytest.fail("identity validation must precede path budgeting")
+
+    monkeypatch.setattr(pkg, "path_budget", budget_must_not_run)
+    out = _out(tmp_path)
+    report = tmp_path / f"{variant}.json"
+    command = ["--bundle", str(bundle), "--out", str(out), "--json", str(report), "--quiet"]
+    for unit in selected:
+        command.extend(["--unit", unit])
+
+    assert pkg.main(command) == pkg.EXIT_UNIT_FAILED
+    payload = json.loads(report.read_text(encoding="utf-8"))
+    assert payload["requested"] == expected_requested
+    assert payload["units"] == [] and payload["refused"] == [] and payload["unaccounted"] == []
+    assert [row["reason_code"] for row in payload["failed"]] == [reason_code, reason_code]
+    assert [row["unit"] for row in payload["construction"]["blocked"]] == expected_requested
+    assert payload["construction"]["totals"] == {"requested": 2, "assembled": 0, "blocked": 2}
+    assert out.is_dir() and list(out.iterdir()) == []
+
+
+def test_brief_cardinality_uses_the_original_request_before_identity_filtering(tmp_path: Path) -> None:
+    """A single ambiguous request reaches BLOCKED instead of escaping through the filtered list."""
+    bundle, _oracle = _bundle(tmp_path)
+    write_engine_report(bundle, workbooks=[UNIT, UNIT])
+    brief = tmp_path / "migration-brief.md"
+    brief.write_text("one requested unit", encoding="utf-8")
+    report = tmp_path / "brief-blocked.json"
+
+    code = pkg.main(
+        [
+            "--bundle",
+            str(bundle),
+            "--out",
+            str(_out(tmp_path)),
+            "--unit",
+            UNIT,
+            "--brief",
+            str(brief),
+            "--json",
+            str(report),
+            "--quiet",
+        ]
+    )
+
+    payload = json.loads(report.read_text(encoding="utf-8"))
+    assert code == pkg.EXIT_UNIT_FAILED
+    assert payload["requested"] == [UNIT]
+    assert payload["unaccounted"] == []
+    assert payload["failed"][0]["reason_code"] == pkg.IDENTITY_ENGINE_DUPLICATE
+    assert payload["construction"]["totals"] == {"requested": 1, "assembled": 0, "blocked": 1}
+
+
+def test_selecting_one_engine_alias_still_blocks_before_it_can_overwrite_its_sibling(tmp_path: Path) -> None:
+    """An explicit `--unit Book` cannot make the engine's separate `book` identity disappear."""
+    bundle, _oracle = _bundle(tmp_path)
+    write_engine_report(bundle, workbooks=[UNIT, UNIT.lower()])
+    report = tmp_path / "selected-alias.json"
+
+    assert (
+        pkg.main(
+            [
+                "--bundle",
+                str(bundle),
+                "--out",
+                str(_out(tmp_path)),
+                "--unit",
+                UNIT,
+                "--json",
+                str(report),
+                "--quiet",
+            ]
+        )
+        == pkg.EXIT_UNIT_FAILED
+    )
+    payload = json.loads(report.read_text(encoding="utf-8"))
+    assert payload["requested"] == [UNIT]
+    assert payload["failed"][0]["reason_code"] == pkg.IDENTITY_DESTINATION_ALIAS
+    assert payload["construction"]["totals"] == {"requested": 1, "assembled": 0, "blocked": 1}
+    assert not (_out(tmp_path) / UNIT).exists()
 
 
 def test_write_png_is_a_real_image_so_these_fixtures_could_fail(tmp_path: Path) -> None:
@@ -3818,8 +3932,9 @@ def test_main_accounts_for_a_too_deep_unit_without_blocking_siblings(
         pkg.main(["--bundle", str(bundle), "--out", str(out), "--json", str(report), "--quiet"]) == pkg.EXIT_UNIT_FAILED
     )
     payload = json.loads(report.read_text(encoding="utf-8"))
-    assert [item["unit"] for item in payload["blocked"]] == sorted([BUDGET_UNIT, "Second_Unit"])
-    assert {item["blocker"] for item in payload["blocked"]} == {"CONSTRUCTION_FAILED"}
+    assert [item["unit"] for item in payload["construction"]["blocked"]] == sorted([BUDGET_UNIT, "Second_Unit"])
+    assert {item["reason_code"] for item in payload["construction"]["blocked"]} == {"path_budget_exceeded"}
+    assert [item["unit"] for item in payload["failed"]] == sorted([BUDGET_UNIT, "Second_Unit"])
     assert payload["totals"]["requested"] == 2
     assert attempted == []
     assert not list(out.glob("*/package-manifest.json"))
@@ -3835,7 +3950,7 @@ def test_the_batch_budget_failures_name_every_offending_unit(
     assert pkg.main(["--bundle", str(bundle), "--out", str(out)]) == pkg.EXIT_UNIT_FAILED
     message = capsys.readouterr().out
     assert BUDGET_UNIT in message and "Second_Unit" in message
-    assert "[host location redacted]" in message
+    assert message.count("[path_budget_exceeded]") == 2
 
 
 def test_a_budget_measurement_exception_is_unassessable_for_one_unit_only(
@@ -3855,14 +3970,15 @@ def test_a_budget_measurement_exception_is_unassessable_for_one_unit_only(
     report = tmp_path / "packaging.json"
     assert _batch_main(tmp_path, bundle, oracle, report, "--quiet") == pkg.EXIT_CANNOT_ASSESS
     payload = json.loads(report.read_text(encoding="utf-8"))
-    assert [item["unit"] for item in payload["blocked"]] == [BATCH_BOOM]
-    assert payload["blocked"][0]["blocker"] == "UNASSESSABLE_INPUT"
-    assert "builtins.ValueError" in payload["blocked"][0]["reason"]
-    assert "Neutral Canary" not in payload["blocked"][0]["reason"]
-    assert "builtins.ValueError" in (payload["blocked"][0]["traceback"] or "")
-    assert "test_package_unit.py" in (payload["blocked"][0]["traceback"] or "")
-    assert "fail_one" in (payload["blocked"][0]["traceback"] or "")
-    assert "Neutral Canary" not in (payload["blocked"][0]["traceback"] or "")
+    assert [item["unit"] for item in payload["construction"]["blocked"]] == [BATCH_BOOM]
+    failure = payload["failed"][0]
+    assert failure["reason_code"] == "unassessable_input"
+    assert failure["exception_class"] == "builtins.ValueError"
+    assert "Neutral Canary" not in failure["reason"]
+    assert "builtins.ValueError" in (failure["traceback"] or "")
+    assert "test_package_unit.py" in (failure["traceback"] or "")
+    assert "fail_one" in (failure["traceback"] or "")
+    assert "Neutral Canary" not in (failure["traceback"] or "")
     assert (_out(tmp_path) / BATCH_LATE / pkg.MANIFEST_NAME).is_file()
 
 
@@ -3903,7 +4019,8 @@ def test_a_unit_named_like_another_units_staging_directory_cannot_delete_it(tmp_
     code = pkg.main(["--bundle", str(bundle), "--out", str(out), "--quiet", "--json", str(report)])
 
     assert code == pkg.EXIT_UNIT_FAILED, "the alias name is refused, and a refusal is never exit 0"
-    assembled = [row["unit"] for row in json.loads(report.read_text(encoding="utf-8"))["assembled"]]
+    payload = json.loads(report.read_text(encoding="utf-8"))
+    assembled = [row["unit"] for row in payload["construction"]["assembled"]]
     assert alias not in assembled, "a name that aliases a staging path must never be reported ASSEMBLED"
     assert all((out / name).is_dir() for name in assembled), (
         f"every unit reported ASSEMBLED must be on disk: {assembled} vs {sorted(p.name for p in out.iterdir())}"
@@ -4645,6 +4762,20 @@ def _batch_bundle(tmp_path: Path) -> tuple[Path, Path]:
     return bundle, oracle
 
 
+def _many_unit_bundle(tmp_path: Path, units: list[str]) -> tuple[Path, Path]:
+    """A real packageable bundle for every named workbook occurrence."""
+    bundle, oracle = _bundle(tmp_path)
+    assets = tmp_path / "assets"
+    write_engine_report(bundle, workbooks=units)
+    for name in units:
+        if name == UNIT:
+            continue
+        source = write_workbook(assets / f"{name}.twb", worksheets=["Sales"])
+        write_handover(bundle, name, source_id=str(Path("_runs") / "999-x" / "assets" / f"{name}.twb"))
+        write_report(bundle, name, _page_ids(source))
+    return bundle, oracle
+
+
 def _arm_boom(monkeypatch: pytest.MonkeyPatch, boom: str, attempted: list[str]) -> None:
     """Make ``boom`` raise the CUSTOMER's exception, and record every unit assembly is attempted for.
 
@@ -4670,79 +4801,64 @@ def _batch_main(tmp_path: Path, bundle: Path, oracle: Path, report: Path, *extra
     )
 
 
-def _status_result(unit: str) -> dict:
-    """Minimal real-result shape for status-fold controls; construction itself is covered above."""
-    return {
-        "unit": unit,
-        "kind": pkg.KIND_WORKBOOK,
-        "mode": pkg.ASSEMBLY_MODE,
-        "construction_status": pkg.STATUS_ASSEMBLED,
-        "has_engine_working_copy": True,
-        "dispatch_readiness": dict(EXPECTED_DISPATCH_READINESS),
-        "self_contained": True,
-        "oracle": {"objects": [], "route": None},
-        "data_sources": {"binding": None},
-        "notes": [],
-    }
-
-
 def test_eleven_of_fourteen_keeps_the_original_denominator_and_names_every_blocker(  # pylint: disable=too-many-locals
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """The customer-shaped 11/14 result is construction-only, explicit, complete and nonzero."""
+    """Eleven real guarded swaps survive three real construction boundaries."""
     requested = [UNIT, *[f"Status_{index:02d}" for index in range(1, 14)]]
     assembled_names = requested[:11]
     crashed, unreadable, edited = requested[11:]
-    bundle, oracle = _bundle(tmp_path)
-    write_engine_report(bundle, workbooks=requested)
-
-    def all_fit(
-        _bundle_root: Path,
-        units: list[str],
-        _out_root: Path,
-        _assets_dir: Path | None,
-        _failed: list[pkg.PackagingError],
-    ) -> tuple[list[str], list[pkg.PathBudget]]:
-        return list(units), []
-
-    def inject_outcomes(*args: object, **_kwargs: object) -> None:
-        selected = args[0]
-        results = args[6]
-        refused = args[7]
-        failed = args[8]
-        assert sorted(selected) == sorted(requested)
-        results.extend(_status_result(unit) for unit in assembled_names)
-        failed.append(pkg.UnitCrashed(crashed, RuntimeError("fixture hard failure")))
-        failed.append(pkg.UnassessableInput(unreadable, ["fixture unreadable input"]))
-        refused.append(pkg.PackageEditsRefused(edited, tmp_path / edited, ["fabric/edit.tmdl"], None))
-
-    monkeypatch.setattr(pkg, "_measure_unit_budgets", all_fit)
-    monkeypatch.setattr(pkg, "_package_each", inject_outcomes)
+    bundle, oracle = _many_unit_bundle(tmp_path, requested)
+    out = _out(tmp_path)
+    pkg.package_unit(bundle, edited, out, oracle_dir=oracle, assets_dir=bundle.parent / "assets")
+    preserved_edit = out / edited / "fabric" / f"{edited}.Report" / "definition" / "agent-edit.json"
+    preserved_edit.parent.mkdir(parents=True, exist_ok=True)
+    preserved_edit.write_text('{"edited": true}', encoding="utf-8")
+    (bundle / "handover" / f"{unreadable}.json").write_text("{ truncated", encoding="utf-8")
+    attempted: list[str] = []
+    _arm_boom(monkeypatch, crashed, attempted)
     report = tmp_path / "status.json"
 
     code = _batch_main(tmp_path, bundle, oracle, report)
     payload = json.loads(report.read_text(encoding="utf-8"))
     summary = capsys.readouterr().out
+    construction = payload["construction"]
 
     assert code != pkg.EXIT_OK
     assert payload["requested"] == sorted(requested)
-    assert payload["totals"] == {"requested": 14, "assembled": 11, "blocked": 3}
-    assert [row["unit"] for row in payload["assembled"]] == assembled_names
-    blockers = {row["unit"]: row["blocker"] for row in payload["blocked"]}
-    assert blockers == {
-        crashed: "CONSTRUCTION_FAILED",
-        unreadable: "UNASSESSABLE_INPUT",
-        edited: "PACKAGE_EDITS_REFUSED",
+    assert payload["totals"] == {
+        "requested": 14,
+        "units": 11,
+        "failed": 2,
+        "refused": 1,
+        "unaccounted": 0,
+        "assembled": 11,
+        "blocked": 3,
     }
-    assert payload["accounting_findings"] == []
+    assert construction["totals"] == {"requested": 14, "assembled": 11, "blocked": 3}
+    assert [row["unit"] for row in payload["units"]] == assembled_names
+    assert [row["unit"] for row in construction["assembled"]] == assembled_names
+    assert {row["status"] for row in construction["assembled"]} == {pkg.STATUS_ASSEMBLED}
+    assert {row["status"] for row in construction["blocked"]} == {pkg.STATUS_BLOCKED}
+    blockers = {row["unit"]: row["reason_code"] for row in construction["blocked"]}
+    assert blockers == {
+        crashed: "unit_exception",
+        unreadable: "unassessable_input",
+        edited: "package_edits_refused",
+    }
+    assert payload["unaccounted"] == []
     assert payload["dispatch_readiness"]["availability"] == "UNAVAILABLE"
     assert payload["dispatch_readiness"]["status"] == pkg.DISPATCH_READINESS_NOT_EVALUATED
+    assert all((out / unit / pkg.MANIFEST_NAME).is_file() for unit in assembled_names)
+    assert not (out / crashed).exists() and not (out / unreadable).exists()
+    assert preserved_edit.is_file(), "the edit-refused package was overwritten"
+    assert crashed in attempted and unreadable in attempted and edited not in attempted
     assert "ASSEMBLED: 11/14" in summary
     assert "BLOCKED: 3/14" in summary
     assert all(f"BLOCKED {unit}" in summary for unit in (crashed, unreadable, edited))
     assert pkg.NOT_START_READY_NOTICE in summary
     assert not re.search(r"(?m)^packaged\b", summary, re.IGNORECASE)
-    assert '"packaged":' not in report.read_text(encoding="utf-8")
+    assert '"status": "packaged"' not in report.read_text(encoding="utf-8").casefold()
 
 
 def test_one_unit_raising_does_not_stop_the_units_after_it(
@@ -4768,16 +4884,41 @@ def test_one_unit_raising_does_not_stop_the_units_after_it(
     assert not (_out(tmp_path) / BATCH_BOOM).exists(), "the failed unit left a package behind"
     assert code == pkg.EXIT_UNIT_FAILED, "a batch with a failed unit exited as if nothing had gone wrong"
 
-    assert [item["unit"] for item in payload["blocked"]] == [BATCH_BOOM]
-    assert payload["blocked"][0]["blocker"] == "CONSTRUCTION_FAILED"
-    assert "shutil.Error" in payload["blocked"][0]["reason"]
-    assert "shutil.Error" in (payload["blocked"][0]["traceback"] or ""), "a crash without its traceback is not a report"
-    assert "WinError 3" not in payload["blocked"][0]["reason"]
-    assert BATCH_BOOM not in {item["unit"] for item in payload["assembled"]}
+    assert [item["unit"] for item in payload["construction"]["blocked"]] == [BATCH_BOOM]
+    failure = payload["failed"][0]
+    assert failure["reason_code"] == "unit_exception"
+    assert failure["exception_class"] == "shutil.Error"
+    assert "shutil.Error" in (failure["traceback"] or ""), "a crash without its class is not a report"
+    assert "WinError 3" not in failure["reason"]
+    assert BATCH_BOOM not in {item["unit"] for item in payload["construction"]["assembled"]}
     assert f"BLOCKED {BATCH_BOOM}" in summary
     assert "WinError 3" not in summary
     assert "UNIT FAILED: 1 unit(s) raised" in summary
     assert f"ASSEMBLED {BATCH_LATE}" in summary
+
+
+def test_blocked_crash_persistence_withholds_exception_urls_queries_and_tokens(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Stable class/code evidence replaces the raw exception message on every persisted surface."""
+    bundle, oracle = _bundle(tmp_path)
+    secret = "https://customer.example/query?token=do-not-persist"
+
+    def explode(*_args: object, **_kwargs: object) -> tuple[dict, Callable[[], None]]:
+        raise RuntimeError(secret)
+
+    monkeypatch.setattr(pkg, "_assemble_unit", explode)
+    report = tmp_path / "packaging.json"
+    assert _batch_main(tmp_path, bundle, oracle, report, "--quiet") == pkg.EXIT_UNIT_FAILED
+    text = report.read_text(encoding="utf-8")
+    output = str(capsys.readouterr())
+    failure = json.loads(text)["failed"][0]
+
+    assert failure["reason_code"] == "unit_exception"
+    assert failure["exception_class"] == "builtins.RuntimeError"
+    assert "builtins.RuntimeError" in (failure["traceback"] or "")
+    assert secret not in text + output
+    assert "token=" not in (text + output).casefold()
 
 
 @pytest.mark.parametrize(
@@ -4792,6 +4933,7 @@ def test_one_unit_raising_does_not_stop_the_units_after_it(
             str(PurePosixPath("/", "home", "NeutralCanary", "secret.csv")),
             str(PurePosixPath("/", "home", "NeutralCanary", "package.py")),
         ),
+        ("https://customer.example/query?token=do-not-persist", str(PurePosixPath("project", "package.py"))),
         ("ordinary failure text", str(PurePosixPath("project", "package.py"))),
     ],
 )
@@ -4812,8 +4954,7 @@ def test_a_crash_diagnostic_redacts_host_locations_but_keeps_actionable_context(
     assert "RuntimeError" in report
     assert "line 1, in <module>" in crash.traceback
     assert Path(filename.replace("\\", "/")).name in crash.traceback
-    if "ordinary" in message:
-        assert "ordinary failure text" in report
+    assert message not in report
 
 
 def test_crash_diagnostic_redacts_whole_messages_with_host_locations() -> None:
@@ -4888,10 +5029,10 @@ def test_a_staging_tree_that_survives_cleanup_fails_its_unit_rather_than_being_a
     payload = json.loads(report.read_text(encoding="utf-8"))
 
     assert code == pkg.EXIT_UNIT_FAILED
-    assert [item["unit"] for item in payload["blocked"]] == [BATCH_BOOM]
-    assert "[host location redacted]" in payload["blocked"][0]["reason"]
+    assert [item["unit"] for item in payload["construction"]["blocked"]] == [BATCH_BOOM]
+    assert payload["failed"][0]["reason_code"] == "construction_failed"
     assert not (out_root / BATCH_BOOM).exists(), "a package was built out of another build's residue"
-    assert sorted(item["unit"] for item in payload["assembled"]) == [
+    assert sorted(item["unit"] for item in payload["construction"]["assembled"]) == [
         name for name in BATCH_UNITS if name != BATCH_BOOM
     ], "the residue refusal stopped the rest of the batch"
 
@@ -4932,11 +5073,9 @@ def test_a_residue_found_while_a_unit_is_already_failing_does_not_replace_the_ro
     errors = capsys.readouterr().err
 
     assert code == pkg.EXIT_UNIT_FAILED
-    assert [item["unit"] for item in payload["blocked"]] == [BATCH_BOOM]
-    assert "shutil.Error" in payload["blocked"][0]["reason"], "the residue message replaced the root cause"
-    assert "[host location redacted]" in (payload["blocked"][0]["traceback"] or ""), (
-        "the residue was not recorded at all"
-    )
+    assert [item["unit"] for item in payload["construction"]["blocked"]] == [BATCH_BOOM]
+    assert payload["failed"][0]["exception_class"] == "shutil.Error"
+    assert "diagnostic_notes_withheld=1" in (payload["failed"][0]["traceback"] or "")
     assert "[host location redacted]" in errors
     assert str(staging) not in errors
     assert (_out(tmp_path) / BATCH_LATE / pkg.MANIFEST_NAME).is_file(), "the unit after the failure was skipped"
@@ -4957,13 +5096,22 @@ def test_the_construction_states_partition_the_request(
     _batch_main(tmp_path, bundle, oracle, report)
     payload = json.loads(report.read_text(encoding="utf-8"))
     summary = capsys.readouterr().out
-    buckets = [item["unit"] for item in payload["assembled"]] + [item["unit"] for item in payload["blocked"]]
+    construction = payload["construction"]
+    buckets = [item["unit"] for item in construction["assembled"]] + [item["unit"] for item in construction["blocked"]]
 
     assert payload["requested"] == BATCH_UNITS
     assert sorted(buckets) == payload["requested"], "a requested unit reached no bucket, or reached two"
     assert len(buckets) == len(set(buckets)) == payload["totals"]["requested"]
-    assert payload["totals"] == {"requested": 4, "assembled": 3, "blocked": 1}
-    assert payload["accounting_findings"] == []
+    assert payload["totals"] == {
+        "requested": 4,
+        "units": 3,
+        "failed": 1,
+        "refused": 0,
+        "unaccounted": 0,
+        "assembled": 3,
+        "blocked": 1,
+    }
+    assert payload["unaccounted"] == []
     assert "package_unit: 4 requested unit(s)" in summary
     assert "ASSEMBLED: 3/4" in summary
     assert "BLOCKED: 1/4" in summary
@@ -4984,13 +5132,13 @@ def test_a_requested_unit_in_no_bucket_is_named_rather_than_counted_clean() -> N
 
     assert pkg.partition_gaps(["A", "B", "C"], assembled, failed, [refusal]) == []
     assert pkg.partition_gaps(["A", "B", "C", "D"], assembled, failed, [refusal]) == [
-        {"unit": "D", "state": "not_attempted", "reason": "requested but recorded in no outcome bucket"}
+        {"unit": "D", "state": "not_attempted", "reason": "requested occurrence recorded in no outcome bucket"}
     ]
     assert pkg.partition_gaps(["A", "B"], assembled, failed, [refusal]) == [
-        {"unit": "C", "state": "never_requested", "reason": "recorded although it was never requested"}
+        {"unit": "C", "state": "never_requested", "reason": "requested 0 time(s) but recorded 1 outcome(s)"}
     ]
     assert pkg.partition_gaps(["A"], assembled + assembled, [], []) == [
-        {"unit": "A", "state": "recorded_twice", "reason": "recorded in 2 buckets"}
+        {"unit": "A", "state": "recorded_too_many", "reason": "requested 1 time(s) but recorded 2 outcome(s)"}
     ]
 
 
@@ -5010,20 +5158,28 @@ def test_an_unaccounted_unit_is_reported_and_cannot_exit_zero(
     payload = json.loads(report.read_text(encoding="utf-8"))
     summary = capsys.readouterr().out
 
-    assert payload["accounting_findings"] == [
-        {"unit": UNIT, "state": "not_attempted", "reason": "requested but recorded in no outcome bucket"}
+    assert payload["unaccounted"] == [
+        {"unit": UNIT, "state": "not_attempted", "reason": "requested occurrence recorded in no outcome bucket"}
     ]
-    assert payload["totals"] == {"requested": 1, "assembled": 0, "blocked": 1}
-    assert payload["blocked"] == [
+    assert payload["totals"] == {
+        "requested": 1,
+        "units": 0,
+        "failed": 0,
+        "refused": 0,
+        "unaccounted": 1,
+        "assembled": 0,
+        "blocked": 1,
+    }
+    assert payload["construction"]["blocked"] == [
         {
             "unit": UNIT,
-            "construction_status": pkg.STATUS_BLOCKED,
-            "blocker": "UNATTEMPTED",
-            "reason": "requested but recorded in no outcome bucket",
+            "status": pkg.STATUS_BLOCKED,
+            "reason_code": "outcome_accounting_mismatch",
+            "reason": "the requested occurrence did not reach exactly one construction bucket",
         }
     ]
     assert "1 requested = 0 ASSEMBLED + 1 BLOCKED" in summary
-    assert f"BLOCKED {UNIT} [UNATTEMPTED]" in summary
+    assert f"BLOCKED {UNIT} [outcome_accounting_mismatch]" in summary
     assert code == pkg.EXIT_CANNOT_ASSESS, "a unit nobody can account for left the run clean"
 
 
@@ -5044,20 +5200,18 @@ def test_a_crash_outranks_a_refusal_and_neither_hides_the_other(
     summary = capsys.readouterr().out
 
     assert code == pkg.EXIT_UNIT_FAILED
-    blocked = {item["unit"]: item for item in payload["blocked"]}
-    assert blocked[BATCH_EARLY]["blocker"] == "PACKAGE_EDITS_REFUSED"
-    assert blocked[BATCH_BOOM]["blocker"] == "CONSTRUCTION_FAILED"
-    assert payload["accounting_findings"] == []
+    blocked = {item["unit"]: item for item in payload["construction"]["blocked"]}
+    assert blocked[BATCH_EARLY]["reason_code"] == "package_edits_refused"
+    assert blocked[BATCH_BOOM]["reason_code"] == "unit_exception"
+    assert payload["unaccounted"] == []
     assert "4 requested = 2 ASSEMBLED + 2 BLOCKED" in summary
     assert edited.is_file(), "the refused unit's edit was destroyed by a batch that continued past it"
 
 
-def test_an_operator_interrupt_still_ends_the_run(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """The broad clause catches `Exception`, NOT `BaseException`.
-
-    Ctrl-C is the operator ending the run, not a unit failing - swallowing it would make a 47-unit
-    batch un-interruptible, one caught `KeyboardInterrupt` per remaining unit.
-    """
+def test_an_operator_interrupt_before_publish_is_persisted_and_stops_the_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A handled Ctrl-C overwrites JSON and distinguishes interrupted from unattempted units."""
     bundle, oracle = _batch_bundle(tmp_path)
     real = pkg._assemble_unit  # noqa: SLF001  # pylint: disable=protected-access
 
@@ -5067,9 +5221,85 @@ def test_an_operator_interrupt_still_ends_the_run(tmp_path: Path, monkeypatch: p
         return real(bundle_root, unit, dest, **kwargs)
 
     monkeypatch.setattr(pkg, "_assemble_unit", spy)
+    report = tmp_path / "packaging.json"
+    report.write_text('{"stale": true}', encoding="utf-8")
 
-    with pytest.raises(KeyboardInterrupt):
-        _batch_main(tmp_path, bundle, oracle, tmp_path / "packaging.json", "--quiet")
+    assert _batch_main(tmp_path, bundle, oracle, report, "--quiet") == pkg.EXIT_CANNOT_ASSESS
+    payload = json.loads(report.read_text(encoding="utf-8"))
+    assert "stale" not in payload
+    assert payload["interruption"] == {
+        "unit": BATCH_BOOM,
+        "reason_code": "assembly_interrupted_before_publish",
+        "published": False,
+        "rollback_failed": False,
+    }
+    assert payload["failed"][0]["unit"] == BATCH_BOOM
+    assert payload["failed"][0]["reason_code"] == "assembly_interrupted_before_publish"
+    assert BATCH_LATE in [row["unit"] for row in payload["unaccounted"]]
+
+
+def test_interrupt_after_publish_keeps_the_package_assembled_and_invalidates_prior_json(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The rename's observed filesystem state outranks the interrupted control flow."""
+    bundle, oracle = _many_unit_bundle(tmp_path, [UNIT, BATCH_LATE])
+    out = _out(tmp_path)
+    final = out / UNIT
+    real = pkg._rename_retrying  # pylint: disable=protected-access
+
+    def publish_then_interrupt(src: Path, dst: Path) -> None:
+        real(src, dst)
+        if dst == final:
+            raise KeyboardInterrupt("https://customer.example/query?token=do-not-persist")
+
+    monkeypatch.setattr(pkg, "_rename_retrying", publish_then_interrupt)
+    report = tmp_path / "packaging.json"
+    report.write_text('{"stale": true}', encoding="utf-8")
+
+    assert _batch_main(tmp_path, bundle, oracle, report) == pkg.EXIT_CANNOT_ASSESS
+    payload = json.loads(report.read_text(encoding="utf-8"))
+    construction = payload["construction"]
+    assert "stale" not in payload
+    assert payload["interruption"] == {
+        "unit": UNIT,
+        "reason_code": "assembly_interrupted_after_publish",
+        "published": True,
+        "rollback_failed": False,
+    }
+    assert [row["unit"] for row in payload["units"]] == [UNIT]
+    assert [row["unit"] for row in construction["assembled"]] == [UNIT]
+    assert UNIT not in [row["unit"] for row in construction["blocked"]]
+    assert [row["unit"] for row in construction["blocked"]] == [BATCH_LATE]
+    assert (final / pkg.MANIFEST_NAME).is_file()
+    assert "do-not-persist" not in report.read_text(encoding="utf-8")
+
+
+def test_failed_rollback_cannot_mask_keyboard_interrupt(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Rollback failure is attached as state while KeyboardInterrupt remains the raised class."""
+    staged = tmp_path / "staged"
+    final = tmp_path / "final"
+    staged.mkdir()
+    final.mkdir()
+    retired = pkg.retired_dir(final)
+    real = pkg._rename_retrying  # pylint: disable=protected-access
+
+    def interrupt_and_fail_rollback(src: Path, dst: Path) -> None:
+        if src == final:
+            real(src, dst)
+        elif src == staged:
+            raise KeyboardInterrupt("primary interruption")
+        else:
+            raise RuntimeError("rollback must not replace KeyboardInterrupt")
+
+    monkeypatch.setattr(pkg, "_rename_retrying", interrupt_and_fail_rollback)
+    with pytest.raises(pkg.AssemblyInterrupted) as caught:
+        pkg.replace_dir(staged, final, verify_staged=lambda: None)
+
+    assert isinstance(caught.value, KeyboardInterrupt)
+    assert caught.value.published is False
+    assert caught.value.rollback_failed is True
+    assert isinstance(caught.value.__cause__, KeyboardInterrupt)
+    assert not final.exists() and retired.is_dir() and staged.is_dir()
 
 
 def test_a_single_unit_run_is_unchanged_by_the_batch_contract(
@@ -5084,9 +5314,17 @@ def test_a_single_unit_run_is_unchanged_by_the_batch_contract(
     summary = capsys.readouterr().out
 
     assert code == pkg.EXIT_OK
-    assert payload["requested"] == [UNIT] and payload["blocked"] == [] and payload["accounting_findings"] == []
-    assert [item["unit"] for item in payload["assembled"]] == [UNIT]
-    assert payload["totals"] == {"requested": 1, "assembled": 1, "blocked": 0}
+    assert payload["requested"] == [UNIT] and payload["construction"]["blocked"] == [] and payload["unaccounted"] == []
+    assert [item["unit"] for item in payload["construction"]["assembled"]] == [UNIT]
+    assert payload["totals"] == {
+        "requested": 1,
+        "units": 1,
+        "failed": 0,
+        "refused": 0,
+        "unaccounted": 0,
+        "assembled": 1,
+        "blocked": 0,
+    }
     assert "ASSEMBLED: 1/1" in summary
     assert "BLOCKED: 0/1" in summary
     assert "1 requested = 1 ASSEMBLED + 0 BLOCKED" in summary

--- a/tests/test_package_unit.py
+++ b/tests/test_package_unit.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import errno
 import hashlib
+import inspect
 import json
 import os
 import re
@@ -37,6 +38,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
 
 import check_path_ceiling as cpc  # noqa: E402  # pylint: disable=wrong-import-position
+import check_migration_progress as cmp  # noqa: E402  # pylint: disable=wrong-import-position
 import host_paths as hp  # noqa: E402  # pylint: disable=wrong-import-position
 import manifest_scope as ms  # noqa: E402  # pylint: disable=wrong-import-position
 import package_unit as pkg  # noqa: E402  # pylint: disable=wrong-import-position
@@ -4801,6 +4803,36 @@ def _batch_main(tmp_path: Path, bundle: Path, oracle: Path, report: Path, *extra
     )
 
 
+def _run_with_line_interrupt(
+    function: Callable,
+    marker: str,
+    action: Callable[[], int],
+    *,
+    occurrence: int = 1,
+) -> int:
+    """Raise KeyboardInterrupt on one exact executable line in ``function``."""
+    source, start = inspect.getsourcelines(function)
+    matches = [start + index for index, line in enumerate(source) if line.rstrip() == marker]
+    assert len(matches) >= occurrence, (marker, occurrence, matches)
+    target_line = matches[occurrence - 1]
+    fired = False
+
+    def trace(frame, event, arg):  # pylint: disable=unused-argument
+        nonlocal fired
+        if frame.f_code is function.__code__ and event == "line" and frame.f_lineno == target_line:
+            fired = True
+            sys.settrace(None)
+            raise KeyboardInterrupt("line-trace interrupt")
+        return trace
+
+    sys.settrace(trace)
+    try:
+        return action()
+    finally:
+        sys.settrace(None)
+        assert fired, f"line trace never reached {function.__name__}:{target_line}"
+
+
 def test_eleven_of_fourteen_keeps_the_original_denominator_and_names_every_blocker(  # pylint: disable=too-many-locals
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -5232,46 +5264,75 @@ def test_an_operator_interrupt_before_publish_is_persisted_and_stops_the_run(
         "reason_code": "assembly_interrupted_before_publish",
         "published": False,
         "rollback_failed": False,
+        "secondary_code": None,
     }
     assert payload["failed"][0]["unit"] == BATCH_BOOM
     assert payload["failed"][0]["reason_code"] == "assembly_interrupted_before_publish"
     assert BATCH_LATE in [row["unit"] for row in payload["unaccounted"]]
 
 
-def test_interrupt_after_publish_keeps_the_package_assembled_and_invalidates_prior_json(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """The rename's observed filesystem state outranks the interrupted control flow."""
+def test_post_return_line_interrupt_uses_verified_final_package_state(tmp_path: Path) -> None:
+    """An interrupt after replace_dir returns still observes the just-published package."""
     bundle, oracle = _many_unit_bundle(tmp_path, [UNIT, BATCH_LATE])
     out = _out(tmp_path)
     final = out / UNIT
-    real = pkg._rename_retrying  # pylint: disable=protected-access
-
-    def publish_then_interrupt(src: Path, dst: Path) -> None:
-        real(src, dst)
-        if dst == final:
-            raise KeyboardInterrupt("https://customer.example/query?token=do-not-persist")
-
-    monkeypatch.setattr(pkg, "_rename_retrying", publish_then_interrupt)
     report = tmp_path / "packaging.json"
     report.write_text('{"stale": true}', encoding="utf-8")
 
-    assert _batch_main(tmp_path, bundle, oracle, report) == pkg.EXIT_CANNOT_ASSESS
+    code = _run_with_line_interrupt(
+        pkg.package_unit,
+        "        if result is None:",
+        lambda: _batch_main(tmp_path, bundle, oracle, report),
+    )
     payload = json.loads(report.read_text(encoding="utf-8"))
     construction = payload["construction"]
+    assert code == pkg.EXIT_CANNOT_ASSESS
     assert "stale" not in payload
     assert payload["interruption"] == {
         "unit": UNIT,
         "reason_code": "assembly_interrupted_after_publish",
         "published": True,
         "rollback_failed": False,
+        "secondary_code": None,
     }
     assert [row["unit"] for row in payload["units"]] == [UNIT]
     assert [row["unit"] for row in construction["assembled"]] == [UNIT]
     assert UNIT not in [row["unit"] for row in construction["blocked"]]
     assert [row["unit"] for row in construction["blocked"]] == [BATCH_LATE]
     assert (final / pkg.MANIFEST_NAME).is_file()
-    assert "do-not-persist" not in report.read_text(encoding="utf-8")
+    assert list(out.rglob(pkg.MANIFEST_NAME)) == [final / pkg.MANIFEST_NAME]
+    assert cmp.discover_package_roots(bundle, out) == [final]
+
+
+def test_post_rename_line_interrupt_hides_retired_manifest_before_reporting_status(tmp_path: Path) -> None:
+    """The old package cannot remain discoverable beside the published replacement."""
+    bundle, oracle = _many_unit_bundle(tmp_path, [UNIT, BATCH_LATE])
+    out = _out(tmp_path)
+    final = out / UNIT
+    pkg.package_unit(bundle, UNIT, out, oracle_dir=oracle, assets_dir=bundle.parent / "assets")
+    report = tmp_path / "packaging.json"
+    report.write_text('{"stale": true}', encoding="utf-8")
+
+    code = _run_with_line_interrupt(
+        pkg.replace_dir,
+        "            _discard_scratch(retired)",
+        lambda: _batch_main(tmp_path, bundle, oracle, report),
+        occurrence=2,
+    )
+    payload = json.loads(report.read_text(encoding="utf-8"))
+    construction = payload["construction"]
+    assert code == pkg.EXIT_CANNOT_ASSESS
+    assert payload["interruption"] == {
+        "unit": UNIT,
+        "reason_code": "assembly_interrupted_after_publish",
+        "published": True,
+        "rollback_failed": False,
+        "secondary_code": None,
+    }
+    assert [row["unit"] for row in construction["assembled"]] == [UNIT]
+    assert [row["unit"] for row in construction["blocked"]] == [BATCH_LATE]
+    assert list(out.rglob(pkg.MANIFEST_NAME)) == [final / pkg.MANIFEST_NAME]
+    assert cmp.discover_package_roots(bundle, out) == [final]
 
 
 def test_failed_rollback_cannot_mask_keyboard_interrupt(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -5298,6 +5359,7 @@ def test_failed_rollback_cannot_mask_keyboard_interrupt(tmp_path: Path, monkeypa
     assert isinstance(caught.value, KeyboardInterrupt)
     assert caught.value.published is False
     assert caught.value.rollback_failed is True
+    assert caught.value.secondary_code == "rollback_failed"
     assert isinstance(caught.value.__cause__, KeyboardInterrupt)
     assert not final.exists() and retired.is_dir() and staged.is_dir()
 

--- a/tests/test_package_unit.py
+++ b/tests/test_package_unit.py
@@ -56,6 +56,11 @@ from test_check_reference_readiness import (  # noqa: E402  # pylint: disable=wr
 UNIT = "Book"
 WB_LUID = "11111111-2222-3333-4444-555555555555"
 OTHER_LUID = "99999999-8888-7777-6666-555555555555"
+EXPECTED_DISPATCH_READINESS = {
+    "availability": "UNAVAILABLE",
+    "status": pkg.DISPATCH_READINESS_NOT_EVALUATED,
+    "message": pkg.NOT_START_READY_NOTICE,
+}
 
 
 def _view(name: str, luid: str, *, workbook_luid: str, workbook_name: str, view_type: str | None) -> dict:
@@ -1492,12 +1497,12 @@ def test_a_source_that_cannot_be_shipped_is_a_LOUD_omission_not_a_silent_skip(tm
     assert _absolute_literals(root) == []
 
 
-def test_a_unit_shipping_without_its_rows_is_a_NONZERO_verdict(tmp_path: Path) -> None:
-    """Round-2 finding 1: `package_unit_exit=0` while the package could not refresh a partition.
+def test_a_unit_shipping_without_its_rows_is_assembled_but_not_ready(tmp_path: Path) -> None:
+    """A constructed diagnostic package stays ASSEMBLED even when it cannot refresh a partition.
 
-    Exit 0 is the only signal an automated caller reads, so a package that is missing the rows its
-    own model names must not earn it. Both directions from one fixture: the same bundle with the
-    source PRESENT exits 0, so this cannot pass by refusing everything.
+    Construction status no longer doubles as dispatch readiness. Both directions from one fixture:
+    the same bundle with the source PRESENT and ABSENT assembles, while the manifest keeps the
+    self-containment distinction and explicitly refuses a START_READY claim.
     """
     bundle, oracle = _bundle(tmp_path)
     payload = tmp_path / "extract" / "Extract_Extract.csv"
@@ -1508,7 +1513,11 @@ def test_a_unit_shipping_without_its_rows_is_a_NONZERO_verdict(tmp_path: Path) -
     assert pkg.main(argv) == pkg.EXIT_OK
 
     payload.unlink()
-    assert pkg.main([*argv, "--discard-package-edits"]) == pkg.EXIT_NOT_SELF_CONTAINED
+    assert pkg.main([*argv, "--discard-package-edits"]) == pkg.EXIT_OK
+    record = json.loads((_out(tmp_path) / UNIT / pkg.MANIFEST_NAME).read_text(encoding="utf-8"))
+    assert record["construction_status"] == pkg.STATUS_ASSEMBLED
+    assert record["self_contained"] is False
+    assert record["dispatch_readiness"]["status"] == pkg.DISPATCH_READINESS_NOT_EVALUATED
 
 
 def test_an_oversized_source_is_refused_by_the_ceiling_rather_than_copied(tmp_path: Path) -> None:
@@ -3345,29 +3354,107 @@ def test_every_finding_is_one_line_with_a_stable_prefix(tmp_path: Path) -> None:
 # --------------------------------------------------------------------------------------------
 
 
-def test_a_unit_with_no_engine_working_copy_is_still_packaged_and_reported(tmp_path: Path) -> None:
+def test_a_unit_with_no_engine_working_copy_is_still_assembled_and_reported(tmp_path: Path) -> None:
     """Measured on a real estate run: `report.json` lists 48 workbooks, `pbip/` holds 44.
 
     Deriving the unit list from the filesystem dropped the other four silently - the same class of
     defect this packaging exists to remove. They package for their source, reference and handover,
-    `packaged` is false, and the exit code says so.
+    It is a valid diagnostic ASSEMBLED result, while `has_engine_working_copy` keeps the limitation.
     """
     bundle, oracle = _bundle(tmp_path)
     write_engine_report(bundle, workbooks=[UNIT, "Never_Emitted"])
     assert "Never_Emitted" in pkg.bundle_units(bundle)
     code = pkg.main(["--bundle", str(bundle), "--out", str(_out(tmp_path)), "--quiet"])
     manifest = json.loads((_out(tmp_path) / "Never_Emitted" / "package-manifest.json").read_text(encoding="utf-8"))
-    assert manifest["packaged"] is False
-    assert code == 1
+    assert manifest["construction_status"] == pkg.STATUS_ASSEMBLED
+    assert manifest["has_engine_working_copy"] is False
+    assert manifest["dispatch_readiness"]["status"] == pkg.DISPATCH_READINESS_NOT_EVALUATED
+    assert code == pkg.EXIT_OK
 
 
 def test_packaging_every_emitted_unit_exits_zero(tmp_path: Path) -> None:
     """Also pins `--oracle` auto-discovery: the capture is found beside the bundle, unflagged."""
     bundle, oracle = _bundle(tmp_path)
     assert pkg.main(["--bundle", str(bundle), "--out", str(_out(tmp_path)), "--quiet"]) == 0
-    assert (_out(tmp_path) / UNIT / "fabric" / f"{UNIT}.Report").is_dir()
+    package = _out(tmp_path) / UNIT
+    assert (package / "fabric" / f"{UNIT}.Report").is_dir()
+    record = json.loads((package / pkg.MANIFEST_NAME).read_text(encoding="utf-8"))
+    assert record["construction_status"] == pkg.STATUS_ASSEMBLED
+    assert record["dispatch_readiness"] == EXPECTED_DISPATCH_READINESS
+    assert "packaged" not in record
     assert pkg.discover_dir(bundle, ("oracle", "_oracle")) == oracle.resolve()
-    assert (_out(tmp_path) / UNIT / "oracle" / "oracle-manifest.json").is_file()
+    assert (package / "oracle" / "oracle-manifest.json").is_file()
+
+
+def test_assemble_only_is_an_explicit_alias_for_the_existing_construction_behavior(  # pylint: disable=too-many-locals
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Default and `--assemble-only` construct the same package and never claim dispatch readiness."""
+    bundle, oracle = _bundle(tmp_path)
+    actual_run = pkg.subprocess.run
+    commands: list[list[str]] = []
+
+    def observed(command: list[object], *args: object, **kwargs: object):
+        commands.append([str(part) for part in command])
+        return actual_run(command, *args, **kwargs)  # pylint: disable=subprocess-run-check
+
+    monkeypatch.setattr(pkg.subprocess, "run", observed)
+    default_out = tmp_path / "default-packages"
+    explicit_out = tmp_path / "explicit-packages"
+    default_json = tmp_path / "default.json"
+    explicit_json = tmp_path / "explicit.json"
+    common = ["--bundle", str(bundle), "--oracle", str(oracle), "--assets", str(bundle.parent / "assets"), "--quiet"]
+
+    assert pkg.main([*common, "--out", str(default_out), "--json", str(default_json)]) == pkg.EXIT_OK
+    assert (
+        pkg.main(
+            [
+                *common,
+                "--out",
+                str(explicit_out),
+                "--json",
+                str(explicit_json),
+                "--assemble-only",
+            ]
+        )
+        == pkg.EXIT_OK
+    )
+
+    output = capsys.readouterr().out
+    assert output.strip() == pkg.NOT_START_READY_NOTICE
+    default_report = json.loads(default_json.read_text(encoding="utf-8"))
+    explicit_report = json.loads(explicit_json.read_text(encoding="utf-8"))
+    assert default_report["mode"]["name"] == pkg.ASSEMBLY_MODE
+    assert default_report["mode"]["explicit"] is False
+    assert "inherently construction-only" in default_report["mode"]["description"]
+    assert explicit_report["mode"]["name"] == pkg.ASSEMBLY_MODE
+    assert explicit_report["mode"]["explicit"] is True
+    assert default_report["dispatch_readiness"] == EXPECTED_DISPATCH_READINESS
+    assert explicit_report["dispatch_readiness"] == EXPECTED_DISPATCH_READINESS
+    assert (
+        default_report["totals"]
+        == explicit_report["totals"]
+        == {
+            "requested": 1,
+            "assembled": 1,
+            "blocked": 0,
+        }
+    )
+    for report_path in (default_json, explicit_json):
+        assert '"packaged":' not in report_path.read_text(encoding="utf-8")
+
+    default_package = default_out / UNIT
+    explicit_package = explicit_out / UNIT
+    assert {path.relative_to(default_package) for path in default_package.rglob("*") if path.is_file()} == {
+        path.relative_to(explicit_package) for path in explicit_package.rglob("*") if path.is_file()
+    }
+    assert (default_package / "data-access.json").read_bytes() == (explicit_package / "data-access.json").read_bytes()
+    assert not [
+        path
+        for path in explicit_package.rglob("*")
+        if path.name.casefold() in {"start-ready.json", "dispatch-authorization.json"}
+    ]
+    assert all("check_reference_readiness.py" not in " ".join(command) for command in commands)
 
 
 def test_an_unknown_unit_is_a_usage_error_not_an_empty_package(tmp_path: Path) -> None:
@@ -3731,7 +3818,8 @@ def test_main_accounts_for_a_too_deep_unit_without_blocking_siblings(
         pkg.main(["--bundle", str(bundle), "--out", str(out), "--json", str(report), "--quiet"]) == pkg.EXIT_UNIT_FAILED
     )
     payload = json.loads(report.read_text(encoding="utf-8"))
-    assert [item["unit"] for item in payload["failed"]] == sorted([BUDGET_UNIT, "Second_Unit"])
+    assert [item["unit"] for item in payload["blocked"]] == sorted([BUDGET_UNIT, "Second_Unit"])
+    assert {item["blocker"] for item in payload["blocked"]} == {"CONSTRUCTION_FAILED"}
     assert payload["totals"]["requested"] == 2
     assert attempted == []
     assert not list(out.glob("*/package-manifest.json"))
@@ -3767,14 +3855,14 @@ def test_a_budget_measurement_exception_is_unassessable_for_one_unit_only(
     report = tmp_path / "packaging.json"
     assert _batch_main(tmp_path, bundle, oracle, report, "--quiet") == pkg.EXIT_CANNOT_ASSESS
     payload = json.loads(report.read_text(encoding="utf-8"))
-    assert [item["unit"] for item in payload["failed"]] == [BATCH_BOOM]
-    assert payload["failed"][0]["state"] == "cannot_assess"
-    assert "builtins.ValueError" in payload["failed"][0]["reason"]
-    assert "Neutral Canary" not in payload["failed"][0]["reason"]
-    assert "builtins.ValueError" in (payload["failed"][0]["traceback"] or "")
-    assert "test_package_unit.py" in (payload["failed"][0]["traceback"] or "")
-    assert "fail_one" in (payload["failed"][0]["traceback"] or "")
-    assert "Neutral Canary" not in (payload["failed"][0]["traceback"] or "")
+    assert [item["unit"] for item in payload["blocked"]] == [BATCH_BOOM]
+    assert payload["blocked"][0]["blocker"] == "UNASSESSABLE_INPUT"
+    assert "builtins.ValueError" in payload["blocked"][0]["reason"]
+    assert "Neutral Canary" not in payload["blocked"][0]["reason"]
+    assert "builtins.ValueError" in (payload["blocked"][0]["traceback"] or "")
+    assert "test_package_unit.py" in (payload["blocked"][0]["traceback"] or "")
+    assert "fail_one" in (payload["blocked"][0]["traceback"] or "")
+    assert "Neutral Canary" not in (payload["blocked"][0]["traceback"] or "")
     assert (_out(tmp_path) / BATCH_LATE / pkg.MANIFEST_NAME).is_file()
 
 
@@ -3815,10 +3903,10 @@ def test_a_unit_named_like_another_units_staging_directory_cannot_delete_it(tmp_
     code = pkg.main(["--bundle", str(bundle), "--out", str(out), "--quiet", "--json", str(report)])
 
     assert code == pkg.EXIT_UNIT_FAILED, "the alias name is refused, and a refusal is never exit 0"
-    packaged = [row["unit"] for row in json.loads(report.read_text(encoding="utf-8"))["units"]]
-    assert alias not in packaged, "a name that aliases a staging path must never be reported packaged"
-    assert all((out / name).is_dir() for name in packaged), (
-        f"every unit reported packaged must be on disk: {packaged} vs {sorted(p.name for p in out.iterdir())}"
+    assembled = [row["unit"] for row in json.loads(report.read_text(encoding="utf-8"))["assembled"]]
+    assert alias not in assembled, "a name that aliases a staging path must never be reported ASSEMBLED"
+    assert all((out / name).is_dir() for name in assembled), (
+        f"every unit reported ASSEMBLED must be on disk: {assembled} vs {sorted(p.name for p in out.iterdir())}"
     )
     assert (out / victim).is_dir(), "the unit that IS packageable still packages"
 
@@ -4246,8 +4334,11 @@ def test_a_TRUNCATED_ORACLE_still_packages_so_the_entry_gate_can_report_those_pa
     """
     bundle, oracle = _bundle(tmp_path)
     (oracle / "oracle-manifest.json").write_text('{"views": [', encoding="utf-8")
-    assert _cli(tmp_path, bundle, "--unit", UNIT) in {0, pkg.EXIT_NO_WORKING_COPY}
-    assert (_out(tmp_path) / UNIT / "package-manifest.json").is_file()
+    assert _cli(tmp_path, bundle, "--unit", UNIT) == pkg.EXIT_OK
+    record = json.loads((_out(tmp_path) / UNIT / "package-manifest.json").read_text(encoding="utf-8"))
+    assert record["construction_status"] == pkg.STATUS_ASSEMBLED
+    assert record["oracle"]["objects"] == []
+    assert record["dispatch_readiness"]["status"] == pkg.DISPATCH_READINESS_NOT_EVALUATED
 
 
 # --- B3: the declared digest is enforced, and a staged path is read in its OWN flavour --------
@@ -4340,7 +4431,7 @@ def test_a_host_path_the_packager_cannot_classify_is_still_CONTAINED(tmp_path: P
     bundle, _oracle = _bundle(tmp_path)
     _point_partition_at(bundle, literal)
     code = _cli(tmp_path, bundle, "--unit", UNIT)
-    assert code == pkg.EXIT_NOT_SELF_CONTAINED
+    assert code == pkg.EXIT_OK
 
     shipped = "\n".join(path.read_text(encoding="utf-8") for path in (_out(tmp_path) / UNIT / "fabric").rglob("*.tmdl"))
     assert literal not in shipped, "the customer's host path shipped inside the package"
@@ -4389,7 +4480,7 @@ def test_an_unclassifiable_literal_in_an_UNKNOWN_field_is_recorded_and_left_alon
         "\t\t\t\tSource\n",
         encoding="utf-8",
     )
-    assert _cli(tmp_path, bundle, "--unit", UNIT) == pkg.EXIT_NOT_SELF_CONTAINED
+    assert _cli(tmp_path, bundle, "--unit", UNIT) == pkg.EXIT_OK
     shipped = "\n".join(path.read_text(encoding="utf-8") for path in (_out(tmp_path) / UNIT / "fabric").rglob("*.tmdl"))
     assert route in shipped, "an uncatalogued route was rewritten on shape alone"
     assert pkg.UNAVAILABLE_TOKEN not in shipped
@@ -4440,7 +4531,7 @@ def test_a_report_pointing_at_a_model_outside_the_package_is_NOT_self_contained(
     """
     bundle, _ = _bundle(tmp_path)
     _bind_report_to(bundle, "../../Shared/Shared.SemanticModel")
-    assert _cli(tmp_path, bundle, "--unit", UNIT) == pkg.EXIT_NOT_SELF_CONTAINED
+    assert _cli(tmp_path, bundle, "--unit", UNIT) == pkg.EXIT_OK
 
     record = json.loads((_out(tmp_path) / UNIT / "package-manifest.json").read_text(encoding="utf-8"))
     assert record["self_contained"] is False
@@ -4479,7 +4570,7 @@ def test_a_byPath_escaping_through_the_package_root_does_not_count_as_resolved(t
     outside.mkdir(parents=True, exist_ok=True)
     (outside / "model.tmdl").write_text("model Model\n", encoding="utf-8")
     _bind_report_to(bundle, "../../../Shared.SemanticModel")
-    assert _cli(tmp_path, bundle, "--unit", UNIT) == pkg.EXIT_NOT_SELF_CONTAINED
+    assert _cli(tmp_path, bundle, "--unit", UNIT) == pkg.EXIT_OK
 
 
 def test_a_byConnection_report_makes_no_containment_claim(tmp_path: Path) -> None:
@@ -4579,6 +4670,81 @@ def _batch_main(tmp_path: Path, bundle: Path, oracle: Path, report: Path, *extra
     )
 
 
+def _status_result(unit: str) -> dict:
+    """Minimal real-result shape for status-fold controls; construction itself is covered above."""
+    return {
+        "unit": unit,
+        "kind": pkg.KIND_WORKBOOK,
+        "mode": pkg.ASSEMBLY_MODE,
+        "construction_status": pkg.STATUS_ASSEMBLED,
+        "has_engine_working_copy": True,
+        "dispatch_readiness": dict(EXPECTED_DISPATCH_READINESS),
+        "self_contained": True,
+        "oracle": {"objects": [], "route": None},
+        "data_sources": {"binding": None},
+        "notes": [],
+    }
+
+
+def test_eleven_of_fourteen_keeps_the_original_denominator_and_names_every_blocker(  # pylint: disable=too-many-locals
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The customer-shaped 11/14 result is construction-only, explicit, complete and nonzero."""
+    requested = [UNIT, *[f"Status_{index:02d}" for index in range(1, 14)]]
+    assembled_names = requested[:11]
+    crashed, unreadable, edited = requested[11:]
+    bundle, oracle = _bundle(tmp_path)
+    write_engine_report(bundle, workbooks=requested)
+
+    def all_fit(
+        _bundle_root: Path,
+        units: list[str],
+        _out_root: Path,
+        _assets_dir: Path | None,
+        _failed: list[pkg.PackagingError],
+    ) -> tuple[list[str], list[pkg.PathBudget]]:
+        return list(units), []
+
+    def inject_outcomes(*args: object, **_kwargs: object) -> None:
+        selected = args[0]
+        results = args[6]
+        refused = args[7]
+        failed = args[8]
+        assert sorted(selected) == sorted(requested)
+        results.extend(_status_result(unit) for unit in assembled_names)
+        failed.append(pkg.UnitCrashed(crashed, RuntimeError("fixture hard failure")))
+        failed.append(pkg.UnassessableInput(unreadable, ["fixture unreadable input"]))
+        refused.append(pkg.PackageEditsRefused(edited, tmp_path / edited, ["fabric/edit.tmdl"], None))
+
+    monkeypatch.setattr(pkg, "_measure_unit_budgets", all_fit)
+    monkeypatch.setattr(pkg, "_package_each", inject_outcomes)
+    report = tmp_path / "status.json"
+
+    code = _batch_main(tmp_path, bundle, oracle, report)
+    payload = json.loads(report.read_text(encoding="utf-8"))
+    summary = capsys.readouterr().out
+
+    assert code != pkg.EXIT_OK
+    assert payload["requested"] == sorted(requested)
+    assert payload["totals"] == {"requested": 14, "assembled": 11, "blocked": 3}
+    assert [row["unit"] for row in payload["assembled"]] == assembled_names
+    blockers = {row["unit"]: row["blocker"] for row in payload["blocked"]}
+    assert blockers == {
+        crashed: "CONSTRUCTION_FAILED",
+        unreadable: "UNASSESSABLE_INPUT",
+        edited: "PACKAGE_EDITS_REFUSED",
+    }
+    assert payload["accounting_findings"] == []
+    assert payload["dispatch_readiness"]["availability"] == "UNAVAILABLE"
+    assert payload["dispatch_readiness"]["status"] == pkg.DISPATCH_READINESS_NOT_EVALUATED
+    assert "ASSEMBLED: 11/14" in summary
+    assert "BLOCKED: 3/14" in summary
+    assert all(f"BLOCKED {unit}" in summary for unit in (crashed, unreadable, edited))
+    assert pkg.NOT_START_READY_NOTICE in summary
+    assert not re.search(r"(?m)^packaged\b", summary, re.IGNORECASE)
+    assert '"packaged":' not in report.read_text(encoding="utf-8")
+
+
 def test_one_unit_raising_does_not_stop_the_units_after_it(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -4602,16 +4768,16 @@ def test_one_unit_raising_does_not_stop_the_units_after_it(
     assert not (_out(tmp_path) / BATCH_BOOM).exists(), "the failed unit left a package behind"
     assert code == pkg.EXIT_UNIT_FAILED, "a batch with a failed unit exited as if nothing had gone wrong"
 
-    assert [item["unit"] for item in payload["failed"]] == [BATCH_BOOM]
-    assert payload["failed"][0]["state"] == "unit_failed"
-    assert "shutil.Error" in payload["failed"][0]["reason"]
-    assert "shutil.Error" in (payload["failed"][0]["traceback"] or ""), "a crash without its traceback is not a report"
-    assert "WinError 3" not in payload["failed"][0]["reason"]
-    assert BATCH_BOOM not in {item["unit"] for item in payload["units"]}, "a failed unit was reported as packaged"
-    assert f"FAIL {BATCH_BOOM}" in summary
+    assert [item["unit"] for item in payload["blocked"]] == [BATCH_BOOM]
+    assert payload["blocked"][0]["blocker"] == "CONSTRUCTION_FAILED"
+    assert "shutil.Error" in payload["blocked"][0]["reason"]
+    assert "shutil.Error" in (payload["blocked"][0]["traceback"] or ""), "a crash without its traceback is not a report"
+    assert "WinError 3" not in payload["blocked"][0]["reason"]
+    assert BATCH_BOOM not in {item["unit"] for item in payload["assembled"]}
+    assert f"BLOCKED {BATCH_BOOM}" in summary
     assert "WinError 3" not in summary
     assert "UNIT FAILED: 1 unit(s) raised" in summary
-    assert f"OK   {BATCH_LATE}" in summary
+    assert f"ASSEMBLED {BATCH_LATE}" in summary
 
 
 @pytest.mark.parametrize(
@@ -4722,12 +4888,12 @@ def test_a_staging_tree_that_survives_cleanup_fails_its_unit_rather_than_being_a
     payload = json.loads(report.read_text(encoding="utf-8"))
 
     assert code == pkg.EXIT_UNIT_FAILED
-    assert [item["unit"] for item in payload["failed"]] == [BATCH_BOOM]
-    assert "[host location redacted]" in payload["failed"][0]["reason"]
+    assert [item["unit"] for item in payload["blocked"]] == [BATCH_BOOM]
+    assert "[host location redacted]" in payload["blocked"][0]["reason"]
     assert not (out_root / BATCH_BOOM).exists(), "a package was built out of another build's residue"
-    assert sorted(item["unit"] for item in payload["units"]) == [name for name in BATCH_UNITS if name != BATCH_BOOM], (
-        "the residue refusal stopped the rest of the batch"
-    )
+    assert sorted(item["unit"] for item in payload["assembled"]) == [
+        name for name in BATCH_UNITS if name != BATCH_BOOM
+    ], "the residue refusal stopped the rest of the batch"
 
 
 def test_a_residue_found_while_a_unit_is_already_failing_does_not_replace_the_root_cause(
@@ -4766,9 +4932,9 @@ def test_a_residue_found_while_a_unit_is_already_failing_does_not_replace_the_ro
     errors = capsys.readouterr().err
 
     assert code == pkg.EXIT_UNIT_FAILED
-    assert [item["unit"] for item in payload["failed"]] == [BATCH_BOOM]
-    assert "shutil.Error" in payload["failed"][0]["reason"], "the residue message replaced the root cause"
-    assert "[host location redacted]" in (payload["failed"][0]["traceback"] or ""), (
+    assert [item["unit"] for item in payload["blocked"]] == [BATCH_BOOM]
+    assert "shutil.Error" in payload["blocked"][0]["reason"], "the residue message replaced the root cause"
+    assert "[host location redacted]" in (payload["blocked"][0]["traceback"] or ""), (
         "the residue was not recorded at all"
     )
     assert "[host location redacted]" in errors
@@ -4776,7 +4942,7 @@ def test_a_residue_found_while_a_unit_is_already_failing_does_not_replace_the_ro
     assert (_out(tmp_path) / BATCH_LATE / pkg.MANIFEST_NAME).is_file(), "the unit after the failure was skipped"
 
 
-def test_the_batch_buckets_partition_the_request(
+def test_the_construction_states_partition_the_request(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     """Every requested unit is in EXACTLY one bucket, and the totals are measured against the REQUEST.
@@ -4791,21 +4957,19 @@ def test_the_batch_buckets_partition_the_request(
     _batch_main(tmp_path, bundle, oracle, report)
     payload = json.loads(report.read_text(encoding="utf-8"))
     summary = capsys.readouterr().out
-    buckets = (
-        [item["unit"] for item in payload["units"]]
-        + [item["unit"] for item in payload["failed"]]
-        + [item["unit"] for item in payload["refused"]]
-    )
+    buckets = [item["unit"] for item in payload["assembled"]] + [item["unit"] for item in payload["blocked"]]
 
     assert payload["requested"] == BATCH_UNITS
     assert sorted(buckets) == payload["requested"], "a requested unit reached no bucket, or reached two"
     assert len(buckets) == len(set(buckets)) == payload["totals"]["requested"]
-    assert payload["totals"] == {"requested": 4, "units": 3, "failed": 1, "refused": 0, "unaccounted": 0}
-    assert payload["unaccounted"] == []
-    assert "package_unit: 4 unit(s)" in summary, "the denominator shrank to whatever survived the run"
-    assert "packaged 3/4" in summary
-    assert "4 requested = 3 attempted + 1 failed + 0 kept" in summary
-    assert "UNACCOUNTED" not in summary
+    assert payload["totals"] == {"requested": 4, "assembled": 3, "blocked": 1}
+    assert payload["accounting_findings"] == []
+    assert "package_unit: 4 requested unit(s)" in summary
+    assert "ASSEMBLED: 3/4" in summary
+    assert "BLOCKED: 1/4" in summary
+    assert "4 requested = 3 ASSEMBLED + 1 BLOCKED" in summary
+    assert not re.search(r"(?m)^packaged\b", summary, re.IGNORECASE)
+    assert pkg.NOT_START_READY_NOTICE in summary
 
 
 def test_a_requested_unit_in_no_bucket_is_named_rather_than_counted_clean() -> None:
@@ -4814,18 +4978,18 @@ def test_a_requested_unit_in_no_bucket_is_named_rather_than_counted_clean() -> N
     A unit that vanished before it could be recorded anywhere would otherwise shrink the denominator,
     and the run would read as a clean pass over a smaller estate.
     """
-    packaged = [{"unit": "A"}]
+    assembled = [{"unit": "A"}]
     failed = [pkg.UnitCrashed("B", RuntimeError("boom"))]
     refusal = pkg.PackageEditsRefused("C", Path("C"), [], None)
 
-    assert pkg.partition_gaps(["A", "B", "C"], packaged, failed, [refusal]) == []
-    assert pkg.partition_gaps(["A", "B", "C", "D"], packaged, failed, [refusal]) == [
+    assert pkg.partition_gaps(["A", "B", "C"], assembled, failed, [refusal]) == []
+    assert pkg.partition_gaps(["A", "B", "C", "D"], assembled, failed, [refusal]) == [
         {"unit": "D", "state": "not_attempted", "reason": "requested but recorded in no outcome bucket"}
     ]
-    assert pkg.partition_gaps(["A", "B"], packaged, failed, [refusal]) == [
+    assert pkg.partition_gaps(["A", "B"], assembled, failed, [refusal]) == [
         {"unit": "C", "state": "never_requested", "reason": "recorded although it was never requested"}
     ]
-    assert pkg.partition_gaps(["A"], packaged + packaged, [], []) == [
+    assert pkg.partition_gaps(["A"], assembled + assembled, [], []) == [
         {"unit": "A", "state": "recorded_twice", "reason": "recorded in 2 buckets"}
     ]
 
@@ -4836,7 +5000,7 @@ def test_an_unaccounted_unit_is_reported_and_cannot_exit_zero(
     """If the loop ever loses a unit again, the run SAYS so and refuses to exit 0.
 
     `_package_each` is stubbed out entirely, which is the crudest possible version of the defect:
-    every requested unit silently disappears. `packaged 0/1` at exit 0 would be the fail-open shape.
+    every requested unit silently disappears. `ASSEMBLED 0/1` at exit 0 would be the fail-open shape.
     """
     bundle, oracle = _bundle(tmp_path)
     monkeypatch.setattr(pkg, "_package_each", lambda *args, **kwargs: None)
@@ -4846,12 +5010,20 @@ def test_an_unaccounted_unit_is_reported_and_cannot_exit_zero(
     payload = json.loads(report.read_text(encoding="utf-8"))
     summary = capsys.readouterr().out
 
-    assert payload["unaccounted"] == [
+    assert payload["accounting_findings"] == [
         {"unit": UNIT, "state": "not_attempted", "reason": "requested but recorded in no outcome bucket"}
     ]
-    assert payload["totals"] == {"requested": 1, "units": 0, "failed": 0, "refused": 0, "unaccounted": 1}
-    assert "1 requested = 0 attempted + 0 failed + 0 kept + 1 UNACCOUNTED" in summary
-    assert "UNACCOUNTED: 1 requested unit(s)" in summary and UNIT in summary
+    assert payload["totals"] == {"requested": 1, "assembled": 0, "blocked": 1}
+    assert payload["blocked"] == [
+        {
+            "unit": UNIT,
+            "construction_status": pkg.STATUS_BLOCKED,
+            "blocker": "UNATTEMPTED",
+            "reason": "requested but recorded in no outcome bucket",
+        }
+    ]
+    assert "1 requested = 0 ASSEMBLED + 1 BLOCKED" in summary
+    assert f"BLOCKED {UNIT} [UNATTEMPTED]" in summary
     assert code == pkg.EXIT_CANNOT_ASSESS, "a unit nobody can account for left the run clean"
 
 
@@ -4872,10 +5044,11 @@ def test_a_crash_outranks_a_refusal_and_neither_hides_the_other(
     summary = capsys.readouterr().out
 
     assert code == pkg.EXIT_UNIT_FAILED
-    assert [item["unit"] for item in payload["refused"]] == [BATCH_EARLY]
-    assert [item["unit"] for item in payload["failed"]] == [BATCH_BOOM]
-    assert payload["unaccounted"] == []
-    assert "4 requested = 2 attempted + 1 failed + 1 kept" in summary
+    blocked = {item["unit"]: item for item in payload["blocked"]}
+    assert blocked[BATCH_EARLY]["blocker"] == "PACKAGE_EDITS_REFUSED"
+    assert blocked[BATCH_BOOM]["blocker"] == "CONSTRUCTION_FAILED"
+    assert payload["accounting_findings"] == []
+    assert "4 requested = 2 ASSEMBLED + 2 BLOCKED" in summary
     assert edited.is_file(), "the refused unit's edit was destroyed by a batch that continued past it"
 
 
@@ -4911,8 +5084,10 @@ def test_a_single_unit_run_is_unchanged_by_the_batch_contract(
     summary = capsys.readouterr().out
 
     assert code == pkg.EXIT_OK
-    assert payload["requested"] == [UNIT] and payload["failed"] == [] and payload["unaccounted"] == []
-    assert [item["unit"] for item in payload["units"]] == [UNIT]
-    assert "packaged 1/1" in summary
-    assert "1 requested = 1 attempted + 0 failed + 0 kept" in summary
-    assert "FAIL" not in summary and "UNACCOUNTED" not in summary
+    assert payload["requested"] == [UNIT] and payload["blocked"] == [] and payload["accounting_findings"] == []
+    assert [item["unit"] for item in payload["assembled"]] == [UNIT]
+    assert payload["totals"] == {"requested": 1, "assembled": 1, "blocked": 0}
+    assert "ASSEMBLED: 1/1" in summary
+    assert "BLOCKED: 0/1" in summary
+    assert "1 requested = 1 ASSEMBLED + 0 BLOCKED" in summary
+    assert pkg.NOT_START_READY_NOTICE in summary

--- a/tests/test_package_unit_reproductions.py
+++ b/tests/test_package_unit_reproductions.py
@@ -289,7 +289,9 @@ def test_producer_keeps_a_strict_cannot_file_when_policy_is_unparsed(tmp_path: P
     assert (assessment.state, assessment.codes) == ("cannot_establish", ("projection-invalid",))
     assert assessment.source_keys == () and assessment.effective_scope is None
     assert "DATA_ACCESS limitation=brief_policy_not_parsed" in result["notes"]
-    assert result["packaged"] is True and result["self_contained"] is True
+    assert result["construction_status"] == pkg.STATUS_ASSEMBLED
+    assert result["has_engine_working_copy"] is True and result["self_contained"] is True
+    assert result["dispatch_readiness"]["status"] == pkg.DISPATCH_READINESS_NOT_EVALUATED
     assert pkg.pri.verify_s1(package).integrity.is_clean
 
 
@@ -878,7 +880,7 @@ def test_explicit_separate_provider_command_and_no_retroactive_or_sibling_rescue
     bundle, oracle = _shared_bundle(tmp_path)
     out = tmp_path / "out"
     command = _package_command(bundle, oracle, out, UNIT, _brief(tmp_path, UNIT, "report_only_shared_model"))
-    assert pkg.main(command) == 4, "shared binding still does not become package-local containment"
+    assert pkg.main(command) == 0, "a non-self-contained diagnostic package is still ASSEMBLED"
     consumer = out / UNIT
     initial = (consumer / "data-access.json").read_bytes()
     assert pkg.data_access.read_data_access(consumer / "data-access.json").codes == ("provider-missing",)
@@ -886,9 +888,9 @@ def test_explicit_separate_provider_command_and_no_retroactive_or_sibling_rescue
     provider = out / DS_UNIT
     assert pkg.data_access.read_data_access(provider / "data-access.json").state == "local_import_ready"
     assert (consumer / "data-access.json").read_bytes() == initial, "publishing a provider must not reopen consumers"
-    assert pkg.main(command) == 4
+    assert pkg.main(command) == 0
     assert (consumer / "data-access.json").read_bytes() == initial, "a sibling is not an explicit provider"
-    assert pkg.main([*command, "--provider-package", str(provider)]) == 4
+    assert pkg.main([*command, "--provider-package", str(provider)]) == 0
     inherited = pkg.data_access.read_data_access(consumer / "data-access.json")
     assert (inherited.state, inherited.provider_state, inherited.validation, inherited.effective_scope) == (
         "provider_inherited",
@@ -932,12 +934,12 @@ def test_provider_first_ordering_preserves_requested_denominator_and_final_publi
     args = ["--bundle", str(bundle), "--out", str(out), "--oracle", str(oracle), "--json", str(json_path), "--quiet"]
     for unit in selected:
         args.extend(["--unit", unit])
-    assert pkg.main(args) == 4
+    assert pkg.main(args) == 0
     payload = json.loads(json_path.read_text(encoding="utf-8"))
     assert attempted == [DS_UNIT, UNIT], "the alphabetical consumer must wait for the datasource's final swap"
     assert payload["requested"] == [UNIT, DS_UNIT]
-    assert payload["totals"] == {"requested": 2, "units": 2, "failed": 0, "refused": 0, "unaccounted": 0}
-    assert [row["unit"] for row in payload["units"]] == [DS_UNIT, UNIT]
+    assert payload["totals"] == {"requested": 2, "assembled": 2, "blocked": 0}
+    assert [row["unit"] for row in payload["assembled"]] == [UNIT, DS_UNIT]
 
 
 @pytest.mark.parametrize("failure", ["assembly", "budget", "refused"])
@@ -998,9 +1000,12 @@ def test_selected_failed_provider_never_reuses_even_an_explicit_stale_output(
     assert (provider / "package-manifest.json").read_bytes() == prior
     assert pkg.pri.verify_s1(provider).integrity.is_clean
     report = json.loads(json_path.read_text(encoding="utf-8"))
-    assert report["requested"] == [UNIT, DS_UNIT] and report["unaccounted"] == []
-    assert [row["unit"] for row in report["units"]] == [UNIT]
-    assert [row["unit"] for row in report["refused" if failure == "refused" else "failed"]] == [DS_UNIT]
+    assert report["requested"] == [UNIT, DS_UNIT] and report["accounting_findings"] == []
+    assert [row["unit"] for row in report["assembled"]] == [UNIT]
+    assert [row["unit"] for row in report["blocked"]] == [DS_UNIT]
+    assert report["blocked"][0]["blocker"] == (
+        "PACKAGE_EDITS_REFUSED" if failure == "refused" else "CONSTRUCTION_FAILED"
+    )
 
 
 @pytest.mark.usefixtures("desktop")

--- a/tests/test_package_unit_reproductions.py
+++ b/tests/test_package_unit_reproductions.py
@@ -938,8 +938,17 @@ def test_provider_first_ordering_preserves_requested_denominator_and_final_publi
     payload = json.loads(json_path.read_text(encoding="utf-8"))
     assert attempted == [DS_UNIT, UNIT], "the alphabetical consumer must wait for the datasource's final swap"
     assert payload["requested"] == [UNIT, DS_UNIT]
-    assert payload["totals"] == {"requested": 2, "assembled": 2, "blocked": 0}
-    assert [row["unit"] for row in payload["assembled"]] == [UNIT, DS_UNIT]
+    assert payload["totals"] == {
+        "requested": 2,
+        "units": 2,
+        "failed": 0,
+        "refused": 0,
+        "unaccounted": 0,
+        "assembled": 2,
+        "blocked": 0,
+    }
+    assert [row["unit"] for row in payload["units"]] == [DS_UNIT, UNIT]
+    assert [row["unit"] for row in payload["construction"]["assembled"]] == [DS_UNIT, UNIT]
 
 
 @pytest.mark.parametrize("failure", ["assembly", "budget", "refused"])
@@ -1000,11 +1009,13 @@ def test_selected_failed_provider_never_reuses_even_an_explicit_stale_output(
     assert (provider / "package-manifest.json").read_bytes() == prior
     assert pkg.pri.verify_s1(provider).integrity.is_clean
     report = json.loads(json_path.read_text(encoding="utf-8"))
-    assert report["requested"] == [UNIT, DS_UNIT] and report["accounting_findings"] == []
-    assert [row["unit"] for row in report["assembled"]] == [UNIT]
-    assert [row["unit"] for row in report["blocked"]] == [DS_UNIT]
-    assert report["blocked"][0]["blocker"] == (
-        "PACKAGE_EDITS_REFUSED" if failure == "refused" else "CONSTRUCTION_FAILED"
+    assert report["requested"] == [UNIT, DS_UNIT] and report["unaccounted"] == []
+    assert [row["unit"] for row in report["construction"]["assembled"]] == [UNIT]
+    assert [row["unit"] for row in report["construction"]["blocked"]] == [DS_UNIT]
+    assert report["construction"]["blocked"][0]["reason_code"] == (
+        "package_edits_refused"
+        if failure == "refused"
+        else ("unit_exception" if failure == "assembly" else "construction_failed")
     )
 
 


### PR DESCRIPTION
## Scope

Implements the plan-approved **status-only** slice of #614.

- Construction states are `ASSEMBLED` and `BLOCKED` against the immutable requested denominator.
- `ASSEMBLED` means a diagnostic package directory was constructed, even when it has no working copy, is not self-contained, is unbound, or lacks oracle evidence.
- Human output, batch JSON, and package manifests explicitly report dispatch readiness as unavailable / `NOT_EVALUATED` and print `NOT START_READY`.
- `--assemble-only` is an explicit alias/status marker for the command's existing assembly-only behavior; it creates no alternate construction path or dispatch authorization.
- Binding, reseal, and actionable `START_READY` remain entirely in #622 and the final #562 consumer.

Refs #614

## Exact base / head

- Implementation base: `deec6537194038f8be3b25d0aa984c2afd536dd7`
- Status implementation commit: `65209b72b36359bdd7d8b17d91ded1f000313575`
- Integration merge: `8323820de0d342e7835db798fee0f980084ef4b5`
- R1 head: `36846c5292136cddb4174828755b98f6d6844be6`
- Frozen-scope final head: `ea6b3e75e79fbec153220259eb942f48a8450b9c`
- Merge parents: `65209b72b36359bdd7d8b17d91ded1f000313575` + `e17c2055d19f5d3ed4473b4796075f24b53a1b6b`
- Target branch: `master` at `e17c2055d19f5d3ed4473b4796075f24b53a1b6b`, merged once with history preserved

## File surface

Production:
- `scripts/package_unit.py`

Tests:
- `tests/test_package_unit.py`
- `tests/test_package_unit_reproductions.py`
- `tests/mutate_package_unit.py`

Documentation:
- `README.md`
- `scripts/README.md`
- `docs/migration-phases.md`
- `docs/reference-readiness.md`

Direct inspection found no package-status ownership in `scripts/run_estate.py`, so it is unchanged. `scripts/check_reference_readiness.py` is unchanged.

## Denominator and classification controls

- All requested units assembled: exact `ASSEMBLED N/N`, `BLOCKED 0/N`, exit 0, readiness not evaluated.
- Customer-shaped partial fold: exact `ASSEMBLED 11/14`, `BLOCKED 3/14`; hard failure, `UnassessableInput`, and `PackageEditsRefused` are each named; exit is nonzero.
- Unattempted requests become named `BLOCKED [UNATTEMPTED]` rows without denominator shrinkage.
- A constructed package with no engine working copy, non-self-contained data/model binding, unbound package data, or missing/truncated oracle remains `ASSEMBLED` diagnostic output and never `START_READY`.
- Human and JSON totals are derived from the same fold; the old bare `packaged` state/key is absent.
- Three independent mutations break (1) denominator, (2) ASSEMBLED/BLOCKED classification, and (3) partial-batch nonzero exit. Each fails its intended assertion; the no-op control survives.

## Validation

All commands were judged by exit code.

- `ruff format` + `ruff check --fix` on all changed Python files: exit 0.
- `pylint scripts/package_unit.py`: exit 0.
- Changed tests linted at exit 0 with only their pre-existing file-level debt categories excluded; comparison against the exact base showed no new pylint finding classes/counts.
- Focused package suites: `349 passed, 1 skipped`, exit 0.
- Direct status controls: `14 passed`, exit 0.
- #614 mutation slice: `3/3 mutations caught`; negative control survived, exit 0.
- Navigation index check: exit 0.
- Host-path check: exit 0.
- Full serial gate of record: `8975 passed, 16 skipped, 16 deselected`, exit 0.

The full serial run used an ignored, dummy-endpoint `multi-source-live.twbx` generated only to avoid a pre-existing Windows expected-skip path-separator mismatch; it and all validation logs/caches were removed afterward.

## Could not verify

- No independent code review was performed; this PR is intentionally draft.
- No real customer 14-unit estate was assembled; the 11/14 control drives the production status fold with explicit outcome objects, while real construction/continuation is covered by the focused package suites.
- The parallel tier could not produce a verdict because an unrelated gzip timestamp is embedded in a parametrized test ID, causing xdist workers to collect different node IDs. The serial gate of record passed.
- Dispatch binding/reseal/readiness and live credential authorization were not tested or changed; they are out of scope for this slice.

## Three review questions

1. Does every path through `construction_outcomes` put each originally requested unit in exactly one `ASSEMBLED` or `BLOCKED` row without shrinking the denominator?
2. Can any human line, batch JSON field, package-manifest field, or `--assemble-only` behavior still be read as actionable `START_READY` or as credential-gate authorization?
3. Did retiring exit 1/4 as construction failures preserve the existing per-unit continuation, provider ordering, guarded swap/edit preservation, and data-access projection while keeping all #622 binding/reseal behavior out of this PR?


## Integration-only pass

- Merged `origin/master` once with history preserved; merge commit `8323820de0d342e7835db798fee0f980084ef4b5` has parents `65209b72b36359bdd7d8b17d91ded1f000313575` and `e17c2055d19f5d3ed4473b4796075f24b53a1b6b`.
- Conflicts: **0** (`git ls-files -u` empty).
- Master added only `docs/reference-capture.md`, `scripts/capture_tableau_oracle.py`, and `tests/test_capture_tableau_oracle_parallel.py`.
- All eight #614 status-slice blobs are byte-identical to commit `65209b72`; specifically `scripts/package_unit.py` and its three changed test files retained exact blob IDs `ccaaee6f...`, `e3cd9a6a...`, `b49597e3...`, and `17631b89...`.
- Focused package suites: `349 passed, 1 skipped`, exit 0.
- Full serial gate: `9016 passed, 16 skipped, 16 deselected`, exit 0.
- Status mutations: `3/3` caught; negative control survived, exit 0.
- Ruff ritual, scoped pylint, navigation, privacy/host-path, clean-tree and blob-equality gates: exit 0.
- Exact-tip CI run `34666738327` evaluated head `8323820de0d342e7835db798fee0f980084ef4b5`: `checks`, `engine-integration`, and `windows-bundle` passed; conditional `engine-drift` skipped.

No #622 binding/reseal/START_READY/readiness logic was changed. This remains a draft awaiting blind review.


## R1 bounded correction

Head: `36846c5292136cddb4174828755b98f6d6844be6`.

- Restored the ordered compatibility `units` / `failed` / `refused` / `unaccounted` buckets and legacy totals under the existing `package-unit` identifier. They are explicitly marked construction-only. `construction` is the single ASSEMBLED/BLOCKED projection, and provider-first result ordering is preserved.
- Restored the legacy manifest `packaged` boolean as an adjacent-documented alias for engine-working-copy presence; no human output uses `packaged` as a success state.
- Added pre-write/pre-budget blocking for repeated `--unit`, exact duplicate engine rows, workbook/datasource same-name collisions, and Windows-canonical destination aliases (`Book`/`book`), including explicit selection of only one aliased engine identity.
- Swap interruption state is armed before publication and classified from the post-rename filesystem. Published packages remain ASSEMBLED; handled interruptions overwrite prior JSON, identify interrupted/unattempted units, and remain nonzero. Rollback failure cannot replace `KeyboardInterrupt`.
- Persisted failures now carry stable `reason_code` / `exception_class` and code-owned traceback frames only; raw exception messages, URLs, queries and tokens are withheld.
- Removed the filtered-list brief-cardinality check; only the original requested list is validated.
- Replaced the synthetic 11/14 proof with 11 real package constructions/guarded swaps plus real hard-failure, unassessable-input and edit-refusal boundaries.
- Generated and top-level package documentation now states that source, rows, working copy and reference evidence are conditional.

Validation by exit code:

- Python ritual and scoped pylint: pass.
- Focused package suites: `359 passed, 1 skipped`.
- Full serial suite: `9026 passed, 16 skipped, 16 deselected`.
- #614 mutations: `3/3` caught against the exact real 11/14 assertions; negative control survived.
- Navigation and host-path/privacy gates: pass.
- Exact-tip CI run `34673600511` evaluated `36846c5292136cddb4174828755b98f6d6844be6`: `checks`, `engine-integration`, and `windows-bundle` passed; conditional `engine-drift` skipped.

No #622 binding, reseal, actionable START_READY, or readiness-consumer logic changed. The PR remains draft for blind review.


## Frozen publication-boundary correction

Head: `ea6b3e75e79fbec153220259eb942f48a8450b9c`.

Only `scripts/package_unit.py`, `tests/test_package_unit.py`, and `tests/mutate_package_unit.py` changed.

- `package_unit()` now owns KeyboardInterrupt classification across assembly, `replace_dir()`, scratch cleanup, and its return boundary.
- Published status requires the exact candidate manifest digest, a clean final S1 verification, absent staging, and no discoverable staging/retired package manifest.
- A post-rename interruption cleans the reserved retired tree or removes/hides its discovery marker before status is emitted. Physical manifest count and `check_migration_progress.discover_package_roots()` both prove only the final package remains discoverable.
- Cleanup/rollback failures retain the original KeyboardInterrupt and may add only a stable `secondary_code`.
- Exact line-trace controls cover the line after `replace_dir()` returns and the line immediately after the publish rename. Pre-publication interruption, stale JSON replacement, and unattempted-tail behavior remain covered.
- Added one mutation arm that disables retired-manifest cleanup; the exact physical/discovery assertion fails.

Validation by exit code:

- Python ritual and scoped pylint: pass.
- Focused package suites: `360 passed, 1 skipped`.
- Full serial suite: `9027 passed, 16 skipped, 16 deselected` (the first run had one transient copied-skill failure; its isolated rerun and the complete rerun passed).
- #614 mutations: `4/4` caught; negative control survived.
- Exact-tip CI run `34678492628` evaluated `ea6b3e75e79fbec153220259eb942f48a8450b9c`: `checks`, `engine-integration`, and `windows-bundle` passed; conditional `engine-drift` skipped.

No #622, readiness, schema, identity, status-fold, provider-order, or other production surface changed. The PR remains draft for blind review.
