### PR TITLE
Correct issued S2 handoff authority and topology applicability (Refs #562)

### DIFF
--- a/scripts/package_role_identity.py
+++ b/scripts/package_role_identity.py
@@ -379,6 +379,7 @@ class Phase1RoleIdentityResult:  # pylint: disable=too-many-instance-attributes
         The caller cannot substitute a root or obtain an undeclared file by its familiar name.
         S1 rechecks only the two small roles and manifest, not unrelated asset content. The held
         spec is not reparsed/reclassified. Copies cannot borrow the original role result's authority.
+        Renewal requires fresh S1 and S2, not a fresh S1 grafted into the issued S2 result.
         """
         verified = self.verified
         if type(verified) is not VerifiedPackage or not verified.is_bound_to(str(root)):
@@ -456,8 +457,9 @@ class VerifiedPackage:
 
 
 def _handoff_authority_state(result: Phase1RoleIdentityResult) -> tuple:
-    """The role/fact consistency binding, without re-running any role or connection classifier."""
+    """Capture scalar role/fact values without re-running any role or connection classifier."""
     snapshot = result._data_access_snapshot  # pylint: disable=protected-access
+    identity, policy = result.source_identity, result.brief_policy
     return (
         result.verdict,
         result.unit,
@@ -466,7 +468,15 @@ def _handoff_authority_state(result: Phase1RoleIdentityResult) -> tuple:
         result.blockers,
         result.authorized_limitations,
         tuple((row.role, row.state, row.cardinality, row.paths, row.code) for row in result.roles),
-        result.source_identity,
+        (
+            identity.kind,
+            identity.sha256,
+            identity.tableau_luid,
+            identity.published_key,
+            identity.revision,
+        )
+        if identity is not None
+        else None,
         tuple(
             (
                 row.state,
@@ -479,7 +489,7 @@ def _handoff_authority_state(result: Phase1RoleIdentityResult) -> tuple:
             )
             for row in result.dependencies
         ),
-        result.brief_policy,
+        (policy.requested_scope, policy.fallback_authorization) if policy is not None else None,
         snapshot.declared,
         (snapshot.spec.relative_path, snapshot.spec.sha256, snapshot.spec.root_identity),
     )
@@ -1462,7 +1472,7 @@ def _assess_roles(facts: _Facts) -> None:
 
 
 def _verdict(facts: _Facts) -> Phase1RoleIdentityResult:
-    """Fold assessed local roles and the cohort's dependency rows without dropping either."""
+    """Fold assessed roles and dependencies, then contextualize the already-derived source facts."""
     topology = facts.topology or _topology(facts)
     roles = list(facts.roles)
     for row in facts.dependencies:
@@ -1478,6 +1488,24 @@ def _verdict(facts: _Facts) -> Phase1RoleIdentityResult:
     if topology == TOPOLOGY_PUBLISHED_CONSUMER and not facts.dependencies:
         roles.append(_role(ROLE_PUBLISHED_DEPENDENCY, STATE_MISSING, "1 provider", [], CODE_PROVIDER_MISSING))
     blockers = [*facts.blockers, *(role.code or role.state for role in roles if role.blocks)]
+    spec_facts = facts.spec_facts
+    if spec_facts is not None:
+        sources = facts.spec_document.get("data_sources") if isinstance(facts.spec_document, Mapping) else None
+        # Self-publication metadata is not a proxy leg; only applicability depends on cohort topology.
+        spec_facts = spec_facts._replace(
+            direct_applicable=(
+                topology in (TOPOLOGY_OWNED_MODEL, TOPOLOGY_STANDALONE_DATASOURCE, TOPOLOGY_PUBLISHED_PROVIDER)
+                and spec_facts.refusal_code is None
+                and isinstance(sources, list)
+                and all(
+                    isinstance(row, Mapping)
+                    and isinstance(row.get("connection", {}), Mapping)
+                    and (row.get("connection", {}).get("class") or "").casefold() != "sqlproxy"
+                    for row in sources
+                )
+            ),
+            published_only=topology == TOPOLOGY_PUBLISHED_CONSUMER and spec_facts.published_only,
+        )
     result = Phase1RoleIdentityResult(
         verdict=VERDICT_BLOCKED if blockers else VERDICT_START_READY,
         unit=facts.unit,
@@ -1501,10 +1529,10 @@ def _verdict(facts: _Facts) -> Phase1RoleIdentityResult:
             _DataAccessSnapshot(
                 facts.verified.integrity,
                 facts.spec_member,
-                facts.spec_facts,
+                spec_facts,
                 facts.artifacts.get("data_access") == DATA_ACCESS_NAME,
             )
-            if facts.spec_member is not None and facts.spec_facts is not None
+            if facts.spec_member is not None and spec_facts is not None
             else None
         ),
     )
@@ -1514,6 +1542,7 @@ def _verdict(facts: _Facts) -> Phase1RoleIdentityResult:
         state = _handoff_authority_state(result)
         source_facts = snapshot.facts
         verified = result.verified
+        issued_integrity = verified.integrity
         object.__setattr__(
             result,
             "_authority",
@@ -1521,6 +1550,9 @@ def _verdict(facts: _Facts) -> Phase1RoleIdentityResult:
                 owner() is candidate
                 and candidate.verified is verified
                 and candidate._data_access_snapshot is snapshot  # pylint: disable=protected-access
+                and candidate.verified.integrity is issued_integrity
+                and snapshot.integrity is issued_integrity
+                and issued_integrity.has_read_authority()
                 and snapshot.facts is source_facts
                 and _handoff_authority_state(candidate) == state
             ),

--- a/scripts/package_role_identity.py
+++ b/scripts/package_role_identity.py
@@ -1500,7 +1500,7 @@ def _verdict(facts: _Facts) -> Phase1RoleIdentityResult:
                 and all(
                     isinstance(row, Mapping)
                     and isinstance(row.get("connection", {}), Mapping)
-                    and (row.get("connection", {}).get("class") or "").casefold() != "sqlproxy"
+                    and row.get("connection", {}).get("class") != "sqlproxy"
                     for row in sources
                 )
             ),

--- a/tests/test_package_start_handoffs.py
+++ b/tests/test_package_start_handoffs.py
@@ -932,6 +932,41 @@ def test_published_provider_applicability_uses_final_cohort_topology(
         assert results[1].topology == "published_consumer" and results[1].dependencies[0].provider_ordinal == 0
 
 
+@pytest.mark.parametrize("publication_metadata", [False, True])
+@pytest.mark.parametrize("selected", [False, True])
+def test_mixed_case_sqlproxy_retains_canonical_direct_applicability(
+    tmp_path: Path, publication_metadata: bool, selected: bool
+) -> None:
+    rows = source_rows({**PUBLISHED["connection"], "class": "SQLPROXY"})
+    if publication_metadata:
+        rows[0]["published_datasource"] = {"luid": DS_LUID, "key": PUBLISHED_KEY}
+    canonical = gate.package_spec_facts({"data_sources": rows})
+    assert tuple(canonical) == ((), False, not publication_metadata, False, None)
+    assert canonical.all_flat is (not publication_metadata)
+    provider = with_data_access(datasource_package(tmp_path / "Provider", unit="Shared"), rows)
+    roots = [provider]
+    if selected:
+        roots.append(
+            with_data_access(
+                workbook_package(
+                    tmp_path / "Consumer",
+                    published={"luid": DS_LUID, "key": PUBLISHED_KEY},
+                    binding="../../../Provider/fabric/Shared.SemanticModel",
+                ),
+                [PUBLISHED],
+            )
+        )
+    results = pri.verify_phase1_role_identity(roots)
+    assert all(result.is_start_ready for result in results)
+    assert results[0].topology == ("published_provider" if selected else "standalone_datasource")
+    facts = require_handoff(results[0].data_access_handoff(provider)).facts
+    assert tuple(facts) == ((), False, True, False, None)
+    assert facts.all_flat
+    if selected:
+        assert results[1].topology == "published_consumer" and results[1].dependencies[0].provider_ordinal == 0
+        assert require_handoff(results[1].data_access_handoff(roots[1])).facts.published_only
+
+
 @pytest.mark.parametrize(
     "additional,keys,review",
     [(None, (), False), (LIVE, (LIVE_KEY,), False), (REVIEW, (), True)],

--- a/tests/test_package_start_handoffs.py
+++ b/tests/test_package_start_handoffs.py
@@ -812,3 +812,183 @@ def test_r1_member_read_does_not_claim_fresh_integrity_for_unrelated_content(tmp
     (package / SPEC).write_bytes(b"unrelated changed content")
     assert require_held(pfs.read_verified_member(package, original, PROJECTION)).content == b'{"held":true}\r\n'
     assert verify(package).first_code == "package_file_digest_mismatch"
+
+
+@pytest.mark.parametrize(
+    "member,field,value",
+    [
+        ("source_identity", "kind", "workbook"),
+        ("source_identity", "sha256", "0" * 64),
+        ("source_identity", "tableau_luid", WB_LUID),
+        ("source_identity", "published_key", "HANDOFF_PRIVATE_KEY"),
+        ("source_identity", "revision", "HANDOFF_PRIVATE_REVISION"),
+        ("brief_policy", "requested_scope", "model_and_report"),
+        ("brief_policy", "fallback_authorization", "model_only_unvalidated"),
+    ],
+)
+def test_issued_s2_binds_each_source_and_brief_scalar(tmp_path: Path, member: str, field: str, value: str) -> None:
+    package = with_data_access(datasource_package(tmp_path / "Source"), source_rows(LIVE), LIVE_PROJECTION)
+    original = pri.verify_phase1_role_identity([package])[0]
+    require_handoff(original.data_access_handoff(package))
+    component = getattr(original, member)
+    assert getattr(component, field) != value
+    object.__setattr__(component, field, value)
+    assert getattr(original, member) is component and original.is_start_ready
+    refused = original.data_access_handoff(package)
+    assert_refusal(refused, "package_member_not_verified")
+    assert "HANDOFF_PRIVATE" not in json.dumps(refused.as_dict())
+
+
+def test_issued_s2_preserves_absent_brief_policy(tmp_path: Path) -> None:
+    package = with_data_access(datasource_package(tmp_path / "Source", luid=None), source_rows(FLAT))
+    (package / "migration-brief.md").write_text("Migrate it.\n", encoding="utf-8")
+    seal(package, **json.loads((package / "package-manifest.json").read_bytes()))
+    original = pri.verify_phase1_role_identity([package])[0]
+    assert original.is_start_ready and original.brief_policy is None
+    assert (original.source_identity.tableau_luid, original.source_identity.published_key) == (None, None)
+    assert require_handoff(original.data_access_handoff(package)).facts.all_flat
+    object.__setattr__(original, "brief_policy", pri.BriefPolicy("model_only", "stop"))
+    assert_refusal(original.data_access_handoff(package), "package_member_not_verified")
+
+
+def test_fresh_s1_cannot_renew_stale_s2_by_grafting_both_integrity_references(tmp_path: Path) -> None:
+    package = with_data_access(datasource_package(tmp_path / "Source"), source_rows(LIVE), LIVE_PROJECTION)
+    stale = pri.verify_phase1_role_identity([package])[0]
+    held = require_handoff(stale.data_access_handoff(package))
+    wrapper, snapshot = stale.verified, stale._data_access_snapshot
+    issued_integrity = wrapper.integrity
+    brief = package / "migration-brief.md"
+    before = brief.read_bytes()
+    after = before.replace(b'fallback_authorization = "stop"', b'fallback_authorization = "model_only_unvalidated"')
+    assert after != before
+    brief.write_bytes(after)
+    seal(package, **json.loads((package / "package-manifest.json").read_bytes()))
+    fresh_s1 = pri.verify_s1(package)
+    assert fresh_s1.integrity.is_clean and fresh_s1.integrity.has_read_authority()
+    assert fresh_s1.integrity is not issued_integrity
+    assert require_held(fresh_s1.read_verified_member(package, SPEC)).content == held.migration_spec.content
+    assert require_held(fresh_s1.read_verified_member(package, PROJECTION)).content == held.data_access.content
+    object.__setattr__(wrapper, "integrity", fresh_s1.integrity)
+    object.__setattr__(snapshot, "integrity", fresh_s1.integrity)
+    assert stale.verified is wrapper and stale._data_access_snapshot is snapshot
+    assert stale.brief_policy.fallback_authorization == "stop"
+    assert_refusal(stale.data_access_handoff(package), "package_member_not_verified")
+
+    renewed = pri.verify_phase1_role_identity([package], verified=[fresh_s1])[0]
+    assert renewed.is_start_ready and renewed.brief_policy.fallback_authorization == "model_only_unvalidated"
+    assert renewed.verified.integrity is not fresh_s1.integrity
+    assert require_handoff(renewed.data_access_handoff(package)).facts.live_source_keys == (LIVE_KEY,)
+
+
+def test_issued_s2_requires_its_integrity_to_retain_read_authority(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    package = with_data_access(datasource_package(tmp_path / "Source"), source_rows(FLAT))
+    original = pri.verify_phase1_role_identity([package])[0]
+    require_handoff(original.data_access_handoff(package))
+    integrity = original.verified.integrity
+    object.__setattr__(integrity, "files_verified", 0)
+    assert original._data_access_snapshot.integrity is integrity and not integrity.has_read_authority()
+
+    def forbidden(*_args: object, **_kwargs: object) -> None:
+        pytest.fail("an S2 capability with inconsistent issuing S1 authority reached a member read")
+
+    monkeypatch.setattr(pfs, "read_verified_member", forbidden)
+    assert_refusal(original.data_access_handoff(package), "package_member_not_verified")
+
+
+@pytest.mark.parametrize("connection,keys,all_flat", [(FLAT, (), True), (LIVE, (LIVE_KEY,), False)])
+@pytest.mark.parametrize("selected", [False, True])
+def test_published_provider_applicability_uses_final_cohort_topology(
+    tmp_path: Path, connection: dict, keys: tuple[str, ...], all_flat: bool, selected: bool
+) -> None:
+    rows = [{**source_rows(connection)[0], "published_datasource": {"luid": DS_LUID, "key": PUBLISHED_KEY}}]
+    provider = with_data_access(
+        datasource_package(tmp_path / "Provider", unit="Shared", published_key=PUBLISHED_KEY), rows
+    )
+    roots = [provider]
+    if selected:
+        roots.append(
+            with_data_access(
+                workbook_package(
+                    tmp_path / "Consumer",
+                    published={"luid": DS_LUID, "key": PUBLISHED_KEY},
+                    binding="../../../Provider/fabric/Shared.SemanticModel",
+                ),
+                [PUBLISHED],
+            )
+        )
+    canonical = gate.package_spec_facts({"data_sources": rows})
+    assert tuple(canonical) == (keys, False, False, False, None), "the one-argument canonical API must not change"
+    results = pri.verify_phase1_role_identity(roots)
+    assert all(result.is_start_ready for result in results)
+    provider_result = results[0]
+    assert provider_result.topology == ("published_provider" if selected else "standalone_datasource")
+    assert provider_result.source_identity.published_key == PUBLISHED_KEY
+    facts = require_handoff(provider_result.data_access_handoff(provider)).facts
+    assert tuple(facts) == (keys, False, True, False, None)
+    assert facts.all_flat is all_flat
+    if selected:
+        assert results[1].topology == "published_consumer" and results[1].dependencies[0].provider_ordinal == 0
+
+
+@pytest.mark.parametrize(
+    "additional,keys,review",
+    [(None, (), False), (LIVE, (LIVE_KEY,), False), (REVIEW, (), True)],
+)
+def test_consumer_applicability_preserves_strict_proxy_and_mixed_canonical_facts(
+    tmp_path: Path, additional: dict | None, keys: tuple[str, ...], review: bool
+) -> None:
+    provider = with_data_access(datasource_package(tmp_path / "Provider", unit="Shared"), source_rows(FLAT))
+    rows = [PUBLISHED, *(source_rows(additional) if additional is not None else [])]
+    consumer = with_data_access(
+        workbook_package(
+            tmp_path / "Consumer",
+            published={"luid": DS_LUID, "key": PUBLISHED_KEY},
+            binding="../../../Provider/fabric/Shared.SemanticModel",
+        ),
+        rows,
+    )
+    canonical = gate.package_spec_facts({"data_sources": rows})
+    assert tuple(canonical) == (keys, review, False, additional is None, None)
+    results = pri.verify_phase1_role_identity([provider, consumer])
+    assert all(result.is_start_ready for result in results)
+    assert results[0].topology == "published_provider" and results[1].topology == "published_consumer"
+    facts = require_handoff(results[1].data_access_handoff(consumer)).facts
+    assert tuple(facts) == (keys, review, False, additional is None, None)
+    assert not facts.all_flat
+
+
+def test_datasource_proxy_cannot_borrow_consumer_applicability(tmp_path: Path) -> None:
+    package = with_data_access(datasource_package(tmp_path / "Source"), [PUBLISHED])
+    assert tuple(gate.package_spec_facts({"data_sources": [PUBLISHED]})) == ((), False, False, True, None)
+    result = pri.verify_phase1_role_identity([package])[0]
+    assert result.is_start_ready and result.topology == "standalone_datasource"
+    facts = require_handoff(result.data_access_handoff(package)).facts
+    assert tuple(facts) == ((), False, False, False, None)
+    assert not facts.all_flat
+
+
+def test_handoff_consistency_refusal_preserves_private_policy_and_public_shapes(tmp_path: Path) -> None:
+    package = with_data_access(datasource_package(tmp_path / "Source", luid=None), source_rows(LIVE), LIVE_PROJECTION)
+    result = pri.verify_phase1_role_identity([package])[0]
+    handoff = require_handoff(result.data_access_handoff(package))
+    public_role, public_integrity = result.as_dict(), result.verified.integrity.as_dict()
+    assert set(public_role["source_identity"]) == {"kind", "sha256", "tableau_luid", "published_key"}
+    assert set(public_integrity) == {"status", "files_declared", "files_verified", "findings", "unassessable"}
+    assert tuple(field.name for field in fields(handoff)) == ("migration_spec", "facts", "data_access")
+    assert handoff.facts._fields == (
+        "live_source_keys",
+        "has_review",
+        "direct_applicable",
+        "published_only",
+        "refusal_code",
+    )
+    object.__setattr__(result.brief_policy, "fallback_authorization", "HANDOFF_PRIVATE credential endpoint")
+    refused = result.data_access_handoff(package)
+    assert_refusal(refused, "package_member_not_verified")
+    assert result.as_dict() == public_role and result.verified.integrity.as_dict() == public_integrity
+    assert set(refused.as_dict()) == set(public_integrity)
+    assert set(refused.as_dict()["findings"][0]) == {"code", "detail"}
+    serialized = json.dumps(refused.as_dict())
+    assert "HANDOFF_PRIVATE" not in serialized and str(package) not in serialized


### PR DESCRIPTION
## Bounded post-merge correction

Refs #562. Corrects the independently plan-approved findings in merged PR #615; **not the final START_READY consumer**.

- Exact base: `f48a2cf2b2b4b10b5b9a162a8ec604b372d2b8f4`
- Exact head: `19045d612dcfbb6dad413c64ee90c37bd180a74b`
- Branch: `fix/start-ready-handoff-authority-562`
- Exact two-file surface: `scripts/package_role_identity.py` and `tests/test_package_start_handoffs.py` (253 insertions, 6 deletions).

### Correction

1. Reuse `_handoff_authority_state()` and its weak-owner closure. Capture SourceIdentity's five scalar values and BriefPolicy's two scalar values, preserving explicit `None`. Bind both integrity references to the exact S1 object held at issuance and require that object's continuing read authority. Retain original result/wrapper/snapshot ownership and held-member/digest checks. Fresh S1 grafted under stale S2 refuses; fresh complete S1+S2 renews.
2. In `_verdict()`, after final cohort topology, contextualize **only** `direct_applicable` and `published_only` from the already-parsed rows/facts. Real nonproxy flat/live provider rows remain direct despite self-publication metadata. Only a strict proxy consumer is published-only; proxy mixtures and a proxy datasource gain neither applicability. Canonical live keys, review and refusal facts are preserved, without reparsing, reclassification or key filtering.

### R1 correction-only delta

Correction parent: `3d4e5eada9fba12228989c9354eefce5cb5fca70`. The delta is **one production line replaced and 35 test lines added**, still only the two approved files.

Restore the canonical exact case-sensitive comparison with `sqlproxy`; do not casefold the class. `SQLPROXY` plus `flat_file` must not become a proxy in S2 when the unchanged canonical authority does not classify it that way. Four direct controls cross publication metadata absent/present with standalone/selected-provider topology. They assert literal canonical facts and the intended final-topology/direct/all-flat behavior. Canonical keys/review/refusal and all other applicability/cardinality/identity rules are unchanged. The existing lowercase proxy controls remain intact. Reviewer follow-up is limited to this reproduction.

### Current-head controls and exit-code verification

- Before the one-line correction: **4 intended assertion failures**, all at the incorrect direct-applicability flag, not setup/import failures.
- Current-head combined focused and adjacent S1/S2/source/readiness/package/data-access suites: **1,592 passed, 5 expected platform skips** in **606.56 s**. This includes the 138-case focused handoff file and the unchanged adjacent suites. Skips are Windows symlink privilege, case-insensitive spelling and POSIX FIFO controls.
- Both changed files: `ruff format`, `ruff check --fix`, and `pylint` exited **0**; Pylint **10.00/10**. `git diff --check` passed.
- Exact-tip hosted CI: **SUCCESS on attempt 1**, explicit `workflow_dispatch` run **34685410166** at `19045d612dcfbb6dad413c64ee90c37bd180a74b`. `gh run watch --exit-status` exited **0**; no retry.
  - Main full suite: **8,940 passed, 126 skipped, 16 GUI deselected** in **1,006.66 s**. All required lint/contract/privacy/model/navigation steps passed.
  - Windows bundle: **412 passed, 3 expected skips, 16 GUI deselected**; signing-policy controls: **84 passed**; GUI opt-in: **16 passed**.
  - Pinned engine integration: **111 passed**; upstream-drift job: **111 passed**.
  - Separate current-head PR workflow **34685357294** also passed all applicable checks without a retry; its schedule/dispatch-only engine-drift job was skipped as configured.

The original controls remain: every SourceIdentity/BriefPolicy scalar changes independently and requires exact `package_member_not_verified`; genuinely fresh S1 graft refusal versus complete S1+S2 renewal; continuing read authority; absent policy; flat/live provider topology; strict/mixed proxy consumers; privacy and public shapes. Existing copy/deepcopy/replace/reconstruction, role/dependency, missing/ambiguous provider, malformed and large-asset matrices are reused unchanged.

**Prior-head CI history, not current-head credit:** at `3d4e5eada9fba12228989c9354eefce5cb5fca70`, exact-tip run **34683094654** passed on attempt 2 after one Windows-only retry. Attempt 1 exited 1 on the unchanged GUI tests `test_credential_text_reachable_only_through_textpattern_is_a_hard_stop` and `test_credential_text_beyond_the_element_cap_convicts_when_the_cap_allows_it`; those original failures remain recorded. Their underlying nondeterminism was not diagnosed or changed here. Prior-head PR run **34683098736** passed without a retry. These prior passes do not substitute for the new exact-tip run.

### Privacy, compatibility and limits

`credential_gate.py` is byte-identical to the base; `package_spec_facts` keeps its one-argument API. No new snapshot, registry, token, signature, digest framework, serialized field, receipt or public serialization change. New consistency refusals use the existing privacy-safe code; existing root/digest/unassessable codes remain. Brief policy stays private and SourceIdentity's serialized shape is unchanged.

No final readiness fold, #622 binding/reseal implementation, production package write, probe or authorization is added. **Future #622 must obtain fresh S1+S2; final #562 still assesses policy and projection. Handoff/applicability is not authorization or provider permission.**

Unverified limits remain explicit: these are in-process consistency checks, not protection against arbitrary Python code or cryptographic proof of an unsigned manifest. No new claim about lstat/open races, concurrent mutation or atomic filesystem snapshots. Bounded member reads do not establish fresh integrity for unrelated large-asset content. No live credential/provider-permission or binding lifecycle is certified here.

**DRAFT. No self-review or merge performed.**