### PR TITLE
fix: enforce invocation-owned A1 observations

### DIFF
--- a/.github/skills/pbip-model-refresh/scripts/_abf.py
+++ b/.github/skills/pbip-model-refresh/scripts/_abf.py
@@ -9,20 +9,21 @@ it in atomically, and restoring a provisional compatibility alignment when the w
 every public name here is re-exported from ``refresh_pbip_model`` so callers and tests reach them
 through that module.
 
-Extracted from ``refresh_pbip_model`` so that module stays under its line cap; nothing here depends on
-the rest of the bundle, only on ``os``/``struct``/``pathlib``.
+Extracted from ``refresh_pbip_model`` so that module stays under its line cap. The observation-request
+guard is shared with the bundled probe; cache validation itself requires no native libraries.
 """
 
 from __future__ import annotations
 
 import os
 import hashlib
-import io
 import struct
 import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
+
+from probe_desktop_query import _validate_observation_request
 
 # THE FORMAT, MEASURED - not assumed. An earlier round asserted a cache.abf was a Microsoft Compound
 # File Binary (OLE2/CFBF, magic `D0 CF 11 E0 ...`). It is NOT, and the cost of that guess was total:
@@ -44,6 +45,7 @@ _ABF_BLOCK_HEADER_BYTES = 8 + len(_ABF_BLOCK_MAGIC)  # uint32 uncompressed + uin
 # less. That fixed interior size is load-bearing: without it, a write truncated exactly on a block
 # boundary can land cleanly on EOF and look complete.
 _ABF_MAX_BLOCK_BYTES = 2 * 1024 * 1024
+_ABF_READ_BYTES = 1024 * 1024
 
 
 @dataclass(frozen=True, slots=True)
@@ -66,15 +68,24 @@ class _ImageInstallation:
     ambiguous: bool = False
 
 
-def _checked_image(path: Path) -> tuple[bytes | None, str | None]:
-    try:
-        blob = path.read_bytes()
-        preamble = blob[: len(_ABF_PREAMBLE)]
-        if preamble != _ABF_PREAMBLE:
-            return None, f"not an AS backup preamble (first {len(preamble)} byte(s): {preamble[:16].hex(' ')})"
-        return blob, _walk_abf_blocks(io.BytesIO(blob), len(blob))
-    except OSError as exc:
-        return None, f"unreadable ({type(exc).__name__})"
+def _checked_image(path: Path) -> tuple[str, int]:
+    """Validate and hash one sequential pass, including pad/payload/EOF, in bounded memory.
+
+    The returned facts are unavailable until the reader's context exits successfully. File size is
+    only a bound: consuming every declared byte and checking EOF must independently agree with it.
+    """
+    with path.open("rb") as handle:
+        size = path.stat().st_size
+        digest = hashlib.sha256()
+        prefix = handle.read(_ABF_FIRST_BLOCK_OFFSET)
+        digest.update(prefix)
+        if len(prefix) != _ABF_FIRST_BLOCK_OFFSET or prefix[: len(_ABF_PREAMBLE)] != _ABF_PREAMBLE:
+            raise ValueError("not a complete AS backup preamble")
+        reason = _walk_abf_blocks(handle, size, digest=digest)
+        if reason is not None:
+            raise ValueError(reason)
+        checked = digest.hexdigest(), size
+    return checked
 
 
 def _abf_rejection_reason(path: Path) -> str | None:
@@ -94,7 +105,15 @@ def _abf_rejection_reason(path: Path) -> str | None:
     multiple of 2 MiB, whose final block would then be full-sized; none of the 13 measured files is
     such a file, and the cost if one appears is the fallback, not data loss.
     """
-    return _checked_image(path)[1]
+    try:
+        with path.open("rb") as handle:
+            size = path.stat().st_size
+            preamble = handle.read(len(_ABF_PREAMBLE))
+            if preamble != _ABF_PREAMBLE:
+                return f"not an AS backup preamble (first {len(preamble)} byte(s): {preamble[:16].hex(' ')})"
+            return _walk_abf_blocks(handle, size)
+    except OSError as exc:
+        return f"unreadable ({type(exc).__name__})"
 
 
 def _abf_block_header_problem(header: bytes, ordinal: int, offset: int, size: int) -> str | None:
@@ -111,13 +130,27 @@ def _abf_block_header_problem(header: bytes, ordinal: int, offset: int, size: in
     return None
 
 
-def _walk_abf_blocks(handle, size: int) -> str | None:
-    """Walk the XPress9 block chain from the first header; return a reason string, or None if intact."""
+def _hash_abf_payload(handle, digest, remaining: int) -> str | None:
+    """Consume exactly this payload, without seeking, retaining chunks or trusting a stat alone."""
+    while remaining:
+        chunk = handle.read(min(remaining, _ABF_READ_BYTES))
+        digest.update(chunk)
+        if not chunk or len(chunk) > remaining:
+            return "payload byte count disagrees with the declared block length"
+        remaining -= len(chunk)
+    return None
+
+
+def _walk_abf_blocks(handle, size: int, *, digest=None) -> str | None:
+    """Check the same block chain in both modes: legacy header seeks, or sequential hashing."""
     offset = _ABF_FIRST_BLOCK_OFFSET
     blocks = 0
     while True:
-        handle.seek(offset)
+        if digest is None:
+            handle.seek(offset)
         header = handle.read(_ABF_BLOCK_HEADER_BYTES)
+        if digest is not None:
+            digest.update(header)
         problem = _abf_block_header_problem(header, blocks + 1, offset, size)
         if problem is not None:
             return problem
@@ -126,6 +159,10 @@ def _walk_abf_blocks(handle, size: int) -> str | None:
         end = offset + 8 + length
         if end > size:
             return f"block {blocks} needs {end} byte(s) but the file is {size} - truncated write"
+        if digest is not None:
+            problem = _hash_abf_payload(handle, digest, length - len(_ABF_BLOCK_MAGIC))
+            if problem is not None:
+                return problem
         if end < size:
             if uncompressed != _ABF_MAX_BLOCK_BYTES:
                 return (
@@ -135,8 +172,15 @@ def _walk_abf_blocks(handle, size: int) -> str | None:
             offset = end
             continue
         if uncompressed == _ABF_MAX_BLOCK_BYTES:
-            return f"ends on a full {_ABF_MAX_BLOCK_BYTES}-byte block boundary after {blocks} block(s) - more was due"
-        return None
+            problem = (
+                f"ends on a full {_ABF_MAX_BLOCK_BYTES}-byte block boundary after {blocks} block(s) - more was due"
+            )
+        elif digest is not None:
+            trailer = handle.read(1)
+            digest.update(trailer)
+            if trailer:
+                problem = "backup has bytes beyond its declared size"
+        return problem
 
 
 def _is_complete_abf(path: Path) -> bool:
@@ -160,14 +204,15 @@ def _staging_path(cache_path: Path) -> Path:
     return cache_path.with_name(f"{cache_path.name}.{os.getpid()}-{uuid.uuid4().hex}.tmp")
 
 
-def _staged_image_write(
+def _staged_image_write(  # pylint: disable=too-many-arguments
     cache_path: Path,
     write_image,
     staging: Path | None = None,
     *,
     observations: list[ImageObservation] | None = None,
     installation: _ImageInstallation | None = None,
-) -> bool:
+    return_observation: bool = False,
+) -> bool | tuple[str, int]:
     """Write the cache to a staging file and swap it in atomically. Returns True only on a COMPLETE write.
 
     `FileMode.Create` on the live `cache.abf` truncates a good cache the instant the write begins, so
@@ -181,25 +226,33 @@ def _staged_image_write(
     staging file is removed, letting the caller roll the compatibility bump back; and even on a clean
     return the staged file must look like a backup (`_is_complete_abf`) before it is swapped in.
 
-    A normal replace return establishes installation, not durability. Its private state is set BEFORE
-    optional readback/hash/list work. A raised replace never produces an observation; if its stage
+    Observation mode returns only the checked staged digest and byte count, never installed evidence.
+    The caller must declare compatibility, check the installed bytes once, and finish its contexts.
+    A normal replace return establishes installation, not durability. A raised replace never produces
+    an observation; if its stage
     vanished, the outcome is ambiguous and the caller must not roll compatibility back underneath a
     possibly installed image. No durable commitment is inferred from close/replace/readback.
 
     A staged file that is REJECTED is announced, not swallowed. A silent "did not swap" is how a
     wrong acceptance predicate hid for a whole review round while persist-by-default was dead.
     """
+    _validate_observation_request(return_observation, observations)
     cache_path.parent.mkdir(parents=True, exist_ok=True)
     if staging is None:
         staging = _staging_path(cache_path)
     if staging.exists():
         staging.unlink()
     installation = installation if installation is not None else _ImageInstallation()
+    intended = None
     try:
         write_image(staging)
-        intended, reason = _checked_image(staging)
+        if return_observation:
+            intended = _checked_image(staging)
+            reason = None
+        else:
+            reason = _abf_rejection_reason(staging)
         if reason is None:
-            installation.size = len(intended)
+            installation.size = intended[1] if return_observation else staging.stat().st_size
             # Cover an interrupt after replace returns but before its success flag is stored.
             installation.ambiguous = True
             try:
@@ -210,27 +263,13 @@ def _staged_image_write(
                 raise
             installation.installed = True
             installation.ambiguous = False
-            if observations is not None:
-                installed = cache_path.read_bytes()
-                if staging.exists() or installed != intended:
-                    raise CompatRollbackError(
-                        "installed cache differs from the intended image; observation unavailable"
-                    )
-                observations.append(
-                    ImageObservation(
-                        hashlib.sha256(intended).hexdigest(),
-                        len(intended),
-                        hashlib.sha256(installed).hexdigest(),
-                        len(installed),
-                    )
-                )
         else:
             print(f"  save   : staged cache REJECTED - {reason}")
     finally:
         # Cleanup cannot establish installation: the caller retains the pre-cleanup outcome.
-        if not installation.installed and staging.exists():
-            staging.unlink()
-    return installation.installed
+        if not installation.installed:
+            _cleanup_staging(staging)
+    return intended if return_observation else installation.installed
 
 
 class CompatRollbackError(RuntimeError):
@@ -246,7 +285,7 @@ def _cleanup_staging(staging: Path) -> None:
     try:
         if staging.exists():
             staging.unlink()
-    except OSError:
+    except Exception:  # pylint: disable=broad-exception-caught
         pass
 
 

--- a/.github/skills/pbip-model-refresh/scripts/probe_desktop_query.py
+++ b/.github/skills/pbip-model-refresh/scripts/probe_desktop_query.py
@@ -258,24 +258,30 @@ def _validate_identity(payload: dict, pid: int) -> None:
         raise ValueError("identity")
 
 
-@_observation_errors()
-def catalogue_id(connection) -> str:
-    """Read exactly one canonical Desktop catalogue ID; missing/ambiguous identity is refused."""
-    command = connection.CreateCommand()
-    command.CommandTimeout = 30
-    command.CommandText = "SELECT [CATALOG_NAME] FROM $SYSTEM.DBSCHEMA_CATALOGS"
-    reader = command.ExecuteReader()
-    try:
-        if not reader.Read():
-            raise ValueError("missing catalogue")
-        value = str(reader.GetValue(0))
-        if reader.Read() or str(uuid.UUID(value)) != value:
-            raise ValueError("ambiguous catalogue")
-        return value
-    except (ValueError, TypeError):
-        raise ObservationUnavailable("CATALOGUE_UNESTABLISHED") from None
-    finally:
-        _close_observation_connection(reader)
+def catalogue_id(connection, *, observation_mode: bool = False) -> str:
+    """Read one canonical catalogue, retaining raw query/Close failures for legacy callers.
+
+    Only observation mode closes the error surface and treats ordinary reader teardown as best-effort.
+    """
+    with _observation_errors(observation_mode):
+        command = connection.CreateCommand()
+        command.CommandTimeout = 30
+        command.CommandText = "SELECT [CATALOG_NAME] FROM $SYSTEM.DBSCHEMA_CATALOGS"
+        reader = command.ExecuteReader()
+        try:
+            if not reader.Read():
+                raise ValueError("missing catalogue")
+            value = str(reader.GetValue(0))
+            if reader.Read() or str(uuid.UUID(value)) != value:
+                raise ValueError("ambiguous catalogue")
+            return value
+        except (ValueError, TypeError):
+            raise ObservationUnavailable("CATALOGUE_UNESTABLISHED") from None
+        finally:
+            if observation_mode:
+                _close_observation_connection(reader)
+            else:
+                reader.Close()
 
 
 def _observation_credential_check(pid: int, *, in_flight: bool) -> None:
@@ -360,7 +366,7 @@ def bind_desktop(pid: int, supplied_port: int | None = None) -> BoundDesktop:
         connection = _load_adomd()(f"Data Source=localhost:{identity.port};Connect Timeout=30")
         try:
             connection.Open()
-            bound = BoundDesktop(identity, catalogue_id(connection))
+            bound = BoundDesktop(identity, catalogue_id(connection, observation_mode=True))
             if desktop_identity(pid) != identity:
                 raise ObservationUnavailable("PID_REUSED")
             return bound
@@ -370,13 +376,16 @@ def bind_desktop(pid: int, supplied_port: int | None = None) -> BoundDesktop:
     return _observation_call(pid, discover, OBSERVATION_TIMEOUT_SECONDS)
 
 
-@_observation_errors()
-def recheck_bound(bound: BoundDesktop, connection) -> None:
-    """Refuse PID reuse, a changed child/listener, or a different/multiple catalogue."""
-    if desktop_identity(bound.identity.pid) != bound.identity:
-        raise ObservationUnavailable("PID_REUSED")
-    if catalogue_id(connection) != bound.catalogue or str(connection.Database) != bound.catalogue:
-        raise ObservationUnavailable("CATALOGUE_CHANGED")
+def recheck_bound(bound: BoundDesktop, connection, *, observation_mode: bool = False) -> None:
+    """Recheck the binding without changing a legacy caller's catalogue failure semantics."""
+    with _observation_errors(observation_mode):
+        if desktop_identity(bound.identity.pid) != bound.identity:
+            raise ObservationUnavailable("PID_REUSED")
+        if (
+            catalogue_id(connection, observation_mode=observation_mode) != bound.catalogue
+            or str(connection.Database) != bound.catalogue
+        ):
+            raise ObservationUnavailable("CATALOGUE_CHANGED")
 
 
 @_observation_errors()
@@ -393,9 +402,9 @@ def bound_call(
         )
         try:
             connection.Open()
-            recheck_bound(bound, connection)
+            recheck_bound(bound, connection, observation_mode=True)
             result = operation(connection)
-            recheck_bound(bound, connection)
+            recheck_bound(bound, connection, observation_mode=True)
             return result
         finally:
             _close_observation_connection(connection)

--- a/.github/skills/pbip-model-refresh/scripts/probe_desktop_query.py
+++ b/.github/skills/pbip-model-refresh/scripts/probe_desktop_query.py
@@ -41,16 +41,22 @@ import sys
 import threading
 import time
 import uuid
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, NoReturn, TypeVar
+from typing import Callable, Iterator, NoReturn, TypeVar
 
 from _verdict import derive_data_verdict
 
 from _credential_modal import (
     CredentialDetection,
+    CredentialMissingError,
     CredentialModal,
+    CredentialUnknownError,
+    DesktopGoneError,
+    DesktopUnreadyError,
     DialogFinding,
+    DialogFoundError,
     describe_dialog_finding,
     describe_modal,
     dialog_guidance,
@@ -85,6 +91,88 @@ class ObservationUnavailable(RuntimeError):
     """A locally named refusal; native exceptions are mapped to TOOL_UNAVAILABLE, not reflected."""
 
 
+_OBSERVATION_CODES = frozenset(
+    {
+        "IDENTITY_UNESTABLISHED",
+        "WRONG_PID_PORT",
+        "PID_REUSED",
+        "CATALOGUE_UNESTABLISHED",
+        "CATALOGUE_CHANGED",
+        "CANARIES_REQUIRED",
+        "CREDENTIAL_MISSING",
+        "CREDENTIAL_UNKNOWN",
+        "DESKTOP_GONE",
+        "DESKTOP_UNREADY",
+        "DIALOG_NEEDS_HUMAN",
+        "DIALOG_UNREADABLE",
+        "DIALOG_UNRECOGNIZED",
+        "REFRESH_IN_PROGRESS",
+        "TIMEOUT",
+        "TOOL_UNAVAILABLE",
+    }
+)
+
+
+def _fresh_observation_error(error: BaseException) -> BaseException:
+    """Copy a local code only, never native arguments, evidence, notes or exception state."""
+    if isinstance(error, KeyboardInterrupt):
+        return KeyboardInterrupt()
+    code = "TOOL_UNAVAILABLE"
+    if type(error) is ObservationUnavailable and len(error.args) == 1:  # pylint: disable=unidiomatic-typecheck
+        code = error.args[0]
+    elif type(error) is DialogFoundError and type(error.finding) is DialogFinding:  # pylint: disable=unidiomatic-typecheck
+        code = error.finding.verdict
+    else:
+        code = {
+            CredentialMissingError: "CREDENTIAL_MISSING",
+            CredentialUnknownError: "CREDENTIAL_UNKNOWN",
+            DesktopGoneError: "DESKTOP_GONE",
+            DesktopUnreadyError: "DESKTOP_UNREADY",
+            TimeoutError: "TIMEOUT",
+        }.get(type(error), code)
+    if type(code) is not str or code not in _OBSERVATION_CODES:  # pylint: disable=unidiomatic-typecheck
+        code = "TOOL_UNAVAILABLE"
+    return ObservationUnavailable(code)
+
+
+def _raise_closed_error(error: BaseException) -> NoReturn:
+    """Sever even an exception active in the caller; ``from None`` only hides that context."""
+    try:
+        raise error from None
+    except BaseException:  # pylint: disable=broad-exception-caught
+        error.__context__ = None
+        error.__cause__ = None
+        raise
+
+
+@contextmanager
+def _observation_errors(enabled: bool = True, *, preserve: tuple[type[Exception], ...] = ()) -> Iterator[None]:
+    """A closed public error boundary; legacy calls keep their original exceptions."""
+    try:
+        yield
+    except BaseException as error:  # pylint: disable=broad-exception-caught
+        if not enabled:
+            raise
+        failure = type(error)("TOOL_UNAVAILABLE") if type(error) in preserve else _fresh_observation_error(error)
+    else:
+        return
+    _raise_closed_error(failure)
+
+
+def _validate_observation_request(return_observation: bool, sink) -> None:
+    """Retired sinks are refused by identity alone, before inspecting them or doing any I/O."""
+    if type(return_observation) is not bool or sink is not None:  # pylint: disable=unidiomatic-typecheck
+        _raise_closed_error(ObservationUnavailable("TOOL_UNAVAILABLE"))
+
+
+def _close_observation_connection(connection) -> None:
+    """Ordinary ADOMD teardown is best-effort; an interrupt must still refuse publication."""
+    try:
+        connection.Close()
+    except Exception:  # pylint: disable=broad-exception-caught
+        pass
+
+
 @dataclass(frozen=True, slots=True)
 class DesktopIdentity:
     """Exact OS parent/child start identities and the child's sole listener."""
@@ -112,8 +200,10 @@ class CanaryObservation:
     table: str
     query: str
     returned_rows: int
+    identity: DesktopIdentity
 
 
+@_observation_errors()
 def desktop_identity(pid: int, supplied_port: int | None = None) -> DesktopIdentity:
     """Read one exact PID/start -> child/start -> unique port, without alternate-PID fallback."""
     if os.name != "nt" or type(pid) is not int or not 0 < pid < 2**32:  # pylint: disable=unidiomatic-typecheck
@@ -168,6 +258,7 @@ def _validate_identity(payload: dict, pid: int) -> None:
         raise ValueError("identity")
 
 
+@_observation_errors()
 def catalogue_id(connection) -> str:
     """Read exactly one canonical Desktop catalogue ID; missing/ambiguous identity is refused."""
     command = connection.CreateCommand()
@@ -184,7 +275,7 @@ def catalogue_id(connection) -> str:
     except (ValueError, TypeError):
         raise ObservationUnavailable("CATALOGUE_UNESTABLISHED") from None
     finally:
-        reader.Close()
+        _close_observation_connection(reader)
 
 
 def _observation_credential_check(pid: int, *, in_flight: bool) -> None:
@@ -200,10 +291,11 @@ def _observation_credential_check(pid: int, *, in_flight: bool) -> None:
             raise ObservationUnavailable(code)
 
 
+@_observation_errors()
 def _observation_call(pid: int, operation: Callable[[], _T], timeout_seconds: float) -> _T:
     """Bound reads, including credential inspection. Timed-out native work is not cancellable.
 
-    Workers are daemon-only and never publish a late result to a caller's observation sink.
+    Workers are daemon-only; results stay invocation-private until both workers terminate.
     This helper is for reads, NOT a lifecycle wrapper around refresh or persistence.
     """
     if type(timeout_seconds) not in (int, float) or not 0 < timeout_seconds <= OBSERVATION_TIMEOUT_SECONDS:  # pylint: disable=unidiomatic-typecheck
@@ -211,61 +303,74 @@ def _observation_call(pid: int, operation: Callable[[], _T], timeout_seconds: fl
     outcome = queue.Queue()
     stopped = threading.Event()
 
-    def guarded(call) -> None:
+    def poll() -> None:
         try:
-            outcome.put((True, call()))
+            while not stopped.wait(0.1):
+                _observation_credential_check(pid, in_flight=True)
         except BaseException as error:  # pylint: disable=broad-exception-caught
             outcome.put((False, error))
 
-    def poll() -> None:
-        while not stopped.wait(0.1):
-            _observation_credential_check(pid, in_flight=True)
+    monitor = threading.Thread(target=poll, name="observation-inspection", daemon=True)
 
-    def run() -> _T | None:
-        _observation_credential_check(pid, in_flight=False)
-        if stopped.is_set():
-            return None
-        threading.Thread(target=lambda: guarded(poll), daemon=True).start()
-        result = operation()
-        if not stopped.is_set():
-            _observation_credential_check(pid, in_flight=True)
-        return result
+    def run() -> None:
+        try:
+            _observation_credential_check(pid, in_flight=False)
+            if stopped.is_set():
+                return
+            monitor.start()
+            result = operation()
+            if not stopped.is_set():
+                _observation_credential_check(pid, in_flight=True)
+                outcome.put((True, result))
+        except BaseException as error:  # pylint: disable=broad-exception-caught
+            outcome.put((False, error))
 
     deadline = time.monotonic() + timeout_seconds
-    threading.Thread(target=lambda: guarded(run), daemon=True).start()
+    worker = threading.Thread(target=run, name="observation-read", daemon=True)
+    worker.start()
     try:
         succeeded, value = outcome.get(timeout=max(0, deadline - time.monotonic()))
-        if time.monotonic() > deadline:
-            raise ObservationUnavailable("TIMEOUT")
         if not succeeded:
-            if isinstance(value, (ObservationUnavailable, KeyboardInterrupt)):
-                raise value
-            raise ObservationUnavailable("TOOL_UNAVAILABLE") from None
-        return value
+            raise value
+        stopped.set()
+        worker.join(max(0, deadline - time.monotonic()))
+        monitor.join(max(0, deadline - time.monotonic()))
+        if worker.is_alive() or monitor.is_alive() or time.monotonic() > deadline:
+            raise ObservationUnavailable("TIMEOUT")
+        # An in-flight inspection can refuse after the operation queued its private result.
+        try:
+            _, failure = outcome.get_nowait()
+        except queue.Empty:
+            pass
+        else:
+            raise failure
     except queue.Empty:
         raise ObservationUnavailable("TIMEOUT") from None
     finally:
         stopped.set()
+    return value
 
 
+@_observation_errors()
 def bind_desktop(pid: int, supplied_port: int | None = None) -> BoundDesktop:
     """Bracket catalogue discovery with PID/start observations, within one bounded read."""
 
     def discover() -> BoundDesktop:
         identity = desktop_identity(pid, supplied_port)
         connection = _load_adomd()(f"Data Source=localhost:{identity.port};Connect Timeout=30")
-        connection.Open()
         try:
+            connection.Open()
             bound = BoundDesktop(identity, catalogue_id(connection))
             if desktop_identity(pid) != identity:
                 raise ObservationUnavailable("PID_REUSED")
             return bound
         finally:
-            connection.Close()
+            _close_observation_connection(connection)
 
     return _observation_call(pid, discover, OBSERVATION_TIMEOUT_SECONDS)
 
 
+@_observation_errors()
 def recheck_bound(bound: BoundDesktop, connection) -> None:
     """Refuse PID reuse, a changed child/listener, or a different/multiple catalogue."""
     if desktop_identity(bound.identity.pid) != bound.identity:
@@ -274,6 +379,7 @@ def recheck_bound(bound: BoundDesktop, connection) -> None:
         raise ObservationUnavailable("CATALOGUE_CHANGED")
 
 
+@_observation_errors()
 def bound_call(
     bound: BoundDesktop, operation: Callable[[object], _T], *, timeout_seconds: float = OBSERVATION_TIMEOUT_SECONDS
 ) -> _T:
@@ -292,11 +398,12 @@ def bound_call(
             recheck_bound(bound, connection)
             return result
         finally:
-            connection.Close()
+            _close_observation_connection(connection)
 
     return _observation_call(bound.identity.pid, read, timeout_seconds)
 
 
+@_observation_errors()
 def probe_observations(
     bound: BoundDesktop, canaries: list[str], *, timeout_seconds: float = OBSERVATION_TIMEOUT_SECONDS
 ) -> tuple[CanaryObservation, ...]:
@@ -312,10 +419,10 @@ def probe_observations(
     def read(connection) -> tuple[CanaryObservation, ...]:
         observed = []
         for name in targets:
-            rows = _probe_one(bound.identity.port, connection, name, emit=lambda _: None)
+            rows = _probe_one(bound.identity.port, connection, name, emit=lambda _: None, observation_mode=True)
             if type(rows) is not int or rows < 0:  # pylint: disable=unidiomatic-typecheck
                 raise ObservationUnavailable("TOOL_UNAVAILABLE")
-            observed.append(CanaryObservation(bound.catalogue, name, _canary_query(name), rows))
+            observed.append(CanaryObservation(bound.catalogue, name, _canary_query(name), rows, bound.identity))
         return tuple(observed)
 
     return bound_call(bound, read, timeout_seconds=timeout_seconds)
@@ -567,12 +674,7 @@ def _canary_query(table: str) -> str:
     return f"EVALUATE TOPN(1, '{table.replace(chr(39), chr(39) * 2)}')"
 
 
-def _probe_one(port: int, conn, table: str, emit=print) -> int:
-    """Run EVALUATE TOPN(1, '<table>') for one table, print the evidence, and return the row count."""
-    dax = _canary_query(table)
-    cmd = conn.CreateCommand()
-    cmd.CommandText = dax
-    reader = cmd.ExecuteReader()
+def _read_canary(reader) -> tuple[list[str], int, list[str]]:
     cols = [reader.GetName(i) for i in range(reader.FieldCount)]
     rows = 0
     first_values: list[str] = []
@@ -580,7 +682,23 @@ def _probe_one(port: int, conn, table: str, emit=print) -> int:
         rows += 1
         if rows == 1:
             first_values = [str(reader.GetValue(i)) for i in range(reader.FieldCount)]
-    reader.Close()
+    return cols, rows, first_values
+
+
+def _probe_one(port: int, conn, table: str, emit=print, *, observation_mode: bool = False) -> int:
+    """Run EVALUATE TOPN(1, '<table>') for one table, print the evidence, and return the row count."""
+    dax = _canary_query(table)
+    cmd = conn.CreateCommand()
+    cmd.CommandText = dax
+    reader = cmd.ExecuteReader()
+    if observation_mode:
+        try:
+            cols, rows, first_values = _read_canary(reader)
+        finally:
+            _close_observation_connection(reader)
+    else:
+        cols, rows, first_values = _read_canary(reader)
+        reader.Close()
     emit(f"port={port}  table='{table}'  dax={dax}")
     emit(f"  columns ({len(cols)}): {cols[:8]}")
     if rows:

--- a/.github/skills/pbip-model-refresh/scripts/refresh_pbip_model.py
+++ b/.github/skills/pbip-model-refresh/scripts/refresh_pbip_model.py
@@ -104,6 +104,8 @@ from probe_desktop_query import (
     DesktopIdentity,
     ObservationUnavailable,
     _load_adomd,
+    _observation_errors,
+    _validate_observation_request,
     column_names,
     desktop_identity,
     discover_port,
@@ -125,6 +127,7 @@ from _abf import (  # noqa: F401  # pylint: disable=unused-import
     ImageObservation,
     _ImageInstallation,
     _abf_rejection_reason,
+    _checked_image,
     _cleanup_staging,
     _is_complete_abf,
     _restore_rollback_snapshot,
@@ -191,6 +194,7 @@ class PersistenceObservation:
     catalogue: str
     compatibility_level: int
     image: ImageObservation
+    identity: DesktopIdentity
     method: Literal["AMO_ImageSave"] = "AMO_ImageSave"
 
 
@@ -396,6 +400,7 @@ def _join_refresh_worker(
     initial_state: CredentialDetection | None,
     total_timeout: float,
     progress_monitor: RefreshProgressMonitor | None,
+    observation_mode: bool = False,
 ) -> bool:
     """Wait for the refresh thread, with credential polling and optional progress liveness.
 
@@ -406,7 +411,7 @@ def _join_refresh_worker(
     refresh it was reporting on. Measured: ``DialogFoundError(REFRESH_IN_PROGRESS)`` on the first poll,
     with no ``in_flight`` argument reaching the detector at all.
     """
-    if progress_monitor is None:
+    if progress_monitor is None and not observation_mode:
         if desktop_pid is None:
             worker.join(total_timeout)
             return not worker.is_alive()
@@ -431,10 +436,11 @@ def _join_refresh_worker(
         absolute_remaining = max(0.0, total_timeout - elapsed)
         if absolute_remaining <= 0:
             break
-        progress_monitor.print_liveness_warning_if_due()
+        if progress_monitor is not None:
+            progress_monitor.print_liveness_warning_if_due()
         wait_for = min(
             absolute_remaining,
-            progress_monitor.seconds_until_liveness_warning(),
+            progress_monitor.seconds_until_liveness_warning() if progress_monitor is not None else absolute_remaining,
             REFRESH_CREDENTIAL_POLL_SECONDS,
             max(0.0, next_heartbeat - elapsed),
         )
@@ -444,15 +450,18 @@ def _join_refresh_worker(
             raise_terminal_detection(desktop_pid, state, source_hint)
             if state.dialog is not None and latched_dialog is None:
                 latched_dialog = state.dialog
-                print_dialog_observed_notice(desktop_pid, state.dialog)
+                if not observation_mode:
+                    print_dialog_observed_notice(desktop_pid, state.dialog)
             if state.desktop_unready and latched_desktop_unready is None:
                 latched_desktop_unready = state.desktop_unready
             if state.unknown_reason and latched_unknown is None:
                 latched_unknown = state.unknown_reason
-                print_indeterminate_state_notice(desktop_pid, state.unknown_reason)
+                if not observation_mode:
+                    print_indeterminate_state_notice(desktop_pid, state.unknown_reason)
         elapsed = time.monotonic() - started
         if elapsed >= next_heartbeat and worker.is_alive():
-            progress_monitor.print_evidence_heartbeat(elapsed, total_timeout)
+            if progress_monitor is not None:
+                progress_monitor.print_evidence_heartbeat(elapsed, total_timeout)
             next_heartbeat += REFRESH_HEARTBEAT_SECONDS
     if worker.is_alive():
         # The latches used to be computed here and DISCARDED, so this branch always degraded to the
@@ -484,8 +493,13 @@ def refresh(
     absolute_timeout_sec: float = REFRESH_ABSOLUTE_TIMEOUT_SECONDS,
     bound: BoundDesktop | None = None,
     observations: list[RefreshObservation] | None = None,
-) -> tuple[bool, str]:
-    """Send a TMSL refresh over XMLA. Returns (ok, message).
+    return_observation: bool = False,
+) -> tuple[bool, str] | RefreshObservation:
+    """Send a TMSL refresh over XMLA; return the legacy tuple or one bound observation.
+
+    ``return_observation`` requires an exact bool. True returns only this invocation's immutable
+    facts after the worker and teardown finish, or raises a closed, detail-free refusal. Retired
+    ``observations`` sinks reject every non-None value before I/O; no collector can carry authority.
 
     Refreshing named tables is preferred over the whole database: a full refresh can hang for
     minutes on a large table that no report even uses. ``refresh_type='calculate'`` is an opt-in
@@ -524,11 +538,43 @@ def refresh(
     90 s" because there was no 90. Never take a timing measurement against a bundle preflight reports
     as STALE.
     """
+    _validate_observation_request(return_observation, observations)
+    with _observation_errors(return_observation, preserve=(CompatRollbackError, ModelLockTimeout)):
+        return _refresh(
+            port,
+            tables,
+            timeout_sec,
+            refresh_type=refresh_type,
+            desktop_pid=desktop_pid,
+            source_hint=source_hint,
+            initial_state=initial_state,
+            progress_enabled=progress_enabled,
+            progress_liveness_sec=progress_liveness_sec,
+            absolute_timeout_sec=absolute_timeout_sec,
+            bound=bound,
+            return_observation=return_observation,
+        )
+
+
+def _refresh(
+    port: int,
+    tables: list[str] | None,
+    timeout_sec: int,
+    *,
+    refresh_type: str,
+    desktop_pid: int | None,
+    source_hint: str | None,
+    initial_state: CredentialDetection | None,
+    progress_enabled: bool,
+    progress_liveness_sec: float,
+    absolute_timeout_sec: float,
+    bound: BoundDesktop | None,
+    return_observation: bool,
+) -> tuple[bool, str] | RefreshObservation:
+    """Run the existing refresh lifecycle with invocation-private results."""
     if refresh_type not in REFRESH_TYPES:
         raise ValueError(f"unsupported refresh type {refresh_type!r}; expected one of {sorted(REFRESH_TYPES)}")
-    if observations:
-        raise ObservationUnavailable("OBSERVATIONS_NOT_EMPTY")
-    if observations is not None and bound is None:
+    if return_observation and bound is None:
         raise ObservationUnavailable("IDENTITY_UNESTABLISHED")
     if bound is not None and (bound.identity.port != port or bound.identity.pid != desktop_pid):
         raise ObservationUnavailable("WRONG_PID_PORT")
@@ -548,7 +594,10 @@ def refresh(
         total_timeout = absolute_timeout_sec
         untraced_absolute_backstop = True
         try:
-            progress_monitor = _start_refresh_progress_trace(port, progress_liveness_sec)
+            if return_observation:
+                progress_monitor = _start_refresh_progress_trace(port, progress_liveness_sec, observation_mode=True)
+            else:
+                progress_monitor = _start_refresh_progress_trace(port, progress_liveness_sec)
             untraced_absolute_backstop = False
             print(
                 f"[progress] enabled: no progress event for {progress_liveness_sec:.1f}s prints a warning "
@@ -556,16 +605,19 @@ def refresh(
                 flush=True,
             )
         except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught
-            print(
-                f"[progress] unavailable ({type(exc).__name__}: {exc}). Row counts and the liveness "
-                "warning are OFF for this run; you cannot tell a slow refresh from a stuck one. "
-                f"The {absolute_timeout_sec:.0f}s absolute backstop still applies. To regain visibility: "
-                "restore the AMO package (Microsoft.AnalysisServices.NetCore.retail.amd64), or use "
-                "the operator refresh strategy and watch Desktop's own row counter.",
-                file=sys.stderr,
-                flush=True,
-            )
-    if desktop_pid is not None:
+            if return_observation:
+                print("[progress] unavailable (TOOL_UNAVAILABLE); absolute backstop retained", file=sys.stderr)
+            else:
+                print(
+                    f"[progress] unavailable ({type(exc).__name__}: {exc}). Row counts and the liveness "
+                    "warning are OFF for this run; you cannot tell a slow refresh from a stuck one. "
+                    f"The {absolute_timeout_sec:.0f}s absolute backstop still applies. To regain visibility: "
+                    "restore the AMO package (Microsoft.AnalysisServices.NetCore.retail.amd64), or use "
+                    "the operator refresh strategy and watch Desktop's own row counter.",
+                    file=sys.stderr,
+                    flush=True,
+                )
+    if desktop_pid is not None and not return_observation:
         state = initial_state or CredentialDetection()
         if progress_monitor is None:
             if untraced_absolute_backstop:
@@ -614,41 +666,38 @@ def refresh(
     def _run() -> None:
         conn = None
         try:
-            adomd_connection = _load_adomd()
-            selection = f";Initial Catalog={bound.catalogue};Connect Timeout=30" if bound is not None else ""
-            conn = adomd_connection(f"Data Source=localhost:{port}{selection}")
-            conn.Open()
-            if bound is not None:
-                recheck_bound(bound, conn)
-            catalog = bound.catalogue if bound is not None else _catalog_id(conn)
-            if targets:
-                objects = [{"database": catalog, "table": t} for t in targets]
-            else:
-                objects = [{"database": catalog}]
-            tmsl = json.dumps({"refresh": {"type": refresh_type, "objects": objects}})
-            cmd = conn.CreateCommand()
-            cmd.CommandText = tmsl
-            cmd.CommandTimeout = command_timeout
-            cmd.ExecuteNonQuery()
-            if bound is not None:
-                recheck_bound(bound, conn)
-                result["observation"] = RefreshObservation(
-                    catalog, refresh_type, "tables" if targets else "database", targets, bound.identity
-                )
-            target = "/".join(tables) if tables else "entire database"
-            verb = "calculated" if refresh_type == REFRESH_TYPE_CALCULATE else "refreshed"
-            result["ok"] = (True, f"{verb} {target} (catalog {catalog})")
+            try:
+                adomd_connection = _load_adomd()
+                selection = f";Initial Catalog={bound.catalogue};Connect Timeout=30" if bound is not None else ""
+                conn = adomd_connection(f"Data Source=localhost:{port}{selection}")
+                conn.Open()
+                if bound is not None:
+                    recheck_bound(bound, conn)
+                catalog = bound.catalogue if bound is not None else _catalog_id(conn)
+                objects = [{"database": catalog, "table": t} for t in targets] if targets else [{"database": catalog}]
+                cmd = conn.CreateCommand()
+                cmd.CommandText = json.dumps({"refresh": {"type": refresh_type, "objects": objects}})
+                cmd.CommandTimeout = command_timeout
+                cmd.ExecuteNonQuery()
+                if bound is not None:
+                    recheck_bound(bound, conn)
+                    result["observation"] = RefreshObservation(
+                        catalog, refresh_type, "tables" if targets else "database", targets, bound.identity
+                    )
+                target = "/".join(targets) if targets else "entire database"
+                verb = "calculated" if refresh_type == REFRESH_TYPE_CALCULATE else "refreshed"
+                result["ok"] = (True, f"{verb} {target} (catalog {catalog})")
+            finally:
+                if conn is not None:
+                    try:
+                        conn.Close()
+                    except Exception:  # noqa: BLE001  # pylint: disable=broad-exception-caught
+                        pass
         except BaseException as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught
             # Everything the worker can raise has to be handed back, not left to die on the thread:
             # `main` classifies on the exception text, and an unhandled thread exception would reach
             # it as "worker returned no result" - a generic failure masking a specific, actionable one.
             result["ok"] = exc
-        finally:
-            if conn is not None:
-                try:
-                    conn.Close()
-                except Exception:  # noqa: BLE001  # pylint: disable=broad-exception-caught
-                    pass
 
     worker = threading.Thread(target=_run, name="xmla-refresh", daemon=True)
     try:
@@ -662,6 +711,7 @@ def refresh(
             initial_state=initial_state,
             total_timeout=total_timeout,
             progress_monitor=progress_monitor,
+            observation_mode=return_observation,
         )
         if worker.is_alive():
             if desktop_pid is not None:
@@ -684,16 +734,19 @@ def refresh(
             )
     finally:
         if progress_monitor is not None:
-            progress_monitor.close()
+            try:
+                progress_monitor.close()
+            except Exception:  # pylint: disable=broad-exception-caught
+                if not return_observation:
+                    raise
+                print("[progress] teardown unavailable (TOOL_UNAVAILABLE)")
 
     outcome = result.get("ok")
     if isinstance(outcome, BaseException):
         raise outcome
     if outcome is None:  # pragma: no cover - defensive; the worker always records something
         raise RuntimeError("refresh worker returned no result")
-    if observations is not None:
-        observations.append(result["observation"])
-    return outcome
+    return result["observation"] if return_observation else outcome
 
 
 # pylint: enable=too-many-arguments,too-many-statements
@@ -825,6 +878,7 @@ class RefreshProgressMonitor:  # pylint: disable=too-many-instance-attributes
         clock=time.monotonic,
         printer=print,
         current_event_values: set[str] | None = None,
+        observation_mode: bool = False,
     ) -> None:
         self.trace = trace
         self.server = server
@@ -832,7 +886,8 @@ class RefreshProgressMonitor:  # pylint: disable=too-many-instance-attributes
         self.liveness_seconds = liveness_seconds
         self.throttle_seconds = throttle_seconds
         self.clock = clock
-        self.printer = printer
+        self.printer = (lambda *_args, **_kwargs: None) if observation_mode else printer
+        self._observation_mode = observation_mode
         self._lock = threading.Lock()
         self._started_at = clock()
         self._last_event_at = self._started_at
@@ -941,11 +996,13 @@ class RefreshProgressMonitor:  # pylint: disable=too-many-instance-attributes
             try:
                 self.trace.Stop()
             except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught
-                print(f"[progress] trace stop failed ({type(exc).__name__}: {exc})")
+                detail = "TOOL_UNAVAILABLE" if self._observation_mode else f"{type(exc).__name__}: {exc}"
+                print(f"[progress] trace stop failed ({detail})")
             try:
                 self.trace.Drop()
             except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught
-                print(f"[progress] trace drop failed ({type(exc).__name__}: {exc})")
+                detail = "TOOL_UNAVAILABLE" if self._observation_mode else f"{type(exc).__name__}: {exc}"
+                print(f"[progress] trace drop failed ({detail})")
         if self.server is not None:
             try:
                 self.server.Disconnect()
@@ -1038,7 +1095,9 @@ def _negotiate_progress_trace_columns(trace, trace_event_class, trace_column, tr
     raise RuntimeError("progress trace column negotiation did not converge")
 
 
-def _start_refresh_progress_trace(port: int, liveness_seconds: float) -> RefreshProgressMonitor:
+def _start_refresh_progress_trace(
+    port: int, liveness_seconds: float, *, observation_mode: bool = False
+) -> RefreshProgressMonitor:
     """Start a server-level progress trace, or raise so the caller can safely degrade."""
     server_type, trace_column, trace_event_class, trace_event_type = _load_amo_trace_types()
     server = server_type()
@@ -1054,6 +1113,7 @@ def _start_refresh_progress_trace(port: int, liveness_seconds: float) -> Refresh
             trace_column,
             liveness_seconds=liveness_seconds,
             current_event_values=_progress_event_values(trace_event_class, "ProgressReportCurrent"),
+            observation_mode=observation_mode,
         )
         trace.OnEvent += monitor.handle_event
         setattr(trace, "_py_progress_handler", monitor.handle_event)  # noqa: B010
@@ -1237,7 +1297,9 @@ def _persist_image(  # pylint: disable=too-many-arguments
     lock_timeout: float = PERSIST_LOCK_TIMEOUT_SECONDS,
     *,
     on_observation=None,
-) -> tuple[bool, str]:
+    return_observation: bool = False,
+    final_check=None,
+) -> tuple[bool, str] | ImageObservation:
     """Align compat, stage the cache write, and restore metadata only when no installation occurred.
 
     Pure-Python (no .NET), so the guarantees are unit-testable without a live AS instance.
@@ -1254,15 +1316,32 @@ def _persist_image(  # pylint: disable=too-many-arguments
     lock is reclaimed rather than blocking forever, and a live holder that overruns ``lock_timeout``
     surfaces as :class:`ModelLockTimeout` rather than an unbounded wait.
     """
-    cache_path.parent.mkdir(parents=True, exist_ok=True)
-    lock_path = cache_path.with_name(cache_path.name + ".lock")
-    with model_lock(lock_path, timeout=lock_timeout):
-        return _persist_image_locked(cache_path, model_dir, live_level, write_image, on_observation=on_observation)
+    _validate_observation_request(return_observation, on_observation)
+    with _observation_errors(return_observation, preserve=(CompatRollbackError, ModelLockTimeout)):
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path = cache_path.with_name(cache_path.name + ".lock")
+        with model_lock(lock_path, timeout=lock_timeout):
+            observation = _persist_image_locked(
+                cache_path,
+                model_dir,
+                live_level,
+                write_image,
+                return_observation=return_observation,
+                final_check=final_check,
+            )
+        return observation
 
 
-def _persist_image_locked(
-    cache_path: Path, model_dir: Path | None, live_level: int, write_image, *, on_observation=None
-) -> tuple[bool, str]:
+def _persist_image_locked(  # pylint: disable=too-many-arguments
+    cache_path: Path,
+    model_dir: Path | None,
+    live_level: int,
+    write_image,
+    *,
+    on_observation=None,
+    return_observation: bool = False,
+    final_check=None,
+) -> tuple[bool, str] | ImageObservation:
     """The persist transaction itself, run while the per-model lock is held (see :func:`_persist_image`).
 
     ``KeyboardInterrupt`` handling is the subtle part (issue #113 route 2). The commit-detection and
@@ -1273,18 +1352,21 @@ def _persist_image_locked(
     rollback. If the rollback itself fails, :class:`CompatRollbackError` is raised INSTEAD (chained
     from the interrupt): a bricked project matters more than a tidy Ctrl+C.
     """
+    _validate_observation_request(return_observation, on_observation)
     rollback_paths = _compat_rollback_paths(model_dir)
     snapshot = _snapshot_rollback_paths(rollback_paths)
     staging = _staging_path(cache_path)
     installation = _ImageInstallation()
-    observations = [] if on_observation is not None else None
+    intended = None
     write_error: BaseException | None = None
     pending_declaration: tuple[Path, Path, str, str, str] | None = None
     try:
         aligned, pending_declaration = _align_compatibility(model_dir, live_level, defer_declaration=True)
-        if aligned:
+        if aligned and not return_observation:
             print(f"  save   : {aligned}")
-        _staged_image_write(cache_path, write_image, staging, observations=observations, installation=installation)
+        intended = _staged_image_write(
+            cache_path, write_image, staging, installation=installation, return_observation=return_observation
+        )
     except BaseException as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught  # KeyboardInterrupt must NOT bypass rollback; commit judged below by the filesystem
         write_error = exc
 
@@ -1292,10 +1374,15 @@ def _persist_image_locked(
         _cleanup_staging(staging)
         if pending_declaration is not None:
             _append_generated_edit_declaration(*pending_declaration)
-        if on_observation is not None:
+        if return_observation:
             if write_error is not None:
                 raise write_error
-            on_observation(observations[0])
+            installed = _checked_image(cache_path)
+            if installed != intended:
+                raise CompatRollbackError("installed cache differs from the intended image; observation unavailable")
+            if final_check is not None:
+                final_check()
+            return ImageObservation(intended[0], intended[1], installed[0], installed[1])
         size_note = f"{installation.size / 1024:.1f} KB, "
         return True, f"persisted via AMO ImageSave ({size_note}compatibilityLevel {live_level})"
 
@@ -1318,17 +1405,40 @@ def _persist_image_locked(
         # consistent again, so re-raise. For an interrupt this honours the Ctrl+C; for an ordinary
         # ImageSave failure the caller falls back to the UI save.
         raise write_error
+    if return_observation:
+        raise ObservationUnavailable("TOOL_UNAVAILABLE")
     return False, "ImageSave did not produce a complete cache file (compatibility alignment rolled back)"
 
 
-def image_save(
+def image_save(  # pylint: disable=too-many-arguments
     port: int,
     cache_path: Path,
     model_dir: Path | None = None,
     *,
     bound: BoundDesktop | None = None,
     on_persist=None,
-):
+    return_observation: bool = False,
+) -> tuple[bool, str] | PersistenceObservation:
+    """Return the legacy save tuple, or this invocation's bound ImageSave/readback observation.
+
+    An exact True opts into closed errors and requires a binding. The retired ``on_persist`` sink
+    refuses all non-None values. Nothing is published until finalization, the two bounded cache
+    passes, compatibility declaration, final recheck, lock exit and AMO teardown have completed.
+    This is neither a durable-write barrier nor proof of a cold reopen.
+    """
+    _validate_observation_request(return_observation, on_persist)
+    with _observation_errors(return_observation, preserve=(CompatRollbackError, ModelLockTimeout)):
+        return _image_save(port, cache_path, model_dir, bound=bound, return_observation=return_observation)
+
+
+def _image_save(
+    port: int,
+    cache_path: Path,
+    model_dir: Path | None,
+    *,
+    bound: BoundDesktop | None,
+    return_observation: bool,
+) -> tuple[bool, str] | PersistenceObservation:
     """Persist the in-memory model to ``<Name>.SemanticModel/.pbi/cache.abf`` via AMO ``ImageSave``.
 
     ⚠️ **A cache is only loadable if its compatibility level MATCHES the project's**, so this
@@ -1351,7 +1461,7 @@ def image_save(
     never written. Note the client throws "The server sent an unrecognizable response" while writing
     correctly, so success is judged by the FILE, never by the absence of an exception.
     """
-    if on_persist is not None and bound is None:
+    if return_observation and bound is None:
         raise ObservationUnavailable("IDENTITY_UNESTABLISHED")
     if bound is not None:
         if bound.identity.port != port:
@@ -1391,26 +1501,32 @@ def image_save(
             finally:
                 stream.Close()
 
-        def record(observation: ImageObservation) -> None:
+        def final_check() -> None:
             if desktop_identity(bound.identity.pid) != bound.identity:
                 raise ObservationUnavailable("PID_REUSED")
             current = list(server.Databases)
             if len(current) != 1 or str(current[0].ID) != bound.catalogue:
                 raise ObservationUnavailable("CATALOGUE_CHANGED")
-            blob = cache_path.read_bytes()
-            if (
-                hashlib.sha256(blob).hexdigest() != observation.installed_sha256
-                or len(blob) != observation.installed_size
-            ):
-                raise CompatRollbackError("installed cache changed before observation; do NOT fall back to UI Save")
-            if on_persist is not None:
-                on_persist(PersistenceObservation(bound.catalogue, live_level, observation))
 
-        return _persist_image(
-            cache_path, model_dir, live_level, write_image, on_observation=record if on_persist is not None else None
+        outcome = _persist_image(
+            cache_path,
+            model_dir,
+            live_level,
+            write_image,
+            return_observation=return_observation,
+            final_check=final_check if return_observation else None,
         )
     finally:
-        server.Disconnect()
+        if return_observation:
+            try:
+                server.Disconnect()
+            except Exception:  # pylint: disable=broad-exception-caught
+                print("[save] AMO disconnect unavailable (TOOL_UNAVAILABLE)")
+        else:
+            server.Disconnect()
+    if return_observation:
+        return PersistenceObservation(bound.catalogue, live_level, outcome, bound.identity)
+    return outcome
 
 
 def save(pid: int) -> tuple[bool, str]:
@@ -1878,6 +1994,9 @@ def _refresh_and_save(  # pylint: disable=too-many-return-statements,too-many-br
                     "REFRESH: NOT_PERSISTED (a concurrent persist of this model holds the lock; "
                     "data is in memory only). Wait for the other run to finish and retry."
                 )
+                return 1
+            except ObservationUnavailable:
+                print("REFRESH: NOT_PERSISTED (observation unavailable; do NOT fall back to UI Save)")
                 return 1
             except Exception as exc:  # noqa: BLE001  # pylint: disable=broad-exception-caught
                 saved, save_message = False, f"ImageSave unavailable ({type(exc).__name__}); falling back to UI"

--- a/.github/skills/pbip-model-refresh/scripts/refresh_pbip_model.py
+++ b/.github/skills/pbip-model-refresh/scripts/refresh_pbip_model.py
@@ -672,7 +672,7 @@ def _refresh(
                 conn = adomd_connection(f"Data Source=localhost:{port}{selection}")
                 conn.Open()
                 if bound is not None:
-                    recheck_bound(bound, conn)
+                    recheck_bound(bound, conn, observation_mode=return_observation)
                 catalog = bound.catalogue if bound is not None else _catalog_id(conn)
                 objects = [{"database": catalog, "table": t} for t in targets] if targets else [{"database": catalog}]
                 cmd = conn.CreateCommand()
@@ -680,7 +680,7 @@ def _refresh(
                 cmd.CommandTimeout = command_timeout
                 cmd.ExecuteNonQuery()
                 if bound is not None:
-                    recheck_bound(bound, conn)
+                    recheck_bound(bound, conn, observation_mode=return_observation)
                     result["observation"] = RefreshObservation(
                         catalog, refresh_type, "tables" if targets else "database", targets, bound.identity
                     )

--- a/.github/skills/pbip-model-refresh/tests/test_canary_data_gate.py
+++ b/.github/skills/pbip-model-refresh/tests/test_canary_data_gate.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 import re
 import threading
 import time
+import queue
+import traceback
 from dataclasses import FrozenInstanceError, replace
 from types import SimpleNamespace
 
@@ -287,7 +289,9 @@ def test_canary_observation_uses_the_bound_query_and_actual_returned_rows(monkey
     bound = _bound_connection(monkeypatch, conn)
     observations = probe_desktop_query.probe_observations(bound, ["Owner's Orders"])
     query = "EVALUATE TOPN(1, 'Owner''s Orders')"
-    assert observations == (probe_desktop_query.CanaryObservation(conn.Database, "Owner's Orders", query, count),)
+    assert observations == (
+        probe_desktop_query.CanaryObservation(conn.Database, "Owner's Orders", query, count, bound.identity),
+    )
     assert conn.queries.count(query) == 1
     assert probe_desktop_query.derive_data_verdict is refresh_pbip_model.derive_data_verdict
     with pytest.raises(FrozenInstanceError):
@@ -301,21 +305,26 @@ def test_canary_observation_uses_the_bound_query_and_actual_returned_rows(monkey
     ids=["implicit", "empty", "empty-name", "blank-name", "bool-name", "string", "mapping", "duplicate"],
 )
 def test_observations_require_nonempty_explicit_unique_canaries(monkeypatch, canaries):
-    bound = _bound_connection(monkeypatch, _Conn([("Parameters", False)], {"Parameters": 1}))
+    conn = _Conn([("Parameters", False)], {"Parameters": 1})
+    bound = _bound_connection(monkeypatch, conn)
+    before = list(conn.queries)
     with pytest.raises(probe_desktop_query.ObservationUnavailable, match="^CANARIES_REQUIRED$"):
         probe_desktop_query.probe_observations(bound, canaries)
+    assert conn.queries == before, "canary-set guard must precede opening/querying a new connection"
 
 
 @pytest.mark.parametrize("count", [True, False, 1.0, -1])
 def test_observation_counts_are_not_coerced(monkeypatch, count):
     conn = _Conn([("Orders", False)], {})
     bound = _bound_connection(monkeypatch, conn)
-    monkeypatch.setattr(probe_desktop_query, "_probe_one", lambda *_args, **_kwargs: count)
+    queried = []
+    monkeypatch.setattr(probe_desktop_query, "_probe_one", lambda *_args, **_kwargs: queried.append(1) or count)
     with pytest.raises(probe_desktop_query.ObservationUnavailable, match="^TOOL_UNAVAILABLE$"):
         probe_desktop_query.probe_observations(bound, ["Orders"])
+    assert queried == [1], "returned-row type guard must reject an actual current query result"
 
 
-@pytest.mark.parametrize("changed", ["catalogue", "process_start", "as_pid", "as_process_start", "port"])
+@pytest.mark.parametrize("changed", ["catalogue", "pid", "process_start", "as_pid", "as_process_start", "port"])
 def test_query_result_is_not_returned_after_bound_identity_changes(monkeypatch, changed):
     conn = _Conn([("Orders", False)], {"Orders": 1})
     bound = _bound_connection(monkeypatch, conn)
@@ -397,3 +406,215 @@ def test_observation_deadline_bounds_native_query_and_inspection(monkeypatch):
             assert queried == ([1] if blocked == "query" else [])
         finally:
             release.set()
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("pid", 333),
+        ("process_start", "200"),
+        ("as_pid", 444),
+        ("as_process_start", "201"),
+        ("port", 52002),
+    ],
+)
+def test_canary_identity_does_not_collapse_same_catalogue_sessions(monkeypatch, field, value):
+    conn = _Conn([("Orders", False)], {"Orders": 1})
+    first = _bound_connection(monkeypatch, conn)
+    prior = probe_desktop_query.probe_observations(first, ["Orders"])[0]
+    second = replace(first, identity=replace(first.identity, **{field: value}))
+    monkeypatch.setattr(probe_desktop_query, "desktop_identity", lambda *_: second.identity)
+    current = probe_desktop_query.probe_observations(second, ["Orders"])[0]
+    assert prior.catalogue == current.catalogue
+    assert current.identity == second.identity and prior != current, f"{field} must remain bound to its query"
+    assert conn.queries.count("EVALUATE TOPN(1, 'Orders')") == 2
+
+
+def test_canary_inputs_and_old_results_cannot_mutate_current_invocation(monkeypatch):
+    conn = _Conn([("Orders", False)], {"Orders": 1})
+    bound = _bound_connection(monkeypatch, conn)
+    prior = probe_desktop_query.probe_observations(bound, ["Orders"])[0]
+    entered, release = threading.Event(), threading.Event()
+    query = probe_desktop_query._probe_one
+    published = []
+
+    def blocked_query(*args, **kwargs):
+        rows = query(*args, **kwargs)
+        entered.set()
+        assert release.wait(5)
+        return rows
+
+    monkeypatch.setattr(probe_desktop_query, "_probe_one", blocked_query)
+    canaries = ["Orders"]
+    caller = threading.Thread(target=lambda: published.append(probe_desktop_query.probe_observations(bound, canaries)))
+    caller.start()
+    try:
+        assert entered.wait(3), "mutation must occur after the current canary entered its read"
+        object.__setattr__(prior, "returned_rows", 999)
+        canaries[:] = ["Forged"]
+        assert published == [] and caller.is_alive()
+    finally:
+        release.set()
+        caller.join(5)
+    assert not caller.is_alive() and len(published) == 1
+    assert published[0][0].table == "Orders" and published[0][0].returned_rows == 1
+
+    def failed_retry(*_args, **_kwargs):
+        entered.clear()
+        raise RuntimeError("retry failed")
+
+    monkeypatch.setattr(probe_desktop_query, "_probe_one", failed_retry)
+    with pytest.raises(probe_desktop_query.ObservationUnavailable, match="^TOOL_UNAVAILABLE$"):
+        published.append(probe_desktop_query.probe_observations(bound, ["Orders"]))
+    assert not entered.is_set() and len(published) == 1, "a failed new read cannot return an old observation"
+
+
+@pytest.mark.parametrize("phase", ["connection-close", "canary-reader-close", "catalogue-reader-close"])
+@pytest.mark.parametrize("error_type", [RuntimeError, KeyboardInterrupt, SystemExit])
+def test_canary_adomd_teardown_is_best_effort_but_does_not_swallow_interrupts(monkeypatch, phase, error_type):
+    conn = _Conn([("Orders", False)], {"Orders": 1})
+    bound = _bound_connection(monkeypatch, conn)
+    entered = []
+
+    def close():
+        entered.append(phase)
+        raise error_type("PRIVATE_ADOMD_CLOSE")
+
+    if phase == "connection-close":
+        conn.Close = close
+    else:
+        reader_for = conn.reader_for
+
+        def reader(text):
+            result = reader_for(text)
+            if ("TOPN" in text) == (phase == "canary-reader-close"):
+                result.Close = close
+            return result
+
+        conn.reader_for = reader
+    if error_type is RuntimeError:
+        observed = probe_desktop_query.probe_observations(bound, ["Orders"])
+        assert observed[0].returned_rows == 1 and observed[0].identity == bound.identity
+    else:
+        expected = KeyboardInterrupt if error_type is KeyboardInterrupt else probe_desktop_query.ObservationUnavailable
+        with pytest.raises(expected) as caught:
+            probe_desktop_query.probe_observations(bound, ["Orders"])
+        assert caught.value.args == (() if error_type is KeyboardInterrupt else ("TOOL_UNAVAILABLE",))
+    assert entered, f"must enter {phase}, not refuse for an unrelated reason"
+
+
+@pytest.mark.parametrize("observe", [False, True], ids=["legacy", "observation"])
+@pytest.mark.parametrize(
+    "kind,code",
+    [
+        ("native", "TOOL_UNAVAILABLE"),
+        ("exit", "TOOL_UNAVAILABLE"),
+        ("interrupt", None),
+        ("known", "CATALOGUE_CHANGED"),
+        ("forged", "TOOL_UNAVAILABLE"),
+    ],
+)
+def test_canary_error_privacy_has_an_unchanged_legacy_control(monkeypatch, capsys, observe, kind, code):
+    conn = _Conn([("Orders", False)], {"Orders": 1})
+    bound = _bound_connection(monkeypatch, conn)
+    sentinel = "PRIVATE_QUERY_ENDPOINT_TOKEN_PATH_PAYLOAD"
+    error = {
+        "native": RuntimeError(sentinel),
+        "exit": SystemExit(sentinel),
+        "interrupt": KeyboardInterrupt(sentinel),
+        "known": probe_desktop_query.ObservationUnavailable("CATALOGUE_CHANGED"),
+        "forged": probe_desktop_query.ObservationUnavailable(sentinel),
+    }[kind]
+    error.add_note(sentinel)
+    cause = RuntimeError(sentinel)
+    reader_for = conn.reader_for
+
+    def native_reader(text):
+        if "TOPN" in text:
+            conn.queries.append(text)
+            raise error from cause
+        return reader_for(text)
+
+    conn.reader_for = native_reader
+    with pytest.raises(BaseException) as caught:
+        if observe:
+            probe_desktop_query.probe_observations(bound, ["Orders"])
+        else:
+            probe_desktop_query.probe(52001, ["Orders"])
+    assert conn.queries.count("EVALUATE TOPN(1, 'Orders')") == 1, "must enter the native query failure"
+    if observe:
+        expected = KeyboardInterrupt if kind == "interrupt" else probe_desktop_query.ObservationUnavailable
+        assert type(caught.value) is expected and caught.value is not error
+        assert caught.value.args == (() if code is None else (code,))
+        assert caught.value.__context__ is caught.value.__cause__ is None
+        assert not getattr(caught.value, "__notes__", ())
+        rendered = "".join(traceback.format_exception(caught.value))
+        assert sentinel not in rendered and "native_reader" not in rendered
+        assert sentinel not in str(capsys.readouterr())
+    else:
+        assert caught.value is error and caught.value.__cause__ is cause and caught.value.__notes__ == [sentinel]
+
+
+def test_read_result_waits_for_worker_termination_not_queue_publication(monkeypatch):
+    entered, release = threading.Event(), threading.Event()
+    workers, published = [], []
+
+    class DelayedQueue(queue.Queue):
+        def put(self, item, *args, **kwargs):
+            super().put(item, *args, **kwargs)
+            if item[0] is True:
+                workers.append(threading.current_thread())
+                entered.set()
+                assert release.wait(5), "test must release its own post-result worker"
+
+    monkeypatch.setattr(probe_desktop_query.queue, "Queue", DelayedQueue)
+    try:
+        with pytest.raises(probe_desktop_query.ObservationUnavailable, match="^TIMEOUT$"):
+            published.append(probe_desktop_query._observation_call(111, lambda: "private facts", 0.1))
+        assert entered.is_set() and workers[0].is_alive(), "must reject a queued result from an unfinished worker"
+    finally:
+        release.set()
+        for worker in workers:
+            worker.join(5)
+    assert published == [] and all(not worker.is_alive() for worker in workers)
+
+
+def test_inspection_failure_after_queued_read_still_refuses(monkeypatch):
+    inspecting, release, queued = threading.Event(), threading.Event(), threading.Event()
+    published, failures = [], []
+
+    class ObservedQueue(queue.Queue):
+        def put(self, item, *args, **kwargs):
+            super().put(item, *args, **kwargs)
+            if item[0] is True:
+                queued.set()
+
+    def inspect_state(_pid, **_kwargs):
+        if threading.current_thread().name == "observation-inspection":
+            inspecting.set()
+            assert release.wait(5)
+            return probe_desktop_query.CredentialDetection(modal=object())
+        return probe_desktop_query.CredentialDetection()
+
+    def read():
+        assert inspecting.wait(3), "inspection must be in flight before the read completes"
+        return "private facts"
+
+    def call():
+        try:
+            published.append(probe_desktop_query._observation_call(111, read, 4))
+        except probe_desktop_query.ObservationUnavailable as error:
+            failures.append(error)
+
+    monkeypatch.setattr(probe_desktop_query.queue, "Queue", ObservedQueue)
+    monkeypatch.setattr(probe_desktop_query, "_credential_state", inspect_state)
+    caller = threading.Thread(target=call)
+    caller.start()
+    try:
+        assert queued.wait(3), "must queue a read result while the inspection is unfinished"
+        assert caller.is_alive() and published == []
+    finally:
+        release.set()
+        caller.join(5)
+    assert not caller.is_alive() and published == []
+    assert len(failures) == 1 and failures[0].args == ("CREDENTIAL_MISSING",)

--- a/.github/skills/pbip-model-refresh/tests/test_desktop_instance_binding.py
+++ b/.github/skills/pbip-model-refresh/tests/test_desktop_instance_binding.py
@@ -17,8 +17,11 @@ candidates), and prove the connected model really is the one that owns the cache
 from __future__ import annotations
 
 import json
+import inspect
 import re
-from dataclasses import asdict
+import threading
+import traceback
+from dataclasses import FrozenInstanceError, asdict, replace
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -253,38 +256,37 @@ def test_observation_catalogue_is_one_exact_id_and_reader_is_closed(catalogues):
 @pytest.mark.parametrize("tables", [(), ("Orders",)], ids=["database", "tables"])
 def test_refresh_observation_matches_the_executed_scope(monkeypatch, kind, tables):
     bound = probe_desktop_query.BoundDesktop(OBSERVED_IDENTITY, OBSERVED_CATALOGUE)
-    sent, observations = [], []
+    sent = []
     command = SimpleNamespace()
     command.ExecuteNonQuery = lambda: sent.append(json.loads(command.CommandText))
     connection = SimpleNamespace(CreateCommand=lambda: command, Open=lambda: None, Close=lambda: None)
     monkeypatch.setattr(refresh_pbip_model, "_load_adomd", lambda: lambda _: connection)
     monkeypatch.setattr(refresh_pbip_model, "recheck_bound", lambda *_: None)
-    ok, _ = refresh_pbip_model.refresh(
+    observation = refresh_pbip_model.refresh(
         52001,
         list(tables),
         desktop_pid=111,
         refresh_type=kind,
         bound=bound,
-        observations=observations,
+        return_observation=True,
         progress_enabled=False,
     )
-    assert ok is True
     objects = [{"database": OBSERVED_CATALOGUE, "table": "Orders"}] if tables else [{"database": OBSERVED_CATALOGUE}]
     assert sent == [{"refresh": {"type": kind, "objects": objects}}]
-    assert observations == [
-        refresh_pbip_model.RefreshObservation(
-            OBSERVED_CATALOGUE, kind, "tables" if tables else "database", tables, OBSERVED_IDENTITY
-        )
-    ]
+    assert observation == refresh_pbip_model.RefreshObservation(
+        OBSERVED_CATALOGUE, kind, "tables" if tables else "database", tables, OBSERVED_IDENTITY
+    )
+    with pytest.raises(FrozenInstanceError):
+        observation.catalogue = "caller mutation"
     with pytest.raises(probe_desktop_query.ObservationUnavailable, match="^WRONG_PID_PORT$"):
-        refresh_pbip_model.refresh(52002, None, desktop_pid=111, bound=bound, observations=[])
+        refresh_pbip_model.refresh(52002, None, desktop_pid=111, bound=bound, return_observation=True)
     with pytest.raises(probe_desktop_query.ObservationUnavailable, match="^IDENTITY_UNESTABLISHED$"):
-        refresh_pbip_model.refresh(52001, None, observations=[])
+        refresh_pbip_model.refresh(52001, None, return_observation=True)
 
 
 def test_a_failed_retry_cannot_reuse_a_prior_refresh_observation(monkeypatch):
     bound = probe_desktop_query.BoundDesktop(OBSERVED_IDENTITY, OBSERVED_CATALOGUE)
-    opened, executed, observed = [], [], []
+    opened, executed = [], []
 
     def execute():
         executed.append(1)
@@ -296,42 +298,395 @@ def test_a_failed_retry_cannot_reuse_a_prior_refresh_observation(monkeypatch):
     monkeypatch.setattr(refresh_pbip_model, "_load_adomd", lambda: lambda _: connection)
     monkeypatch.setattr(refresh_pbip_model, "recheck_bound", lambda *_: None)
     options = dict(desktop_pid=111, bound=bound, progress_enabled=False)
-    assert refresh_pbip_model.refresh(52001, None, observations=observed, **options)[0] is True
-    prior = tuple(observed)
-    error = None
-    try:
-        refresh_pbip_model.refresh(52001, None, observations=observed, **options)
-    except BaseException as caught:
-        error = caught
-    assert opened == executed == [1], "a reused collector must be refused before native work"
-    assert isinstance(error, probe_desktop_query.ObservationUnavailable) and str(error) == "OBSERVATIONS_NOT_EMPTY"
-    assert tuple(observed) == prior
-    fresh = []
-    with pytest.raises(RuntimeError, match="native retry failed"):
-        refresh_pbip_model.refresh(52001, None, observations=fresh, **options)
-    assert fresh == [] and tuple(observed) == prior
+    prior = refresh_pbip_model.refresh(52001, None, return_observation=True, **options)
+    published = []
+    with pytest.raises(probe_desktop_query.ObservationUnavailable, match="^TOOL_UNAVAILABLE$"):
+        published.append(refresh_pbip_model.refresh(52001, None, return_observation=True, **options))
+    assert opened == executed == [1, 1], "the retry must enter XMLA, not merely reject an old collector"
+    assert published == [] and prior.identity == OBSERVED_IDENTITY
 
 
 def test_same_catalogue_refreshes_retain_their_distinct_desktop_and_as_identity(monkeypatch):
-    second = probe_desktop_query.DesktopIdentity(333, "200", 444, "201", 52002)
     command = SimpleNamespace(ExecuteNonQuery=lambda: None)
     connection = SimpleNamespace(CreateCommand=lambda: command, Open=lambda: None, Close=lambda: None)
     monkeypatch.setattr(refresh_pbip_model, "_load_adomd", lambda: lambda _: connection)
     monkeypatch.setattr(refresh_pbip_model, "recheck_bound", lambda *_: None)
     observations = []
-    for identity in (OBSERVED_IDENTITY, second):
+    for identity in (
+        OBSERVED_IDENTITY,
+        *(
+            replace(OBSERVED_IDENTITY, **{field: value})
+            for field, value in (
+                ("pid", 333),
+                ("process_start", "200"),
+                ("as_pid", 444),
+                ("as_process_start", "201"),
+                ("port", 52002),
+            )
+        ),
+    ):
         bound = probe_desktop_query.BoundDesktop(identity, OBSERVED_CATALOGUE)
-        own = []
-        assert (
-            refresh_pbip_model.refresh(
-                identity.port, None, desktop_pid=identity.pid, bound=bound, observations=own, progress_enabled=False
-            )[0]
-            is True
+        own = refresh_pbip_model.refresh(
+            identity.port, None, desktop_pid=identity.pid, bound=bound, return_observation=True, progress_enabled=False
         )
-        assert len(own) == 1 and own[0].identity == identity
-        observations.extend(own)
-    assert observations[0].catalogue == observations[1].catalogue == OBSERVED_CATALOGUE
-    assert observations[0] != observations[1]
+        assert own.identity == identity
+        observations.append(own)
+    assert {item.catalogue for item in observations} == {OBSERVED_CATALOGUE}
+    assert len(set(observations)) == 6, "every identity component is authoritative, even in the same catalogue"
+
+
+class _HostileObservationArgument:
+    def __init__(self):
+        self.touched = []
+
+    def __bool__(self):
+        self.touched.append("bool")
+        raise AssertionError("retired argument inspected")
+
+    def __len__(self):
+        self.touched.append("len")
+        raise AssertionError("retired argument inspected")
+
+    def __iter__(self):
+        self.touched.append("iter")
+        raise AssertionError("retired argument inspected")
+
+    def __call__(self, *_args):
+        self.touched.append("call")
+        raise AssertionError("retired argument invoked")
+
+    def append(self, _value):
+        self.touched.append("append")
+        raise AssertionError("retired argument invoked")
+
+
+def _observation_entry(name, cache, **options):
+    bound = probe_desktop_query.BoundDesktop(OBSERVED_IDENTITY, OBSERVED_CATALOGUE)
+    if name == "refresh":
+        return refresh_pbip_model.refresh(52001, None, desktop_pid=111, bound=bound, **options)
+    if name == "image_save":
+        return refresh_pbip_model.image_save(52001, cache, bound=bound, **options)
+    if name == "_staged_image_write":
+        return refresh_pbip_model._staged_image_write(cache, lambda _path: None, **options)
+    return getattr(refresh_pbip_model, name)(cache, cache.parent.parent, 1606, lambda _path: None, **options)
+
+
+@pytest.mark.parametrize(
+    "name,sink_name",
+    [
+        ("refresh", "observations"),
+        ("image_save", "on_persist"),
+        ("_persist_image", "on_observation"),
+        ("_persist_image_locked", "on_observation"),
+        ("_staged_image_write", "observations"),
+    ],
+)
+@pytest.mark.parametrize("mode", [False, True])
+@pytest.mark.parametrize("sink_kind", ["empty", "populated", "false", "callable", "hostile"])
+def test_all_retired_sinks_refuse_without_inspection_or_io(monkeypatch, tmp_path, name, sink_name, mode, sink_kind):
+    touched = []
+    hostile = _HostileObservationArgument()
+    sink = {
+        "empty": [],
+        "populated": [object()],
+        "false": False,
+        "callable": lambda _: touched.append("called"),
+        "hostile": hostile,
+    }[sink_kind]
+
+    def unexpected(*_args, **_kwargs):
+        touched.append("I/O")
+        raise AssertionError("retired-sink guard ran too late")
+
+    with monkeypatch.context() as patch:
+        for module, attr in (
+            (refresh_pbip_model, "_load_adomd"),
+            (refresh_pbip_model, "_load_amo"),
+            (refresh_pbip_model, "desktop_identity"),
+            (refresh_pbip_model, "_credential_state"),
+            (refresh_pbip_model, "_snapshot_rollback_paths"),
+            (Path, "mkdir"),
+        ):
+            patch.setattr(module, attr, unexpected)
+        with pytest.raises(probe_desktop_query.ObservationUnavailable, match="^TOOL_UNAVAILABLE$"):
+            _observation_entry(name, tmp_path / "cache.abf", return_observation=mode, **{sink_name: sink})
+    assert touched == hostile.touched == [], "the retired-sink identity guard must precede all inspection/work"
+
+
+@pytest.mark.parametrize(
+    "name", ["refresh", "image_save", "_persist_image", "_persist_image_locked", "_staged_image_write"]
+)
+@pytest.mark.parametrize(
+    "mode",
+    [None, 0, 1, 0.0, 1.0, "", "True", [], _HostileObservationArgument()],
+    ids=["none", "zero", "one", "float-zero", "float-one", "empty-text", "text", "list", "hostile"],
+)
+def test_observation_mode_is_an_exact_bool_before_io(monkeypatch, tmp_path, name, mode):
+    touched = []
+
+    def unexpected(*_args, **_kwargs):
+        touched.append("I/O")
+        raise AssertionError("exact-mode guard ran too late")
+
+    with monkeypatch.context() as patch:
+        patch.setattr(Path, "mkdir", unexpected)
+        patch.setattr(refresh_pbip_model, "_load_adomd", unexpected)
+        patch.setattr(refresh_pbip_model, "_load_amo", unexpected)
+        patch.setattr(refresh_pbip_model, "desktop_identity", unexpected)
+        patch.setattr(refresh_pbip_model, "_credential_state", unexpected)
+        patch.setattr(refresh_pbip_model, "_snapshot_rollback_paths", unexpected)
+        with pytest.raises(probe_desktop_query.ObservationUnavailable, match="^TOOL_UNAVAILABLE$"):
+            _observation_entry(name, tmp_path / "cache.abf", return_observation=mode)
+    assert touched == [], "bool substitutes must not enter native or filesystem phases"
+    if isinstance(mode, _HostileObservationArgument):
+        assert mode.touched == []
+
+
+def test_public_observation_modes_are_keyword_only_and_default_to_legacy():
+    for function in (refresh_pbip_model.refresh, refresh_pbip_model.image_save):
+        parameter = inspect.signature(function).parameters["return_observation"]
+        assert parameter.kind is inspect.Parameter.KEYWORD_ONLY and parameter.default is False
+
+
+def _refresh_connection(monkeypatch):
+    """A local connection double with the real bound/catalogue rechecks still in the path."""
+    events = []
+    bound = probe_desktop_query.BoundDesktop(OBSERVED_IDENTITY, OBSERVED_CATALOGUE)
+    connection = SimpleNamespace(
+        Database=OBSERVED_CATALOGUE, Open=lambda: events.append("open"), Close=lambda: events.append("adomd-close")
+    )
+
+    def command():
+        cmd = SimpleNamespace()
+        cmd.ExecuteReader = lambda: _FakeReader([(connection.Database, False)])
+        cmd.ExecuteNonQuery = lambda: events.append(json.loads(cmd.CommandText))
+        return cmd
+
+    connection.CreateCommand = command
+    monkeypatch.setattr(probe_desktop_query, "desktop_identity", lambda *_: bound.identity)
+    monkeypatch.setattr(refresh_pbip_model, "_load_adomd", lambda: lambda _: connection)
+    return bound, connection, events
+
+
+@pytest.mark.parametrize("explicit", [False, True], ids=["default", "explicit-false"])
+def test_refresh_legacy_tuple_is_unchanged(monkeypatch, explicit):
+    _, _, events = _refresh_connection(monkeypatch)
+    options = {"return_observation": False} if explicit else {}
+    result = refresh_pbip_model.refresh(52001, ["Orders"], progress_enabled=False, **options)
+    assert result == (True, f"refreshed Orders (catalog {OBSERVED_CATALOGUE})")
+    assert events[-1] == "adomd-close"
+
+
+@pytest.mark.parametrize("field", ["pid", "process_start", "as_pid", "as_process_start", "port", "catalogue"])
+def test_refresh_rechecks_each_identity_component_after_xmla(monkeypatch, field):
+    bound, connection, events = _refresh_connection(monkeypatch)
+    create = connection.CreateCommand
+
+    def command():
+        cmd = create()
+        execute = cmd.ExecuteNonQuery
+
+        def change_after_execution():
+            execute()
+            if field == "catalogue":
+                connection.Database = "22222222-2222-3333-4444-555555555555"
+            else:
+                value = "200" if "start" in field else 777
+                monkeypatch.setattr(
+                    probe_desktop_query, "desktop_identity", lambda *_: replace(bound.identity, **{field: value})
+                )
+
+        cmd.ExecuteNonQuery = change_after_execution
+        return cmd
+
+    connection.CreateCommand = command
+    code = "CATALOGUE_CHANGED" if field == "catalogue" else "PID_REUSED"
+    with pytest.raises(probe_desktop_query.ObservationUnavailable, match=f"^{code}$"):
+        refresh_pbip_model.refresh(
+            52001, None, bound=bound, desktop_pid=111, progress_enabled=False, return_observation=True
+        )
+    assert isinstance(events[1], dict) and events[-1] == "adomd-close", "must reach the post-XMLA recheck"
+
+
+def test_caller_mutation_cannot_change_an_event_blocked_refresh(monkeypatch):
+    bound, connection, events = _refresh_connection(monkeypatch)
+    options = dict(bound=bound, desktop_pid=111, progress_enabled=False, return_observation=True)
+    prior = refresh_pbip_model.refresh(52001, ["Orders"], **options)
+    entered, release = threading.Event(), threading.Event()
+    create = connection.CreateCommand
+    published = []
+
+    def command():
+        cmd = create()
+        execute = cmd.ExecuteNonQuery
+
+        def block():
+            execute()
+            entered.set()
+            assert release.wait(5), "test failed to release its owned XMLA worker"
+
+        cmd.ExecuteNonQuery = block
+        return cmd
+
+    connection.CreateCommand = command
+    tables = ["Orders"]
+    caller = threading.Thread(target=lambda: published.append(refresh_pbip_model.refresh(52001, tables, **options)))
+    caller.start()
+    try:
+        assert entered.wait(3), "must enter the current invocation before mutating caller-owned state"
+        object.__setattr__(prior, "catalogue", "forged old result")
+        tables[:] = ["Forged"]
+        assert published == [] and caller.is_alive()
+    finally:
+        release.set()
+        caller.join(5)
+    assert not caller.is_alive() and len(published) == 1
+    assert published[0].catalogue == OBSERVED_CATALOGUE and published[0].tables == ("Orders",)
+    assert events[-2]["refresh"]["objects"] == [{"database": OBSERVED_CATALOGUE, "table": "Orders"}]
+
+
+def test_refresh_refuses_when_join_returns_before_worker_teardown(monkeypatch):
+    bound, connection, events = _refresh_connection(monkeypatch)
+    entered, release = threading.Event(), threading.Event()
+    workers, published = [], []
+
+    def close():
+        events.append("adomd-close-entered")
+        entered.set()
+        assert release.wait(5)
+
+    def premature_join(worker, **_kwargs):
+        workers.append(worker)
+        assert entered.wait(3), "must reach close with a completed XMLA result"
+        return True
+
+    connection.Close = close
+    monkeypatch.setattr(refresh_pbip_model, "_join_refresh_worker", premature_join)
+    try:
+        with pytest.raises(probe_desktop_query.ObservationUnavailable, match="^TIMEOUT$"):
+            published.append(
+                refresh_pbip_model.refresh(
+                    52001, None, bound=bound, desktop_pid=111, progress_enabled=False, return_observation=True
+                )
+            )
+        assert workers[0].is_alive() and isinstance(events[1], dict), "worker-completion guard must be exercised"
+    finally:
+        release.set()
+        for worker in workers:
+            worker.join(5)
+    assert published == [] and all(not worker.is_alive() for worker in workers), "no late publication after refusal"
+
+
+@pytest.mark.parametrize("phase", ["adomd-close", "trace-stop", "trace-drop", "trace-disconnect", "monitor-close"])
+@pytest.mark.parametrize("error_type", [RuntimeError, KeyboardInterrupt, SystemExit])
+def test_refresh_teardown_distinguishes_ordinary_failures_from_interrupts(monkeypatch, capsys, phase, error_type):
+    bound, connection, events = _refresh_connection(monkeypatch)
+
+    def action(name):
+        def call():
+            events.append(name)
+            if name == phase:
+                raise error_type("PRIVATE_TEARDOWN_DETAIL")
+
+        return call
+
+    connection.Close = action("adomd-close")
+    monitor = refresh_pbip_model.RefreshProgressMonitor(
+        trace=SimpleNamespace(Stop=action("trace-stop"), Drop=action("trace-drop")),
+        server=SimpleNamespace(Disconnect=action("trace-disconnect")),
+        observation_mode=True,
+    )
+    if phase == "monitor-close":
+        monitor.close = action(phase)
+    monkeypatch.setattr(refresh_pbip_model, "_start_refresh_progress_trace", lambda *_a, **_k: monitor)
+    published = []
+    if error_type is RuntimeError:
+        published.append(refresh_pbip_model.refresh(52001, None, bound=bound, desktop_pid=111, return_observation=True))
+        assert type(published[0]) is refresh_pbip_model.RefreshObservation
+        expected = (
+            ["adomd-close", "monitor-close"]
+            if phase == "monitor-close"
+            else ["adomd-close", "trace-stop", "trace-drop", "trace-disconnect"]
+        )
+        assert events[-len(expected) :] == expected, "ordinary failure must not skip later teardown attempts"
+    else:
+        expected_type = (
+            KeyboardInterrupt if error_type is KeyboardInterrupt else probe_desktop_query.ObservationUnavailable
+        )
+        with pytest.raises(expected_type) as caught:
+            published.append(
+                refresh_pbip_model.refresh(52001, None, bound=bound, desktop_pid=111, return_observation=True)
+            )
+        assert caught.value.args == (() if error_type is KeyboardInterrupt else ("TOOL_UNAVAILABLE",))
+    assert phase in events and isinstance(events[1], dict), "must enter teardown after XMLA completion"
+    assert "PRIVATE_TEARDOWN_DETAIL" not in str(capsys.readouterr())
+
+
+@pytest.mark.parametrize("observe", [False, True], ids=["legacy", "observation"])
+@pytest.mark.parametrize(
+    "kind,code",
+    [
+        ("native", "TOOL_UNAVAILABLE"),
+        ("system-exit", "TOOL_UNAVAILABLE"),
+        ("interrupt", None),
+        ("known", "PID_REUSED"),
+        ("unknown-code", "TOOL_UNAVAILABLE"),
+        ("timeout", "TIMEOUT"),
+    ],
+)
+def test_refresh_errors_are_fresh_closed_observations_or_unchanged_legacy(monkeypatch, capsys, observe, kind, code):
+    bound, connection, events = _refresh_connection(monkeypatch)
+    sentinel = "PRIVATE_NATIVE_PATH_ENDPOINT_TOKEN_PAYLOAD"
+    error = {
+        "native": RuntimeError(sentinel),
+        "system-exit": SystemExit(sentinel),
+        "interrupt": KeyboardInterrupt(sentinel),
+        "known": probe_desktop_query.ObservationUnavailable("PID_REUSED"),
+        "unknown-code": probe_desktop_query.ObservationUnavailable(sentinel),
+        "timeout": TimeoutError(sentinel),
+    }[kind]
+    error.add_note(sentinel)
+    cause = RuntimeError(sentinel)
+    create = connection.CreateCommand
+
+    def command():
+        cmd = create()
+
+        def native_execute():
+            events.append("native-execute")
+            raise error from cause
+
+        cmd.ExecuteNonQuery = native_execute
+        return cmd
+
+    connection.CreateCommand = command
+    with pytest.raises(BaseException) as caught:
+        refresh_pbip_model.refresh(
+            52001, None, bound=bound, desktop_pid=111, progress_enabled=False, return_observation=observe
+        )
+    assert events == ["open", "native-execute", "adomd-close"], "must reach the actual worker error"
+    if observe:
+        expected = KeyboardInterrupt if kind == "interrupt" else probe_desktop_query.ObservationUnavailable
+        assert type(caught.value) is expected and caught.value is not error
+        assert caught.value.args == (() if code is None else (code,))
+        assert caught.value.__cause__ is caught.value.__context__ is None
+        assert not getattr(caught.value, "__notes__", ())
+        rendered = "".join(traceback.format_exception(caught.value))
+        assert sentinel not in rendered and "native_execute" not in rendered
+        assert sentinel not in str(capsys.readouterr())
+    else:
+        assert caught.value is error and caught.value.__cause__ is cause
+        assert caught.value.__notes__ == [sentinel]
+
+
+def test_closed_refusal_severs_an_exception_active_in_the_caller():
+    try:
+        raise RuntimeError("PRIVATE_OUTER_CONTEXT")
+    except RuntimeError:
+        with pytest.raises(probe_desktop_query.ObservationUnavailable) as caught:
+            refresh_pbip_model.refresh(52001, None, observations=[])
+    assert caught.value.args == ("TOOL_UNAVAILABLE",)
+    assert caught.value.__cause__ is caught.value.__context__ is None
 
 
 def test_table_names_filters_the_auto_date_scaffolding_but_can_keep_hidden_tables() -> None:

--- a/.github/skills/pbip-model-refresh/tests/test_desktop_instance_binding.py
+++ b/.github/skills/pbip-model-refresh/tests/test_desktop_instance_binding.py
@@ -261,7 +261,7 @@ def test_refresh_observation_matches_the_executed_scope(monkeypatch, kind, table
     command.ExecuteNonQuery = lambda: sent.append(json.loads(command.CommandText))
     connection = SimpleNamespace(CreateCommand=lambda: command, Open=lambda: None, Close=lambda: None)
     monkeypatch.setattr(refresh_pbip_model, "_load_adomd", lambda: lambda _: connection)
-    monkeypatch.setattr(refresh_pbip_model, "recheck_bound", lambda *_: None)
+    monkeypatch.setattr(refresh_pbip_model, "recheck_bound", lambda *_args, **_kwargs: None)
     observation = refresh_pbip_model.refresh(
         52001,
         list(tables),
@@ -296,7 +296,7 @@ def test_a_failed_retry_cannot_reuse_a_prior_refresh_observation(monkeypatch):
     command = SimpleNamespace(ExecuteNonQuery=execute)
     connection = SimpleNamespace(CreateCommand=lambda: command, Open=lambda: opened.append(1), Close=lambda: None)
     monkeypatch.setattr(refresh_pbip_model, "_load_adomd", lambda: lambda _: connection)
-    monkeypatch.setattr(refresh_pbip_model, "recheck_bound", lambda *_: None)
+    monkeypatch.setattr(refresh_pbip_model, "recheck_bound", lambda *_args, **_kwargs: None)
     options = dict(desktop_pid=111, bound=bound, progress_enabled=False)
     prior = refresh_pbip_model.refresh(52001, None, return_observation=True, **options)
     published = []
@@ -310,7 +310,7 @@ def test_same_catalogue_refreshes_retain_their_distinct_desktop_and_as_identity(
     command = SimpleNamespace(ExecuteNonQuery=lambda: None)
     connection = SimpleNamespace(CreateCommand=lambda: command, Open=lambda: None, Close=lambda: None)
     monkeypatch.setattr(refresh_pbip_model, "_load_adomd", lambda: lambda _: connection)
-    monkeypatch.setattr(refresh_pbip_model, "recheck_bound", lambda *_: None)
+    monkeypatch.setattr(refresh_pbip_model, "recheck_bound", lambda *_args, **_kwargs: None)
     observations = []
     for identity in (
         OBSERVED_IDENTITY,
@@ -475,6 +475,83 @@ def test_refresh_legacy_tuple_is_unchanged(monkeypatch, explicit):
     result = refresh_pbip_model.refresh(52001, ["Orders"], progress_enabled=False, **options)
     assert result == (True, f"refreshed Orders (catalog {OBSERVED_CATALOGUE})")
     assert events[-1] == "adomd-close"
+
+
+@pytest.mark.parametrize("mode", ["default", "false", "true"])
+@pytest.mark.parametrize("phase", ["before-xmla", "after-xmla"])
+@pytest.mark.parametrize("fault", ["execute-reader", "reader-close"])
+def test_bound_refresh_catalogue_failures_respect_observation_mode(monkeypatch, capsys, mode, phase, fault):
+    """Exercise both production rechecks, not a helper that the legacy refresh could bypass."""
+    bound, connection, events = _refresh_connection(monkeypatch)
+    create = connection.CreateCommand
+    sentinel = "PRIVATE_CATALOGUE_QUERY_OR_CLOSE_DIAGNOSTIC"
+    error = RuntimeError(sentinel)
+    cause = OSError("PRIVATE_CATALOGUE_CAUSE")
+    error.add_note("PRIVATE_CATALOGUE_NOTE")
+    entered, readers = [], []
+
+    def native_catalogue_failure():
+        entered.append((phase, fault))
+        raise error from cause
+
+    def command():
+        cmd = create()
+        execute_reader = cmd.ExecuteReader
+
+        def read():
+            assert cmd.CommandText == "SELECT [CATALOG_NAME] FROM $SYSTEM.DBSCHEMA_CATALOGS"
+            current_phase = "after-xmla" if any(isinstance(event, dict) for event in events) else "before-xmla"
+            targeted = current_phase == phase
+            if targeted and fault == "execute-reader":
+                native_catalogue_failure()
+            reader = execute_reader()
+            readers.append(reader)
+            if targeted and fault == "reader-close":
+                close = reader.Close
+
+                def fail_close():
+                    close()
+                    native_catalogue_failure()
+
+                reader.Close = fail_close
+            return reader
+
+        cmd.ExecuteReader = read
+        return cmd
+
+    connection.CreateCommand = command
+    options = {} if mode == "default" else {"return_observation": mode == "true"}
+    result, failure = None, None
+    try:
+        result = refresh_pbip_model.refresh(
+            52001, None, bound=bound, desktop_pid=111, progress_enabled=False, **options
+        )
+    except BaseException as caught:
+        failure = caught
+    assert entered == [(phase, fault)], "the actual catalogue query/Close must enter the intended recheck phase"
+    assert events[-1] == "adomd-close" and all(reader.closed for reader in readers)
+    executed = sum(isinstance(event, dict) for event in events)
+    assert executed == int(phase == "after-xmla" or (mode == "true" and fault == "reader-close")), (
+        "legacy failure at the initial catalogue recheck must abort before XMLA"
+    )
+    if mode != "true":
+        assert failure is error, "legacy catalogue errors, including Close failures, must propagate the original object"
+        assert result is None, "legacy Close failure must abort rather than report successful refresh"
+        assert type(failure) is RuntimeError and failure.args == (sentinel,)
+        assert failure.__cause__ is cause and failure.__notes__ == ["PRIVATE_CATALOGUE_NOTE"]
+        rendered = "".join(traceback.format_exception(failure))
+        assert sentinel in rendered and "native_catalogue_failure" in rendered
+    elif fault == "reader-close":
+        assert failure is None and type(result) is refresh_pbip_model.RefreshObservation
+        assert result.identity == bound.identity and result.catalogue == bound.catalogue
+    else:
+        assert result is None and type(failure) is probe_desktop_query.ObservationUnavailable and failure is not error
+        assert failure.args == ("TOOL_UNAVAILABLE",) and failure.__cause__ is failure.__context__ is None
+        assert not getattr(failure, "__notes__", ())
+        rendered = "".join(traceback.format_exception(failure))
+        assert sentinel not in rendered and "native_catalogue_failure" not in rendered
+    if mode == "true":
+        assert sentinel not in str(capsys.readouterr())
 
 
 @pytest.mark.parametrize("field", ["pid", "process_start", "as_pid", "as_process_start", "port", "catalogue"])

--- a/.github/skills/pbip-model-refresh/tests/test_persist_atomicity.py
+++ b/.github/skills/pbip-model-refresh/tests/test_persist_atomicity.py
@@ -39,13 +39,16 @@ from __future__ import annotations
 import json
 import hashlib
 import inspect
-from dataclasses import fields
+from contextlib import contextmanager
+from dataclasses import FrozenInstanceError, fields, replace
 import os
 import socket
 import struct
 import subprocess
 import sys
+import threading
 import time
+import traceback
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -55,7 +58,7 @@ import pytest
 # ruff: noqa: E402  (the conftest-provided path must be in place before these imports)
 import refresh_pbip_model
 import _abf
-from probe_desktop_query import DesktopIdentity
+from probe_desktop_query import BoundDesktop, DesktopIdentity, ObservationUnavailable
 
 SKILL_ROOT = Path(__file__).resolve().parents[1]
 
@@ -204,7 +207,7 @@ def test_image_observation_does_not_infer_commitment_from_replacement_bytes(tmp_
     cache.write_bytes(content)  # An old identical image cannot stand in for this operation.
     stamp = cache.stat().st_mtime_ns
     native_replace = os.replace
-    observed = []
+    published = []
 
     def replace_cache(source, destination):
         if Path(destination) == cache:
@@ -227,27 +230,24 @@ def test_image_observation_does_not_infer_commitment_from_replacement_bytes(tmp_
             cache.parent.parent,
             1606,
             lambda path: path.write_bytes(content[:-1] if mode == "truncated" else content),
-            on_observation=observed.append,
-        )[0]
+            return_observation=True,
+        )
 
-    if mode == "wrong-image":
-        with pytest.raises(refresh_pbip_model.CompatRollbackError, match="intended image"):
-            persist()
-    elif mode == "commit-raise":
-        with pytest.raises(refresh_pbip_model.CompatRollbackError, match="unestablished"):
-            persist()
-    elif mode == "failed-replace":
-        with pytest.raises(OSError, match="replace failed"):
-            persist()
+    if mode in ("wrong-image", "commit-raise"):
+        with pytest.raises(refresh_pbip_model.CompatRollbackError, match="^TOOL_UNAVAILABLE$"):
+            published.append(persist())
+    elif mode in ("failed-replace", "truncated"):
+        with pytest.raises(ObservationUnavailable, match="^TOOL_UNAVAILABLE$"):
+            published.append(persist())
     else:
-        assert persist() is (mode != "truncated")
+        published.append(persist())
     if mode == "normal":
         digest = hashlib.sha256(content).hexdigest()
-        assert observed == [refresh_pbip_model.ImageObservation(digest, len(content), digest, len(content))]
-        assert observed[0].commitment == "UNESTABLISHED"
+        assert published == [refresh_pbip_model.ImageObservation(digest, len(content), digest, len(content))]
+        assert published[0].commitment == "UNESTABLISHED"
         assert cache.read_bytes() == content
     else:
-        assert observed == []
+        assert published == []
     level = "1606" if mode in ("normal", "commit-raise", "wrong-image") else "1604"
     assert f"compatibilityLevel: {level}" in (cache.parent.parent / "definition" / "database.tmdl").read_text()
     assert _no_staging_files(cache)
@@ -267,7 +267,7 @@ def test_imagesave_observation_is_bound_and_exports_only_native_facts(tmp_path, 
         "ambiguous": [database, database],
         "wrong": [SimpleNamespace(ID="other", CompatibilityLevel=1606)],
     }[catalogues]
-    writes, observed = [], []
+    writes = []
 
     def write(catalogue, stream):
         writes.append(catalogue)
@@ -291,56 +291,57 @@ def test_imagesave_observation_is_bound_and_exports_only_native_facts(tmp_path, 
         ),
     )
 
-    def record(observation):
-        assert cache.with_name("cache.abf.lock").exists()
-        observed.append(observation)
-
     if catalogues != "one":
         code = "CATALOGUE_CHANGED" if catalogues == "wrong" else "CATALOGUE_UNESTABLISHED"
         with pytest.raises(refresh_pbip_model.ObservationUnavailable, match=f"^{code}$"):
-            refresh_pbip_model.image_save(52001, cache, cache.parent.parent, bound=identity, on_persist=record)
-        assert writes == observed == []
+            refresh_pbip_model.image_save(52001, cache, cache.parent.parent, bound=identity, return_observation=True)
+        assert writes == []
         return
-    assert (
-        refresh_pbip_model.image_save(52001, cache, cache.parent.parent, bound=identity, on_persist=record)[0] is True
+    observation = refresh_pbip_model.image_save(
+        52001, cache, cache.parent.parent, bound=identity, return_observation=True
     )
-    assert writes == [identity.catalogue] and len(observed) == 1
-    assert observed[0].catalogue == identity.catalogue and observed[0].method == "AMO_ImageSave"
-    assert observed[0].compatibility_level == 1606
-    assert {item.name for item in fields(observed[0])} == {"catalogue", "compatibility_level", "image", "method"}
-    assert observed[0].image.commitment == "UNESTABLISHED"
+    assert writes == [identity.catalogue]
+    assert observation.catalogue == identity.catalogue and observation.method == "AMO_ImageSave"
+    assert observation.compatibility_level == 1606 and observation.identity == identity.identity
+    assert {item.name for item in fields(observation)} == {
+        "catalogue",
+        "compatibility_level",
+        "image",
+        "identity",
+        "method",
+    }
+    assert observation.image.commitment == "UNESTABLISHED"
+    with pytest.raises(FrozenInstanceError):
+        observation.catalogue = "caller mutation"
     assert not cache.with_name("cache.abf.lock").exists()
     with pytest.raises(refresh_pbip_model.ObservationUnavailable, match="^WRONG_PID_PORT$"):
-        refresh_pbip_model.image_save(52002, cache, bound=identity, on_persist=record)
+        refresh_pbip_model.image_save(52002, cache, bound=identity, return_observation=True)
     with pytest.raises(refresh_pbip_model.ObservationUnavailable, match="^IDENTITY_UNESTABLISHED$"):
-        refresh_pbip_model.image_save(52001, cache, on_persist=record)
+        refresh_pbip_model.image_save(52001, cache, return_observation=True)
 
 
 def test_a_missing_or_failing_flush_barrier_never_becomes_durable_evidence(tmp_path, monkeypatch):
     cache = _model(tmp_path, compat=1604)
-    observed, flushes = [], []
+    flushes = []
 
     def failing_flush(_descriptor):
         flushes.append(1)
         raise OSError("durable flush failed")
 
     monkeypatch.setattr(os, "fsync", failing_flush)
-    assert (
-        refresh_pbip_model._persist_image(
-            cache,
-            cache.parent.parent,
-            1606,
-            lambda path: path.write_bytes(_abf_bytes()),
-            on_observation=observed.append,
-        )[0]
-        is True
+    observation = refresh_pbip_model._persist_image(
+        cache,
+        cache.parent.parent,
+        1606,
+        lambda path: path.write_bytes(_abf_bytes()),
+        return_observation=True,
     )
-    assert observed[0].commitment == "UNESTABLISHED"
+    assert observation.commitment == "UNESTABLISHED"
     assert flushes == []  # Exact review control: close/replace/readback did not exercise a barrier.
     assert not hasattr(_abf, "ImageCommit")
 
     old = cache.read_bytes()
-    observed.clear()
+    published = []
 
     def writer_with_barrier(path):
         with path.open("wb") as handle:
@@ -348,11 +349,13 @@ def test_a_missing_or_failing_flush_barrier_never_becomes_durable_evidence(tmp_p
             handle.flush()
             os.fsync(handle.fileno())
 
-    with pytest.raises(OSError, match="durable flush failed"):
-        refresh_pbip_model._persist_image(
-            cache, cache.parent.parent, 1702, writer_with_barrier, on_observation=observed.append
+    with pytest.raises(ObservationUnavailable, match="^TOOL_UNAVAILABLE$"):
+        published.append(
+            refresh_pbip_model._persist_image(
+                cache, cache.parent.parent, 1702, writer_with_barrier, return_observation=True
+            )
         )
-    assert flushes == [1] and observed == [] and cache.read_bytes() == old
+    assert flushes == [1] and published == [] and cache.read_bytes() == old
     assert "compatibilityLevel: 1606" in (cache.parent.parent / "definition" / "database.tmdl").read_text()
 
 
@@ -361,7 +364,7 @@ def test_removed_stage_and_raised_replace_cannot_reuse_identical_old_target(tmp_
     cache.parent.mkdir()
     content = _abf_bytes()
     cache.write_bytes(content)
-    observed = []
+    published = []
     replace_file = os.replace
 
     def failed_replace(source, destination):
@@ -371,24 +374,26 @@ def test_removed_stage_and_raised_replace_cannot_reuse_identical_old_target(tmp_
         return replace_file(source, destination)
 
     monkeypatch.setattr(os, "replace", failed_replace)
-    with pytest.raises(refresh_pbip_model.CompatRollbackError, match="unestablished"):
-        refresh_pbip_model._persist_image(
-            cache, cache.parent.parent, 1606, lambda path: path.write_bytes(content), on_observation=observed.append
+    with pytest.raises(refresh_pbip_model.CompatRollbackError, match="^TOOL_UNAVAILABLE$"):
+        published.append(
+            refresh_pbip_model._persist_image(
+                cache, cache.parent.parent, 1606, lambda path: path.write_bytes(content), return_observation=True
+            )
         )
-    assert observed == [] and cache.read_bytes() == content
+    assert published == [] and cache.read_bytes() == content
     assert "compatibilityLevel: 1606" in (cache.parent.parent / "definition" / "database.tmdl").read_text()
 
 
-@pytest.mark.parametrize("fault", ["read", "hash", "list", "interrupt"])
+@pytest.mark.parametrize("fault", ["read", "hash", "reader-exit", "interrupt"])
 @pytest.mark.parametrize("observe", [False, True], ids=["legacy", "observing"])
 def test_post_swap_observation_faults_never_roll_compatibility_back(tmp_path, monkeypatch, fault, observe):
     cache = _model(tmp_path, compat=1604)
     cache.parent.mkdir()
     cache.write_bytes(_abf_bytes(seed=1))
     intended = _abf_bytes(seed=2)
-    observed, attempted = [], []
+    attempted = []
     swapped = False
-    replace_file, read_bytes, digest, stage = os.replace, Path.read_bytes, hashlib.sha256, _abf._staged_image_write
+    replace_file, open_file, digest = os.replace, Path.open, hashlib.sha256
 
     def install(source, destination):
         nonlocal swapped
@@ -401,45 +406,39 @@ def test_post_swap_observation_faults_never_roll_compatibility_back(tmp_path, mo
         attempted.append(fault)
         raise KeyboardInterrupt() if fault == "interrupt" else OSError(f"post-swap {fault}")
 
-    def read(path):
-        if swapped and path == cache and fault in ("read", "interrupt"):
+    @contextmanager
+    def open_reader(path, *args, **kwargs):
+        with open_file(path, *args, **kwargs) as handle:
+            if swapped and path == cache and fault in ("read", "interrupt"):
+                fail()
+            yield handle
+        if swapped and path == cache and fault == "reader-exit":
             fail()
-        return read_bytes(path)
 
     def hash_bytes(*args, **kwargs):
         if swapped and fault == "hash":
             fail()
         return digest(*args, **kwargs)
 
-    class FailingList(list):
-        def append(self, _item):
-            fail()
-
-    def write_stage(*args, **kwargs):
-        if fault == "list" and kwargs["observations"] is not None:
-            kwargs["observations"] = FailingList()
-        return stage(*args, **kwargs)
-
-    monkeypatch.setattr(os, "replace", install)
-    monkeypatch.setattr(Path, "read_bytes", read)
-    monkeypatch.setattr(hashlib, "sha256", hash_bytes)
-    monkeypatch.setattr(refresh_pbip_model, "_staged_image_write", write_stage)
     result, error = None, None
-    try:
-        result = refresh_pbip_model._persist_image(
-            cache,
-            cache.parent.parent,
-            1606,
-            lambda path: path.write_bytes(intended),
-            on_observation=observed.append if observe else None,
-        )
-    except BaseException as caught:
-        error = caught
-    assert swapped and read_bytes(cache) == intended
+    with monkeypatch.context() as patch:
+        patch.setattr(os, "replace", install)
+        patch.setattr(Path, "open", open_reader)
+        patch.setattr(hashlib, "sha256", hash_bytes)
+        try:
+            result = refresh_pbip_model._persist_image(
+                cache,
+                cache.parent.parent,
+                1606,
+                lambda path: path.write_bytes(intended),
+                return_observation=observe,
+            )
+        except BaseException as caught:
+            error = caught
+    assert swapped and cache.read_bytes() == intended
     assert "compatibilityLevel: 1606" in (cache.parent.parent / "definition" / "database.tmdl").read_text()
-    assert observed == []
     if observe:
-        assert isinstance(error, KeyboardInterrupt if fault == "interrupt" else OSError)
+        assert result is None and type(error) is (KeyboardInterrupt if fault == "interrupt" else ObservationUnavailable)
         assert attempted == [fault]
     else:
         assert error is None and result[0] is True
@@ -472,7 +471,7 @@ def test_interrupt_after_replace_returns_before_installed_flag_preserves_alignme
     cache.parent.mkdir()
     cache.write_bytes(_abf_bytes(seed=1))
     intended = _abf_bytes(seed=2)
-    observed, interrupted = [], []
+    published, interrupted = [], []
     stage = _abf._staged_image_write
     lines, first_line = inspect.getsourcelines(stage)
     flag_line = first_line + next(
@@ -492,12 +491,14 @@ def test_interrupt_after_replace_returns_before_installed_flag_preserves_alignme
     error = None
     try:
         sys.settrace(interrupt)
-        refresh_pbip_model._persist_image(
-            cache,
-            cache.parent.parent,
-            1606,
-            lambda path: path.write_bytes(intended),
-            on_observation=observed.append,
+        published.append(
+            refresh_pbip_model._persist_image(
+                cache,
+                cache.parent.parent,
+                1606,
+                lambda path: path.write_bytes(intended),
+                return_observation=True,
+            )
         )
     except BaseException as caught:
         error = caught
@@ -507,8 +508,8 @@ def test_interrupt_after_replace_returns_before_installed_flag_preserves_alignme
     assert cache.read_bytes() == intended
     assert "compatibilityLevel: 1606" in (cache.parent.parent / "definition" / "database.tmdl").read_text()
     assert interrupted[0][:2] == (False, True)
-    assert isinstance(error, refresh_pbip_model.CompatRollbackError) and "unestablished" in str(error)
-    assert observed == []
+    assert isinstance(error, refresh_pbip_model.CompatRollbackError) and error.args == ("TOOL_UNAVAILABLE",)
+    assert published == []
     assert not hasattr(_abf, "ImageCommit")
     assert _no_staging_files(cache)
 
@@ -1316,3 +1317,808 @@ def test_a_failed_persist_preserves_the_definition_mtime(tmp_path: Path) -> None
     assert database_tmdl.read_bytes() == before_bytes, "bytes must be restored exactly"
     assert database_tmdl.stat().st_mtime_ns == before_mtime, "the mtime must be restored too"
     assert cache.stat().st_mtime > database_tmdl.stat().st_mtime, "the existing cache must stay valid"
+
+
+def _native_imagesave(monkeypatch, cache, *, identity=None, content=None):
+    """Native doubles only: retain the real persistence transaction, validators and rechecks."""
+    bound = BoundDesktop(
+        identity or DesktopIdentity(111, "100", 222, "101", 52001),
+        "11111111-2222-3333-4444-555555555555",
+    )
+    events, calls = [], []
+    content = _abf_bytes(seed=3) if content is None else content
+
+    def stream(path, *_args):
+        events.append("stream-open")
+        return SimpleNamespace(path=Path(path), Close=lambda: events.append("stream-close"))
+
+    def write(catalogue, handle):
+        events.append("write")
+        calls.append(catalogue)
+        handle.path.write_bytes(content)
+
+    server = SimpleNamespace(
+        Databases=[SimpleNamespace(ID=bound.catalogue, CompatibilityLevel=1606)],
+        Connect=lambda _: events.append("connect"),
+        Disconnect=lambda: events.append("amo-disconnect"),
+        ImageSave=write,
+    )
+    native_io = SimpleNamespace(
+        FileAccess=SimpleNamespace(Write=1), FileMode=SimpleNamespace(Create=2), FileStream=stream
+    )
+    monkeypatch.setitem(sys.modules, "System.IO", native_io)
+    monkeypatch.setattr(refresh_pbip_model, "_load_amo", lambda: lambda: server)
+    monkeypatch.setattr(refresh_pbip_model, "desktop_identity", lambda *_: events.append("identity") or bound.identity)
+    return SimpleNamespace(bound=bound, server=server, io=native_io, events=events, calls=calls, content=content)
+
+
+def _save_observed(cache, native, **options):
+    return refresh_pbip_model.image_save(
+        native.bound.identity.port, cache, cache.parent.parent, bound=native.bound, return_observation=True, **options
+    )
+
+
+@pytest.mark.parametrize("explicit", [False, True], ids=["default", "explicit-false"])
+def test_imagesave_preserves_the_legacy_tuple(monkeypatch, tmp_path, explicit):
+    cache = _model(tmp_path, compat=1604)
+    native = _native_imagesave(monkeypatch, cache)
+    options = {"return_observation": False} if explicit else {}
+    result = refresh_pbip_model.image_save(52001, cache, cache.parent.parent, **options)
+    assert result == (
+        True,
+        f"persisted via AMO ImageSave ({len(native.content) / 1024:.1f} KB, compatibilityLevel 1606)",
+    )
+    assert native.calls == [native.bound.catalogue] and native.events[-1] == "amo-disconnect"
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("pid", 333),
+        ("process_start", "200"),
+        ("as_pid", 444),
+        ("as_process_start", "201"),
+        ("port", 52002),
+    ],
+)
+def test_persistence_keeps_every_identity_component_even_for_one_catalogue(monkeypatch, tmp_path, field, value):
+    cache = _model(tmp_path, compat=1604)
+    first = _native_imagesave(monkeypatch, cache)
+    prior = _save_observed(cache, first)
+    second = _native_imagesave(monkeypatch, cache, identity=replace(first.bound.identity, **{field: value}))
+    current = _save_observed(cache, second)
+    assert prior.catalogue == current.catalogue and prior.image == current.image
+    assert current.identity == second.bound.identity and prior != current, f"persistence must retain {field}"
+
+
+@pytest.mark.parametrize("field", ["pid", "process_start", "as_pid", "as_process_start", "port", "catalogue"])
+def test_persistence_final_recheck_refuses_each_changed_identity(monkeypatch, tmp_path, field):
+    cache = _model(tmp_path, compat=1604)
+    native = _native_imagesave(monkeypatch, cache)
+    checked = refresh_pbip_model._checked_image
+    entered = []
+
+    def change_after_readback(path):
+        result = checked(path)
+        assert path == cache, "the mutation must occur after installed, not staged, readback"
+        entered.append(field)
+        if field == "catalogue":
+            native.server.Databases[0].ID = "22222222-2222-3333-4444-555555555555"
+        else:
+            value = "200" if "start" in field else 777
+            monkeypatch.setattr(
+                refresh_pbip_model, "desktop_identity", lambda *_: replace(native.bound.identity, **{field: value})
+            )
+        return result
+
+    monkeypatch.setattr(refresh_pbip_model, "_checked_image", change_after_readback)
+    code = "CATALOGUE_CHANGED" if field == "catalogue" else "PID_REUSED"
+    with pytest.raises(ObservationUnavailable, match=f"^{code}$"):
+        _save_observed(cache, native)
+    assert entered == [field] and native.calls == [native.bound.catalogue]
+    assert native.events[-1] == "amo-disconnect" and cache.read_bytes() == native.content
+    assert refresh_pbip_model.read_declared_compatibility(cache.parent.parent)[0] == 1606
+
+
+def test_caller_mutation_and_failed_retry_cannot_supply_persistence_observations(monkeypatch, tmp_path):
+    cache = _model(tmp_path, compat=1604)
+    native = _native_imagesave(monkeypatch, cache)
+    prior = _save_observed(cache, native)
+    entered, release = threading.Event(), threading.Event()
+    published = []
+    write = native.server.ImageSave
+
+    def blocked_write(*args):
+        write(*args)
+        entered.set()
+        assert release.wait(5)
+
+    native.server.ImageSave = blocked_write
+    caller = threading.Thread(target=lambda: published.append(_save_observed(cache, native)))
+    caller.start()
+    try:
+        assert entered.wait(3), "must mutate old caller state while this invocation is inside ImageSave"
+        object.__setattr__(prior, "catalogue", "forged prior")
+        object.__setattr__(prior.image, "installed_sha256", "forged digest")
+        assert published == [] and caller.is_alive()
+    finally:
+        release.set()
+        caller.join(5)
+    assert not caller.is_alive() and len(published) == 1
+    assert published[0].catalogue == native.bound.catalogue
+    assert published[0].image.installed_sha256 == hashlib.sha256(native.content).hexdigest()
+
+    def failed_retry(*_args):
+        entered.clear()
+        raise RuntimeError("retry failed")
+
+    native.server.ImageSave = failed_retry
+    with pytest.raises(ObservationUnavailable, match="^TOOL_UNAVAILABLE$"):
+        published.append(_save_observed(cache, native))
+    assert not entered.is_set() and len(published) == 1, "failed retry must enter the writer but publish nothing"
+
+
+class _TrackedCacheReader:
+    def __init__(self, handle, role, events):
+        self.handle, self.role, self.events = handle, role, events
+        self.reads, self.seeks = [], []
+
+    def __enter__(self):
+        self.handle.__enter__()
+        self.events.append(f"{self.role}-open")
+        return self
+
+    def read(self, size=-1):
+        assert 0 <= size <= 1024 * 1024, "cache reads must request at most 1 MiB"
+        offset = self.handle.tell()
+        chunk = self.handle.read(size)
+        self.reads.append((offset, size, len(chunk)))
+        return chunk
+
+    def seek(self, offset):
+        self.seeks.append(offset)
+        return self.handle.seek(offset)
+
+    def __exit__(self, *args):
+        result = self.handle.__exit__(*args)
+        self.events.append(f"{self.role}-exit")
+        return result
+
+
+@pytest.mark.parametrize("observe", [False, True], ids=["legacy-headers-only", "two-sequential-observation-passes"])
+def test_persistence_cache_traversal_and_publication_order_are_exact(monkeypatch, tmp_path, observe):
+    cache = _model(tmp_path, compat=1604)
+    (tmp_path / "input_manifest.json").write_text(
+        json.dumps({"generated_artifacts": {"version": 1, "run_id": "test-run"}}), encoding="utf-8"
+    )
+    payload = 1024 * 1024 + 13
+    content = _abf_bytes(((_ABF_MAX_BLOCK_BYTES, payload), (128, 17)))
+    native = _native_imagesave(monkeypatch, cache, content=content)
+    events, readers, hashes = native.events, [], []
+    open_file, replace_file = Path.open, os.replace
+    declaration, lock = refresh_pbip_model._append_generated_edit_declaration, refresh_pbip_model.model_lock
+
+    def open_path(path, mode="r", *args, **kwargs):
+        handle = open_file(path, mode, *args, **kwargs)
+        if mode == "rb" and path.name.startswith("cache.abf"):
+            reader = _TrackedCacheReader(handle, "installed" if path == cache else "stage", events)
+            readers.append(reader)
+            return reader
+        return handle
+
+    def install(source, destination):
+        result = replace_file(source, destination)
+        if Path(destination) == cache:
+            events.append("replace")
+        return result
+
+    def declare(*args):
+        result = declaration(*args)
+        events.append("declare")
+        return result
+
+    @contextmanager
+    def model_lock(*args, **kwargs):
+        with lock(*args, **kwargs):
+            yield
+        events.append("lock-exit")
+
+    class CountingHash:
+        def __init__(self):
+            self.digest, self.count = hashlib.sha256(), 0
+            hashes.append(self)
+
+        def update(self, data):
+            self.count += len(data)
+            self.digest.update(data)
+
+        def hexdigest(self):
+            return self.digest.hexdigest()
+
+    monkeypatch.setattr(Path, "open", open_path)
+    monkeypatch.setattr(os, "replace", install)
+    monkeypatch.setattr(refresh_pbip_model, "_append_generated_edit_declaration", declare)
+    monkeypatch.setattr(refresh_pbip_model, "model_lock", model_lock)
+    monkeypatch.setattr(_abf, "hashlib", SimpleNamespace(sha256=CountingHash))
+    result = refresh_pbip_model.image_save(
+        52001, cache, cache.parent.parent, bound=native.bound, return_observation=observe
+    )
+    if observe:
+        next_header = 102 + 12 + payload
+        expected = [
+            (0, 102, 102),
+            (102, 12, 12),
+            (114, 1024 * 1024, 1024 * 1024),
+            (114 + 1024 * 1024, 13, 13),
+            (next_header, 12, 12),
+            (next_header + 12, 17, 17),
+            (len(content), 1, 0),
+        ]
+        assert [reader.role for reader in readers] == ["stage", "installed"], "exactly two cache opens/passes"
+        assert all(reader.reads == expected and reader.seeks == [] for reader in readers), (
+            "no skips, rewinds or rereads"
+        )
+        assert [digest.count for digest in hashes] == [len(content), len(content)], (
+            "hash every consumed byte exactly once"
+        )
+        assert events == [
+            "identity",
+            "connect",
+            "stream-open",
+            "write",
+            "stream-close",
+            "stage-open",
+            "stage-exit",
+            "replace",
+            "declare",
+            "installed-open",
+            "installed-exit",
+            "identity",
+            "lock-exit",
+            "amo-disconnect",
+        ]
+        assert result.image.intended_sha256 == result.image.installed_sha256 == hashlib.sha256(content).hexdigest()
+        assert result.image.intended_size == result.image.installed_size == len(content)
+        assert result.image.commitment == "UNESTABLISHED"
+    else:
+        assert len(readers) == 1 and readers[0].role == "stage" and hashes == []
+        assert readers[0].reads == [(0, 100, 100), (102, 12, 12), (102 + 12 + payload, 12, 12)]
+        assert readers[0].seeks == [102, 102 + 12 + payload], "legacy validation must not traverse payload bytes"
+        assert result[0] is True
+    assert events[-2:] == ["lock-exit", "amo-disconnect"], "publish only after the contexts and teardown"
+
+
+class _LogicalImage:
+    """More than 3 GiB of logical ABF data, backed by one reusable 1 MiB payload buffer."""
+
+    block_span = 2 * 1024 * 1024
+    full_blocks = 1536
+    last_payload = 31
+
+    def __init__(self):
+        self.size = 102 + self.full_blocks * self.block_span + 12 + self.last_payload
+        self.position, self.consumed, self.maximum, self.eofs, self.closed = 0, 0, 0, 0, False
+        self.payload = memoryview(bytes(1024 * 1024))
+
+    def stat(self):
+        return SimpleNamespace(st_size=self.size)
+
+    def open(self, mode):
+        assert mode == "rb" and self.position == 0, "one fresh sequential read only"
+        return self
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        self.closed = True
+
+    def read(self, size):
+        assert 0 < size <= 1024 * 1024, "multi-GiB input must never request a whole-cache allocation"
+        self.maximum = max(self.maximum, size)
+        if self.position == self.size:
+            self.eofs += 1
+            return b""
+        if self.position < 102:
+            data = (_ABF_PREAMBLE + b"\0\0")[self.position : self.position + size]
+        else:
+            index, within = divmod(self.position - 102, self.block_span)
+            final = index == self.full_blocks
+            payload = self.last_payload if final else self.block_span - 12
+            if within < 12:
+                header = struct.pack("<II", 128 if final else 2 * 1024 * 1024, payload + 4) + b"\x2a\xd7\x86\x4e"
+                data = header[within : within + size]
+            else:
+                data = self.payload[: min(size, payload - (within - 12))]
+        self.position += len(data)
+        self.consumed += len(data)
+        return data
+
+    def seek(self, *_args):
+        raise AssertionError("logical cache cannot be rewound or skipped")
+
+    def read_bytes(self):
+        raise AssertionError("whole-cache reads are forbidden")
+
+
+def test_multigib_image_uses_bounded_sequential_reads_and_a_counting_hash(monkeypatch):
+    logical = _LogicalImage()
+    hashes = []
+
+    class CountingHash:
+        def __init__(self):
+            self.count = 0
+            hashes.append(self)
+
+        def update(self, data):
+            self.count += len(data)
+
+        def hexdigest(self):
+            return f"{self.count:064x}"
+
+    monkeypatch.setattr(_abf, "hashlib", SimpleNamespace(sha256=CountingHash))
+    digest, size = _abf._checked_image(logical)
+    assert size == logical.size > 3 * 1024**3 and digest == f"{size:064x}"
+    assert logical.consumed == size and logical.eofs == 1 and logical.closed
+    assert logical.maximum == 1024 * 1024 and len(logical.payload) == 1024 * 1024
+    assert len(hashes) == 1 and hashes[0].count == size, "hash byte-count must agree with EOF, not a stat proxy"
+
+
+def test_small_image_uses_the_real_sha256_digest_and_byte_count(tmp_path):
+    cache = tmp_path / "cache.abf"
+    content = _abf_bytes(((_ABF_MAX_BLOCK_BYTES, 19), (128, 31)), seed=7)
+    cache.write_bytes(content)
+    assert _abf._checked_image(cache) == (hashlib.sha256(content).hexdigest(), len(content))
+
+
+@pytest.mark.parametrize(
+    "phase",
+    [
+        "stream-close",
+        "stage-read",
+        "stage-hash",
+        "stage-exit",
+        "replace",
+        "declaration",
+        "installed-read",
+        "installed-hash",
+        "installed-exit",
+        "lock-exit",
+    ],
+)
+@pytest.mark.parametrize("error_type", [RuntimeError, KeyboardInterrupt, SystemExit])
+def test_required_persistence_failure_never_publishes_and_respects_installation(
+    monkeypatch, tmp_path, capsys, phase, error_type
+):
+    cache = _model(tmp_path, compat=1604)
+    cache.parent.mkdir()
+    old = _abf_bytes(seed=1)
+    cache.write_bytes(old)
+    (tmp_path / "input_manifest.json").write_text(
+        json.dumps({"generated_artifacts": {"version": 1, "run_id": "test-run"}}), encoding="utf-8"
+    )
+    native = _native_imagesave(monkeypatch, cache)
+    attempted, published = [], []
+    installed = False
+    open_file, replace_file = Path.open, os.replace
+    declaration, lock = refresh_pbip_model._append_generated_edit_declaration, refresh_pbip_model.model_lock
+    file_stream = native.io.FileStream
+
+    def fail():
+        attempted.append(phase)
+        raise error_type("PRIVATE_REQUIRED_FAILURE")
+
+    def stream(*args):
+        handle = file_stream(*args)
+        close = handle.Close
+
+        def finalize():
+            close()
+            if phase == "stream-close":
+                fail()
+
+        handle.Close = finalize
+        return handle
+
+    @contextmanager
+    def open_path(path, mode="r", *args, **kwargs):
+        role = (
+            ("installed" if path == cache else "stage") if path.name.startswith("cache.abf") and mode == "rb" else None
+        )
+        with open_file(path, mode, *args, **kwargs) as handle:
+            if role:
+                native.events.append(f"{role}-read")
+                if phase == f"{role}-read":
+                    fail()
+            yield handle
+        if role:
+            native.events.append(f"{role}-exit")
+            if phase == f"{role}-exit":
+                fail()
+
+    def digest():
+        if phase == ("installed-hash" if installed else "stage-hash"):
+            fail()
+        return hashlib.sha256()
+
+    def install(source, destination):
+        nonlocal installed
+        if Path(destination) == cache and phase == "replace":
+            fail()
+        result = replace_file(source, destination)
+        if Path(destination) == cache:
+            installed = True
+            native.events.append("replace")
+        return result
+
+    def declare(*args):
+        result = declaration(*args)
+        native.events.append("declare")
+        if phase == "declaration":
+            fail()
+        return result
+
+    @contextmanager
+    def model_lock(*args, **kwargs):
+        with lock(*args, **kwargs):
+            yield
+        native.events.append("lock-exit")
+        if phase == "lock-exit":
+            fail()
+
+    with monkeypatch.context() as patch:
+        patch.setattr(native.io, "FileStream", stream)
+        patch.setattr(Path, "open", open_path)
+        patch.setattr(os, "replace", install)
+        patch.setattr(_abf, "hashlib", SimpleNamespace(sha256=digest))
+        patch.setattr(refresh_pbip_model, "_append_generated_edit_declaration", declare)
+        patch.setattr(refresh_pbip_model, "model_lock", model_lock)
+        expected_type = KeyboardInterrupt if error_type is KeyboardInterrupt else ObservationUnavailable
+        with pytest.raises(expected_type) as caught:
+            published.append(_save_observed(cache, native))
+    assert attempted == [phase] and "stream-close" in native.events, f"must reach the intended {phase} boundary"
+    after_install = phase in {"declaration", "installed-read", "installed-hash", "installed-exit", "lock-exit"}
+    assert installed is after_install and published == []
+    assert cache.read_bytes() == (native.content if after_install else old)
+    assert refresh_pbip_model.read_declared_compatibility(cache.parent.parent)[0] == (1606 if after_install else 1604)
+    assert native.events[-1] == "amo-disconnect", "required failure must still attempt AMO teardown"
+    assert caught.value.args == (() if error_type is KeyboardInterrupt else ("TOOL_UNAVAILABLE",))
+    assert caught.value.__cause__ is caught.value.__context__ is None
+    assert "PRIVATE_REQUIRED_FAILURE" not in str(capsys.readouterr())
+
+
+@pytest.mark.parametrize(
+    "phase,error_type",
+    [
+        ("staging-exists", OSError),
+        ("staging-exists", RuntimeError),
+        ("staging-unlink", OSError),
+        ("staging-unlink", RuntimeError),
+        ("lock-unlink", OSError),
+        ("amo-disconnect", OSError),
+        ("amo-disconnect", RuntimeError),
+    ],
+)
+def test_best_effort_persistence_cleanup_does_not_erase_established_facts(
+    monkeypatch, tmp_path, capsys, phase, error_type
+):
+    cache = _model(tmp_path, compat=1604)
+    native = _native_imagesave(monkeypatch, cache)
+    attempted, stages = [], []
+    replace_file, exists, unlink, os_unlink = os.replace, Path.exists, Path.unlink, os.unlink
+    installed = False
+
+    def fail():
+        attempted.append(phase)
+        raise error_type("PRIVATE_BEST_EFFORT_FAILURE")
+
+    def install(source, destination):
+        nonlocal installed
+        result = replace_file(source, destination)
+        if Path(destination) == cache:
+            stages.append(Path(source))
+            installed = True
+            if phase == "staging-unlink":
+                Path(source).write_bytes(b"leftover staging, not authority")
+        return result
+
+    def path_exists(path):
+        if installed and path in stages and phase == "staging-exists":
+            fail()
+        return exists(path)
+
+    def path_unlink(path, *args, **kwargs):
+        if installed and path in stages and phase == "staging-unlink":
+            fail()
+        return unlink(path, *args, **kwargs)
+
+    def remove(path, *args, **kwargs):
+        if installed and Path(path) == cache.with_name("cache.abf.lock") and phase == "lock-unlink":
+            fail()
+        return os_unlink(path, *args, **kwargs)
+
+    def disconnect():
+        native.events.append("amo-disconnect")
+        if phase == "amo-disconnect":
+            fail()
+
+    with monkeypatch.context() as patch:
+        patch.setattr(os, "replace", install)
+        patch.setattr(Path, "exists", path_exists)
+        patch.setattr(Path, "unlink", path_unlink)
+        patch.setattr(os, "unlink", remove)
+        patch.setattr(native.server, "Disconnect", disconnect)
+        result = _save_observed(cache, native)
+    assert installed and attempted == [phase], "exercise the actual caught cleanup operation after replacement"
+    assert type(result) is refresh_pbip_model.PersistenceObservation and result.identity == native.bound.identity
+    assert result.image.installed_sha256 == hashlib.sha256(native.content).hexdigest()
+    assert native.events[-1] == "amo-disconnect" and cache.read_bytes() == native.content
+    assert "PRIVATE_BEST_EFFORT_FAILURE" not in str(capsys.readouterr())
+
+
+@pytest.mark.parametrize("observe", [False, True], ids=["legacy", "observation"])
+@pytest.mark.parametrize("phase", ["load", "write", "stream-close", "disconnect"])
+@pytest.mark.parametrize(
+    "kind,code",
+    [
+        ("native", "TOOL_UNAVAILABLE"),
+        ("exit", "TOOL_UNAVAILABLE"),
+        ("interrupt", None),
+        ("known", "PID_REUSED"),
+        ("forged", "TOOL_UNAVAILABLE"),
+    ],
+)
+def test_imagesave_error_boundary_is_closed_and_legacy_errors_are_unchanged(
+    monkeypatch, tmp_path, capsys, observe, phase, kind, code
+):
+    cache = _model(tmp_path, compat=1604)
+    cache.parent.mkdir()
+    old = _abf_bytes(seed=1)
+    cache.write_bytes(old)
+    native = _native_imagesave(monkeypatch, cache)
+    sentinel = "PRIVATE_IMAGE_ENDPOINT_PATH_TOKEN_PAYLOAD"
+    error = {
+        "native": OSError(sentinel),
+        "exit": SystemExit(sentinel),
+        "interrupt": KeyboardInterrupt(sentinel),
+        "known": ObservationUnavailable("PID_REUSED"),
+        "forged": ObservationUnavailable(sentinel),
+    }[kind]
+    error.add_note(sentinel)
+    cause = RuntimeError(sentinel)
+    attempted, published = [], []
+
+    def native_failure(*_args):
+        attempted.append(phase)
+        raise error from cause
+
+    if phase == "load":
+        monkeypatch.setattr(refresh_pbip_model, "_load_amo", native_failure)
+    elif phase == "write":
+        native.server.ImageSave = native_failure
+    elif phase == "disconnect":
+        native.server.Disconnect = native_failure
+    else:
+        file_stream = native.io.FileStream
+
+        def stream(*args):
+            handle = file_stream(*args)
+            handle.Close = native_failure
+            return handle
+
+        native.io.FileStream = stream
+    suppressed = observe and phase == "disconnect" and isinstance(error, Exception)
+    if suppressed:
+        published.append(
+            refresh_pbip_model.image_save(
+                52001, cache, cache.parent.parent, bound=native.bound, return_observation=observe
+            )
+        )
+        assert type(published[0]) is refresh_pbip_model.PersistenceObservation
+    else:
+        with pytest.raises(BaseException) as caught:
+            published.append(
+                refresh_pbip_model.image_save(
+                    52001, cache, cache.parent.parent, bound=native.bound, return_observation=observe
+                )
+            )
+        assert published == []
+        if observe:
+            expected = KeyboardInterrupt if kind == "interrupt" else ObservationUnavailable
+            assert type(caught.value) is expected and caught.value is not error
+            assert caught.value.args == (() if code is None else (code,))
+            assert caught.value.__context__ is caught.value.__cause__ is None
+            assert not getattr(caught.value, "__notes__", ())
+            rendered = "".join(traceback.format_exception(caught.value))
+            assert sentinel not in rendered and "native_failure" not in rendered
+        else:
+            assert caught.value is error and caught.value.__cause__ is cause and caught.value.__notes__ == [sentinel]
+    assert attempted == [phase], "privacy control must exercise the specified native phase"
+    assert cache.read_bytes() == (native.content if phase == "disconnect" else old)
+    assert refresh_pbip_model.read_declared_compatibility(cache.parent.parent)[0] == (
+        1606 if phase == "disconnect" else 1604
+    )
+    if observe:
+        assert sentinel not in str(capsys.readouterr())
+
+
+@pytest.mark.parametrize("observe", [False, True], ids=["legacy", "observation"])
+@pytest.mark.parametrize("error_type", [refresh_pbip_model.ModelLockTimeout, refresh_pbip_model.CompatRollbackError])
+def test_lock_and_compatibility_errors_keep_only_their_public_type_in_observation_mode(
+    monkeypatch, tmp_path, observe, error_type
+):
+    cache = _model(tmp_path, compat=1604)
+    native = _native_imagesave(monkeypatch, cache)
+    error = error_type("PRIVATE_LOCK_OR_COMPATIBILITY_DETAIL")
+    error.add_note("PRIVATE_NOTE")
+    entered = []
+
+    @contextmanager
+    def refuse_lock(*_args, **_kwargs):
+        entered.append("lock-enter")
+        raise error
+        yield  # pragma: no cover - make entry failure a real context-manager failure
+
+    monkeypatch.setattr(refresh_pbip_model, "model_lock", refuse_lock)
+    with pytest.raises(error_type) as caught:
+        refresh_pbip_model.image_save(52001, cache, cache.parent.parent, bound=native.bound, return_observation=observe)
+    assert entered == ["lock-enter"] and native.calls == [], "must refuse at lock entry, before ImageSave"
+    assert native.events[-1] == "amo-disconnect"
+    if observe:
+        assert caught.value is not error and caught.value.args == ("TOOL_UNAVAILABLE",)
+        assert caught.value.__cause__ is caught.value.__context__ is None
+        assert not getattr(caught.value, "__notes__", ())
+    else:
+        assert caught.value is error and caught.value.__notes__ == ["PRIVATE_NOTE"]
+
+
+@pytest.mark.parametrize("phase", ["stage", "installed"])
+@pytest.mark.parametrize("change", ["truncate", "append"])
+def test_cache_eof_and_actual_byte_count_are_required_even_after_stat(monkeypatch, tmp_path, phase, change):
+    cache = _model(tmp_path, compat=1604)
+    cache.parent.mkdir()
+    old = _abf_bytes(seed=1)
+    cache.write_bytes(old)
+    native = _native_imagesave(monkeypatch, cache)
+    stat = Path.stat
+    touched, published = [], []
+
+    def stale_size(path, *args, **kwargs):
+        result = stat(path, *args, **kwargs)
+        is_target = (
+            path == cache if phase == "installed" else path.name.startswith("cache.abf.") and path.suffix == ".tmp"
+        )
+        if is_target and not touched:
+            touched.append(path)
+            content = native.content[:-1] if change == "truncate" else native.content + b"unexpected tail"
+            path.write_bytes(content)
+        return result
+
+    # Apply the race after the writer has closed, not to an earlier exists()/staging preparation stat.
+    file_stream = native.io.FileStream
+
+    def stream(*args):
+        handle = file_stream(*args)
+        close = handle.Close
+
+        def finalize():
+            close()
+            monkeypatch.setattr(Path, "stat", stale_size)
+
+        handle.Close = finalize
+        return handle
+
+    native.io.FileStream = stream
+    with pytest.raises(ObservationUnavailable, match="^TOOL_UNAVAILABLE$"):
+        published.append(_save_observed(cache, native))
+    assert len(touched) == 1 and "stream-close" in native.events, "must race a real cache read after ImageSave"
+    assert published == []
+    expected = (
+        old
+        if phase == "stage"
+        else (native.content[:-1] if change == "truncate" else native.content + b"unexpected tail")
+    )
+    assert cache.read_bytes() == expected
+    assert refresh_pbip_model.read_declared_compatibility(cache.parent.parent)[0] == (
+        1604 if phase == "stage" else 1606
+    )
+
+
+@pytest.mark.parametrize("observe", [False, True], ids=["legacy", "observation"])
+def test_benign_native_imagesave_error_still_requires_a_valid_closed_image(monkeypatch, tmp_path, observe):
+    cache = _model(tmp_path, compat=1604)
+    native = _native_imagesave(monkeypatch, cache)
+    write = native.server.ImageSave
+
+    def benign(*args):
+        write(*args)
+        raise RuntimeError("The server sent an unrecognizable response")
+
+    native.server.ImageSave = benign
+    result = refresh_pbip_model.image_save(
+        52001, cache, cache.parent.parent, bound=native.bound, return_observation=observe
+    )
+    assert native.events[-1] == "amo-disconnect" and "stream-close" in native.events
+    if observe:
+        assert result.image.installed_sha256 == hashlib.sha256(native.content).hexdigest()
+    else:
+        assert result[0] is True
+
+
+@pytest.mark.parametrize("phase", ["staging-exists", "staging-unlink", "lock-unlink"])
+@pytest.mark.parametrize("error_type", [KeyboardInterrupt, SystemExit])
+def test_persistence_cleanup_interrupts_cannot_publish(monkeypatch, tmp_path, phase, error_type):
+    cache = _model(tmp_path, compat=1604)
+    native = _native_imagesave(monkeypatch, cache)
+    stages, entered, published = [], [], []
+    replace_file, exists, unlink, os_unlink = os.replace, Path.exists, Path.unlink, os.unlink
+
+    def fail():
+        entered.append(phase)
+        raise error_type("PRIVATE_CLEANUP_INTERRUPT")
+
+    def install(source, destination):
+        result = replace_file(source, destination)
+        if Path(destination) == cache:
+            stages.append(Path(source))
+            if phase == "staging-unlink":
+                Path(source).write_bytes(b"leftover stage")
+        return result
+
+    def path_exists(path):
+        if path in stages and phase == "staging-exists":
+            fail()
+        return exists(path)
+
+    def path_unlink(path, *args, **kwargs):
+        if path in stages and phase == "staging-unlink":
+            fail()
+        return unlink(path, *args, **kwargs)
+
+    def remove(path, *args, **kwargs):
+        if stages and Path(path) == cache.with_name("cache.abf.lock") and phase == "lock-unlink":
+            fail()
+        return os_unlink(path, *args, **kwargs)
+
+    with monkeypatch.context() as patch:
+        patch.setattr(os, "replace", install)
+        patch.setattr(Path, "exists", path_exists)
+        patch.setattr(Path, "unlink", path_unlink)
+        patch.setattr(os, "unlink", remove)
+        expected = KeyboardInterrupt if error_type is KeyboardInterrupt else ObservationUnavailable
+        with pytest.raises(expected) as caught:
+            published.append(_save_observed(cache, native))
+    assert entered == [phase] and len(stages) == 1, "interrupt must enter actual cleanup after replacement"
+    assert published == [] and caught.value.args == (() if error_type is KeyboardInterrupt else ("TOOL_UNAVAILABLE",))
+    assert caught.value.__cause__ is caught.value.__context__ is None
+    assert cache.read_bytes() == native.content
+    assert refresh_pbip_model.read_declared_compatibility(cache.parent.parent)[0] == 1606
+    assert native.events[-1] == "amo-disconnect"
+
+
+@pytest.mark.parametrize("observe", [False, True], ids=["legacy-fallback", "observation-refusal"])
+def test_observation_refusal_cannot_fall_through_to_ui_save(monkeypatch, tmp_path, capsys, observe):
+    cache = _model(tmp_path, compat=1604)
+    native = _native_imagesave(monkeypatch, cache)
+    entered, ui_saves = [], []
+    image_save = refresh_pbip_model.image_save
+
+    def failed_write(*_args):
+        entered.append("native-write")
+        raise RuntimeError("PRIVATE_WRITE_FAILURE")
+
+    def selected_mode(port, path, model_dir):
+        return image_save(port, path, model_dir, bound=native.bound, return_observation=observe)
+
+    native.server.ImageSave = failed_write
+    monkeypatch.setattr(refresh_pbip_model, "image_save", selected_mode)
+    monkeypatch.setattr(refresh_pbip_model, "refresh", lambda *_a, **_k: (True, "refreshed"))
+    monkeypatch.setattr(refresh_pbip_model, "save", lambda pid: ui_saves.append(pid) or (True, "UI save"))
+    args = refresh_pbip_model._build_arg_parser().parse_args(["--pid", "111"])
+    result = refresh_pbip_model._refresh_and_save(111, 52001, cache, args)
+    assert entered == ["native-write"] and native.events[-1] == "amo-disconnect"
+    if observe:
+        assert result == 1 and ui_saves == [], "typed observation refusal must stop, never invoke the fallback"
+        assert "PRIVATE_WRITE_FAILURE" not in str(capsys.readouterr())
+    else:
+        assert result is None and ui_saves == [111], "ordinary legacy unavailability still permits the UI path"


### PR DESCRIPTION
Refs #363 (intentionally left open). Corrects merged PR #612.

## Approved A1 contract

Implement the PLAN_APPROVED revision-2 correction only. `refresh` and `image_save` accept keyword-only, exact-bool `return_observation=False`: false preserves legacy tuples, true returns one invocation-owned typed observation or raises. All retained public/private sink keywords refuse every non-None value before inspection or I/O; copied-out sink consumers must migrate to direct returns (intentional compatibility break, no adapter).

Canary and persistence observations now carry the existing full DesktopIdentity. Publication waits for worker termination, required stream finalization, final identity/catalogue checks, propagating context exits, and attempted teardown. Ordinary caught best-effort cleanup failures do not erase established facts; interrupts are not swallowed. Persistence uses one staged validate/hash pass, replacement and compatibility declaration, then one installed validate/hash pass under the existing lock. Cache reads are bounded to 1 MiB, without whole-cache allocation or a third pass; legacy validation reads preamble/headers only.

Observation exceptions are fresh, code-allowlisted, cause/context/native-traceback/note-free; KeyboardInterrupt is message-free. Legacy raw exception controls remain. Observation refusal cannot invoke the UI-save fallback.

## Exact surface: N=6

Production:
1. `.github/skills/pbip-model-refresh/scripts/_abf.py`
2. `.github/skills/pbip-model-refresh/scripts/probe_desktop_query.py`
3. `.github/skills/pbip-model-refresh/scripts/refresh_pbip_model.py`

Tests:
4. `.github/skills/pbip-model-refresh/tests/test_desktop_instance_binding.py`
5. `.github/skills/pbip-model-refresh/tests/test_canary_data_gate.py`
6. `.github/skills/pbip-model-refresh/tests/test_persist_atomicity.py`

Original A1 implementation base: `f48a2cf2b2b4b10b5b9a162a8ec604b372d2b8f4`

Head to review: `331fb545946a441966d2f5df4febdbd4a4403ae6`

No seventh file, A2, receipt-v3, status taxonomy, registry, cancellation mechanism, or cache-copy framework.

## Pre-integration validation — correction tip `9eb40f6526f49b078ab92956d1cdb5c9be9b0a83`

All successful gates below exited 0:
- Mandatory `ruff format` and `ruff check --fix` on all six files; final read-only format/lint checks also passed.
- Production pylint on the three changed scripts: **10.00/10**, exit 0. Tests are outside the repository's production pylint score gate.
- Three changed suites on the committed head: **484 passed, 3 skipped**, 21.63 seconds.
- Entire pbip-model-refresh bundle, including adjacent regressions, with GUI excluded: **699 passed, 3 skipped, 16 deselected**, 117.68 seconds.
- Separate-process copy-out, no-host-only-import, and both forwarding-shim regressions: **4 passed**, 115.68 seconds.
- `git diff --check` passed; local and pushed head SHAs agree.

The first combined bundle/root-test selector invocation failed during collection by resolving forwarding shims. No tests from that invocation are credited. Bundle and copy-out gates above ran in separate Python processes.

Direct controls cover hostile retired sinks and exact modes; every identity component; mutation of old caller state and event-blocked current work; failed retries and late worker results; each required versus best-effort teardown branch, including post-success AMO disconnect; exact two-pass/header-only traversal; a >3-GiB logical stream with a counting/non-cryptographic hash double plus a separate small real-SHA256 fixture; pre/post-replace faults and ambiguity/rollback controls; privacy/interrupt pairs and unchanged legacy controls. Negatives assert entry into the intended failing phase. No new mutation runner is introduced.

## Residual / native ceiling

`ImageObservation.commitment` remains **UNESTABLISHED**. Identity is sampled, not leased; final readback is not durable-storage proof. Native calls may still block. The three skips are the absent real-cache corpus. No Power BI Desktop was opened, no credentials were used, and no live/native Desktop qualification or cold-reopen test was performed. This change does not establish Phase-2 COMPLETE or close #363.

## Questions for independent review

- Can any current result be replaced by old caller state, a surviving sink transport, an unfinished worker, or a mismatched identity component?
- Does every required failure prevent publication while each ordinary caught best-effort teardown failure preserves already-established evidence, with interrupt-safe rollback intact?
- Is each observation cache consumed exactly once staged and once installed, with complete bounded hashing, EOF/count agreement, declaration ordering and all required exits before publication?
- Are public observation errors truly fresh and closed (including active caller exception context), and are legacy tuple/error/fallback controls still valid?

Draft only. No self-review approval or merge. Any seventh file or newly discovered defect class requires split/re-plan rather than another local expansion.
## R1 correction — legacy catalogue/read-close behavior

Commit `9eb40f6526f49b078ab92956d1cdb5c9be9b0a83` changes only `probe_desktop_query.py`, `refresh_pbip_model.py`, and `test_desktop_instance_binding.py` within the original N=6 surface. It threads observation mode through both refresh rechecks and the shared catalogue read. Legacy/default false preserves raw query exceptions and direct reader.Close propagation, including the original exception object, cause, notes and diagnostics. Observation-only callers explicitly opt into closed errors and best-effort reader close. No cache, sink, identity, or other cleanup behavior changed in this correction.

Twelve production-path controls cover ExecuteReader and catalogue-reader Close failures before/after XMLA in default, false and true modes. Before the correction: **8 intended legacy failures, 4 passing observation controls**. After the correction: all twelve pass within the **484-pass** changed-suite result above. The **699-pass** adjacent/bundle and **4-pass** copy-out/shim results above are also from this exact tip.

Exact-tip CI: **SUCCESS**, run `34687514551`, head `9eb40f6526f49b078ab92956d1cdb5c9be9b0a83`. `checks`, `windows-bundle`, and `engine-integration` all succeeded; schedule-only `engine-drift` was skipped. The checks job finished on September 12, 2026 at 10:23:47 UTC (18m33s). No prior-tip CI is credited.

R1 re-review is limited to the reviewer's two verified catalogue reproductions. Draft remains open; no self-review approval or merge.
## Integration-only build for final re-review

Merge head: `331fb545946a441966d2f5df4febdbd4a4403ae6`

Parents, in order:
1. Corrected A1 head: `9eb40f6526f49b078ab92956d1cdb5c9be9b0a83`
2. Pinned current origin/master / merged PR #625: `222eaad354a57dc4bbba0645a2a4b125266def4f`

The merge was automatic, with history preserved and no conflicts, manual resolutions, or corrections. The index tree was verified before committing, and the committed tree matches it exactly. Both the base-to-head diff (`222eaad3..331fb545`) and the hosted PR diff are exactly the six approved A1 files. The first immediate post-push hosted-metadata guard was not credited; subsequent GraphQL, REST, and PR-diff reads all agreed on this exact base/head and N=6 without any resolution or code change.

### Blob equality

All six A1 entries below are identical in corrected head `9eb40f65` and merge head `331fb545`:

| Approved file | Unchanged Git blob |
|---|---|
| `scripts/_abf.py` | `cf700c05918aaa421ca2babba783677d61454b01` |
| `scripts/probe_desktop_query.py` | `fa412f5369360bfc7c535404d18fdab01198d9db` |
| `scripts/refresh_pbip_model.py` | `ecc1f28a75c6f2a12a6b0794f6a20f441af0ae13` |
| `tests/test_desktop_instance_binding.py` | `2d8f594f737eed8ec3fb623b0866d208239650c7` |
| `tests/test_canary_data_gate.py` | `9d4906b5ae22e205393b35f9a956a59c8ec96aa9` |
| `tests/test_persist_atomicity.py` | `c9624cf66b52419326ac80b0d86cb44488d21eea` |

These six paths are relative to `.github/skills/pbip-model-refresh/`.

Both PR #625 entries are identical to pinned origin/master `222eaad3`:
- `scripts/package_role_identity.py`: `bb1ca1e3ff1ba045c89ac5c4ec912cd63bedebeb`
- `tests/test_package_start_handoffs.py`: `09070d769ad316198c9744345d64a4f038d3771b`

### Merge-tip validation

All completed local gates exited 0 on `331fb545946a441966d2f5df4febdbd4a4403ae6`:
- Read-only Ruff format/lint checks on all six A1 files and both incoming #625 files. No formatting or fixes were applied.
- Production pylint: bundled three-script invocation and separate incoming `package_role_identity.py` invocation both **10.00/10**, exit 0.
- Focused A1 suites: **484 passed, 3 skipped**, 30.21 seconds.
- Incoming package handoff regressions: **138 passed**, 9.50 seconds.
- Isolated copy-out, no-host-only-import, and forwarding-shim checks: **4 passed**, 95.82 seconds.

Integration-tip CI: **SUCCESS**, run `34688723065`, head `331fb545946a441966d2f5df4febdbd4a4403ae6`. `checks`, `windows-bundle`, and `engine-integration` all succeeded; schedule-only `engine-drift` was skipped. The watcher exited 0, and the run head/status/conclusion and each required job were checked explicitly. The earlier correction-tip CI above is historical and is not credited for this merge build.

The three skips remain the absent real-cache corpus. No live Power BI Desktop qualification, self-review, or PR merge was performed. Draft remains open. Sol re-review is limited to the same two legacy catalogue reproductions, now against this integration SHA.