### PR TITLE
feat: produce neutral-root BOUND/UNVALIDATED package handoff

### DIFF
--- a/scripts/current_artifact_revision.py
+++ b/scripts/current_artifact_revision.py
@@ -24,6 +24,7 @@ from bundle_corpus import is_reparse_entry
 
 REVISION_PREFIX = "sha256:"
 CACHE_RELPATH = (".pbi", "cache.abf")
+PACKAGE_MANIFEST = "package-manifest.json"
 IDENTIFIER = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.-]{0,199}", re.ASCII)
 
 
@@ -130,6 +131,11 @@ def package_working_revision(package: Path, model_dir: Path | None = None) -> st
     """Current package bytes, not its stale packaging-time contents declaration."""
     cache = model_dir.joinpath(*CACHE_RELPATH).relative_to(package).as_posix() if model_dir else None
     return _revision(package, excluded_file=cache, iterations=True)
+
+
+def package_manifest_excluded_revision(package: Path) -> str:
+    """Current package bytes under the existing revision algorithm, excluding only its manifest."""
+    return _revision(package, excluded_file=PACKAGE_MANIFEST)
 
 
 def report_revision(report_dir: Path) -> str:

--- a/scripts/package_unit.py
+++ b/scripts/package_unit.py
@@ -4,6 +4,8 @@ usage:   python scripts/package_unit.py --bundle <bundle> --out <dir> [--unit NA
                                         [--oracle <dir>] [--assets <dir>] [--brief <file>]
                                         [--gate-root <original-root>] [--provider-package <root> ...]
                                         [--assemble-only] [--json <file>] [--quiet]
+         python scripts/package_unit.py --bind-package <package>
+                                        [--provider-package <bound-provider> ...]
 
 Issue #446: the three things an agent needs to start one report all exist and NOTHING assembles them.
 They live in four naming schemes across two trees - the engine keys `pbip/`, `reports/` and
@@ -205,16 +207,22 @@ from collections.abc import Callable, Sequence
 from copy import deepcopy
 from functools import partial
 from pathlib import Path, PurePath, PurePosixPath, PureWindowsPath
-from typing import Any, NamedTuple
+from typing import Any, NamedTuple, NoReturn
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 import read_handover  # noqa: E402  # pylint: disable=wrong-import-position
 import tableau_oracle_manifest  # noqa: E402  # pylint: disable=wrong-import-position
+import current_artifact_revision as artifact_revision  # noqa: E402  # pylint: disable=wrong-import-position
 import package_filesystem as pfs  # noqa: E402  # pylint: disable=wrong-import-position
 import package_role_identity as pri  # noqa: E402  # pylint: disable=wrong-import-position
 import credential_gate as data_access  # noqa: E402  # pylint: disable=wrong-import-position
-from bundle_corpus import is_reparse_entry  # noqa: E402  # pylint: disable=wrong-import-position
+from bundle_corpus import (  # noqa: E402  # pylint: disable=wrong-import-position
+    PLACEMENT_NONE,
+    is_reparse_entry,
+    normalized_parts,
+    package_placement,
+)
 from migration_bundle import load_bundle  # noqa: E402  # pylint: disable=wrong-import-position
 
 # The path budget is measured by `check_path_ceiling.py` and NOWHERE else (#476). Its ceilings were
@@ -229,9 +237,12 @@ from check_path_ceiling import (  # noqa: E402  # pylint: disable=wrong-import-p
     WINDOWS_LIMITS,
     Limits,
     platform_limits,
+    scan as scan_path_ceiling,
     utf16_len,
 )
-from host_paths import discloses_host_location  # noqa: E402  # pylint: disable=wrong-import-position
+from host_paths import (  # noqa: E402  # pylint: disable=wrong-import-position
+    discloses_host_location,
+)
 from manifest_scope import (  # noqa: E402  # pylint: disable=wrong-import-position
     ORACLE_MANIFEST_ALLOW,
     project,
@@ -248,9 +259,13 @@ from object_identity import (  # noqa: E402  # pylint: disable=wrong-import-posi
     KIND_WORKSHEET,
 )
 from path_flavour import (  # noqa: E402  # pylint: disable=wrong-import-position
+    POSIX,
+    WINDOWS,
     flavour,
+    host_flavour,
     is_host_native,
     leaf,
+    normalize as normalize_flavour_path,
 )
 from path_flavour import separator as flavour_separator  # noqa: E402  # pylint: disable=wrong-import-position
 from path_flavour import inside as inside_lexically  # noqa: E402  # pylint: disable=wrong-import-position
@@ -359,7 +374,9 @@ UNAVAILABLE_TOKEN = "<UNAVAILABLE_SOURCE>"
 
 #: The command that binds a package to wherever it now lives. Written into the README and into
 #: `package-manifest.json` so the state and its remedy travel with the artifact.
-BIND_COMMAND = "python scripts/set_data_folder.py --package <path-to-this-folder>"
+BIND_COMMAND = (
+    "python scripts/set_data_folder.py --package <path-to-this-folder> [--provider-package <bound-provider> ...]"
+)
 
 #: This script's exit codes, named so a caller never has to read a bare integer. The table in the
 #: module docstring is the contract; these are the same numbers.
@@ -401,6 +418,27 @@ NOT_START_READY_NOTICE = (
     "Phase-2 dispatch or clear the credential gate."
 )
 DATA_ACCESS_PENDING = NOT_START_READY_NOTICE
+
+# Binding is a producer handoff only. The final #562 consumer remains the sole START_READY authority.
+BINDING_STATE = "BOUND"
+BINDING_PRIVACY_POLICY = "neutral_root"
+BINDING_ROOT_DOMAIN = b"t2p-neutral-root-v1\0"
+BINDING_REVISION_PREFIX = "sha256:"
+BINDING_DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+BINDING_PROVIDER_RE = re.compile(r"^provider-ref:v1:sha256:[0-9a-f]{64}$")
+BINDING_CODE_RE = re.compile(r"^[a-z][a-z0-9_-]*$")
+BINDING_FIELDS = frozenset(
+    {
+        "state",
+        "privacy_policy",
+        "canonical_root_identity",
+        "manifest_excluded_revision",
+        "bound_members",
+        "data_access_authority",
+    }
+)
+BINDING_DATA_ACCESS_FIELDS = frozenset({"identity", "state", "validation", "scope", "provider_cohort"})
+BINDING_PROVIDER_FIELDS = frozenset({"identity", "revision", "ordinal"})
 
 #: Refuse to copy a single source larger than this, rather than silently turning a handover folder
 #: into a data lake. Measured on estate run 408 the largest referenced extract is 1.33 MB and the
@@ -467,6 +505,20 @@ class PackagingError(RuntimeError):
         default = type(self).reason_code
         self.reason_code = reason_code or (message if _REASON_CODE_RE.fullmatch(message) else default)
         super().__init__(message)
+
+
+class BindingTransitionError(RuntimeError):
+    """A privacy-safe BOUND/UNVALIDATED refusal with a named authority and stable code."""
+
+    def __init__(self, state: str, authority: str, code: str) -> None:
+        if state not in (STATUS_BLOCKED, "CANNOT_ESTABLISH"):
+            raise ValueError("binding transition state must be BLOCKED or CANNOT_ESTABLISH")
+        if not _REASON_CODE_RE.fullmatch(authority) or not BINDING_CODE_RE.fullmatch(code):
+            raise ValueError("binding transition authority and code must be stable identifiers")
+        self.state = state
+        self.authority = authority
+        self.code = code
+        super().__init__(f"{state} authority={authority} code={code}")
 
 
 class PackageEditsRefused(PackagingError):
@@ -1864,9 +1916,13 @@ README = """# {unit}
 Diagnostic handover package for one migration unit ({kind}). It may carry imported rows, reference
 evidence, source bytes and engine output; `package-manifest.json` names what is present and every
 omission. If it carries a location placeholder it is **not bound to a location**, so do this FIRST,
-wherever this folder now is, before opening the model. Then the two gates, each of which takes THIS
-FOLDER'S PATH as its only argument - a bare unit name is a usage error, never a verdict (exit 2 from
-`check_reference_readiness.py`, exit 64 from `check_unit.py`, both with a message on stderr):
+before opening the model. Binding accepts only an existing native, non-reparse neutral root outside
+the current profile/home/temp hierarchy: use the canonical `.../_runs/<run>/packages/<unit>` layout
+(including a short external `--runs-parent`) or a root-level package directory. A shared-model
+consumer also appends `--provider-package <bound-provider>` for its already-bound datasource
+provider. Then the two gates, each of which takes THIS FOLDER'S PATH as its only argument - a bare
+unit name is a usage error, never a verdict (exit 2 from `check_reference_readiness.py`, exit 64 from
+`check_unit.py`, both with a message on stderr):
 
     python scripts/set_data_folder.py --package <path-to-this-folder>
     python scripts/check_reference_readiness.py <path-to-this-folder>
@@ -3712,6 +3768,7 @@ def replace_dir(
     verify: Callable[[Path], None] | None = None,
     *,
     verify_staged: Callable[[], None],
+    verify_published: Callable[[Path], None] | None = None,
 ) -> None:
     """Put ``staged`` at ``final``, REPLACING whatever was there - never merging into it.
 
@@ -3742,10 +3799,12 @@ def replace_dir(
     3). It is also why the deletion of the retired tree is the LAST thing that happens.
 
     ``verify_staged`` is required and bound to the exact staged snapshot by assembly. After retiring
-    and checking any prior package, it validates the candidate immediately before publication. All
-    path-budget and other producer reads precede this callback; only the atomic rename and existing
-    prior-package cleanup follow. A failed check restores the prior directory without ever exposing
-    the candidate. The callback also runs for a new package and when prior edits are discarded.
+    and checking any prior package, it validates the candidate immediately before publication.
+
+    ``verify_published`` is the optional post-rename authority used by the binding transition. It
+    runs while the complete prior directory is still retired and therefore restorable. If it raises,
+    the candidate is moved back to ``staged`` and the exact retired directory is restored before the
+    error escapes. Ordinary assembly does not supply it and retains its existing behavior.
     """
     final.parent.mkdir(parents=True, exist_ok=True)
     retired = retired_dir(final) if final.exists() else None
@@ -3759,13 +3818,23 @@ def replace_dir(
         verify_staged()
         publish_armed = True
         _rename_retrying(staged, final)
+        if verify_published is not None:
+            verify_published(final)
         if retired is not None:
             _discard_scratch(retired)
         publish_armed = False
     except BaseException as error:  # pylint: disable=broad-exception-caught
         published = publish_armed and final.is_dir() and not staged.exists()
         rollback_failed = False
-        if not published and retired is not None and retired.exists() and not final.exists():
+        if published and retired is not None and retired.exists() and verify_published is not None:
+            try:
+                _rename_retrying(final, staged)
+                _rename_retrying(retired, final)
+                published = False
+            except BaseException:  # pylint: disable=broad-exception-caught
+                rollback_failed = True
+                error.add_note("package rollback failed after published-candidate verification")
+        elif not published and retired is not None and retired.exists() and not final.exists():
             try:
                 _rename_retrying(retired, final)
             except BaseException:  # pylint: disable=broad-exception-caught
@@ -4390,6 +4459,801 @@ def _final_data_access_check(inputs: _DataAccessInputs, generated: dict[str, byt
         raise PackagingError("data_access_provider_changed")
 
 
+class _NeutralRoot(NamedTuple):
+    """A current accepted package root and its privacy-safe canonical identity."""
+
+    path: Path
+    identity: str
+
+
+class _BoundProvider(NamedTuple):
+    """One selected provider handoff, ordered exactly as S2 selected it."""
+
+    identity: str
+    revision: str
+    ordinal: int
+
+
+class _BindingAuthority(NamedTuple):
+    """Exact S1/S2/data-access facts held across one binding publication."""
+
+    roots: tuple[Path, ...]
+    snapshots: tuple[_PackageSnapshot, ...]
+    role_signature: tuple[Any, ...]
+    unit: str
+    kind: str
+    topology: str
+    assessment: data_access.DataAccessAssessment
+    projection_sha256: str
+    spec_sha256: str
+    providers: tuple[_BoundProvider, ...]
+
+
+def _binding_failure(state: str, authority: str, code: str) -> NoReturn:
+    """Raise the one privacy-safe binding refusal type."""
+    raise BindingTransitionError(state, authority, code)
+
+
+def _binding_blocked(authority: str, code: str) -> NoReturn:
+    _binding_failure(STATUS_BLOCKED, authority, code)
+
+
+def _binding_cannot(authority: str, code: str) -> NoReturn:
+    _binding_failure("CANNOT_ESTABLISH", authority, code)
+
+
+def _canonical_root_spelling(value: str, kind: str | None = None) -> str:
+    """Canonical native-root spelling used only as the input to the root-identity digest."""
+    path_kind = flavour(value) if kind is None else kind
+    if path_kind not in (WINDOWS, POSIX):
+        raise ValueError("root flavour is not established")
+    normalized = normalize_flavour_path(value, path_kind)
+    if path_kind == WINDOWS:
+        pure = PureWindowsPath(normalized)
+        if not pure.is_absolute() or pure.anchor.startswith(("\\\\", "//")):
+            raise ValueError("root is not an absolute local Windows path")
+        spelling = str(pure).replace("\\", "/").casefold()
+        return spelling if len(spelling) <= 3 else spelling.rstrip("/")
+    pure = PurePosixPath(normalized)
+    if not pure.is_absolute():
+        raise ValueError("root is not an absolute POSIX path")
+    spelling = str(pure)
+    return spelling if spelling == "/" else spelling.rstrip("/")
+
+
+def _canonical_root_identity(value: str, kind: str | None = None) -> str:
+    """The approved v1 neutral-root digest; the raw spelling never leaves this call."""
+    canonical = _canonical_root_spelling(value, kind).encode("utf-8")
+    return BINDING_REVISION_PREFIX + hashlib.sha256(BINDING_ROOT_DOMAIN + canonical).hexdigest()
+
+
+def _known_private_roots() -> tuple[str, ...]:
+    """Known current profile/home/temp roots, without enumerating arbitrary account names."""
+    candidates: list[str] = []
+    try:
+        candidates.append(str(Path.home()))
+    except (OSError, RuntimeError):
+        pass
+    for name in ("USERPROFILE", "HOME", "TMPDIR", "TEMP", "TMP"):
+        value = os.environ.get(name)
+        if value:
+            candidates.append(value)
+    local_app_data = os.environ.get("LOCALAPPDATA")
+    if local_app_data:
+        candidates.append(str(Path(local_app_data) / "Temp"))
+    if os.name != "nt":
+        candidates.extend(("/tmp", "/var/tmp", "/usr/tmp"))
+    native = []
+    for value in candidates:
+        if flavour(value) != host_flavour():
+            continue
+        try:
+            normalized = _canonical_root_spelling(value)
+        except (TypeError, ValueError, UnicodeError):
+            continue
+        if normalized not in native:
+            native.append(normalized)
+    return tuple(native)
+
+
+def _binder_root_allowed(root: PurePath) -> bool:
+    """The explicit supported-root policy: canonical package placement or one root-level package."""
+    parts = normalized_parts(root)
+    anchor_parts = 1 if root.anchor and parts else 0
+    direct_root_child = len(parts) == anchor_parts + 1
+    return direct_root_child or package_placement(root) != PLACEMENT_NONE
+
+
+def _neutral_root(root: Path) -> _NeutralRoot:  # pylint: disable=too-many-branches
+    """Apply the approved existing/native/non-reparse/private-hierarchy/root-policy predicate."""
+    raw = str(root)
+    if raw.startswith(("\\\\", "//")):
+        _binding_blocked("neutral_root", "binding_root_unc")
+    kind = flavour(raw)
+    if kind is not None and kind != host_flavour():
+        _binding_blocked("neutral_root", "binding_root_foreign_flavour")
+    if kind is None or not Path(raw).is_absolute():
+        _binding_blocked("neutral_root", "binding_root_not_absolute")
+    try:
+        lexical = Path(normalize_flavour_path(raw, kind))
+    except (TypeError, ValueError):
+        _binding_cannot("neutral_root", "binding_root_normalization_failed")
+
+    boundaries = (lexical, *lexical.parents)
+    root_info: os.stat_result | None = None
+    try:
+        for boundary in boundaries:
+            info = os.lstat(boundary)
+            if boundary == lexical:
+                root_info = info
+            if is_reparse_entry(info):
+                _binding_blocked("neutral_root", "binding_root_reparse")
+    except FileNotFoundError:
+        _binding_cannot("neutral_root", "binding_root_missing")
+    except (OSError, ValueError):
+        _binding_cannot("neutral_root", "binding_root_unassessable")
+    if root_info is None or not stat.S_ISDIR(root_info.st_mode):
+        _binding_blocked("neutral_root", "binding_root_not_directory")
+
+    try:
+        resolved = lexical.resolve(strict=True)
+        lexical_identity = _canonical_root_spelling(str(lexical), kind)
+        resolved_identity = _canonical_root_spelling(str(resolved), kind)
+    except (OSError, RuntimeError, TypeError, ValueError, UnicodeError):
+        _binding_cannot("neutral_root", "binding_root_resolution_failed")
+    if lexical_identity != resolved_identity:
+        _binding_blocked("neutral_root", "binding_root_alias")
+    if any(inside_lexically(private, str(resolved)) for private in _known_private_roots()):
+        _binding_blocked("neutral_root", "binding_root_private_hierarchy")
+    if not _binder_root_allowed(resolved):
+        _binding_blocked("neutral_root", "binding_root_policy_refused")
+    if is_reserved_packaging_name(resolved.name):
+        _binding_blocked("neutral_root", "binding_root_reserved_name")
+    try:
+        identity = _canonical_root_identity(str(resolved), kind)
+    except (TypeError, ValueError, UnicodeError):
+        _binding_cannot("neutral_root", "binding_root_identity_failed")
+    return _NeutralRoot(resolved, identity)
+
+
+def _require_binding_path_budget(root: Path) -> None:
+    """Reuse the existing measured Desktop ceilings without exposing the offending host path."""
+    try:
+        report = scan_path_ceiling(root, DEFAULT_LIMITS)
+        counted = report["counted"]
+    except (OSError, TypeError, ValueError, UnicodeError, KeyError):
+        _binding_cannot("path_budget", "binding_path_budget_unassessable")
+    if counted["unknown"] or not counted["measured"]:
+        _binding_cannot("path_budget", "binding_path_budget_unassessable")
+    if counted["over_ceiling"]:
+        _binding_blocked("path_budget", "binding_path_budget_exceeded")
+
+
+def _require_clean_snapshot(root: Path) -> _PackageSnapshot:
+    """Name S1's own refusal code before obtaining the exact producer snapshot."""
+    verified = pri.verify_s1(root)
+    if not verified.integrity.is_clean:
+        code = verified.integrity.first_code or "package_integrity_not_clean"
+        if verified.integrity.status == pfs.STATUS_UNASSESSABLE:
+            _binding_cannot("s1", code)
+        _binding_blocked("s1", code)
+    snapshot = _package_snapshot(root)
+    if snapshot is None:
+        _binding_cannot("s1", "binding_snapshot_unavailable")
+    return snapshot
+
+
+def _snapshot_matches_at(snapshot: _PackageSnapshot, root: Path) -> bool:
+    """Recheck held bytes after the original directory has been renamed to its retired path."""
+    try:
+        if _package_directory_id(root) != snapshot.directory_id or pfs._recheck_boundary(root):  # pylint: disable=protected-access
+            return False
+        walked, findings, _empty = pfs.walk_package(root)
+        expected = dict(snapshot.digests)
+        expected[MANIFEST_NAME] = hashlib.sha256(snapshot.manifest).hexdigest()
+        return (
+            not findings
+            and set(walked) == set(expected)
+            and all(pfs._hash_file(walked[key]) == digest for key, digest in expected.items())  # pylint: disable=protected-access
+        )
+    except (OSError, ValueError, PackagingError):
+        return False
+
+
+def _role_signature(result: pri.Phase1RoleIdentityResult) -> tuple[Any, ...]:
+    """Root-independent S2 identity, including provider ordinals that dataclass equality omits."""
+    identity = result.source_identity
+    source = (
+        None
+        if identity is None
+        else (identity.kind, identity.sha256, identity.tableau_luid, identity.published_key, identity.revision)
+    )
+    dependencies = tuple(
+        (
+            row.state,
+            row.datasource_luid,
+            row.published_key,
+            row.provider_unit,
+            row.model_role,
+            row.code,
+            row.provider_ordinal,
+        )
+        for row in result.dependencies
+    )
+    policy = (
+        None
+        if result.brief_policy is None
+        else (result.brief_policy.requested_scope, result.brief_policy.fallback_authorization)
+    )
+    return (
+        result.verdict,
+        result.unit,
+        result.kind,
+        result.topology,
+        tuple((row.role, row.state, row.cardinality, row.paths, row.code) for row in result.roles),
+        source,
+        dependencies,
+        result.blockers,
+        result.authorized_limitations,
+        policy,
+    )
+
+
+def _read_binding_data_access(
+    result: pri.Phase1RoleIdentityResult, root: Path
+) -> tuple[data_access.DataAccessAssessment, str, str]:
+    """Consume the exact held S1/S2 projection and spec facts; never re-assess or authorize it."""
+    handoff = result.data_access_handoff(root)
+    if isinstance(handoff, pfs.PackageFilesystemResult):
+        code = handoff.first_code or "package_member_not_verified"
+        if handoff.status == pfs.STATUS_UNASSESSABLE:
+            _binding_cannot("data_access", code)
+        _binding_blocked("data_access", code)
+    try:
+        assessment = data_access.parse_data_access(handoff.data_access.content.decode("utf-8"))
+    except (UnicodeDecodeError, data_access.DataAccessProjectionError):
+        _binding_blocked("data_access", "projection_invalid")
+    if assessment.state == "cannot_establish":
+        _binding_cannot("data_access", assessment.codes[0])
+    if assessment.state == "blocked":
+        _binding_blocked("data_access", assessment.codes[0])
+
+    policy = result.brief_policy
+    if policy is None or assessment.effective_scope != policy.requested_scope:
+        _binding_blocked("data_access", "binding_data_access_scope_mismatch")
+    if assessment.state == "authorized_model_only" and policy.fallback_authorization != "model_only_unvalidated":
+        _binding_blocked("data_access", "binding_data_access_policy_mismatch")
+    return assessment, handoff.data_access.sha256, handoff.migration_spec.sha256
+
+
+def _snapshot_manifest(snapshot: _PackageSnapshot) -> dict[str, Any]:
+    """Strictly parse the held manifest bytes without reopening the package."""
+    try:
+        return pfs.parse_manifest_text(snapshot.manifest.decode("utf-8"))
+    except (UnicodeDecodeError, pfs._ManifestError):  # pylint: disable=protected-access
+        _binding_cannot("s1", "package_manifest_unreadable")
+
+
+def _strict_binding_block(  # pylint: disable=too-many-branches,too-many-boolean-expressions
+    manifest: dict[str, Any],
+) -> dict[str, Any]:
+    """Validate the producer's one existing-manifest handoff shape without repairing it."""
+    block = manifest.get("binding")
+    if not isinstance(block, dict):
+        _binding_blocked("binding_handoff", "binding_handoff_missing")
+    if set(block) != BINDING_FIELDS:
+        _binding_blocked("binding_handoff", "binding_handoff_fields_invalid")
+    if (
+        block.get("state") != BINDING_STATE
+        or block.get("privacy_policy") != BINDING_PRIVACY_POLICY
+        or not isinstance(block.get("canonical_root_identity"), str)
+        or not BINDING_DIGEST_RE.fullmatch(block["canonical_root_identity"])
+        or not isinstance(block.get("manifest_excluded_revision"), str)
+        or not BINDING_DIGEST_RE.fullmatch(block["manifest_excluded_revision"])
+    ):
+        _binding_blocked("binding_handoff", "binding_handoff_value_invalid")
+
+    members = block.get("bound_members")
+    if (
+        not isinstance(members, list)
+        or members != sorted(set(members))
+        or any(
+            not isinstance(member, str)
+            or not pfs.is_canonical_key(member)
+            or not member.startswith("fabric/")
+            or not member.endswith(f"/definition/{EXPRESSIONS_TMDL}")
+            for member in members
+        )
+    ):
+        _binding_blocked("binding_handoff", "binding_member_set_invalid")
+
+    authority = block.get("data_access_authority")
+    if not isinstance(authority, dict) or set(authority) != BINDING_DATA_ACCESS_FIELDS:
+        _binding_blocked("binding_handoff", "binding_data_access_fields_invalid")
+    if (
+        not isinstance(authority.get("identity"), str)
+        or not BINDING_DIGEST_RE.fullmatch(authority["identity"])
+        or authority.get("state") not in (*data_access.DIRECT_ACCEPTED_STATES, "provider_inherited")
+        or authority.get("validation") not in data_access.VALIDATION_STATES
+        or authority.get("scope") not in data_access.EFFECTIVE_SCOPES
+    ):
+        _binding_blocked("binding_handoff", "binding_data_access_value_invalid")
+    providers = authority.get("provider_cohort")
+    if not isinstance(providers, list):
+        _binding_blocked("binding_handoff", "binding_provider_cohort_invalid")
+    ordinals: list[int] = []
+    for row in providers:
+        if (
+            not isinstance(row, dict)
+            or set(row) != BINDING_PROVIDER_FIELDS
+            or not isinstance(row.get("identity"), str)
+            or not BINDING_PROVIDER_RE.fullmatch(row["identity"])
+            or not isinstance(row.get("revision"), str)
+            or not BINDING_DIGEST_RE.fullmatch(row["revision"])
+            or not isinstance(row.get("ordinal"), int)
+            or isinstance(row.get("ordinal"), bool)
+            or row["ordinal"] < 0
+        ):
+            _binding_blocked("binding_handoff", "binding_provider_cohort_invalid")
+        ordinals.append(row["ordinal"])
+    if ordinals != sorted(set(ordinals)):
+        _binding_blocked("binding_handoff", "binding_provider_ordinal_invalid")
+    if discloses_host_location(json.dumps(block, ensure_ascii=False)):
+        _binding_blocked("binding_handoff", "binding_handoff_discloses_root")
+    return deepcopy(block)
+
+
+def _data_access_binding_block(
+    assessment: data_access.DataAccessAssessment,
+    projection_sha256: str,
+    providers: Sequence[_BoundProvider],
+) -> dict[str, Any]:
+    """Project only exact accepted authority identities; no root or endpoint text."""
+    return {
+        "identity": f"sha256:{projection_sha256}",
+        "state": assessment.state,
+        "validation": assessment.validation,
+        "scope": assessment.effective_scope,
+        "provider_cohort": [
+            {"identity": row.identity, "revision": row.revision, "ordinal": row.ordinal} for row in providers
+        ],
+    }
+
+
+def _target_directories_exist(plan: Any) -> bool:
+    """Every planned absolute data-folder value resolves to an existing directory."""
+    try:
+        return all(Path(row.new_value.rstrip("\\/")).is_dir() for row in plan.values)
+    except (OSError, ValueError):
+        return False
+
+
+def _plan_existing_binding(root: Path, block: dict[str, Any], *, allow_empty: bool, base: Path | None = None) -> Any:
+    """Reproduce an existing block's complete member set without changing the package."""
+    import set_data_folder as folder_binding  # pylint: disable=import-outside-toplevel
+
+    try:
+        return folder_binding.plan_package_rewrite(
+            root,
+            str(root if base is None else base),
+            previous_root_identity=block["canonical_root_identity"],
+            identity_of=_canonical_root_identity,
+            expected_members=block["bound_members"],
+            allow_empty=allow_empty,
+        )
+    except folder_binding.PackageRewriteError as error:
+        _binding_blocked("rewrite_plan", error.code)
+
+
+def _validate_provider_binding(  # pylint: disable=too-many-locals
+    root: Path,
+    result: pri.Phase1RoleIdentityResult,
+    snapshot: _PackageSnapshot,
+    ordinal: int,
+) -> _BoundProvider:
+    """Consume a provider's already-published immutable BOUND handoff; never certify it."""
+    if not result.is_start_ready or result.topology != pri.TOPOLOGY_PUBLISHED_PROVIDER or not result.unit:
+        code = result.codes()[0] if result.codes() else "binding_provider_role_invalid"
+        _binding_blocked("provider", code)
+    neutral = _neutral_root(root)
+    _require_no_binding_residue(root)
+    _require_binding_path_budget(root)
+    assessment, projection_sha256, _spec_sha256 = _read_binding_data_access(result, root)
+    if assessment.state not in data_access.DIRECT_ACCEPTED_STATES:
+        _binding_blocked("provider", "binding_provider_data_access_invalid")
+    manifest = _snapshot_manifest(snapshot)
+    block = _strict_binding_block(manifest)
+    expected_authority = _data_access_binding_block(assessment, projection_sha256, ())
+    if block["data_access_authority"] != expected_authority:
+        _binding_blocked("provider", "binding_provider_authority_changed")
+    if block["canonical_root_identity"] != neutral.identity:
+        _binding_blocked("provider", "binding_provider_root_changed")
+    try:
+        revision = artifact_revision.package_manifest_excluded_revision(root)
+    except artifact_revision.RevisionError as error:
+        _binding_cannot("provider", error.code.lower())
+    if revision != block["manifest_excluded_revision"]:
+        _binding_blocked("provider", "binding_provider_revision_changed")
+    plan = _plan_existing_binding(root, block, allow_empty=True)
+    if any(row.old_value != row.new_value for row in plan.values) or not _target_directories_exist(plan):
+        _binding_blocked("provider", "binding_provider_target_changed")
+    try:
+        identity = data_access.provider_reference(result.unit)
+    except data_access.DataAccessProjectionError:
+        _binding_cannot("provider", "binding_provider_identity_unestablished")
+    return _BoundProvider(identity, revision, ordinal)
+
+
+def _provider_failure(result: pri.Phase1RoleIdentityResult) -> None:
+    """Route S2 provider cardinality/identity failures without collapsing them into role errors."""
+    codes = result.codes()
+    code = codes[0] if codes else "binding_provider_unestablished"
+    if code in (pri.CODE_PROVIDER_MISSING, pri.CODE_PROVIDER_AMBIGUOUS):
+        _binding_cannot("provider", code)
+    _binding_blocked("provider", code)
+
+
+def _binding_authority(  # pylint: disable=too-many-branches,too-many-locals,too-many-boolean-expressions
+    roots: Sequence[Path],
+) -> _BindingAuthority:
+    """Hold one exact candidate and its exact already-bound provider cohort."""
+    ordered = tuple(roots)
+    if not ordered:
+        _binding_cannot("transition", "binding_candidate_missing")
+    snapshots = tuple(_require_clean_snapshot(root) for root in ordered)
+    roles = pri.verify_phase1_role_identity(ordered)
+    if len(roles) != len(ordered):
+        _binding_cannot("role_identity", "binding_role_count_mismatch")
+    candidate = roles[-1]
+    topology = candidate.topology
+    if candidate.topology == pri.TOPOLOGY_STANDALONE_DATASOURCE:
+        identity = candidate.source_identity
+        if identity is None or not identity.published_key:
+            _binding_blocked("topology", "datasource_only_no_bind")
+        # S2 can only name this a provider once a consumer is in the same cohort. Its own exact
+        # published key is enough to let the provider bind first; the consumer still re-establishes
+        # the cohort and ordinal before it may consume the handoff.
+        topology = pri.TOPOLOGY_PUBLISHED_PROVIDER
+    if not candidate.is_start_ready or not candidate.unit or not candidate.kind or not candidate.topology:
+        if topology == pri.TOPOLOGY_PUBLISHED_CONSUMER:
+            _provider_failure(candidate)
+        code = candidate.codes()[0] if candidate.codes() else "binding_role_identity_unestablished"
+        _binding_blocked("role_identity", code)
+
+    providers: list[_BoundProvider] = []
+    selected_provider: pri.Phase1RoleIdentityResult | None = None
+    selected_root: Path | None = None
+    if topology == pri.TOPOLOGY_PUBLISHED_CONSUMER:
+        dependencies = candidate.dependencies
+        if not dependencies or any(row.state != pri.STATE_RESOLVED for row in dependencies):
+            _provider_failure(candidate)
+        ordinals = {row.provider_ordinal for row in dependencies}
+        if any(not isinstance(ordinal, int) or isinstance(ordinal, bool) for ordinal in ordinals) or len(ordinals) != 1:
+            _binding_cannot("provider", "binding_provider_ordinal_ambiguous")
+        selected = next(iter(ordinals))
+        if selected is None or selected < 0 or selected >= len(ordered) - 1:
+            _binding_cannot("provider", "binding_provider_ordinal_invalid")
+        if set(range(len(ordered) - 1)) != {selected}:
+            _binding_cannot("provider", "binding_provider_cohort_ambiguous")
+        selected_provider = roles[selected]
+        selected_root = ordered[selected]
+        provider = _validate_provider_binding(selected_root, selected_provider, snapshots[selected], selected)
+        providers.append(provider)
+    elif len(ordered) != 1:
+        _binding_blocked("provider", "binding_provider_cohort_unexpected")
+
+    assessment, projection_sha256, spec_sha256 = _read_binding_data_access(candidate, ordered[-1])
+    if topology == pri.TOPOLOGY_PUBLISHED_CONSUMER:
+        assert selected_provider is not None and selected_root is not None
+        provider_assessment = _read_binding_data_access(selected_provider, selected_root)[0]
+        if (
+            assessment.state != "provider_inherited"
+            or assessment.provider_unit != providers[0].identity
+            or assessment.provider_state != provider_assessment.state
+        ):
+            _binding_blocked("provider", "binding_provider_authority_mismatch")
+    elif assessment.state not in data_access.DIRECT_ACCEPTED_STATES:
+        _binding_blocked("data_access", "binding_direct_authority_required")
+
+    signature = (
+        tuple(_role_signature(result) for result in roles),
+        assessment,
+        projection_sha256,
+        spec_sha256,
+        tuple(providers),
+    )
+    return _BindingAuthority(
+        ordered,
+        snapshots,
+        signature,
+        candidate.unit,
+        candidate.kind,
+        topology,
+        assessment,
+        projection_sha256,
+        spec_sha256,
+        tuple(providers),
+    )
+
+
+def _binding_allows_empty_plan(topology: str) -> bool:
+    """Only provider/consumer cohort handoffs may bind without a local data-folder member."""
+    return topology in (pri.TOPOLOGY_PUBLISHED_PROVIDER, pri.TOPOLOGY_PUBLISHED_CONSUMER)
+
+
+def _expected_binding_authority(authority: _BindingAuthority) -> dict[str, Any]:
+    return _data_access_binding_block(authority.assessment, authority.projection_sha256, authority.providers)
+
+
+def _prior_binding_plan(  # pylint: disable=too-many-locals
+    authority: _BindingAuthority, root: Path, neutral: _NeutralRoot
+) -> tuple[dict[str, Any] | None, Any, bool]:
+    """Validate an optional old handoff and return its exact rewrite plan and currentness."""
+    import set_data_folder as folder_binding  # pylint: disable=import-outside-toplevel
+
+    manifest = _snapshot_manifest(authority.snapshots[-1])
+    old = manifest.get("binding")
+    data_sources = manifest.get("data_sources")
+    portable_binding = data_sources.get("binding") if isinstance(data_sources, dict) else None
+    declares_unbound_target = isinstance(portable_binding, dict) and portable_binding.get("state") == "unbound"
+    allow_empty = _binding_allows_empty_plan(authority.topology) or not declares_unbound_target
+    if old is None:
+        try:
+            plan = folder_binding.plan_package_rewrite(root, str(neutral.path), allow_empty=allow_empty)
+        except folder_binding.PackageRewriteError as error:
+            _binding_blocked("rewrite_plan", error.code)
+        return None, plan, False
+
+    block = _strict_binding_block(manifest)
+    allow_empty = allow_empty or not block["bound_members"]
+    try:
+        current_revision = artifact_revision.package_manifest_excluded_revision(root)
+    except artifact_revision.RevisionError as error:
+        _binding_cannot("revision", error.code.lower())
+    if current_revision != block["manifest_excluded_revision"]:
+        _binding_blocked("revision", "binding_manifest_excluded_revision_mismatch")
+
+    expected_access = _expected_binding_authority(authority)
+    old_access = block["data_access_authority"]
+    if {key: value for key, value in old_access.items() if key != "provider_cohort"} != {
+        key: value for key, value in expected_access.items() if key != "provider_cohort"
+    }:
+        _binding_blocked("data_access", "binding_data_access_authority_changed")
+    old_providers = [(row["identity"], row["ordinal"]) for row in old_access["provider_cohort"]]
+    new_providers = [(row["identity"], row["ordinal"]) for row in expected_access["provider_cohort"]]
+    if old_providers != new_providers:
+        _binding_blocked("provider", "binding_provider_identity_or_ordinal_changed")
+
+    plan = _plan_existing_binding(root, block, allow_empty=allow_empty, base=neutral.path)
+    current = (
+        block["canonical_root_identity"] == neutral.identity
+        and old_access["provider_cohort"] == expected_access["provider_cohort"]
+        and all(row.old_value == row.new_value for row in plan.values)
+        and _target_directories_exist(plan)
+    )
+    return block, plan, current
+
+
+def _walked_binding_files(root: Path) -> dict[str, Path]:
+    """One no-follow package walk, promoted to a typed transition refusal."""
+    files, findings, _empty = pfs.walk_package(root)
+    if findings:
+        code = findings[0].code
+        if code in (pfs.CODE_ENTRY_UNASSESSABLE, pfs.CODE_DIRECTORY_UNREADABLE):
+            _binding_cannot("allowed_diff", code)
+        _binding_blocked("allowed_diff", code)
+    return files
+
+
+def _assert_binding_allowed_diff(  # pylint: disable=too-many-branches
+    snapshot: _PackageSnapshot, staged: Path, plan: Any
+) -> None:
+    """Require the complete pre-manifest delta to be exactly the planner's held substitutions."""
+    walked = _walked_binding_files(staged)
+    expected_names = {MANIFEST_NAME, *dict(snapshot.digests)}
+    if set(walked) != expected_names:
+        _binding_blocked("allowed_diff", "binding_file_set_changed")
+    planned = {row.member: row.rewritten for row in plan.members}
+    verified_names = {row.relative_path for row in snapshot.verified.integrity.verified_files}
+    if set(planned) != set(plan.affected_members) or not set(planned) <= verified_names:
+        # The second set check below uses paths; this first branch rejects malformed planner output.
+        _binding_blocked("allowed_diff", "binding_planner_output_invalid")
+    declared = dict(snapshot.digests)
+    for name, path in walked.items():
+        try:
+            raw = path.read_bytes()
+        except OSError:
+            _binding_cannot("allowed_diff", "binding_member_unreadable")
+        if name == MANIFEST_NAME:
+            if raw != snapshot.manifest:
+                _binding_blocked("allowed_diff", "binding_manifest_changed_early")
+        elif name in planned:
+            if raw != planned[name]:
+                _binding_blocked("allowed_diff", "binding_target_change_mismatch")
+        elif hashlib.sha256(raw).hexdigest() != declared[name]:
+            _binding_blocked("allowed_diff", "binding_unrelated_change")
+
+
+def _binding_block(
+    authority: _BindingAuthority, neutral: _NeutralRoot, revision: str, bound_members: Sequence[str]
+) -> dict[str, Any]:
+    """The sole BOUND handoff stored in the existing package manifest."""
+    block = {
+        "state": BINDING_STATE,
+        "privacy_policy": BINDING_PRIVACY_POLICY,
+        "canonical_root_identity": neutral.identity,
+        "manifest_excluded_revision": revision,
+        "bound_members": list(bound_members),
+        "data_access_authority": _expected_binding_authority(authority),
+    }
+    if discloses_host_location(json.dumps(block, ensure_ascii=False)):
+        _binding_blocked("binding_handoff", "binding_handoff_discloses_root")
+    return block
+
+
+def _verify_bound_candidate(  # pylint: disable=too-many-arguments
+    root: Path,
+    final_root: _NeutralRoot,
+    provider_roots: Sequence[Path],
+    expected_authority: _BindingAuthority,
+    expected_block: dict[str, Any],
+    *,
+    published: bool,
+) -> None:
+    """Verify S1/revision/authority/cohort on staged or published bytes."""
+    authority = _binding_authority((*provider_roots, root))
+    if authority.role_signature != expected_authority.role_signature:
+        _binding_blocked("authority_snapshot", "binding_authority_or_cohort_changed")
+    manifest = _snapshot_manifest(authority.snapshots[-1])
+    block = _strict_binding_block(manifest)
+    if block != expected_block:
+        _binding_blocked("binding_handoff", "binding_handoff_changed")
+    try:
+        revision = artifact_revision.package_manifest_excluded_revision(root)
+    except artifact_revision.RevisionError as error:
+        _binding_cannot("revision", error.code.lower())
+    if revision != block["manifest_excluded_revision"]:
+        _binding_blocked("revision", "binding_manifest_excluded_revision_mismatch")
+    if published:
+        current = _neutral_root(root)
+        _require_binding_path_budget(root)
+        if current.identity != block["canonical_root_identity"] or current.identity != final_root.identity:
+            _binding_blocked("neutral_root", "binding_root_identity_mismatch")
+    plan = _plan_existing_binding(
+        root,
+        block,
+        allow_empty=_binding_allows_empty_plan(authority.topology) or not block["bound_members"],
+        base=final_root.path,
+    )
+    if any(row.old_value != row.new_value for row in plan.values):
+        _binding_blocked("rewrite_plan", "binding_target_not_final")
+    if published:
+        if not _target_directories_exist(plan):
+            _binding_blocked("rewrite_plan", "binding_target_directory_missing")
+
+
+def _require_no_binding_residue(final: Path) -> None:
+    """A prior staging/retired candidate makes publication state ambiguous, never clean."""
+    for candidate in (staging_dir(final.parent, final.name), retired_dir(final)):
+        try:
+            os.lstat(candidate)
+        except FileNotFoundError:
+            continue
+        except (OSError, ValueError):
+            _binding_cannot("transition", "binding_publication_ambiguous")
+        _binding_cannot("transition", "binding_publication_ambiguous")
+
+
+def verify_bound_package(package: Path, *, provider_packages: Sequence[Path] = ()) -> dict[str, Any]:
+    """Verify the producer handoff only; this never evaluates or emits START_READY."""
+    neutral = _neutral_root(package)
+    _require_no_binding_residue(neutral.path)
+    provider_roots = tuple(_neutral_root(path).path for path in provider_packages)
+    authority = _binding_authority((*provider_roots, neutral.path))
+    _require_binding_path_budget(neutral.path)
+    manifest = _snapshot_manifest(authority.snapshots[-1])
+    block = _strict_binding_block(manifest)
+    _verify_bound_candidate(
+        neutral.path,
+        neutral,
+        provider_roots,
+        authority,
+        block,
+        published=True,
+    )
+    return block
+
+
+def rebind_package(  # pylint: disable=too-many-locals
+    package: Path, *, provider_packages: Sequence[Path] = ()
+) -> dict[str, Any]:
+    """Bind/reseal one accepted package in private same-volume staging, then publish atomically."""
+    import set_data_folder as folder_binding  # pylint: disable=import-outside-toplevel
+
+    neutral = _neutral_root(package)
+    final = neutral.path
+    _require_no_binding_residue(final)
+    provider_roots = tuple(_neutral_root(path).path for path in provider_packages)
+    authority = _binding_authority((*provider_roots, final))
+    _require_binding_path_budget(final)
+    old_block, plan, current = _prior_binding_plan(authority, final, neutral)
+    if current and old_block is not None:
+        verify_bound_package(final, provider_packages=provider_roots)
+        return _snapshot_manifest(authority.snapshots[-1])
+    if not _target_directories_exist(plan):
+        _binding_blocked("rewrite_plan", "binding_target_directory_missing")
+
+    staging = staging_dir(final.parent, final.name)
+    try:
+        shutil.copytree(final, staging, copy_function=shutil.copy2)
+        folder_binding.apply_package_rewrite_plan(staging, plan)
+        _assert_binding_allowed_diff(authority.snapshots[-1], staging, plan)
+        try:
+            revision = artifact_revision.package_manifest_excluded_revision(staging)
+        except artifact_revision.RevisionError as error:
+            _binding_cannot("revision", error.code.lower())
+        block = _binding_block(authority, neutral, revision, plan.affected_members)
+        manifest = deepcopy(_snapshot_manifest(authority.snapshots[-1]))
+        manifest["binding"] = block
+        _seal_package(staging, manifest)
+        _verify_bound_candidate(
+            staging,
+            neutral,
+            provider_roots,
+            authority,
+            block,
+            published=False,
+        )
+
+        def verify_original(retired: Path) -> None:
+            if not _snapshot_matches_at(authority.snapshots[-1], retired):
+                _binding_cannot("transition", "binding_original_changed")
+            if any(not _snapshot_matches(snapshot) for snapshot in authority.snapshots[:-1]):
+                _binding_cannot("provider", "binding_provider_changed")
+
+        def verify_staged() -> None:
+            _verify_bound_candidate(
+                staging,
+                neutral,
+                provider_roots,
+                authority,
+                block,
+                published=False,
+            )
+
+        def verify_published(published_root: Path) -> None:
+            _verify_bound_candidate(
+                published_root,
+                neutral,
+                provider_roots,
+                authority,
+                block,
+                published=True,
+            )
+
+        replace_dir(
+            staging,
+            final,
+            verify=verify_original,
+            verify_staged=verify_staged,
+            verify_published=verify_published,
+        )
+    except BindingTransitionError:
+        residue = _discard_scratch(staging)
+        if residue or not _snapshot_matches(authority.snapshots[-1]):
+            _binding_cannot("transition", "binding_publication_ambiguous")
+        raise
+    except (OSError, ValueError, TypeError, UnicodeError, shutil.Error):
+        residue = _discard_scratch(staging)
+        if residue or not _snapshot_matches(authority.snapshots[-1]):
+            _binding_cannot("transition", "binding_publication_ambiguous")
+        _binding_cannot("transition", "binding_publication_failed")
+
+    if staging.exists() or retired_dir(final).exists():
+        _binding_cannot("transition", "binding_publication_ambiguous")
+    return _snapshot_manifest(_require_clean_snapshot(final))
+
+
 def _write_data_access_final(
     dest: Path, result: dict[str, Any], snapshot: _PackageSnapshot, generated: dict[str, bytes]
 ) -> None:
@@ -4960,8 +5824,14 @@ def _external_providers(packages: Sequence[Path], out_root: Path, selected: Sequ
 def _build_parser() -> argparse.ArgumentParser:
     """The CLI surface, in its own function so ``main`` stays inside its complexity budget."""
     parser = argparse.ArgumentParser(description=(__doc__ or "").split("Attribution", maxsplit=1)[0])
-    parser.add_argument("--bundle", type=Path, required=True, help="engine bundle root (holds pbip/, handover/)")
-    parser.add_argument("--out", type=Path, required=True, help="directory to write <Unit>/ packages into")
+    parser.add_argument("--bundle", type=Path, help="engine bundle root (holds pbip/, handover/)")
+    parser.add_argument("--out", type=Path, help="directory to write <Unit>/ packages into")
+    parser.add_argument(
+        "--bind-package",
+        type=Path,
+        metavar="DIR",
+        help="bind/reseal one accepted package as BOUND/UNVALIDATED; never evaluates START_READY",
+    )
     parser.add_argument("--unit", action="append", default=[], help="package only this unit (repeatable)")
     parser.add_argument("--oracle", type=Path, help="oracle capture holding oracle-manifest.json")
     parser.add_argument("--assets", type=Path, help="directory holding the harvested .twb/.twbx/.tds assets")
@@ -5121,7 +5991,22 @@ def _warn_shipping(budgets: list[PathBudget]) -> None:
         print(advisory, file=sys.stderr)
 
 
-def main(argv: list[str] | None = None) -> int:  # pylint: disable=too-many-locals
+def _run_binding_cli(package: Path, provider_packages: Sequence[Path]) -> int:
+    """Privacy-safe CLI projection of the guarded binding transition."""
+    try:
+        result = rebind_package(package, provider_packages=provider_packages)
+    except BindingTransitionError as error:
+        print(f"{error.state} authority={error.authority} code={error.code}; package remains UNBOUND")
+        return 1
+    binding = result["binding"]
+    print(
+        "OK - BOUND/UNVALIDATED "
+        f"root_identity={binding['canonical_root_identity']} members={len(binding['bound_members'])}"
+    )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:  # pylint: disable=too-many-locals,too-many-statements
     """Package the requested units and report what each one carries.
 
     The three outcome buckets are separate local lists on purpose: `_package_each` fills them, and
@@ -5130,6 +6015,25 @@ def main(argv: list[str] | None = None) -> int:  # pylint: disable=too-many-loca
     """
     parser = _build_parser()
     args = parser.parse_args(argv)
+
+    if args.bind_package is not None:
+        incompatible = (
+            args.bundle is not None
+            or args.out is not None
+            or bool(args.unit)
+            or args.oracle is not None
+            or args.assets is not None
+            or args.brief is not None
+            or args.gate_root is not None
+            or args.json is not None
+            or args.discard_package_edits
+            or args.assemble_only
+        )
+        if incompatible:
+            parser.error("--bind-package is a separate transition and cannot be combined with assembly options")
+        return _run_binding_cli(args.bind_package, args.provider_package)
+    if args.bundle is None or args.out is None:
+        parser.error("--bundle and --out are required unless --bind-package is used")
 
     bundle = args.bundle.resolve()
     if not bundle.is_dir():

--- a/scripts/set_data_folder.py
+++ b/scripts/set_data_folder.py
@@ -5,12 +5,14 @@ purpose: Manage the per-model folder M-parameter that each generated Fabric sema
          username) ever ships in the repo. Run this once after cloning to point every model at your
          local checkout so Power BI Desktop can refresh with real data. `--package` is the same idea
          for ONE handover package: `scripts/package_unit.py` writes `<PACKAGE_ROOT>` rather than the
-         machine that built the package, so BINDING it to wherever it now lives is a step of using
-         it - run this before opening the model, and again after every move.
+         machine that built the package. It now delegates to package_unit's neutral-root,
+         whole-directory bind/reseal transition and produces BOUND/UNVALIDATED only; run it before
+         opening the model, and again after every move.
 usage:   python scripts/set_data_folder.py            # localize: set every model to THIS checkout's absolute path
          python scripts/set_data_folder.py --sanitize # restore the <REPO_ROOT> placeholder (run before committing)
          python scripts/set_data_folder.py --check     # CI gate: fail if any tracked file leaks an absolute user path
-         python scripts/set_data_folder.py --package <dir>  # bind ONE package to its own data/
+         python scripts/set_data_folder.py --package <dir>  # guarded bind/reseal of ONE package
+                                           [--provider-package <bound-provider> ...]
 """
 
 import argparse
@@ -18,6 +20,9 @@ import re
 import shutil
 import subprocess
 import sys
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from functools import partial
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -53,6 +58,41 @@ EXPRESSIONS_TMDL = "expressions.tmdl"
 #: package, so treating "no model" as "you pointed me at the wrong folder" would make the package's
 #: own first documented command fail for a whole class of units. The manifest tells the two apart.
 PACKAGE_MANIFEST = "package-manifest.json"
+
+
+class PackageRewriteError(RuntimeError):
+    """A fixed package rewrite refusal that never exposes an absolute root."""
+
+    def __init__(self, code: str) -> None:
+        super().__init__(code)
+        self.code = code
+
+
+@dataclass(frozen=True)
+class PackageValueRewrite:
+    """One exact expression-value substitution in one package-relative member."""
+
+    member: str
+    old_value: str
+    new_value: str
+
+
+@dataclass(frozen=True)
+class PackageMemberRewrite:
+    """The exact held and planned bytes for one affected expression member."""
+
+    member: str
+    original: bytes
+    rewritten: bytes
+
+
+@dataclass(frozen=True)
+class PackageRewritePlan:
+    """A write-free package rewrite plan with a complete affected-member set."""
+
+    values: tuple[PackageValueRewrite, ...]
+    members: tuple[PackageMemberRewrite, ...]
+    affected_members: tuple[str, ...]
 
 
 def _model_expression_files() -> list[Path]:
@@ -147,6 +187,130 @@ def _rewritten(text: str, base: str) -> tuple[str, int, list[str]]:
     return EXPRESSION_RE.sub(_sub, text), rewrites, untouched
 
 
+def _data_root(value: str) -> str | None:  # pylint: disable=too-many-return-statements
+    """The spelling before the final `data` segment, preserving a filesystem-root separator."""
+    segments = list(re.finditer(r"[^\\/]+", value))
+    indexes = [index for index, match in enumerate(segments) if match.group(0).casefold() == DATA_SEGMENT]
+    if not indexes:
+        return None
+    match = segments[indexes[-1]]
+    prefix = value[: match.start()]
+    stripped = prefix.rstrip("\\/")
+    if stripped:
+        if re.fullmatch(r"[A-Za-z]:", stripped) and prefix[-1:] in ("\\", "/"):
+            return stripped + prefix[-1]
+        return stripped
+    if prefix.startswith("\\\\"):
+        return "\\\\"
+    if prefix.startswith("//"):
+        return "//"
+    if prefix.startswith("/"):
+        return "/"
+    return stripped
+
+
+def plan_package_rewrite(  # pylint: disable=too-many-arguments,too-many-locals,too-many-statements
+    root: Path,
+    base: str,
+    *,
+    previous_root_identity: str | None = None,
+    identity_of: Callable[[str], str] | None = None,
+    expected_members: Sequence[str] | None = None,
+    allow_empty: bool = False,
+) -> PackageRewritePlan:
+    """Plan exact package data-folder substitutions without changing a byte.
+
+    A portable package may target only the exact ``<PACKAGE_ROOT>`` spelling. A previously bound
+    package may target only values whose old root reproduces its held canonical identity. This lets
+    a moved package be rebound without persisting the old root, while a sanitized or manually
+    changed expression is refused instead of adopted as a new baseline.
+    """
+    expected = None if expected_members is None else tuple(sorted(set(expected_members)))
+    if expected_members is not None and list(expected_members) != list(expected):
+        raise PackageRewriteError("package_rewrite_member_set_invalid")
+
+    values: list[PackageValueRewrite] = []
+    members: list[PackageMemberRewrite] = []
+
+    def _sub(
+        match: re.Match[str],
+        *,
+        member: str,
+        member_values: list[PackageValueRewrite],
+    ) -> str:
+        value = match.group(2)
+        if PACKAGE_PLACEHOLDER in value and _data_tail(value) is None:
+            raise PackageRewriteError("package_root_token_unresolved")
+        if not _is_pathish(value):
+            return match.group(0)
+        tail = _data_tail(value)
+        if tail is None:
+            return match.group(0)
+        old_root = _data_root(value)
+        if previous_root_identity is None:
+            accepted = old_root == PACKAGE_PLACEHOLDER
+        else:
+            if old_root == PACKAGE_PLACEHOLDER or identity_of is None or old_root is None:
+                accepted = False
+            else:
+                try:
+                    accepted = identity_of(old_root) == previous_root_identity
+                except (TypeError, ValueError, UnicodeError):
+                    accepted = False
+        if not accepted:
+            raise PackageRewriteError("package_rewrite_old_value_changed")
+        segments = [DATA_SEGMENT, tail] if tail else [DATA_SEGMENT]
+        rewritten = flavour_join(base, *segments, trailing=value.endswith(("\\", "/")))
+        row = PackageValueRewrite(member, value, rewritten)
+        member_values.append(row)
+        values.append(row)
+        return f"{match.group(1)}{rewritten}{match.group(3)}"
+
+    expression_files = sorted(root.glob(f"fabric/*.SemanticModel/definition/{EXPRESSIONS_TMDL}"))
+    for expr_file in expression_files:
+        member = expr_file.relative_to(root).as_posix()
+        try:
+            original = expr_file.read_bytes()
+            text = original.decode("utf-8")
+        except (OSError, UnicodeDecodeError):
+            raise PackageRewriteError("package_rewrite_member_unreadable") from None
+        member_values: list[PackageValueRewrite] = []
+        rewritten_text = EXPRESSION_RE.sub(partial(_sub, member=member, member_values=member_values), text)
+        if PACKAGE_PLACEHOLDER in rewritten_text:
+            raise PackageRewriteError("package_root_token_unresolved")
+        if member_values:
+            members.append(PackageMemberRewrite(member, original, rewritten_text.encode("utf-8")))
+
+    for tmdl in sorted(root.glob("fabric/*.SemanticModel/definition/**/*.tmdl")):
+        if tmdl.name == EXPRESSIONS_TMDL:
+            continue
+        try:
+            if PACKAGE_PLACEHOLDER in tmdl.read_text(encoding="utf-8"):
+                raise PackageRewriteError("package_root_token_unresolved")
+        except OSError:
+            raise PackageRewriteError("package_rewrite_member_unreadable") from None
+
+    affected = tuple(sorted(member.member for member in members))
+    if expected is not None and affected != expected:
+        raise PackageRewriteError("package_rewrite_member_set_changed")
+    if not values and not allow_empty:
+        raise PackageRewriteError("package_rewrite_expression_missing")
+    return PackageRewritePlan(tuple(values), tuple(members), affected)
+
+
+def apply_package_rewrite_plan(root: Path, plan: PackageRewritePlan) -> None:
+    """Apply a held plan only when every source member still has its exact planned old bytes."""
+    for member in plan.members:
+        path = root.joinpath(*member.member.split("/"))
+        try:
+            current = path.read_bytes()
+        except OSError:
+            raise PackageRewriteError("package_rewrite_source_changed") from None
+        if current != member.original:
+            raise PackageRewriteError("package_rewrite_source_changed")
+        path.write_bytes(member.rewritten)
+
+
 def _rewrite(expr_file: Path, sanitize: bool) -> bool:
     text = expr_file.read_text(encoding="utf-8")
     tree, slug = _tree_and_slug_for(expr_file)
@@ -173,57 +337,27 @@ def _rewrite(expr_file: Path, sanitize: bool) -> bool:
     return False
 
 
-def _package(root: Path) -> int:
-    """Re-point ONE handover package's model at the package's own `data/`. 0 ok / 1 findings.
-
-    `package_unit.py` writes the folder parameter as :data:`PACKAGE_PLACEHOLDER` (Power Query rejects
-    a relative `File.Contents` argument outright, and the builder cannot know where the package will
-    end up), so a package does not resolve its own rows until it is BOUND - which is what this does,
-    and what the package README leads with. Re-run it after every move.
-
-    ⚠️ **Every value is computed and validated BEFORE anything is written.** The old order wrote each
-    file as it went and only then checked what it had produced, so a package that failed the check
-    had already been modified - on POSIX it was left holding `/tmp/package\\data\\...`, an invalid
-    value, with exit 1 as the only sign (round-2 finding 4). A relocation that cannot succeed must
-    leave the package exactly as it found it, because the alternative is a customer artifact in a
-    state neither this script nor its README describes.
-    """
-    root = root.resolve()
-    if not root.is_dir():
-        print(f"--package {root} is not a directory")
+def _package(root: Path, provider_packages: Sequence[Path] = ()) -> int:
+    """Bind/reseal one package through package_unit's guarded whole-directory transition."""
+    command = [
+        sys.executable,
+        str(Path(__file__).resolve().with_name("package_unit.py")),
+        "--bind-package",
+        str(root.absolute()),
+    ]
+    for provider in provider_packages:
+        command.extend(["--provider-package", str(provider.absolute())])
+    completed = subprocess.run(command, capture_output=True, text=True, check=False)  # noqa: S603
+    safe_lines = [
+        line
+        for line in (*completed.stdout.splitlines(), *completed.stderr.splitlines())
+        if line.startswith(("OK - BOUND/UNVALIDATED ", "BLOCKED authority=", "CANNOT_ESTABLISH authority="))
+    ]
+    if not safe_lines:
+        print("CANNOT_ESTABLISH authority=transition code=binding_subprocess_failed; package remains UNBOUND")
         return 1
-    expr_files = sorted(root.glob(f"fabric/*.SemanticModel/definition/{EXPRESSIONS_TMDL}"))
-    if not expr_files:
-        if (root / PACKAGE_MANIFEST).is_file():
-            print(f"OK - nothing to bind: no model in {root.name} declares a data-folder parameter")
-            return 0
-        print(f"no fabric/*.SemanticModel/definition/{EXPRESSIONS_TMDL} under {root} - is this a package folder?")
-        return 1
-    findings: list[str] = []
-    planned: list[tuple[Path, str, int]] = []
-    for expr_file in expr_files:
-        text = expr_file.read_text(encoding="utf-8")
-        new_text, rewrites, untouched = _rewritten(text, str(root))
-        findings += [f"path parameter with no `{DATA_SEGMENT}` segment: {value}" for value in untouched]
-        if rewrites == 0:
-            print(f"  none {expr_file.relative_to(root)} declares no data-folder parameter")
-            continue
-        findings += _unresolved(new_text)
-        planned.append((expr_file, new_text, rewrites))
-    if findings:
-        print("PACKAGE NOT USABLE - nothing was written, the model would still name something that is not there:")
-        for finding in findings:
-            print(f"  {finding}")
-        return 1
-    for expr_file, new_text, rewrites in planned:
-        if new_text != expr_file.read_text(encoding="utf-8"):
-            expr_file.write_text(new_text, encoding="utf-8")
-        print(
-            f"  set  {expr_file.relative_to(root)} -> {flavour_join(str(root), DATA_SEGMENT, trailing=True)}"
-            f" ({rewrites} parameter(s))"
-        )
-    print(f"OK - {len(expr_files)} model(s) re-pointed at {flavour_join(str(root), DATA_SEGMENT, trailing=True)}")
-    return 0
+    print(safe_lines[-1])
+    return 0 if completed.returncode == 0 else 1
 
 
 def _unresolved(text: str) -> list[str]:
@@ -287,12 +421,23 @@ def main() -> None:
         "--package",
         type=Path,
         metavar="DIR",
-        help="bind ONE handover package's model to its own data/, wherever the package now lives",
+        help="bind/reseal ONE handover package through the canonical guarded package transition",
+    )
+    parser.add_argument(
+        "--provider-package",
+        action="append",
+        type=Path,
+        default=[],
+        metavar="DIR",
+        help="exact already-bound datasource provider package (repeatable; --package only)",
     )
     args = parser.parse_args()
 
     if args.package is not None:
-        sys.exit(_package(args.package))
+        sys.exit(_package(args.package, args.provider_package))
+
+    if args.provider_package:
+        parser.error("--provider-package requires --package")
 
     if args.check:
         sys.exit(_check())

--- a/tests/test_package_binding.py
+++ b/tests/test_package_binding.py
@@ -1,0 +1,723 @@
+"""Direct controls for issue #622's neutral-root BOUND/UNVALIDATED producer."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+from dataclasses import replace
+from pathlib import Path, PurePosixPath, PureWindowsPath
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+# Direct authority controls intentionally exercise private production seams and import sibling test fixtures.
+# pylint: disable=protected-access,missing-function-docstring,wrong-import-position
+# pylint: disable=too-many-arguments,too-many-positional-arguments
+
+import current_artifact_revision as revision  # noqa: E402  # pylint: disable=wrong-import-position
+import package_unit as pkg  # noqa: E402  # pylint: disable=wrong-import-position
+import set_data_folder as folder  # noqa: E402  # pylint: disable=wrong-import-position
+from test_package_data_access_snapshot import _files, _local_bundle  # noqa: E402
+from test_package_filesystem import link_directory  # noqa: E402
+from test_package_role_identity import datasource_package, seal  # noqa: E402
+from test_package_start_handoffs import LOCAL_PROJECTION, with_data_access  # noqa: E402
+from test_package_unit_gates import DS_UNIT, UNIT, _brief  # noqa: E402
+from test_package_unit_reproductions import _shared_bundle  # noqa: E402
+
+
+def _allow_test_root(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exercise every other root predicate while keeping pytest's own root out of this control."""
+    monkeypatch.setattr(pkg, "_known_private_roots", lambda: ())
+
+
+def _portable_owned(root: Path) -> Path:
+    bundle, _unused, options = _local_bundle(root)
+    out = root / "neutral" / "packages"
+    pkg.package_unit(bundle, UNIT, out, **options)
+    return out / UNIT
+
+
+def _portable_shared(root: Path) -> tuple[Path, Path]:
+    bundle, oracle = _shared_bundle(root)
+    out = root / "neutral" / "packages"
+    options = {"oracle_dir": oracle, "assets_dir": bundle.parent / "assets"}
+    pkg.package_unit(bundle, DS_UNIT, out, brief=_brief(root, DS_UNIT, "model_only"), **options)
+    provider = out / DS_UNIT
+    pkg.package_unit(
+        bundle,
+        UNIT,
+        out,
+        brief=_brief(root, UNIT, "report_only_shared_model"),
+        provider_packages=(provider,),
+        **options,
+    )
+    return provider, out / UNIT
+
+
+def _manifest(package: Path) -> dict:
+    return json.loads((package / pkg.MANIFEST_NAME).read_text(encoding="utf-8"))
+
+
+def _reseal(package: Path) -> None:
+    seal(package, **_manifest(package))
+
+
+def _expression(package: Path) -> Path:
+    matches = list(package.glob(f"fabric/*.SemanticModel/definition/{pkg.EXPRESSIONS_TMDL}"))
+    assert len(matches) == 1
+    return matches[0]
+
+
+def _expect_binding_error(
+    call,
+    *,
+    state: str,
+    authority: str,
+    code: str,
+) -> pkg.BindingTransitionError:
+    with pytest.raises(pkg.BindingTransitionError) as caught:
+        call()
+    assert (caught.value.state, caught.value.authority, caught.value.code) == (state, authority, code)
+    return caught.value
+
+
+def test_canonical_root_identity_aliases_and_domain_are_pinned(monkeypatch: pytest.MonkeyPatch) -> None:
+    windows = pkg._canonical_root_identity(r"C:\T2P\Unit")
+    assert windows == pkg._canonical_root_identity("c:/t2p/./unit/")
+    posix = pkg._canonical_root_identity("/t2p/./Unit/")
+    assert posix == pkg._canonical_root_identity("/t2p/Unit")
+    assert posix != pkg._canonical_root_identity("/t2p/unit")
+    assert windows != pkg._canonical_root_identity(r"C:\T2P\Other")
+    expected = "sha256:" + hashlib.sha256(b"t2p-neutral-root-v1\0c:/t2p/unit").hexdigest()
+    assert windows == expected
+
+    monkeypatch.setattr(pkg, "BINDING_ROOT_DOMAIN", b"mutated-domain\0")
+    assert pkg._canonical_root_identity(r"C:\T2P\Unit") != expected
+
+
+def test_explicit_root_policy_accepts_both_native_examples_and_package_layouts() -> None:
+    assert pkg._binder_root_allowed(PureWindowsPath(r"C:\t2p"))
+    assert pkg._binder_root_allowed(PurePosixPath("/t2p"))
+    assert pkg._binder_root_allowed(PureWindowsPath(r"C:\work\_runs\001-x\packages\Unit"))
+    assert pkg._binder_root_allowed(PurePosixPath("/work/_runs/001-x/packages/batch/Unit"))
+    assert not pkg._binder_root_allowed(PureWindowsPath(r"C:\work\arbitrary\deep\Unit"))
+    assert not pkg._binder_root_allowed(PurePosixPath("/work/arbitrary/deep/Unit"))
+
+
+def test_native_existing_root_is_classified_without_persisting_its_spelling(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    root = tmp_path / "packages" / "Unit"
+    root.mkdir(parents=True)
+    _allow_test_root(monkeypatch)
+
+    result = pkg._neutral_root(root)
+
+    assert result.path == root.resolve()
+    assert pkg.BINDING_DIGEST_RE.fullmatch(result.identity)
+    assert str(root) not in result.identity
+
+
+def test_current_profile_home_and_temp_hierarchies_are_all_known(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    profile = tmp_path / "profile"
+    home = tmp_path / "home"
+    temporary = tmp_path / "temporary"
+    monkeypatch.setattr(Path, "home", lambda: profile)
+    monkeypatch.setenv("USERPROFILE", str(profile))
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("TEMP", str(temporary))
+    monkeypatch.setenv("TMP", str(temporary))
+
+    roots = set(pkg._known_private_roots())
+
+    assert pkg._canonical_root_spelling(str(profile)) in roots
+    assert pkg._canonical_root_spelling(str(home)) in roots
+    assert pkg._canonical_root_spelling(str(temporary)) in roots
+
+
+def test_private_unc_foreign_and_policy_roots_name_the_refusing_authority(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    private = tmp_path / "packages" / "Unit"
+    private.mkdir(parents=True)
+    monkeypatch.setattr(pkg, "_known_private_roots", lambda: (pkg._canonical_root_spelling(str(tmp_path)),))
+    error = _expect_binding_error(
+        lambda: pkg._neutral_root(private),
+        state=pkg.STATUS_BLOCKED,
+        authority="neutral_root",
+        code="binding_root_private_hierarchy",
+    )
+    assert str(private) not in str(error) and Path.home().name not in str(error)
+
+    unc = PureWindowsPath(r"\\server\share\Unit")
+    _expect_binding_error(
+        lambda: pkg._neutral_root(unc),  # type: ignore[arg-type]
+        state=pkg.STATUS_BLOCKED,
+        authority="neutral_root",
+        code="binding_root_unc",
+    )
+    foreign = PurePosixPath("/t2p") if os.name == "nt" else PureWindowsPath(r"C:\t2p")
+    _expect_binding_error(
+        lambda: pkg._neutral_root(foreign),  # type: ignore[arg-type]
+        state=pkg.STATUS_BLOCKED,
+        authority="neutral_root",
+        code="binding_root_foreign_flavour",
+    )
+
+    arbitrary = tmp_path / "arbitrary" / "deep" / "Unit"
+    arbitrary.mkdir(parents=True)
+    _allow_test_root(monkeypatch)
+    _expect_binding_error(
+        lambda: pkg._neutral_root(arbitrary),
+        state=pkg.STATUS_BLOCKED,
+        authority="neutral_root",
+        code="binding_root_policy_refused",
+    )
+
+
+def test_reparse_root_is_refused_before_identity(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    target = tmp_path / "target"
+    target.mkdir()
+    alias = tmp_path / "packages" / "Alias"
+    alias.parent.mkdir()
+    link_directory(alias, target)
+    _allow_test_root(monkeypatch)
+    try:
+        _expect_binding_error(
+            lambda: pkg._neutral_root(alias),
+            state=pkg.STATUS_BLOCKED,
+            authority="neutral_root",
+            code="binding_root_reparse",
+        )
+    finally:
+        if os.name == "nt":
+            alias.rmdir()
+        else:
+            alias.unlink()
+
+
+def test_missing_original_package_is_cannot_establish(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    missing = tmp_path / "packages" / "Missing"
+    _allow_test_root(monkeypatch)
+    _expect_binding_error(
+        lambda: pkg.rebind_package(missing),
+        state="CANNOT_ESTABLISH",
+        authority="neutral_root",
+        code="binding_root_missing",
+    )
+
+
+def test_planner_is_write_free_exact_and_preserves_tail_and_separator(tmp_path: Path) -> None:
+    package = tmp_path / "package"
+    expression = package / "fabric" / "Model.SemanticModel" / "definition" / pkg.EXPRESSIONS_TMDL
+    expression.parent.mkdir(parents=True)
+    original = (
+        'expression DataFolder = "<PACKAGE_ROOT>\\data\\Nested.Data\\" meta [IsParameterQuery=true]\n'
+        'expression Ordinary = "not-a-path"\n'
+    ).encode()
+    expression.write_bytes(original)
+    destination = PureWindowsPath(r"C:\t2p\Unit") if os.name == "nt" else PurePosixPath("/t2p/Unit")
+
+    plan = folder.plan_package_rewrite(package, str(destination))
+
+    member = f"fabric/Model.SemanticModel/definition/{pkg.EXPRESSIONS_TMDL}"
+    assert expression.read_bytes() == original
+    assert plan.affected_members == (member,)
+    assert [(row.member, row.old_value) for row in plan.values] == [(member, "<PACKAGE_ROOT>\\data\\Nested.Data\\")]
+    separator = "\\" if os.name == "nt" else "/"
+    assert plan.values[0].new_value == f"{destination}{separator}data{separator}Nested.Data{separator}"
+    assert b'expression Ordinary = "not-a-path"' in plan.members[0].rewritten
+
+
+def test_real_portable_package_binds_reseals_and_changes_only_target_tmdl(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    package = _portable_owned(tmp_path)
+    _allow_test_root(monkeypatch)
+    before = _files(package)
+    original_dispatch = _manifest(package)["dispatch_readiness"]
+
+    result = pkg.rebind_package(package)
+    after = _files(package)
+    block = result["binding"]
+
+    expression = _expression(package).relative_to(package).as_posix()
+    assert {name for name in before if before[name] != after[name]} == {expression, pkg.MANIFEST_NAME}
+    assert set(before) == set(after)
+    assert block == {
+        "state": "BOUND",
+        "privacy_policy": "neutral_root",
+        "canonical_root_identity": pkg._canonical_root_identity(str(package.resolve())),
+        "manifest_excluded_revision": revision.package_manifest_excluded_revision(package),
+        "bound_members": [expression],
+        "data_access_authority": {
+            "identity": "sha256:" + hashlib.sha256((package / "data-access.json").read_bytes()).hexdigest(),
+            "state": "local_import_ready",
+            "validation": "validated",
+            "scope": "model_and_report",
+            "provider_cohort": [],
+        },
+    }
+    assert pkg.pri.verify_s1(package).integrity.is_clean
+    assert _manifest(package)["dispatch_readiness"] == original_dispatch
+    assert _manifest(package)["construction_status"] == pkg.STATUS_ASSEMBLED
+    serialized = json.dumps(block)
+    assert str(package) not in serialized and Path.home().name not in serialized
+    assert "START_READY" not in serialized
+
+
+def test_staged_and_published_s1_revision_checks_both_execute(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    package = _portable_owned(tmp_path)
+    _allow_test_root(monkeypatch)
+    observed: list[tuple[bool, str]] = []
+    verify = pkg._verify_bound_candidate
+
+    def record(*args, published: bool, **kwargs) -> None:
+        verify(*args, published=published, **kwargs)
+        root = args[0]
+        assert pkg.pri.verify_s1(root).integrity.is_clean
+        block = _manifest(root)["binding"]
+        current = revision.package_manifest_excluded_revision(root)
+        assert current == block["manifest_excluded_revision"]
+        observed.append((published, current))
+
+    monkeypatch.setattr(pkg, "_verify_bound_candidate", record)
+    pkg.rebind_package(package)
+
+    assert [published for published, _digest in observed] == [False, False, True]
+    assert len({digest for _published, digest in observed}) == 1
+
+
+def test_set_data_folder_package_routes_to_package_unit_transition(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = []
+
+    def run(command, **kwargs):
+        calls.append((command, kwargs))
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout="OK - BOUND/UNVALIDATED root_identity=sha256:" + "a" * 64 + " members=1\n",
+            stderr="",
+        )
+
+    monkeypatch.setattr(folder.subprocess, "run", run)
+    assert folder._package(Path("package"), (Path("provider"),)) == 0
+    command, kwargs = calls[0]
+    assert Path(command[1]).name == "package_unit.py"
+    assert command[2] == "--bind-package" and Path(command[3]).is_absolute()
+    assert command[4] == "--provider-package" and Path(command[5]).is_absolute()
+    assert [Path(command[3]).name, Path(command[5]).name] == ["package", "provider"]
+    assert kwargs == {"capture_output": True, "text": True, "check": False}
+
+
+@pytest.mark.parametrize(
+    ("state", "codes", "expected_state", "expected_code"),
+    [
+        ("blocked", ["marker-only"], "BLOCKED", "marker-only"),
+        ("blocked", ["stale-clear"], "BLOCKED", "stale-clear"),
+        ("cannot_establish", ["audit-missing"], "CANNOT_ESTABLISH", "audit-missing"),
+    ],
+)
+def test_blocked_or_unestablished_data_access_remains_unbound(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    state: str,
+    codes: list[str],
+    expected_state: str,
+    expected_code: str,
+) -> None:
+    package = _portable_owned(tmp_path)
+    _allow_test_root(monkeypatch)
+    payload = {
+        "schema": "phase1-data-access/v1",
+        "state": state,
+        "source_keys": [],
+        "provider_unit": None,
+        "provider_state": None,
+        "validation": "not_established",
+        "effective_scope": None,
+        "max_phase2_claim": "none",
+        "codes": codes,
+    }
+    (package / "data-access.json").write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    _reseal(package)
+    before = _files(package)
+
+    _expect_binding_error(
+        lambda: pkg.rebind_package(package),
+        state=expected_state,
+        authority="data_access",
+        code=expected_code,
+    )
+    assert _files(package) == before and "binding" not in _manifest(package)
+
+
+def test_missing_data_access_authority_names_the_verified_member_refusal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    package = _portable_owned(tmp_path)
+    _allow_test_root(monkeypatch)
+    (package / "data-access.json").unlink()
+    manifest = _manifest(package)
+    manifest["artifacts"]["data_access"] = None
+    seal(package, **manifest)
+
+    _expect_binding_error(
+        lambda: pkg.rebind_package(package),
+        state=pkg.STATUS_BLOCKED,
+        authority="data_access",
+        code=pkg.pfs.CODE_MEMBER_UNVERIFIED,
+    )
+
+
+def test_authorized_model_only_binding_remains_unvalidated(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    provider, _consumer = _portable_shared(tmp_path)
+    _allow_test_root(monkeypatch)
+    brief = provider / "migration-brief.md"
+    brief.write_text(
+        brief.read_text(encoding="utf-8").replace('"stop"', '"model_only_unvalidated"'),
+        encoding="utf-8",
+    )
+    projection = {
+        "schema": "phase1-data-access/v1",
+        "state": "authorized_model_only",
+        "source_keys": ["source-key:ab1baa4b3f77bb70"],
+        "provider_unit": None,
+        "provider_state": None,
+        "validation": "unvalidated",
+        "effective_scope": "model_only",
+        "max_phase2_claim": "structural_only",
+        "codes": ["brief-model-only", "human-authorize"],
+    }
+    (provider / "data-access.json").write_text(json.dumps(projection, indent=2) + "\n", encoding="utf-8")
+    _reseal(provider)
+
+    result = pkg.rebind_package(provider)
+
+    authority = result["binding"]["data_access_authority"]
+    assert (authority["state"], authority["validation"]) == ("authorized_model_only", "unvalidated")
+    assert result["dispatch_readiness"]["status"] == pkg.DISPATCH_READINESS_NOT_EVALUATED
+
+
+def test_standalone_datasource_bind_request_is_refused_by_topology(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    package = with_data_access(
+        datasource_package(tmp_path / "neutral" / "packages" / "Standalone", unit="Standalone", luid=None),
+        projection=LOCAL_PROJECTION,
+    )
+    _allow_test_root(monkeypatch)
+
+    _expect_binding_error(
+        lambda: pkg.rebind_package(package),
+        state=pkg.STATUS_BLOCKED,
+        authority="topology",
+        code="datasource_only_no_bind",
+    )
+    assert "binding" not in _manifest(package)
+
+
+def test_provider_binds_first_then_consumer_records_exact_cohort(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    provider, consumer = _portable_shared(tmp_path)
+    _allow_test_root(monkeypatch)
+
+    provider_result = pkg.rebind_package(provider)
+    consumer_result = pkg.rebind_package(consumer, provider_packages=(provider,))
+
+    provider_block = provider_result["binding"]
+    consumer_block = consumer_result["binding"]
+    cohort = consumer_block["data_access_authority"]["provider_cohort"]
+    expected_identity = pkg.data_access.provider_reference(_manifest(provider)["unit"])
+    assert provider_block["state"] == "BOUND"
+    assert cohort == [
+        {
+            "identity": expected_identity,
+            "revision": provider_block["manifest_excluded_revision"],
+            "ordinal": 0,
+        }
+    ]
+    assert pkg.verify_bound_package(consumer, provider_packages=(provider,)) == consumer_block
+
+
+def test_consumer_without_its_provider_remains_unbound(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    provider, consumer = _portable_shared(tmp_path)
+    _allow_test_root(monkeypatch)
+    pkg.rebind_package(provider)
+
+    error = _expect_binding_error(
+        lambda: pkg.rebind_package(consumer),
+        state="CANNOT_ESTABLISH",
+        authority="provider",
+        code=pkg.pri.CODE_PROVIDER_MISSING,
+    )
+    assert str(provider) not in str(error) and "binding" not in _manifest(consumer)
+
+
+def test_extra_provider_makes_the_consumer_cohort_ambiguous(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    provider, consumer = _portable_shared(tmp_path)
+    _allow_test_root(monkeypatch)
+    pkg.rebind_package(provider)
+    duplicate = provider.parent / "batch" / provider.name
+    duplicate.parent.mkdir()
+    shutil.copytree(provider, duplicate)
+    pkg.rebind_package(duplicate)
+
+    _expect_binding_error(
+        lambda: pkg.rebind_package(consumer, provider_packages=(provider, duplicate)),
+        state="CANNOT_ESTABLISH",
+        authority="provider",
+        code=pkg.pri.CODE_PROVIDER_AMBIGUOUS,
+    )
+
+
+def test_changed_provider_after_snapshot_refuses_before_consumer_publication(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    provider, consumer = _portable_shared(tmp_path)
+    _allow_test_root(monkeypatch)
+    pkg.rebind_package(provider)
+    before = _files(consumer)
+    allowed_diff = pkg._assert_binding_allowed_diff
+    changed = []
+
+    def mutate_provider(*args, **kwargs) -> None:
+        allowed_diff(*args, **kwargs)
+        if not changed:
+            readme = provider / "README.md"
+            readme.write_bytes(readme.read_bytes() + b"\nchanged provider\n")
+            _reseal(provider)
+            changed.append(True)
+
+    monkeypatch.setattr(pkg, "_assert_binding_allowed_diff", mutate_provider)
+    error = _expect_binding_error(
+        lambda: pkg.rebind_package(consumer, provider_packages=(provider,)),
+        state=pkg.STATUS_BLOCKED,
+        authority="provider",
+        code="binding_provider_revision_changed",
+    )
+    assert changed == [True] and str(provider) not in str(error)
+    assert _files(consumer) == before
+
+
+def test_changed_provider_ordinal_refuses_the_staged_candidate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    provider, consumer = _portable_shared(tmp_path)
+    _allow_test_root(monkeypatch)
+    pkg.rebind_package(provider)
+    before = _files(consumer)
+    verify = pkg.pri.verify_phase1_role_identity
+    calls = []
+
+    def changed_ordinal(roots, **kwargs):
+        results = verify(roots, **kwargs)
+        calls.append(tuple(roots))
+        if len(calls) >= 2:
+            candidate = results[-1]
+            dependency = replace(candidate.dependencies[0], provider_ordinal=1)
+            results = (*results[:-1], replace(candidate, dependencies=(dependency,)))
+        return results
+
+    monkeypatch.setattr(pkg.pri, "verify_phase1_role_identity", changed_ordinal)
+    _expect_binding_error(
+        lambda: pkg.rebind_package(consumer, provider_packages=(provider,)),
+        state="CANNOT_ESTABLISH",
+        authority="provider",
+        code="binding_provider_ordinal_invalid",
+    )
+    assert _files(consumer) == before
+
+
+@pytest.mark.parametrize("change", ["extra-file", "other-tmdl"])
+def test_unrelated_staged_change_is_refused_by_allowed_diff(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, change: str
+) -> None:
+    package = _portable_owned(tmp_path)
+    _allow_test_root(monkeypatch)
+    before = _files(package)
+    apply = folder.apply_package_rewrite_plan
+
+    def mutate(root: Path, plan) -> None:
+        apply(root, plan)
+        target = root / (
+            "unexpected.txt" if change == "extra-file" else f"fabric/{UNIT}.SemanticModel/definition/model.tmdl"
+        )
+        target.write_bytes((target.read_bytes() if target.exists() else b"") + b"\nunrelated\n")
+
+    monkeypatch.setattr(folder, "apply_package_rewrite_plan", mutate)
+    code = "binding_file_set_changed" if change == "extra-file" else "binding_unrelated_change"
+    _expect_binding_error(
+        lambda: pkg.rebind_package(package),
+        state=pkg.STATUS_BLOCKED,
+        authority="allowed_diff",
+        code=code,
+    )
+    assert _files(package) == before
+
+
+@pytest.mark.parametrize(
+    ("change", "code"),
+    [
+        ("unresolved", "package_root_token_unresolved"),
+        ("changed", "package_rewrite_old_value_changed"),
+        ("missing", "package_rewrite_expression_missing"),
+    ],
+)
+def test_changed_missing_or_unresolved_expression_is_not_adopted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, change: str, code: str
+) -> None:
+    package = _portable_owned(tmp_path)
+    _allow_test_root(monkeypatch)
+    expression = _expression(package)
+    text = expression.read_text(encoding="utf-8")
+    if change == "unresolved":
+        text = text.replace("<PACKAGE_ROOT>\\data\\", "<PACKAGE_ROOT>\\missing\\")
+    elif change == "changed":
+        foreign = "C:\\other\\data\\" if os.name == "nt" else "/other/data/"
+        text = text.replace("<PACKAGE_ROOT>\\data\\", foreign)
+    else:
+        text = ""
+    expression.write_text(text, encoding="utf-8")
+    _reseal(package)
+
+    _expect_binding_error(
+        lambda: pkg.rebind_package(package),
+        state=pkg.STATUS_BLOCKED,
+        authority="rewrite_plan",
+        code=code,
+    )
+
+
+def test_manual_manifest_digest_mutation_is_refused_by_s1(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    package = _portable_owned(tmp_path)
+    _allow_test_root(monkeypatch)
+    manifest = _manifest(package)
+    manifest["contents"]["files"][_expression(package).relative_to(package).as_posix()] = "0" * 64
+    (package / pkg.MANIFEST_NAME).write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+
+    _expect_binding_error(
+        lambda: pkg.rebind_package(package),
+        state=pkg.STATUS_BLOCKED,
+        authority="s1",
+        code=pkg.pfs.CODE_DIGEST_MISMATCH,
+    )
+
+
+def test_moving_requires_rebind_and_sanitizing_invalidates_revision(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    package = _portable_owned(tmp_path)
+    _allow_test_root(monkeypatch)
+    first = pkg.rebind_package(package)["binding"]
+    moved = package.parent / "batch" / package.name
+    moved.parent.mkdir()
+    shutil.move(package, moved)
+
+    _expect_binding_error(
+        lambda: pkg.verify_bound_package(moved),
+        state=pkg.STATUS_BLOCKED,
+        authority="neutral_root",
+        code="binding_root_identity_mismatch",
+    )
+    second = pkg.rebind_package(moved)["binding"]
+    assert second["canonical_root_identity"] != first["canonical_root_identity"]
+    assert second["manifest_excluded_revision"] != first["manifest_excluded_revision"]
+
+    expression = _expression(moved)
+    current = str(moved.resolve())
+    expression.write_text(
+        expression.read_text(encoding="utf-8").replace(current, pkg.PACKAGE_ROOT_TOKEN),
+        encoding="utf-8",
+    )
+    _reseal(moved)
+    _expect_binding_error(
+        lambda: pkg.rebind_package(moved),
+        state=pkg.STATUS_BLOCKED,
+        authority="revision",
+        code="binding_manifest_excluded_revision_mismatch",
+    )
+
+
+def test_publication_failure_restores_the_complete_old_package(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    package = _portable_owned(tmp_path)
+    _allow_test_root(monkeypatch)
+    before = _files(package)
+    verify = pkg._verify_bound_candidate
+    published_checks = []
+
+    def fail_after_publish(*args, published: bool, **kwargs) -> None:
+        verify(*args, published=published, **kwargs)
+        if published:
+            published_checks.append(True)
+            raise pkg.BindingTransitionError(
+                "CANNOT_ESTABLISH",
+                "publication",
+                "forced_publication_failure",
+            )
+
+    monkeypatch.setattr(pkg, "_verify_bound_candidate", fail_after_publish)
+    _expect_binding_error(
+        lambda: pkg.rebind_package(package),
+        state="CANNOT_ESTABLISH",
+        authority="publication",
+        code="forced_publication_failure",
+    )
+    assert published_checks == [True]
+    assert _files(package) == before
+    assert not pkg.staging_dir(package.parent, package.name).exists()
+    assert not pkg.retired_dir(package).exists()
+
+
+@pytest.mark.parametrize("residue", ["staged", "retired"])
+def test_ambiguous_publication_residue_is_cannot_establish(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, residue: str
+) -> None:
+    package = _portable_owned(tmp_path)
+    _allow_test_root(monkeypatch)
+    before = _files(package)
+    path = pkg.staging_dir(package.parent, package.name) if residue == "staged" else pkg.retired_dir(package)
+    path.mkdir()
+
+    _expect_binding_error(
+        lambda: pkg.rebind_package(package),
+        state="CANNOT_ESTABLISH",
+        authority="transition",
+        code="binding_publication_ambiguous",
+    )
+    assert _files(package) == before
+
+
+def test_manifest_excluded_revision_ignores_only_the_manifest(tmp_path: Path) -> None:
+    package = tmp_path / "package"
+    package.mkdir()
+    (package / "member.txt").write_bytes(b"one")
+    (package / pkg.MANIFEST_NAME).write_bytes(b"first")
+    initial = revision.package_manifest_excluded_revision(package)
+    (package / pkg.MANIFEST_NAME).write_bytes(b"second")
+    assert revision.package_manifest_excluded_revision(package) == initial
+    (package / "member.txt").write_bytes(b"two")
+    assert revision.package_manifest_excluded_revision(package) != initial
+
+
+def test_path_budget_violation_names_existing_authority(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    package = _portable_owned(tmp_path)
+    _allow_test_root(monkeypatch)
+    monkeypatch.setattr(
+        pkg,
+        "scan_path_ceiling",
+        lambda *_args, **_kwargs: {"counted": {"unknown": 0, "measured": 1, "over_ceiling": 1}},
+    )
+
+    _expect_binding_error(
+        lambda: pkg.rebind_package(package),
+        state=pkg.STATUS_BLOCKED,
+        authority="path_budget",
+        code="binding_path_budget_exceeded",
+    )

--- a/tests/test_package_binding.py
+++ b/tests/test_package_binding.py
@@ -577,13 +577,19 @@ def test_changed_missing_or_unresolved_expression_is_not_adopted(
     _allow_test_root(monkeypatch)
     expression = _expression(package)
     text = expression.read_text(encoding="utf-8")
+    value = next(
+        match.group(2)
+        for match in folder.EXPRESSION_RE.finditer(text)
+        if match.group(2).startswith(pkg.PACKAGE_ROOT_TOKEN)
+    )
+    separator = "\\" if "\\" in value else "/"
     if change == "unresolved":
-        text = text.replace("<PACKAGE_ROOT>\\data\\", "<PACKAGE_ROOT>\\missing\\")
+        replacement = value.replace(f"{separator}data{separator}", f"{separator}missing{separator}", 1)
     elif change == "changed":
-        foreign = "C:\\other\\data\\" if os.name == "nt" else "/other/data/"
-        text = text.replace("<PACKAGE_ROOT>\\data\\", foreign)
+        replacement = "C:\\other\\data\\" if os.name == "nt" else "/other/data/"
     else:
-        text = ""
+        replacement = ""
+    text = text.replace(value, replacement, 1)
     expression.write_text(text, encoding="utf-8")
     _reseal(package)
 

--- a/tests/test_package_unit.py
+++ b/tests/test_package_unit.py
@@ -44,7 +44,6 @@ import manifest_scope as ms  # noqa: E402  # pylint: disable=wrong-import-positi
 import package_unit as pkg  # noqa: E402  # pylint: disable=wrong-import-position
 import path_flavour as pf  # noqa: E402  # pylint: disable=wrong-import-position
 import reference_evidence as rev  # noqa: E402  # pylint: disable=wrong-import-position
-import set_data_folder as sdf  # noqa: E402  # pylint: disable=wrong-import-position
 from manifest_scope import KEEP, REPORT_ALLOW, Rows, project  # noqa: E402  # pylint: disable=wrong-import-position
 from test_check_reference_readiness import (  # noqa: E402  # pylint: disable=wrong-import-position
     write_engine_report,
@@ -1359,8 +1358,9 @@ def test_the_data_folder_parameter_names_a_PLACEHOLDER_not_the_machine_that_buil
     the builder's own output folder, so moving the handover package left its rows present on disk
     and unreachable, and shipped a `C:\\Users\\<name>\\...` to a customer.
 
-    The shipped value is a placeholder; binding resolves it, and that is asserted here end to end
-    rather than trusted, because a placeholder nobody can resolve is not an improvement.
+    The shipped value is a placeholder. Issue #622's guarded binding transition is exercised against
+    an authority-complete package in `test_package_binding.py`; this construction control stops at
+    the portable bytes and must not mutate or authorize them.
     """
     root = _package_with_receipt(tmp_path)
     expressions = (_model_definition(root) / pkg.EXPRESSIONS_TMDL).read_text(encoding="utf-8")
@@ -1376,18 +1376,12 @@ def test_the_data_folder_parameter_names_a_PLACEHOLDER_not_the_machine_that_buil
 
     binding = json.loads((root / "package-manifest.json").read_text(encoding="utf-8"))["data_sources"]["binding"]
     assert binding["state"] == "unbound" and binding["token"] == pkg.PACKAGE_ROOT_TOKEN
-    assert sdf._package(root) == 0, "the package could not be bound to its own location"  # noqa: SLF001
-    bound = re.search(
-        rf'expression {pkg.DATA_FOLDER_PARAM} = "([^"]+)"',
-        (_model_definition(root) / pkg.EXPRESSIONS_TMDL).read_text(encoding="utf-8"),
-    )
-    assert bound is not None
-    named = Path(bound.group(1))
-    assert named.is_dir(), f"binding named a directory that does not exist: {named}"
-    assert named.resolve() == (root / pkg.DATA_DIR).resolve()
+    assert "binding" not in json.loads((root / "package-manifest.json").read_text(encoding="utf-8"))
 
 
-def test_a_moved_package_still_reaches_its_rows_once_it_is_BOUND(tmp_path: Path) -> None:
+def test_a_moved_package_still_reaches_its_rows_once_it_is_BOUND(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """The acceptance test for the design decision, and the one the old value could not pass.
 
     Round-2 finding 1 measured `embedded_path_exists_after_move=False` beside
@@ -1396,12 +1390,20 @@ def test_a_moved_package_still_reaches_its_rows_once_it_is_BOUND(tmp_path: Path)
     whole route - package here, MOVE the folder, bind it there, and read the file the partition now
     names off disk.
     """
-    root = _package_with_receipt(tmp_path)
-    moved = tmp_path / "customer" / "delivered" / UNIT
+    from test_package_data_access_snapshot import _local_bundle  # pylint: disable=import-outside-toplevel
+    from test_package_unit_gates import UNIT as GATE_UNIT  # pylint: disable=import-outside-toplevel
+
+    bundle, _unused, options = _local_bundle(tmp_path)
+    out = tmp_path / "neutral" / "packages"
+    pkg.package_unit(bundle, GATE_UNIT, out, **options)
+    root = out / GATE_UNIT
+    monkeypatch.setattr(pkg, "_known_private_roots", lambda: ())
+    pkg.rebind_package(root)
+    moved = root.parent / "delivered" / root.name
     moved.parent.mkdir(parents=True, exist_ok=True)
     shutil.move(str(root), str(moved))
 
-    assert sdf._package(moved) == 0  # noqa: SLF001
+    pkg.rebind_package(moved)
     text = (_model_definition(moved) / pkg.EXPRESSIONS_TMDL).read_text(encoding="utf-8")
     value = re.search(rf'expression {pkg.DATA_FOLDER_PARAM} = "([^"]+)"', text)
     assert value is not None and Path(value.group(1)).is_dir()
@@ -1412,7 +1414,7 @@ def test_a_moved_package_still_reaches_its_rows_once_it_is_BOUND(tmp_path: Path)
     assert tail is not None, "no partition reads the shipped copy through the parameter"
     reached = Path(value.group(1) + tail.group(1))
     assert reached.is_file(), f"the bound model names rows that are not there: {reached}"
-    assert reached.read_text(encoding="utf-8").startswith("Employee_ID")
+    assert reached.read_text(encoding="utf-8").startswith("value")
 
 
 @pytest.mark.parametrize(

--- a/tests/test_package_unit_gates.py
+++ b/tests/test_package_unit_gates.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import re
 import shutil
 import subprocess
@@ -658,36 +659,58 @@ def test_the_readme_command_that_BINDS_the_package_actually_binds_it(tmp_path: P
     invalid value. Round-2 finding 1 makes binding load-bearing rather than a repair, so it is run
     exactly as printed and its effect is read off disk.
 
-    ⚠️ This fixture's unit is report-only, so what it proves is that the README's own first command
-    RUNS and succeeds on a package this packager actually produced - including the model-less shape,
-    which is a whole class of units and used to be answered with "is this a package folder?". The
-    row-level proof (placeholder in, real directory out, partition reads the file) needs a model with
-    imported data and lives in `test_package_unit.py`:
+    The package is moved under the explicit neutral package-root policy first. The child process's
+    profile/temp variables point at a disjoint control hierarchy, so this proves the command rather
+    than depending on where pytest itself happens to allocate `tmp_path`. The row-level proof
+    (placeholder in, real directory out, partition reads the file) lives in `test_package_unit.py`:
     `test_a_moved_package_still_reaches_its_rows_once_it_is_BOUND`.
     """
     bundle, oracle, _ = _bundle(tmp_path, covered=None)
-    unit = _package(tmp_path, bundle, oracle)
+    original = _package(tmp_path, bundle, oracle)
+    control = hashlib.sha256(str(tmp_path).encode("utf-8")).hexdigest()[:12]
+    neutral = SCRIPTS.parent / "_binding-cli-tests" / control
+    unit = neutral / "packages" / original.name
+    unit.parent.mkdir(parents=True)
+    shutil.move(str(original), str(unit))
     readme = (unit / "README.md").read_text(encoding="utf-8")
     printed = [line.split() for line in readme.splitlines() if line.startswith(f"    python {BIND_SCRIPT}")]
     assert len(printed) == 1, f"the package README no longer prints the binding command: {readme[:400]}"
 
     _python, script, *arguments = printed[0]
-    proc = subprocess.run(  # noqa: S603
-        [sys.executable, str(SCRIPTS.parent / script), *[a.replace(PATH_PLACEHOLDER, str(unit)) for a in arguments]],
-        capture_output=True,
-        text=True,
-        check=False,
-        cwd=str(tmp_path),
-        timeout=900,
-    )
-    assert proc.returncode == 0, f"the documented binding command failed: {proc.stdout}\n{proc.stderr}"
-    expressions = list(unit.glob("fabric/*.SemanticModel/definition/expressions.tmdl"))
-    for path in expressions:
-        text = path.read_text(encoding="utf-8")
-        assert pkg.PACKAGE_ROOT_TOKEN not in text, "binding left the placeholder in place"
-        for value in re.findall(r'expression\s+(?:#"[^"]+"|[^\s=]+)\s*=\s*"([^"]*)"', text):
-            if value.startswith(str(unit)):
-                assert Path(value.rstrip("\\/")).is_dir(), f"binding wrote a directory that is not there: {value}"
+    private_control = str(SCRIPTS.parent.parent / "_binding-private-control")
+    env = {
+        **os.environ,
+        "HOME": private_control,
+        "USERPROFILE": private_control,
+        "TMPDIR": private_control,
+        "TEMP": private_control,
+        "TMP": private_control,
+        "LOCALAPPDATA": private_control,
+    }
+    try:
+        proc = subprocess.run(  # noqa: S603
+            [
+                sys.executable,
+                str(SCRIPTS.parent / script),
+                *[a.replace(PATH_PLACEHOLDER, str(unit)) for a in arguments],
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            cwd=str(tmp_path),
+            env=env,
+            timeout=900,
+        )
+        assert proc.returncode == 0, f"the documented binding command failed: {proc.stdout}\n{proc.stderr}"
+        expressions = list(unit.glob("fabric/*.SemanticModel/definition/expressions.tmdl"))
+        for path in expressions:
+            text = path.read_text(encoding="utf-8")
+            assert pkg.PACKAGE_ROOT_TOKEN not in text, "binding left the placeholder in place"
+            for value in re.findall(r'expression\s+(?:#"[^"]+"|[^\s=]+)\s*=\s*"([^"]*)"', text):
+                if value.startswith(str(unit)):
+                    assert Path(value.rstrip("\\/")).is_dir(), f"binding wrote a directory that is not there: {value}"
+    finally:
+        shutil.rmtree(neutral, ignore_errors=True)
 
 
 def _run_gate(script: str, arguments: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:


### PR DESCRIPTION
## Scope

Refs #622.

- Implementation base: `f48a2cf2b2b4b10b5b9a162a8ec604b372d2b8f4` (#614 merged).
- Head: `275d81032894368311b28087559acfd61ef71408`.
- Target `master` at PR creation: `222eaad35f1ac3df9e40845c50b833183f4c8afb`.
- Production surface: **N = 3** — `scripts/set_data_folder.py`, `scripts/package_unit.py`, and the single manifest-excluded helper in `scripts/current_artifact_revision.py`.
- No `check_reference_readiness.py`, promotion, credential-gate, or final readiness change. This producer emits **BOUND/UNVALIDATED only**, never `START_READY`.

## Lifecycle and schema

Portable `<PACKAGE_ROOT>` packages remain unbound. Accepted packages are copied to same-volume private staging, receive only the planned `expressions.tmdl` value substitutions, are resealed in the existing manifest, and publish through `replace_dir` with staged and published verification plus rollback.

The existing `package-manifest.json` gains exactly one block:

```json
"binding": {
  "state": "BOUND",
  "privacy_policy": "neutral_root",
  "canonical_root_identity": "sha256:<digest>",
  "manifest_excluded_revision": "sha256:<digest>",
  "bound_members": ["fabric/<Model>.SemanticModel/definition/expressions.tmdl"],
  "data_access_authority": {
    "identity": "sha256:<existing projection digest>",
    "state": "<accepted state>",
    "validation": "<validated|unvalidated>",
    "scope": "<accepted scope>",
    "provider_cohort": [
      {"identity": "provider-ref:v1:sha256:<digest>", "revision": "sha256:<digest>", "ordinal": 0}
    ]
  }
}
```

No raw root path is persisted in this block or emitted in diagnostics. `package_working_revision()` is unchanged.

## Neutral-root policy

The binder requires an absolute existing native-flavour directory, existing Desktop path budget, non-UNC, no symlink/junction/reparse boundary or resolved alias, and exclusion from the current profile/home/temp hierarchies. The explicit supported-root policy accepts canonical flat/nested `packages/` placement or a root-level package directory. Ambiguous filesystem state is `CANNOT_ESTABLISH`.

Canonical identity is exactly SHA-256 over `b"t2p-neutral-root-v1\0" + canonical_native_root_identity_bytes`; Windows aliases case-fold and render `/`, while POSIX preserves case.

## Controls

- Real model-backed portable package → exact staged rewrite/reseal → BOUND/UNVALIDATED.
- Target-only TMDL delta; all other bytes and file set held.
- Staged/published S1 and manifest-excluded revision equality.
- Published provider first, then exact consumer provider identity/revision/ordinal cohort.
- Standalone datasource no-bind and authorized model-only remains unvalidated.
- Named refusals for private/UNC/reparse/foreign/path-budget roots, blocked/stale/missing data access, missing/changed/unresolved expressions, manifest mutation, provider drift/absence/ambiguity/ordinal drift, moved/sanitized packages, and ambiguous publication residue.
- Forced post-publication verification failure restores the complete prior directory and removes the candidate.
- Windows/POSIX alias, case, move, and domain-tag identity controls.

## Validation (September 12, 2026)

- Ruff: repository gate passed.
- Pylint: `scripts` and changed production/binding tests rated 10.00/10.
- Package/binding suites: **492 passed, 1 platform skip**.
- Direct binding mutation controls: **7 passed**.
- Current-master synthetic merge tree `6ea87a10e37419faa593e83f6be520bfecc55572`: **272 passed** across binding, S1/S2 handoff, revision, and data-access snapshot/swap tests.
- Spec, privacy, data-model, navigation, capability, and agent-convention gates passed.
- Exact-tip CI for `275d81032894368311b28087559acfd61ef71408`: Ubuntu checks, pinned engine integration, and hosted Windows bundle/GUI jobs all passed.

## Unverified native limits

- No real Power BI Desktop refresh was used as a readiness claim; final #562 consumption remains required.
- Exact-tip CI exercised Ubuntu and hosted Windows. Customer-specific mount/reparse behavior outside those hosted filesystems remains unverified.
- A real `subst` root was not created; the policy rejects resolved aliases and does not treat `subst` as canonical.


